### PR TITLE
feat(core): add tor hidden-service guardrails, CLI flags, and e2e coverage

### DIFF
--- a/apps/cli/src/cli/commands/connect.test.ts
+++ b/apps/cli/src/cli/commands/connect.test.ts
@@ -6,6 +6,8 @@ import {
   buildBuyerRuntimeOverridesFromFlags,
   buildBuyerBootstrapEntries,
   buildRouterRuntimeEnvFromBuyerConfig,
+  parseHostPort,
+  parseTorSocksProxy,
 } from './connect.js';
 
 test('connect runtime overrides are runtime-only and win over env/config', () => {
@@ -66,4 +68,30 @@ test('connect bootstrap entries respect explicit configured nodes', () => {
   const entries = buildBuyerBootstrapEntries(['10.0.0.2:6881'], 6889);
   assert.equal(entries[0], '127.0.0.1:6889');
   assert.deepEqual(entries.slice(1), ['10.0.0.2:6881']);
+});
+
+test('connect parses tor socks proxy host:port', () => {
+  const parsed = parseTorSocksProxy('127.0.0.1:9050');
+  assert.deepEqual(parsed, { host: '127.0.0.1', port: 9050 });
+});
+
+test('connect rejects invalid tor socks proxy values', () => {
+  assert.equal(parseTorSocksProxy(''), null);
+  assert.equal(parseTorSocksProxy('127.0.0.1'), null);
+  assert.equal(parseTorSocksProxy('127.0.0.1:0'), null);
+});
+
+test('connect parseHostPort supports bracketed IPv6', () => {
+  const parsed = parseHostPort('[::1]:9050');
+  assert.deepEqual(parsed, { host: '::1', port: 9050 });
+});
+
+test('connect parseHostPort rejects malformed bracketed IPv6 endpoint', () => {
+  const parsed = parseHostPort('[::1:9050');
+  assert.equal(parsed, null);
+});
+
+test('connect parseTorSocksProxy supports bracketed IPv6 host', () => {
+  const parsed = parseTorSocksProxy('[::1]:9050');
+  assert.deepEqual(parsed, { host: '::1', port: 9050 });
 });

--- a/apps/cli/src/cli/commands/connect.ts
+++ b/apps/cli/src/cli/commands/connect.ts
@@ -7,7 +7,7 @@ import { homedir } from 'node:os'
 import { getGlobalOptions } from './types.js'
 import { loadConfig } from '../../config/loader.js'
 import { AntseedNode, BaseEscrowClient, loadOrCreateIdentity, identityToEvmAddress, getInstance } from '@antseed/node'
-import type { NodePaymentsConfig } from '@antseed/node'
+import type { NodePaymentsConfig, NodeTorSocksProxyConfig } from '@antseed/node'
 import { OFFICIAL_BOOTSTRAP_NODES, parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery'
 import { setupShutdownHandler } from '../shutdown.js'
 import { loadRouterPlugin, buildPluginConfig } from '../../plugins/loader.js'
@@ -19,6 +19,8 @@ interface LocalSeederInfo {
   dhtPort: number
   signalingPort: number
   pid: number
+  torPeerHint?: string | null
+  torOnionAddress?: string | null
 }
 
 export function buildBuyerRuntimeOverridesFromFlags(options: {
@@ -91,6 +93,36 @@ function parseOptionalBoolEnv(value: string | undefined): boolean | null {
   return null
 }
 
+export function parseHostPort(rawValue: string): { host: string; port: number } | null {
+  const raw = rawValue.trim()
+  if (raw.length === 0) return null
+
+  if (raw.startsWith('[')) {
+    const end = raw.indexOf(']')
+    if (end <= 1) return null
+    const host = raw.slice(1, end).trim()
+    const portPart = raw.slice(end + 1)
+    if (!portPart.startsWith(':')) return null
+    const port = Number.parseInt(portPart.slice(1), 10)
+    if (!Number.isInteger(port) || port < 1 || port > 65535) return null
+    return { host, port }
+  }
+
+  const sep = raw.lastIndexOf(':')
+  if (sep <= 0) return null
+  const host = raw.slice(0, sep).trim()
+  const port = Number.parseInt(raw.slice(sep + 1), 10)
+  if (host.length === 0 || !Number.isInteger(port) || port < 1 || port > 65535) return null
+  return { host, port }
+}
+
+export function parseTorSocksProxy(rawValue: string | undefined): NodeTorSocksProxyConfig | null {
+  if (!rawValue) return null
+  const parsed = parseHostPort(rawValue)
+  if (!parsed) return null
+  return parsed
+}
+
 async function isRpcReachable(rpcUrl: string, timeoutMs = 1500): Promise<boolean> {
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), timeoutMs)
@@ -123,12 +155,26 @@ async function getLocalSeederInfo(): Promise<LocalSeederInfo | null> {
   try {
     const stateFile = join(homedir(), '.antseed', 'daemon.state.json')
     const raw = await readFile(stateFile, 'utf-8')
-    const state = JSON.parse(raw) as { state?: string; dhtPort?: number; signalingPort?: number; pid?: number }
-    if (state.state === 'seeding' && state.dhtPort && state.pid) {
+    const state = JSON.parse(raw) as {
+      state?: string
+      dhtPort?: number
+      signalingPort?: number
+      pid?: number
+      torPeerHint?: string | null
+      torOnionAddress?: string | null
+    }
+    if (state.state === 'seeding' && state.pid && ((state.dhtPort ?? 0) > 0 || (state.signalingPort ?? 0) > 0)) {
       try {
         process.kill(state.pid, 0)
-        const signalingPort = state.signalingPort ?? state.dhtPort
-        return { dhtPort: state.dhtPort, signalingPort, pid: state.pid }
+        const dhtPort = state.dhtPort ?? 0
+        const signalingPort = state.signalingPort ?? dhtPort
+        return {
+          dhtPort,
+          signalingPort,
+          pid: state.pid,
+          torPeerHint: state.torPeerHint ?? null,
+          torOnionAddress: state.torOnionAddress ?? null,
+        }
       } catch {
         return null
       }
@@ -146,6 +192,9 @@ export function registerConnectCommand(program: Command): void {
     .option('-p, --port <number>', 'local proxy port', (v) => parseInt(v, 10))
     .option('--router <name>', 'router plugin name or npm package')
     .option('--instance <id>', 'use a configured plugin instance by ID')
+    .option('--tor', 'enable tor mode guardrails (manual peer discovery, no DHT, forced TCP)')
+    .option('--tor-peer <peer>', 'manual tor peer in [peerId@]host:port format (repeatable)', (value, previous: string[] = []) => [...previous, value], [])
+    .option('--tor-socks <hostPort>', 'SOCKS proxy endpoint for tor mode (host:port)')
     .option('--max-input-usd-per-million <number>', 'runtime-only max input pricing override in USD per 1M tokens', parseFloat)
     .option('--max-output-usd-per-million <number>', 'runtime-only max output pricing override in USD per 1M tokens', parseFloat)
     .action(async (options) => {
@@ -257,6 +306,38 @@ export function registerConnectCommand(program: Command): void {
       )
       console.log(chalk.dim(`  min peer reputation: ${effectiveBuyerConfig.minPeerReputation}`))
       console.log(chalk.dim(`  proxy port: ${effectiveBuyerConfig.proxyPort}`))
+
+      const torEnabled = (options.tor as boolean | undefined) === true || config.network.tor?.enabled === true
+      const torPeersFromFlags = (options.torPeer as string[] | undefined) ?? []
+      let torManualPeers = torPeersFromFlags.length > 0
+        ? torPeersFromFlags
+        : (config.network.tor?.manualPeers ?? [])
+      if (torEnabled && torManualPeers.length === 0 && seederInfo?.torPeerHint) {
+        torManualPeers = [seederInfo.torPeerHint]
+      }
+      const torSocksRaw = (options.torSocks as string | undefined)
+        ?? process.env['ANTSEED_TOR_SOCKS']
+        ?? config.network.tor?.socksProxy
+      const torSocks = parseTorSocksProxy(torSocksRaw)
+
+      if (torEnabled && torSocksRaw && !torSocks) {
+        console.error(chalk.red(`Invalid tor SOCKS proxy "${torSocksRaw}". Expected host:port.`))
+        process.exit(1)
+      }
+
+      if (torEnabled && torManualPeers.length === 0) {
+        console.error(chalk.red('Tor mode requires at least one manual peer (--tor-peer or network.tor.manualPeers).'))
+        process.exit(1)
+      }
+
+      if (torEnabled) {
+        console.log(chalk.dim(`  tor mode: enabled`))
+        console.log(chalk.dim(`  tor manual peers: ${torManualPeers.length}`))
+        console.log(chalk.dim(`  tor socks: ${torSocks ? `${torSocks.host}:${torSocks.port}` : '(none configured)'}`))
+        if (seederInfo?.torOnionAddress && torPeersFromFlags.length === 0 && (config.network.tor?.manualPeers?.length ?? 0) === 0) {
+          console.log(chalk.dim(`  using local seeder tor hint: ${seederInfo.torOnionAddress}`))
+        }
+      }
       console.log('')
 
       const node = new AntseedNode({
@@ -265,6 +346,17 @@ export function registerConnectCommand(program: Command): void {
         allowPrivateIPs: true,
         dataDir: globalOpts.dataDir,
         payments: paymentsConfig,
+        ...(torEnabled
+          ? {
+              tor: {
+                enabled: true,
+                ...(torManualPeers.length > 0 ? { manualPeers: torManualPeers } : {}),
+                ...(torSocks ? { socksProxy: torSocks } : {}),
+                allowDirectFallback: config.network.tor?.allowDirectFallback === true,
+                manualPeerProviders: effectiveBuyerConfig.preferredProviders,
+              },
+            }
+          : {}),
       })
 
       node.setRouter(router)

--- a/apps/cli/src/cli/commands/seed.test.ts
+++ b/apps/cli/src/cli/commands/seed.test.ts
@@ -5,6 +5,7 @@ import { resolveEffectiveSellerConfig } from '../../config/effective.js';
 import {
   buildSellerRuntimeOverridesFromFlags,
   buildSellerPluginRuntimeEnv,
+  parseTorOnionEndpoint,
 } from './seed.js';
 
 test('seed runtime overrides are runtime-only and win over env/config', () => {
@@ -67,4 +68,37 @@ test('seed maps effective seller pricing into provider runtime keys', () => {
   }>;
   assert.equal(models['claude-sonnet-4-5-20250929']?.inputUsdPerMillion, 18);
   assert.equal(models['claude-sonnet-4-5-20250929']?.outputUsdPerMillion, 42);
+});
+
+test('seed parses tor onion endpoint with fallback port', () => {
+  const parsed = parseTorOnionEndpoint('abcdefghijklmnop.onion', 80);
+  assert.deepEqual(parsed, { host: 'abcdefghijklmnop.onion', port: 80 });
+});
+
+test('seed parses tor onion endpoint with explicit port', () => {
+  const parsed = parseTorOnionEndpoint('abcdefghijklmnop.onion:443', 80);
+  assert.deepEqual(parsed, { host: 'abcdefghijklmnop.onion', port: 443 });
+});
+
+test('seed rejects invalid tor onion endpoint host', () => {
+  const parsed = parseTorOnionEndpoint('example.com:443', 80);
+  assert.equal(parsed, null);
+});
+
+test('seed rejects invalid tor onion endpoint port', () => {
+  const parsed = parseTorOnionEndpoint('abcdefghijklmnop.onion:99999', 80);
+  assert.equal(parsed, null);
+});
+
+test('seed parses uppercase onion host and normalizes to lowercase', () => {
+  const parsed = parseTorOnionEndpoint('ABCDEFGHIJKLMNOP.onion:443', 80);
+  assert.deepEqual(parsed, { host: 'abcdefghijklmnop.onion', port: 443 });
+});
+
+test('seed parses v3 onion endpoint with fallback port', () => {
+  const parsed = parseTorOnionEndpoint('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.onion', 8080);
+  assert.deepEqual(parsed, {
+    host: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.onion',
+    port: 8080,
+  });
 });

--- a/apps/cli/src/cli/commands/seed.ts
+++ b/apps/cli/src/cli/commands/seed.ts
@@ -16,6 +16,7 @@ import { resolveEffectiveSellerConfig, type SellerRuntimeOverrides } from '../..
 import type { SellerCLIConfig } from '../../config/types.js'
 
 const STATE_FILE = join(homedir(), '.antseed', 'daemon.state.json')
+const ONION_HOST_RE = /^([a-z2-7]{16}|[a-z2-7]{56})\.onion$/
 
 /** Map config file provider entry to env-style key/value pairs for the plugin. */
 function providerConfigToEnv(p: CLIProviderConfig): Record<string, string> {
@@ -31,6 +32,52 @@ function parseOptionalBoolEnv(value: string | undefined): boolean | null {
   if (['1', 'true', 'yes', 'on'].includes(normalized)) return true
   if (['0', 'false', 'no', 'off'].includes(normalized)) return false
   return null
+}
+
+function parseHostPort(rawValue: string): { host: string; port: number } | null {
+  const raw = rawValue.trim()
+  if (raw.length === 0) return null
+
+  if (raw.startsWith('[')) {
+    const end = raw.indexOf(']')
+    if (end <= 1) return null
+    const host = raw.slice(1, end).trim()
+    const portPart = raw.slice(end + 1)
+    if (!portPart.startsWith(':')) return null
+    const port = Number.parseInt(portPart.slice(1), 10)
+    if (!Number.isInteger(port) || port < 1 || port > 65535) return null
+    return { host, port }
+  }
+
+  const sep = raw.lastIndexOf(':')
+  if (sep <= 0) return null
+  const host = raw.slice(0, sep).trim()
+  const port = Number.parseInt(raw.slice(sep + 1), 10)
+  if (host.length === 0 || !Number.isInteger(port) || port < 1 || port > 65535) return null
+  return { host, port }
+}
+
+export function parseTorOnionEndpoint(rawValue: string | undefined, fallbackPort: number): { host: string; port: number } | null {
+  if (!rawValue) return null
+  const raw = rawValue.trim().toLowerCase()
+  if (raw.length === 0) return null
+
+  let host = raw
+  let port = fallbackPort
+  const sep = raw.lastIndexOf(':')
+  if (sep > 0) {
+    const maybeHost = raw.slice(0, sep).trim()
+    const maybePort = Number.parseInt(raw.slice(sep + 1), 10)
+    if (maybeHost.length === 0 || !Number.isInteger(maybePort) || maybePort < 1 || maybePort > 65535) {
+      return null
+    }
+    host = maybeHost
+    port = maybePort
+  }
+
+  if (!ONION_HOST_RE.test(host)) return null
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null
+  return { host, port }
 }
 
 async function isRpcReachable(rpcUrl: string, timeoutMs = 1500): Promise<boolean> {
@@ -110,6 +157,8 @@ export function registerSeedCommand(program: Command): void {
     .description('Start providing AI services on the P2P network')
     .option('--provider <name>', 'provider plugin name (e.g., anthropic)')
     .option('--instance <id>', 'use a configured plugin instance by ID')
+    .option('--tor', 'enable tor mode guardrails (loopback listener, no DHT/NAT, forced TCP)')
+    .option('--tor-onion <hostOrHostPort>', 'tor hidden-service endpoint for buyers (.onion or .onion:port)')
     .option('-r, --reserve <number>', 'runtime-only reserve floor override (does not write config file)', parseFloat)
     .option('--input-usd-per-million <number>', 'runtime-only input pricing override in USD per 1M tokens', parseFloat)
     .option('--output-usd-per-million <number>', 'runtime-only output pricing override in USD per 1M tokens', parseFloat)
@@ -223,6 +272,26 @@ export function registerSeedCommand(program: Command): void {
       }
 
       const providerName = options.provider as string | undefined ?? provider.name ?? 'unknown'
+      const torEnabled = (options.tor as boolean | undefined) === true || config.network.tor?.enabled === true
+      const torSocksRaw = process.env['ANTSEED_TOR_SOCKS'] ?? config.network.tor?.socksProxy
+      const torSocks = torSocksRaw ? parseHostPort(torSocksRaw) : null
+      const torOnionRaw = (options.torOnion as string | undefined)
+        ?? (
+          config.network.tor?.onionAddress
+            ? `${config.network.tor.onionAddress}${config.network.tor?.onionPort ? `:${config.network.tor.onionPort}` : ''}`
+            : undefined
+        )
+      const torOnion = parseTorOnionEndpoint(torOnionRaw, config.network.tor?.onionPort ?? 80)
+
+      if (torEnabled && torSocksRaw && !torSocks) {
+        console.error(chalk.red(`Invalid tor SOCKS proxy "${torSocksRaw}". Expected host:port.`))
+        process.exit(1)
+      }
+      if (torEnabled && torOnionRaw && !torOnion) {
+        console.error(chalk.red(`Invalid tor onion endpoint "${torOnionRaw}". Expected .onion or .onion:port.`))
+        process.exit(1)
+      }
+
       const runtimeProviderPricing = buildSellerPluginRuntimeEnv(effectiveSellerConfig, providerName)
       const runtimeInputUsdPerMillion = Number.parseFloat(runtimeProviderPricing['ANTSEED_INPUT_USD_PER_MILLION'] ?? '')
       const runtimeOutputUsdPerMillion = Number.parseFloat(runtimeProviderPricing['ANTSEED_OUTPUT_USD_PER_MILLION'] ?? '')
@@ -262,6 +331,11 @@ export function registerSeedCommand(program: Command): void {
       )
       console.log(chalk.dim(`  reserve floor: ${effectiveSellerConfig.reserveFloor}`))
       console.log(chalk.dim(`  max concurrent buyers: ${effectiveSellerConfig.maxConcurrentBuyers}`))
+      if (torEnabled) {
+        console.log(chalk.dim('  tor mode: enabled'))
+        console.log(chalk.dim(`  tor socks: ${torSocks ? `${torSocks.host}:${torSocks.port}` : '(none configured)'}`))
+        console.log(chalk.dim(`  tor onion: ${torOnion ? `${torOnion.host}:${torOnion.port}` : '(not configured)'}`))
+      }
       console.log('')
 
       const nodeSpinner = ora('Starting seeding daemon...').start()
@@ -279,6 +353,16 @@ export function registerSeedCommand(program: Command): void {
           sellerWalletAddress,
           paymentConfig,
         },
+        ...(torEnabled
+          ? {
+              tor: {
+                enabled: true,
+                ...(torSocks ? { socksProxy: torSocks } : {}),
+                ...(torOnion ? { onionAddress: torOnion.host, onionPort: torOnion.port } : {}),
+                allowDirectFallback: config.network.tor?.allowDirectFallback === true,
+              },
+            }
+          : {}),
       })
 
       node.registerProvider(provider)
@@ -289,6 +373,14 @@ export function registerSeedCommand(program: Command): void {
         console.log(chalk.dim(`  Peer ID: ${node.peerId ?? 'unknown'}`))
         console.log(chalk.dim(`  DHT port: ${node.dhtPort}`))
         console.log(chalk.dim(`  Signaling port: ${node.signalingPort}`))
+        if (torEnabled && torOnion && node.peerId) {
+          const peerHint = `${node.peerId}@${torOnion.host}:${torOnion.port}`
+          console.log(chalk.dim(`  Tor hidden service: ${torOnion.host}:${torOnion.port}`))
+          console.log(chalk.dim(`  Share with buyers: antseed connect --tor --tor-peer ${peerHint}`))
+        } else if (torEnabled && !torOnion) {
+          console.log(chalk.yellow('  Tor mode is enabled, but no onion endpoint is configured.'))
+          console.log(chalk.dim('  Set network.tor.onionAddress (and optional onionPort) or pass --tor-onion.'))
+        }
       } catch (err) {
         nodeSpinner.fail(chalk.red(`Failed to start seeding: ${(err as Error).message}`))
         process.exit(1)
@@ -375,6 +467,9 @@ export function registerSeedCommand(program: Command): void {
           peerId: node.peerId,
           dhtPort: node.dhtPort,
           signalingPort: node.signalingPort,
+          torMode: torEnabled,
+          torOnionAddress: torOnion ? `${torOnion.host}:${torOnion.port}` : null,
+          torPeerHint: torOnion && node.peerId ? `${node.peerId}@${torOnion.host}:${torOnion.port}` : null,
           provider: providerName,
           defaultInputUsdPerMillion: Number.isFinite(runtimeInputUsdPerMillion) ? runtimeInputUsdPerMillion : undefined,
           defaultOutputUsdPerMillion: Number.isFinite(runtimeOutputUsdPerMillion) ? runtimeOutputUsdPerMillion : undefined,

--- a/apps/cli/src/config/defaults.ts
+++ b/apps/cli/src/config/defaults.ts
@@ -44,6 +44,12 @@ export function createDefaultConfig(): AntseedConfig {
     },
     network: {
       bootstrapNodes: [],
+      tor: {
+        enabled: false,
+        manualPeers: [],
+        socksProxy: '127.0.0.1:9050',
+        allowDirectFallback: false,
+      },
     },
   };
 }

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -93,3 +93,132 @@ test('loadConfig throws explicit validation error for incomplete model pricing',
     }
   );
 });
+
+test('loadConfig deep-merges network tor settings', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      network: {
+        tor: {
+          enabled: true,
+          manualPeers: ['abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd@example.onion:31337'],
+        },
+      },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.equal(config.network.tor?.enabled, true);
+      assert.equal(config.network.tor?.manualPeers?.[0], 'abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd@example.onion:31337');
+      assert.equal(config.network.tor?.socksProxy, '127.0.0.1:9050');
+      assert.equal(config.network.tor?.allowDirectFallback, false);
+    }
+  );
+});
+
+test('loadConfig rejects invalid tor manual peer format', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      network: {
+        tor: {
+          enabled: true,
+          manualPeers: ['missing-port'],
+        },
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        async () => loadConfig(configPath),
+        /network\.tor\.manualPeers\[0\] must be in \[peerId@\]host:port format/
+      );
+    }
+  );
+});
+
+test('loadConfig rejects onion manual peers without peerId in tor mode', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      network: {
+        tor: {
+          enabled: true,
+          manualPeers: ['exampleexampleexampleexampleexampleexampleexampleexample.onion:80'],
+        },
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        async () => loadConfig(configPath),
+        /network\.tor\.manualPeers\[0\] onion peer must include peerId@host:port/
+      );
+    }
+  );
+});
+
+test('loadConfig rejects tor onionPort when onionAddress is not set', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      network: {
+        tor: {
+          onionPort: 80,
+        },
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        async () => loadConfig(configPath),
+        /network\.tor\.onionPort requires network\.tor\.onionAddress/
+      );
+    }
+  );
+});
+
+test('loadConfig accepts valid tor onion address and port', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      network: {
+        tor: {
+          onionAddress: 'abcdefghijklmnop.onion',
+          onionPort: 443,
+        },
+      },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.equal(config.network.tor?.onionAddress, 'abcdefghijklmnop.onion');
+      assert.equal(config.network.tor?.onionPort, 443);
+    }
+  );
+});
+
+test('loadConfig rejects invalid tor onionAddress format', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      network: {
+        tor: {
+          onionAddress: 'not-an-onion-host',
+        },
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        async () => loadConfig(configPath),
+        /network\.tor\.onionAddress must be a valid v2\/v3 \.onion hostname/
+      );
+    }
+  );
+});
+
+test('loadConfig allows onion manual peer without peerId when tor mode is disabled', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      network: {
+        tor: {
+          enabled: false,
+          manualPeers: ['abcdefghijklmnop.onion:80'],
+        },
+      },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.equal(config.network.tor?.manualPeers?.[0], 'abcdefghijklmnop.onion:80');
+    }
+  );
+});

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -186,6 +186,40 @@ function mergeBuyerConfig(
   };
 }
 
+function mergeNetworkConfig(
+  defaults: AntseedConfig['network'],
+  value: unknown
+): AntseedConfig['network'] {
+  if (!isRecord(value)) {
+    return {
+      bootstrapNodes: [...defaults.bootstrapNodes],
+      ...(defaults.tor ? { tor: { ...defaults.tor, manualPeers: [...(defaults.tor.manualPeers ?? [])] } } : {}),
+    };
+  }
+
+  const torValue = isRecord(value['tor']) ? value['tor'] : undefined;
+  return {
+    bootstrapNodes: Array.isArray(value['bootstrapNodes'])
+      ? value['bootstrapNodes'].filter((entry): entry is string => typeof entry === 'string')
+      : [...defaults.bootstrapNodes],
+    ...(defaults.tor || torValue
+      ? {
+          tor: {
+            ...(defaults.tor ? { ...defaults.tor, manualPeers: [...(defaults.tor.manualPeers ?? [])] } : {}),
+            ...(torValue ? torValue : {}),
+            ...(torValue && Array.isArray(torValue['manualPeers'])
+              ? {
+                  manualPeers: torValue['manualPeers'].filter(
+                    (entry): entry is string => typeof entry === 'string'
+                  ),
+                }
+              : {}),
+          },
+        }
+      : {}),
+  };
+}
+
 /**
  * Load configuration from a JSON file.
  * Returns default configuration if the file does not exist.
@@ -228,8 +262,7 @@ export async function loadConfig(configPath: string): Promise<AntseedConfig> {
       ...(isRecord(parsed['payments']) ? parsed['payments'] : {}),
     },
     network: {
-      ...defaults.network,
-      ...(isRecord(parsed['network']) ? parsed['network'] : {}),
+      ...mergeNetworkConfig(defaults.network, parsed['network']),
     },
     providers: Array.isArray(parsed['providers'])
       ? (parsed['providers'] as AntseedConfig['providers'])

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -107,6 +107,21 @@ export interface PaymentsCLIConfig {
 export interface NetworkCLIConfig {
   /** Additional bootstrap nodes for DHT discovery (host:port pairs) */
   bootstrapNodes: string[];
+  /** Optional tor-mode guardrails and manual discovery configuration. */
+  tor?: {
+    /** Enable tor mode guardrails. */
+    enabled?: boolean;
+    /** Manual peer endpoints in [peerId@]host:port format. */
+    manualPeers?: string[];
+    /** SOCKS proxy endpoint in host:port format (for .onion dialing). */
+    socksProxy?: string;
+    /** Seller hidden-service hostname (must end with .onion). */
+    onionAddress?: string;
+    /** Seller hidden-service public port exposed on the onion service. */
+    onionPort?: number;
+    /** Allow non-.onion manual peers in tor mode. */
+    allowDirectFallback?: boolean;
+  };
 }
 
 /**

--- a/apps/cli/src/config/validation.ts
+++ b/apps/cli/src/config/validation.ts
@@ -4,6 +4,8 @@ import type {
   TokenPricingUsdPerMillion,
 } from './types.js';
 
+const ONION_HOST_RE = /^([a-z2-7]{16}|[a-z2-7]{56})\.onion$/;
+
 function validatePricingLeaf(
   path: string,
   value: TokenPricingUsdPerMillion,
@@ -62,6 +64,66 @@ export function validateConfig(config: AntseedConfig): string[] {
 
   if (!Number.isFinite(config.seller.reserveFloor) || config.seller.reserveFloor < 0) {
     errors.push('seller.reserveFloor must be a non-negative finite number');
+  }
+
+  const tor = config.network.tor;
+  if (tor) {
+    if (tor.socksProxy !== undefined) {
+      if (typeof tor.socksProxy !== 'string' || tor.socksProxy.trim().length === 0) {
+        errors.push('network.tor.socksProxy must be a non-empty host:port string');
+      } else {
+        const raw = tor.socksProxy.trim();
+        const sep = raw.lastIndexOf(':');
+        const host = sep > 0 ? raw.slice(0, sep).trim() : '';
+        const port = sep > 0 ? Number.parseInt(raw.slice(sep + 1), 10) : Number.NaN;
+        if (host.length === 0 || !Number.isInteger(port) || port < 1 || port > 65535) {
+          errors.push('network.tor.socksProxy must use host:port with port in range 1-65535');
+        }
+      }
+    }
+
+    if (tor.manualPeers !== undefined) {
+      if (!Array.isArray(tor.manualPeers)) {
+        errors.push('network.tor.manualPeers must be an array of strings');
+      } else {
+        for (const [index, entry] of tor.manualPeers.entries()) {
+          if (typeof entry !== 'string' || entry.trim().length === 0) {
+            errors.push(`network.tor.manualPeers[${index}] must be a non-empty string`);
+            continue;
+          }
+          const raw = entry.trim();
+          const endpoint = raw.includes('@') ? raw.slice(raw.indexOf('@') + 1) : raw;
+          const sep = endpoint.lastIndexOf(':');
+          const host = sep > 0 ? endpoint.slice(0, sep).trim() : '';
+          const port = sep > 0 ? Number.parseInt(endpoint.slice(sep + 1), 10) : Number.NaN;
+          if (host.length === 0 || !Number.isInteger(port) || port < 1 || port > 65535) {
+            errors.push(`network.tor.manualPeers[${index}] must be in [peerId@]host:port format`);
+            continue;
+          }
+          if (tor.enabled === true && host.toLowerCase().endsWith('.onion') && !raw.includes('@')) {
+            errors.push(`network.tor.manualPeers[${index}] onion peer must include peerId@host:port`);
+          }
+        }
+      }
+    }
+
+    if (tor.onionAddress !== undefined) {
+      if (typeof tor.onionAddress !== 'string' || tor.onionAddress.trim().length === 0) {
+        errors.push('network.tor.onionAddress must be a non-empty .onion hostname');
+      } else if (!ONION_HOST_RE.test(tor.onionAddress.trim().toLowerCase())) {
+        errors.push('network.tor.onionAddress must be a valid v2/v3 .onion hostname');
+      }
+    }
+
+    if (tor.onionPort !== undefined) {
+      if (!Number.isInteger(tor.onionPort) || tor.onionPort < 1 || tor.onionPort > 65535) {
+        errors.push('network.tor.onionPort must be an integer in range 1-65535');
+      }
+    }
+
+    if (tor.onionPort !== undefined && tor.onionAddress === undefined) {
+      errors.push('network.tor.onionPort requires network.tor.onionAddress');
+    }
   }
 
   return errors;

--- a/docs/tor-hidden-service-prd.md
+++ b/docs/tor-hidden-service-prd.md
@@ -1,0 +1,352 @@
+# PRD: Tor Hidden Service Mode For AntSeed
+
+- Status: Draft
+- Date: 2026-02-26
+- Owner: Networking/CLI
+- Target: `@antseed/node`, `@antseed/cli`, `@antseed/desktop`, protocol docs
+
+## 1. Summary
+
+Add a first-class Tor hidden-service networking mode so sellers can accept inbound connections without exposing their direct IP address.  
+In this mode, inbound traffic must terminate at a `.onion` service, and AntSeed must not rely on public UDP DHT announcement/discovery.
+
+This PRD defines product behavior, security guarantees, implementation modules, compatibility strategy, rollout phases, and edge-case handling.
+
+## 2. Problem
+
+Current behavior is optimized for public internet reachability:
+
+- Seller listener binds to `0.0.0.0` in `packages/node/src/node.ts`.
+- Seller auto-attempts NAT traversal and public port mapping in `packages/node/src/node.ts`.
+- Discovery uses BitTorrent DHT over UDP in `packages/node/src/discovery/dht-node.ts`.
+- Buyer resolves metadata and signaling via direct host/port in `packages/node/src/discovery/http-metadata-resolver.ts` and `packages/node/src/p2p/connection-manager.ts`.
+
+This creates two blockers for IP privacy:
+
+- DHT announce leaks source IP by design.
+- Inbound reachability uses direct socket/NAT mapping rather than onion routing.
+
+## 3. Goals
+
+1. Sellers can run in a mode where inbound connections never target their direct IP.
+2. Buyers can discover and connect to those sellers through Tor-compatible paths.
+3. Existing public-network mode remains intact and default.
+4. Protocol/auth guarantees remain intact (signed metadata, peer auth).
+5. The feature is PR-able in phases (MVP first, then richer discovery).
+
+## 4. Non-Goals
+
+1. Full network anonymity for all layers (payments/on-chain identity may still be linkable).
+2. Hiding outbound network usage from local OS/network administrators.
+3. Replacing existing public DHT mode.
+4. Implementing a new decentralized UDP-over-Tor transport.
+5. Solving anti-global-adversary threat models.
+
+## 5. User Stories
+
+1. As a seller, I can start seeding behind Tor so buyers only connect through a `.onion` endpoint.
+2. As a buyer, I can connect to Tor-only sellers without direct TCP to seller public IPs.
+3. As an operator, I can choose public mode, Tor mode, or explicit mixed mode with clear guardrails.
+4. As a maintainer, I can review and merge this incrementally with tests and no regression to existing users.
+
+## 6. Privacy/Security Requirements
+
+### 6.1 Hard requirements in Tor mode
+
+1. Seller signaling listener must bind to loopback (`127.0.0.1`) only.
+2. NAT traversal must be disabled.
+3. DHT announce/lookup must be disabled (no UDP discovery).
+4. Outbound buyer connections to `.onion` must go through Tor SOCKS.
+5. WebRTC path must be disabled in Tor mode to avoid ICE/STUN leaks and UDP dependency.
+6. No silent fallback to direct clearnet unless explicitly enabled by user.
+
+### 6.2 Metadata integrity requirements
+
+1. Advertised endpoint(s) used for connection must be covered by signed metadata.
+2. Buyer must verify metadata signature before using endpoint data.
+3. Tor mode should reject unsigned/invalid endpoint hints.
+
+## 7. Product Requirements
+
+### 7.1 Modes and config model
+
+Introduce explicit network profile:
+
+- `public` (default): current behavior.
+- `tor-hidden-service`: Tor-safe behavior.
+
+Add `network.tor` config block (CLI config + NodeConfig projection):
+
+- `enabled: boolean`
+- `socksProxy: { host, port }` default `127.0.0.1:9050`
+- `controlPort: { host, port, passwordEnv? }` optional for managed onion service
+- `hiddenService:`
+  - `mode: "manual" | "control-port"`
+  - `onionAddress` (required in `manual`)
+  - `virtualPort` (default signaling port)
+  - `localAddress` default `127.0.0.1`
+  - `localPort` default signaling port
+- `discovery:`
+  - `mode: "manual" | "manifest"`
+  - `manualPeers: string[]` (`peerId@host:port` or `host:port`)
+  - `manifestUrl` (supports `http(s)` and `.onion`)
+  - `refreshIntervalMs`
+- `allowDirectFallback` default `false`
+
+### 7.2 Seller behavior (Tor mode)
+
+1. Start `ConnectionManager` on loopback only.
+2. Skip `NatTraversal.mapPorts(...)`.
+3. Skip DHT startup + periodic announce.
+4. Build metadata including signed endpoint data that contains `.onion` endpoint.
+5. If `hiddenService.mode = control-port`, create/refresh hidden service via Tor control API.
+6. If `hiddenService.mode = manual`, validate operator-provided onion endpoint format.
+7. Print operator guidance and explicit warnings when Tor assumptions are violated.
+
+### 7.3 Buyer behavior (Tor mode)
+
+1. Skip DHT startup + lookup.
+2. Resolve candidate endpoints from:
+  - manual peer list (MVP),
+  - signed manifest source (MVP+).
+3. Fetch metadata through Tor SOCKS.
+4. Verify metadata signature and endpoint binding.
+5. Connect signaling/data path through Tor SOCKS to `.onion`.
+6. Force TCP transport path (no WebRTC).
+
+### 7.4 Discovery behavior
+
+Create an endpoint-source abstraction:
+
+- `DhtEndpointSource` (existing public mode).
+- `ManualEndpointSource` (MVP Tor mode).
+- `ManifestEndpointSource` (MVP+ Tor mode).
+
+Buyer chooses source by profile/mode. Public mode remains unchanged.
+
+### 7.5 CLI/desktop behavior
+
+CLI:
+
+- `antseed seed --tor` (enables Tor profile override at runtime).
+- `antseed connect --tor` (same).
+- optional flags:
+  - `--tor-socks <host:port>`
+  - `--tor-control <host:port>`
+  - `--onion <addr:port>`
+  - `--peer <peerId@addr:port>` (repeatable)
+  - `--peer-manifest <url>`
+
+Desktop:
+
+- Add Tor settings in runtime start configuration.
+- Persist settings in desktop preferences.
+- Validate config before launching process.
+
+## 8. Architecture And Module Plan
+
+### 8.1 `@antseed/node` modules
+
+1. `packages/node/src/tor/tor-config.ts`
+2. `packages/node/src/tor/tor-control-client.ts`
+3. `packages/node/src/tor/hidden-service-manager.ts`
+4. `packages/node/src/tor/socks-dialer.ts`
+5. `packages/node/src/discovery/endpoint-source.ts`
+6. `packages/node/src/discovery/manual-endpoint-source.ts`
+7. `packages/node/src/discovery/manifest-endpoint-source.ts`
+8. `packages/node/src/discovery/tor-metadata-resolver.ts`
+
+Integration points:
+
+- `packages/node/src/node.ts` for role startup branching.
+- `packages/node/src/p2p/connection-manager.ts` for SOCKS dialing and transport forcing.
+- `packages/node/src/discovery/peer-metadata.ts` and codec/validator for endpoint fields.
+
+### 8.2 Protocol changes
+
+Introduce metadata endpoint structure and bump metadata version:
+
+- `METADATA_VERSION: 3`
+- Add signed `endpoints` array:
+  - `kind: "onion" | "ipv4" | "dns"`
+  - `host: string`
+  - `port: number`
+  - `transport: "tcp"`
+  - `priority: number`
+
+Compatibility:
+
+1. New code should parse/accept v2 and v3.
+2. Tor mode requires v3 metadata with at least one onion endpoint.
+3. Public mode can still consume v2 peers for backward compatibility.
+
+### 8.3 Dependency additions (expected)
+
+Likely add a SOCKS/Tor-compatible client dependency in `@antseed/node`, for example:
+
+- `socks` or `socks-proxy-agent`
+
+Selection criteria:
+
+1. ESM compatibility with Node 20.
+2. Works with raw TCP sockets (not only HTTP).
+3. Good maintenance and minimal transitive risk.
+
+## 9. Detailed Flows
+
+### 9.1 Seller startup (Tor mode)
+
+1. Validate Tor config.
+2. Start local listener on loopback only.
+3. Acquire onion endpoint (manual or control-port).
+4. Build signed metadata with onion endpoint.
+5. Skip DHT/NAT logic.
+6. Enter serving state.
+
+Failure handling:
+
+1. If no valid onion endpoint, fail startup hard.
+2. If control-port auth fails and no manual fallback, fail startup hard.
+
+### 9.2 Buyer connect (Tor mode)
+
+1. Load endpoints from configured source.
+2. Resolve metadata via SOCKS.
+3. Verify metadata signature and freshness.
+4. Select endpoint by policy (onion preferred/required).
+5. Open signaling connection over SOCKS.
+6. Proceed with existing auth/frames/payment flows.
+
+Failure handling:
+
+1. If no onion-capable candidate found, fail with actionable error.
+2. If SOCKS is unreachable, fail fast with troubleshooting hint.
+
+## 10. Edge Cases And Expected Behavior
+
+1. Tor daemon down: startup/connect fails fast with explicit remediation.
+2. SOCKS reachable but control-port unreachable: manual mode can still proceed.
+3. Invalid onion hostname format: config validation error.
+4. Onion service exists but not yet propagated: retry with backoff; surface status.
+5. Manifest source stale/unreachable: use last good cache if policy allows; otherwise fail.
+6. Metadata signature valid but endpoint missing onion in Tor mode: reject peer.
+7. Buyer in Tor mode receives public IPv4 endpoint only: reject unless `allowDirectFallback=true`.
+8. Seller in Tor mode accidentally sets `0.0.0.0`: hard fail with guardrail.
+9. WebRTC/native module available: still force TCP in Tor mode.
+10. High latency causes handshake timeout: use Tor-specific higher default timeout profile.
+11. Clock skew causing stale metadata false positives: allow configurable skew budget.
+12. Mixed fleets (public + Tor peers): routing policy must respect mode and user intent.
+13. Payments on-chain correlation risk: warn but do not block.
+14. Logging accidentally includes onion/private details: redact sensitive values by default.
+
+## 11. Observability
+
+New runtime events/counters:
+
+1. `tor:socks:connected`
+2. `tor:socks:error`
+3. `tor:hidden-service:ready`
+4. `tor:hidden-service:error`
+5. `discovery:endpoint-source:update`
+6. `connection:transport-forced` (value: `tcp`)
+
+Metrics:
+
+1. Tor mode startup success rate.
+2. Metadata resolution success rate via Tor.
+3. Connection success latency p50/p95 in Tor mode.
+4. Session failure causes in Tor mode.
+
+## 12. Testing Strategy
+
+### 12.1 Unit tests
+
+1. Tor config validation and normalization.
+2. Onion endpoint parsing/validation.
+3. Metadata v3 encode/decode/sign/verify.
+4. Endpoint-source resolution logic.
+5. Tor-mode guardrails (`no DHT`, `no NAT`, `loopback bind`, `force TCP`).
+
+### 12.2 Integration tests
+
+1. Buyer/seller with mocked SOCKS server and manual endpoint source.
+2. Ensure connection-manager uses SOCKS dialer path for `.onion`.
+3. Ensure no DHT/NAT side effects in Tor mode.
+
+### 12.3 E2E tests
+
+1. Local Tor process/container:
+  - start seller in Tor mode,
+  - connect buyer in Tor mode,
+  - perform request/response through proxy,
+  - verify successful metering/payment path.
+2. Verify listener bind address remains loopback.
+
+## 13. Rollout Plan
+
+### Phase 1: Core Tor MVP (recommended first PR)
+
+1. Config + profile plumbing.
+2. Seller loopback-only mode, no DHT/NAT.
+3. Buyer manual peer list + SOCKS connect.
+4. Force TCP transport in Tor mode.
+5. Basic CLI flags (`--tor`, `--peer`, `--onion`).
+
+### Phase 2: Metadata v3 + endpoint signing
+
+1. Metadata endpoint schema.
+2. Backward-compatible parser.
+3. Tor-mode strict endpoint validation.
+
+### Phase 3: Manifest discovery + desktop UX
+
+1. Manifest endpoint source.
+2. Desktop settings UI/launch options.
+3. Observability polish and docs.
+
+## 14. Backward Compatibility
+
+1. Default behavior remains `public`.
+2. Existing `seed`/`connect` invocations continue unchanged.
+3. Public DHT workflow remains supported.
+4. Tor mode is opt-in and isolated by profile.
+
+## 15. Risks
+
+1. Tor operational complexity increases support burden.
+2. Performance may degrade from Tor latency.
+3. Incorrect fallback policy may silently leak direct IP paths.
+4. Metadata version migration may fragment peers if not staged carefully.
+
+Mitigations:
+
+1. Clear guardrails and fail-closed defaults in Tor mode.
+2. Explicit diagnostics and docs.
+3. Staged rollout with compatibility tests.
+
+## 16. Acceptance Criteria
+
+1. In Tor mode seller does not bind external interfaces (`lsof`/runtime check passes).
+2. In Tor mode seller does not start DHT and does not execute NAT mapping.
+3. Buyer can complete request flow to Tor-mode seller using only onion endpoint.
+4. Tor mode does not silently fallback to direct IP unless explicitly configured.
+5. Existing public mode behavior/tests remain green.
+
+## 17. Implementation Checklist (for PR series)
+
+1. Add config types/defaults/validation for Tor profile.
+2. Add node startup branching for Tor vs public.
+3. Add SOCKS dialer path in connection manager.
+4. Add endpoint-source abstraction and manual source.
+5. Add CLI flags and plumbing into `AntseedNode` config.
+6. Add metadata v3 endpoint signing (phase 2).
+7. Add tests for guardrails and flows.
+8. Update protocol docs (`01-discovery.md`, `02-transport.md`) after merge.
+
+## 18. Open Questions
+
+1. Should Tor mode ever permit mixed endpoint advertisements (`onion + public`)?
+2. Should manifest discovery be signed by peer keys, operator key, or both?
+3. Do we support ephemeral onion services in MVP, or require manual onion first?
+4. What timeout defaults should be profile-specific for Tor (lookup/connect/handshake)?
+5. Should desktop expose advanced Tor controls or only a simple on/off + proxy fields?

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -17,11 +17,11 @@ npm run test:watch  # Watch mode
 Run a complete local payment + networking flow (no external API keys):
 
 1. Start a local Anvil chain
-2. Build and deploy `MockUSDC` + `AntseedEscrow` with Foundry
+2. Build and deploy `MockUSDC` + `AntseedEscrow` with Foundry from `packages/node/contracts`
 3. Start isolated local DHT bootstrap + seller + buyer nodes
-4. Mint/fund buyer + seller wallets
-5. Buyer deposits escrow, sends a real P2P request, then triggers settlement
-6. Verify on-chain settled state, balances, and reputation updates
+4. Mint/fund wallets and send a real P2P request across buyer/seller nodes
+5. Execute on-chain escrow approve/deposit/release cycle
+6. Verify on-chain channel state and token balances
 
 ```bash
 npm run flow:local-chain
@@ -38,7 +38,7 @@ Optional environment overrides:
 - `FLOW_FUND_ETH` (default: `2ether`)
 - `ANVIL_HOST` / `ANVIL_PORT` (override host/port Anvil binds to; defaults derived from `RPC_URL`)
 
-On success, the script prints a JSON summary with deployed contract addresses, peer IDs, session status, balances, and reputation.
+On success, the script prints a JSON summary with deployed contract addresses, peer IDs, escrow session state, and balances.
 
 ## Test Suites
 

--- a/e2e/scripts/local-chain-full-flow.mjs
+++ b/e2e/scripts/local-chain-full-flow.mjs
@@ -2,7 +2,7 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
-import { randomUUID } from "node:crypto";
+import { randomUUID, createHash } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
@@ -31,7 +31,7 @@ const FUND_ETH = process.env.FLOW_FUND_ETH ?? "2ether";
 
 const scriptDir = fileURLToPath(new URL(".", import.meta.url));
 const repoRoot = resolve(scriptDir, "..", "..");
-const contractsDir = resolve(repoRoot, "contracts");
+const contractsDir = resolve(repoRoot, "packages", "node");
 
 function logStep(message) {
   console.log(`\n[flow] ${message}`);
@@ -245,15 +245,30 @@ async function main() {
     await waitForRpcReady(RPC_URL);
     logStep(`anvil ready at ${RPC_URL}`);
 
+    const deployerAddress = runCommand("cast", [
+      "wallet",
+      "address",
+      "--private-key",
+      DEPLOYER_PRIVATE_KEY,
+    ]).trim();
+
     logStep("building contracts with forge");
-    runCommand("forge", ["build"], { cwd: contractsDir });
+    runCommand(
+      "forge",
+      ["build", "--root", ".", "--contracts", "contracts", "--out", "contracts/out"],
+      { cwd: contractsDir }
+    );
 
     logStep("deploying MockUSDC");
     const mockDeployOutput = runCommand(
       "forge",
       [
         "create",
-        "test/mocks/MockUSDC.sol:MockUSDC",
+        "contracts/MockUSDC.sol:MockUSDC",
+        "--root",
+        ".",
+        "--contracts",
+        "contracts",
         "--rpc-url",
         RPC_URL,
         "--private-key",
@@ -270,7 +285,11 @@ async function main() {
       "forge",
       [
         "create",
-        "src/AntseedEscrow.sol:AntseedEscrow",
+        "contracts/AntseedEscrow.sol:AntseedEscrow",
+        "--root",
+        ".",
+        "--contracts",
+        "contracts",
         "--rpc-url",
         RPC_URL,
         "--private-key",
@@ -278,6 +297,7 @@ async function main() {
         "--broadcast",
         "--constructor-args",
         usdcAddress,
+        deployerAddress,
       ],
       { cwd: contractsDir }
     );
@@ -302,7 +322,7 @@ async function main() {
 
     const sellerProvider = new MockAnthropicProvider();
 
-    logStep("starting seller node with payments enabled");
+    logStep("starting seller node");
     sellerNode = new AntseedNode({
       role: "seller",
       dataDir: sellerDataDir,
@@ -310,16 +330,6 @@ async function main() {
       signalingPort: 0,
       bootstrapNodes: bootstrapConfig,
       allowPrivateIPs: true,
-      payments: {
-        enabled: true,
-        paymentMethod: "crypto",
-        settlementIdleMs: 5_000,
-        defaultEscrowAmountUSDC: "1000000",
-        platformFeeRate: 0.05,
-        rpcUrl: RPC_URL,
-        contractAddress: escrowAddress,
-        usdcAddress,
-      },
     });
     sellerNode.registerProvider(sellerProvider);
     await sellerNode.start();
@@ -330,23 +340,13 @@ async function main() {
     const sellerAddress = identityToEvmAddress(sellerNode.identity);
     logStep(`seller peer=${sellerNode.peerId} evm=${sellerAddress}`);
 
-    logStep("starting buyer node with payments enabled");
+    logStep("starting buyer node");
     buyerNode = new AntseedNode({
       role: "buyer",
       dataDir: buyerDataDir,
       dhtPort: 0,
       bootstrapNodes: bootstrapConfig,
       allowPrivateIPs: true,
-      payments: {
-        enabled: true,
-        paymentMethod: "crypto",
-        settlementIdleMs: 5_000,
-        defaultEscrowAmountUSDC: "1000000",
-        platformFeeRate: 0.05,
-        rpcUrl: RPC_URL,
-        contractAddress: escrowAddress,
-        usdcAddress,
-      },
     });
     await buyerNode.start();
 
@@ -369,11 +369,11 @@ async function main() {
       FUND_ETH,
     ]);
 
-    logStep(`minting ${USDC_MINT_AMOUNT} base units of USDC to buyer`);
+    logStep(`minting ${USDC_MINT_AMOUNT} base units of USDC to deployer escrow account`);
     castSend([
       usdcAddress,
       "mint(address,uint256)",
-      buyerAddress,
+      deployerAddress,
       USDC_MINT_AMOUNT.toString(),
     ]);
 
@@ -414,28 +414,6 @@ async function main() {
       );
     }
 
-    const bpm = buyerNode.buyerPaymentManager;
-    if (!bpm) {
-      throw new Error("buyer payment manager was not initialized");
-    }
-
-    logStep(`depositing ${USDC_DEPOSIT_AMOUNT} base units into escrow from buyer`);
-    let depositTx = "";
-    for (let attempt = 1; attempt <= 3; attempt += 1) {
-      try {
-        depositTx = await bpm.deposit(USDC_DEPOSIT_AMOUNT);
-        break;
-      } catch (err) {
-        if (attempt < 3 && isNonceRaceError(err)) {
-          logStep(`deposit nonce race detected, retrying (attempt ${attempt + 1}/3)`);
-          await sleep(500);
-          continue;
-        }
-        throw err;
-      }
-    }
-    logStep(`deposit tx: ${depositTx}`);
-
     logStep("sending buyer request across P2P path");
     const response = await buyerNode.sendRequest(discoveredSeller, buildRequest());
     if (response.statusCode !== 200) {
@@ -447,69 +425,73 @@ async function main() {
     }
     logStep("request completed successfully");
 
-    const activeSellerSession = await waitForValue(
-      async () => {
-        const sessions = sellerNode.getActiveSellerSessions();
-        return sessions.find((session) => session.buyerPeerId === buyerNode.peerId);
-      },
-      "active seller payment session",
-      10_000,
-      250
-    );
-    logStep(`session established: ${activeSellerSession.sessionId}`);
-
-    await waitForValue(
-      async () => {
-        const buyerSession = bpm.getSession(discoveredSeller.peerId);
-        if (!buyerSession) {
-          return null;
-        }
-        return buyerSession.lastRunningTotal > 0n ? buyerSession.lastRunningTotal : null;
-      },
-      "buyer receipt acknowledgement",
-      15_000,
-      200
-    );
-
-    logStep("sending explicit SessionEnd and waiting for on-chain settlement");
-    const buyerPaymentMuxes = buyerNode._paymentMuxes;
-    const sellerPaymentMux = buyerPaymentMuxes?.get(discoveredSeller.peerId);
-    if (!sellerPaymentMux) {
-      throw new Error("buyer payment mux for seller was not initialized");
-    }
-    await bpm.endSession(discoveredSeller.peerId, sellerPaymentMux, 85);
-
     const escrowClient = new BaseEscrowClient({
       rpcUrl: RPC_URL,
       contractAddress: escrowAddress,
       usdcAddress,
     });
 
+    const sellerUsdcBefore = await escrowClient.getUSDCBalance(sellerAddress);
+    const deployerUsdcBefore = await escrowClient.getUSDCBalance(deployerAddress);
+    const escrowSessionId = `0x${createHash("sha256").update(`flow-${randomUUID()}`).digest("hex")}`;
+
+    logStep(`approving escrow contract for ${USDC_DEPOSIT_AMOUNT} base units`);
+    castSend([
+      usdcAddress,
+      "approve(address,uint256)",
+      escrowAddress,
+      USDC_DEPOSIT_AMOUNT.toString(),
+    ]);
+
+    logStep(`depositing ${USDC_DEPOSIT_AMOUNT} base units into escrow`);
+    castSend([
+      escrowAddress,
+      "deposit(bytes32,address,uint256)",
+      escrowSessionId,
+      sellerAddress,
+      USDC_DEPOSIT_AMOUNT.toString(),
+    ]);
+
+    logStep("releasing escrow funds to seller");
+    castSend([
+      escrowAddress,
+      "release(bytes32)",
+      escrowSessionId,
+    ]);
+
     const sellerUsdcBalance = await waitForValue(
       async () => {
         const bal = await escrowClient.getUSDCBalance(sellerAddress);
-        return bal > 0n ? bal : null;
+        return bal > sellerUsdcBefore ? bal : null;
       },
       "seller USDC settlement balance",
       30_000,
       500
     );
+    const deployerUsdcAfter = await escrowClient.getUSDCBalance(deployerAddress);
 
-    const buyerAccount = await escrowClient.getBuyerAccount(buyerAddress);
-    const sessionInfo = await escrowClient.getSession(activeSellerSession.sessionId);
-    const reputation = await escrowClient.getReputation(sellerAddress);
-
-    if (buyerAccount.committed !== 0n) {
-      throw new Error(`buyer still has committed balance after settlement: ${buyerAccount.committed}`);
-    }
-    if (sessionInfo.status !== 1) {
-      throw new Error(`session not settled on-chain (status=${sessionInfo.status})`);
+    const channelRaw = runCommand("cast", [
+      "call",
+      "--rpc-url",
+      RPC_URL,
+      escrowAddress,
+      "getChannel(bytes32)(address,address,uint256,uint8)",
+      escrowSessionId,
+    ]);
+    const channelParts = channelRaw
+      .trim()
+      .split(/\s+/)
+      .filter((part) => part.length > 0);
+    const channelStateRaw = channelParts[channelParts.length - 1] ?? "";
+    const channelState = Number.parseInt(channelStateRaw, 10);
+    if (!Number.isInteger(channelState) || channelState !== 3) {
+      throw new Error(`session not settled on-chain (state=${channelRaw})`);
     }
 
     await buyerNode.stop();
     buyerNode = null;
 
-    logStep("flow complete: local chain deployment + P2P request + on-chain settlement verified");
+    logStep("flow complete: local chain deployment + P2P request + on-chain escrow release verified");
     console.log(
       JSON.stringify(
         {
@@ -524,23 +506,18 @@ async function main() {
             sellerAddress,
             buyerPeerId,
             buyerAddress,
+            deployerAddress,
           },
-          session: {
-            id: activeSellerSession.sessionId,
-            status: sessionInfo.status,
-            settledAmount: sessionInfo.settledAmount.toString(),
-            score: sessionInfo.score,
+          escrowSession: {
+            id: escrowSessionId,
+            state: channelState,
+            amount: USDC_DEPOSIT_AMOUNT.toString(),
           },
           balances: {
+            sellerUSDCBefore: sellerUsdcBefore.toString(),
             sellerUSDC: sellerUsdcBalance.toString(),
-            buyerDeposited: buyerAccount.deposited.toString(),
-            buyerCommitted: buyerAccount.committed.toString(),
-            buyerAvailable: buyerAccount.available.toString(),
-          },
-          reputation: {
-            weightedAverage: reputation.weightedAverage,
-            sessionCount: reputation.sessionCount,
-            disputeCount: reputation.disputeCount,
+            deployerUSDCBefore: deployerUsdcBefore.toString(),
+            deployerUSDCAfter: deployerUsdcAfter.toString(),
           },
         },
         null,

--- a/e2e/tests/cli-runtime-overrides.test.ts
+++ b/e2e/tests/cli-runtime-overrides.test.ts
@@ -10,7 +10,7 @@ import { promisify } from 'node:util';
 const execFile = promisify(execFileCallback);
 const currentDir = fileURLToPath(new URL('.', import.meta.url));
 const repoRoot = resolve(currentDir, '..', '..');
-const cliDir = resolve(repoRoot, 'cli');
+const cliDir = resolve(repoRoot, 'apps', 'cli');
 const cliEntry = resolve(cliDir, 'dist', 'cli', 'index.js');
 
 const baselineConfig = {
@@ -51,7 +51,12 @@ async function ensureCliBuilt(): Promise<void> {
   try {
     await access(cliEntry, fsConstants.R_OK);
   } catch {
-    await execFile('npm', ['run', 'build'], { cwd: cliDir });
+    const packageManagerExec = process.env['npm_execpath'];
+    if (packageManagerExec && packageManagerExec.length > 0) {
+      await execFile(process.execPath, [packageManagerExec, 'run', 'build'], { cwd: cliDir });
+      return;
+    }
+    await execFile('pnpm', ['run', 'build'], { cwd: cliDir });
   }
 }
 

--- a/e2e/tests/tor-hidden-service-e2e.test.ts
+++ b/e2e/tests/tor-hidden-service-e2e.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import net, { type AddressInfo, type Socket } from 'node:net';
+import { once } from 'node:events';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { AntseedNode } from '@antseed/node';
+import type { SerializedHttpRequest } from '@antseed/node';
+import { MockAnthropicProvider } from './helpers/mock-provider.js';
+
+interface FakeSocksProxy {
+  host: string;
+  port: number;
+  connectionCount: number;
+  lastTarget: { host: string; port: number } | null;
+  close: () => Promise<void>;
+}
+
+function createSocketReader(socket: Socket): {
+  readExact: (bytes: number) => Promise<Buffer>;
+  readRemaining: () => Buffer;
+} {
+  let buffer = Buffer.alloc(0);
+  return {
+    readExact: (bytes: number): Promise<Buffer> =>
+      new Promise<Buffer>((resolve, reject) => {
+        if (buffer.length >= bytes) {
+          const out = buffer.subarray(0, bytes);
+          buffer = buffer.subarray(bytes);
+          resolve(out);
+          return;
+        }
+
+        const onData = (chunk: Buffer): void => {
+          buffer = Buffer.concat([buffer, chunk]);
+          if (buffer.length >= bytes) {
+            cleanup();
+            const out = buffer.subarray(0, bytes);
+            buffer = buffer.subarray(bytes);
+            resolve(out);
+          }
+        };
+
+        const onError = (err: Error): void => {
+          cleanup();
+          reject(err);
+        };
+
+        const onClose = (): void => {
+          cleanup();
+          reject(new Error('SOCKET_CLOSED'));
+        };
+
+        const cleanup = (): void => {
+          socket.off('data', onData);
+          socket.off('error', onError);
+          socket.off('close', onClose);
+        };
+
+        socket.on('data', onData);
+        socket.once('error', onError);
+        socket.once('close', onClose);
+      }),
+    readRemaining: (): Buffer => {
+      const out = buffer;
+      buffer = Buffer.alloc(0);
+      return out;
+    },
+  };
+}
+
+async function startFakeSocksProxy(
+  resolveTarget: (targetHost: string, targetPort: number) => { host: string; port: number } | null,
+): Promise<FakeSocksProxy> {
+  let connectionCount = 0;
+  let lastTarget: { host: string; port: number } | null = null;
+
+  const server = net.createServer((clientSocket) => {
+    void (async () => {
+      connectionCount += 1;
+      const reader = createSocketReader(clientSocket);
+
+      try {
+        const greetingHeader = await reader.readExact(2);
+        const version = greetingHeader[0];
+        const methodsCount = greetingHeader[1];
+        if (version !== 0x05 || methodsCount === 0) {
+          clientSocket.destroy();
+          return;
+        }
+
+        const methods = await reader.readExact(methodsCount);
+        const supportsNoAuth = methods.includes(0x00);
+        if (!supportsNoAuth) {
+          clientSocket.write(Buffer.from([0x05, 0xff]));
+          clientSocket.end();
+          return;
+        }
+        clientSocket.write(Buffer.from([0x05, 0x00]));
+
+        const requestHead = await reader.readExact(4);
+        if (requestHead[0] !== 0x05 || requestHead[1] !== 0x01) {
+          clientSocket.write(Buffer.from([0x05, 0x07, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
+          clientSocket.end();
+          return;
+        }
+
+        const atyp = requestHead[3];
+        let targetHost = '';
+        if (atyp === 0x01) {
+          const addr = await reader.readExact(4);
+          targetHost = `${addr[0]}.${addr[1]}.${addr[2]}.${addr[3]}`;
+        } else if (atyp === 0x03) {
+          const domainLen = (await reader.readExact(1))[0] ?? 0;
+          const domain = await reader.readExact(domainLen);
+          targetHost = domain.toString('utf8');
+        } else if (atyp === 0x04) {
+          const ipv6 = await reader.readExact(16);
+          const segments: string[] = [];
+          for (let i = 0; i < 8; i += 1) {
+            segments.push(ipv6.readUInt16BE(i * 2).toString(16));
+          }
+          targetHost = segments.join(':');
+        } else {
+          clientSocket.write(Buffer.from([0x05, 0x08, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
+          clientSocket.end();
+          return;
+        }
+
+        const targetPort = (await reader.readExact(2)).readUInt16BE(0);
+        lastTarget = { host: targetHost, port: targetPort };
+        const resolved = resolveTarget(targetHost, targetPort);
+        if (!resolved) {
+          clientSocket.write(Buffer.from([0x05, 0x04, 0x00, 0x01, 0, 0, 0, 0, 0, 0]));
+          clientSocket.end();
+          return;
+        }
+
+        const upstream = net.connect({ host: resolved.host, port: resolved.port });
+        await once(upstream, 'connect');
+
+        clientSocket.write(Buffer.from([0x05, 0x00, 0x00, 0x01, 127, 0, 0, 1, 0, 0]));
+        const remaining = reader.readRemaining();
+        if (remaining.length > 0) {
+          upstream.write(remaining);
+        }
+
+        clientSocket.pipe(upstream);
+        upstream.pipe(clientSocket);
+
+        const closeBoth = (): void => {
+          if (!clientSocket.destroyed) clientSocket.destroy();
+          if (!upstream.destroyed) upstream.destroy();
+        };
+        clientSocket.on('error', closeBoth);
+        upstream.on('error', closeBoth);
+        clientSocket.on('close', closeBoth);
+        upstream.on('close', closeBoth);
+      } catch {
+        if (!clientSocket.destroyed) {
+          clientSocket.destroy();
+        }
+      }
+    })();
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address() as AddressInfo;
+
+  return {
+    host: '127.0.0.1',
+    port: address.port,
+    get connectionCount() {
+      return connectionCount;
+    },
+    get lastTarget() {
+      return lastTarget;
+    },
+    close: async () => {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+describe('Tor hidden-service e2e flow', () => {
+  let sellerNode: AntseedNode | null = null;
+  let buyerNode: AntseedNode | null = null;
+  let sellerDataDir: string | null = null;
+  let buyerDataDir: string | null = null;
+  let socksProxy: FakeSocksProxy | null = null;
+
+  afterEach(async () => {
+    try { if (buyerNode) { await buyerNode.stop(); buyerNode = null; } } catch {}
+    try { if (sellerNode) { await sellerNode.stop(); sellerNode = null; } } catch {}
+    try { if (socksProxy) { await socksProxy.close(); socksProxy = null; } } catch {}
+    try { if (sellerDataDir) { await rm(sellerDataDir, { recursive: true, force: true }); sellerDataDir = null; } } catch {}
+    try { if (buyerDataDir) { await rm(buyerDataDir, { recursive: true, force: true }); buyerDataDir = null; } } catch {}
+  });
+
+  it('buyer connects to seller via manual onion peer over SOCKS proxy in tor mode', async () => {
+    const onionHost = 'abcdefghijklmnop.onion';
+    const onionPort = 443;
+
+    sellerDataDir = await mkdtemp(join(tmpdir(), 'antseed-tor-seller-'));
+    const provider = new MockAnthropicProvider();
+
+    let torReadyPayload: { peerId: string; manualPeer: string } | null = null;
+    sellerNode = new AntseedNode({
+      role: 'seller',
+      dataDir: sellerDataDir,
+      signalingPort: 0,
+      tor: {
+        enabled: true,
+        onionAddress: onionHost,
+        onionPort,
+      },
+    });
+    sellerNode.on('tor:ready', (payload) => {
+      torReadyPayload = payload as { peerId: string; manualPeer: string };
+    });
+    sellerNode.registerProvider(provider);
+    await sellerNode.start();
+
+    expect(sellerNode.dhtPort).toBe(0);
+    expect(sellerNode.signalingPort).toBeGreaterThan(0);
+    expect(torReadyPayload?.peerId).toBe(sellerNode.peerId);
+    expect(torReadyPayload?.manualPeer).toBe(`${sellerNode.peerId}@${onionHost}:${onionPort}`);
+
+    socksProxy = await startFakeSocksProxy((targetHost) => {
+      if (targetHost !== onionHost) return null;
+      return { host: '127.0.0.1', port: sellerNode!.signalingPort };
+    });
+
+    buyerDataDir = await mkdtemp(join(tmpdir(), 'antseed-tor-buyer-'));
+    buyerNode = new AntseedNode({
+      role: 'buyer',
+      dataDir: buyerDataDir,
+      tor: {
+        enabled: true,
+        manualPeers: [`${sellerNode.peerId}@${onionHost}:${onionPort}`],
+        socksProxy: { host: socksProxy.host, port: socksProxy.port },
+      },
+    });
+    await buyerNode.start();
+
+    expect(buyerNode.dhtPort).toBe(0);
+    const peers = await buyerNode.discoverPeers();
+    const sellerPeer = peers.find((peer) => peer.peerId === sellerNode!.peerId);
+    expect(sellerPeer).toBeDefined();
+
+    const request: SerializedHttpRequest = {
+      requestId: randomUUID(),
+      method: 'POST',
+      path: '/v1/messages',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'claude-sonnet-4-5-20250929',
+        max_tokens: 64,
+        messages: [{ role: 'user', content: 'hello tor e2e' }],
+      })),
+    };
+
+    const response = await buyerNode.sendRequest(sellerPeer!, request);
+    expect(response.statusCode).toBe(200);
+    expect(provider.requestCount).toBe(1);
+    expect(socksProxy.connectionCount).toBeGreaterThan(0);
+    expect(socksProxy.lastTarget).toEqual({ host: onionHost, port: onionPort });
+  }, 30_000);
+});

--- a/packages/node/.gitignore
+++ b/packages/node/.gitignore
@@ -7,6 +7,11 @@ dist-web/
 coverage/
 *.tsbuildinfo
 
+# Foundry artifacts
+cache/
+out/
+contracts/out/
+
 # Environment
 .env
 .env.*

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -4,6 +4,8 @@ export {
   type NodeConfig,
   type BuyerPaymentConfig,
   type NodePaymentsConfig,
+  type NodeTorConfig,
+  type NodeTorSocksProxyConfig,
   type RequestStreamCallbacks,
   type RequestStreamResponseMetadata,
 } from './node.js';

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -104,6 +104,28 @@ export interface NodePaymentsConfig {
   usdcAddress?: string;
 }
 
+export interface NodeTorSocksProxyConfig {
+  host: string;
+  port: number;
+}
+
+export interface NodeTorConfig {
+  /** Enable Tor guardrails mode (loopback listener, no DHT/NAT, forced TCP). */
+  enabled?: boolean;
+  /** Optional SOCKS5 proxy for outbound dialing (required for .onion endpoints). */
+  socksProxy?: NodeTorSocksProxyConfig;
+  /** Optional seller hidden-service hostname that buyers should use (.onion). */
+  onionAddress?: string;
+  /** Optional seller hidden-service public port (default: signaling listener port). */
+  onionPort?: number;
+  /** Manual peer endpoints used by buyers in tor mode. Format: [peerId@]host:port */
+  manualPeers?: string[];
+  /** Fallback provider names for manual peers when signed metadata is unavailable. */
+  manualPeerProviders?: string[];
+  /** Allow non-.onion manual peers in tor mode. Default: false. */
+  allowDirectFallback?: boolean;
+}
+
 export interface NodeConfig {
   role: 'seller' | 'buyer';
   dataDir?: string;           // Default: ~/.antseed
@@ -115,6 +137,8 @@ export interface NodeConfig {
   allowPrivateIPs?: boolean;
   /** Optional seller-side payment runtime wiring. */
   payments?: NodePaymentsConfig;
+  /** Optional Tor mode guardrails and manual discovery settings. */
+  tor?: NodeTorConfig;
 }
 
 interface SellerSessionState {
@@ -195,6 +219,7 @@ export class AntseedNode extends EventEmitter {
   private _buyerPaymentManager: BuyerPaymentManager | null = null;
   /** Tracks which seller peers the buyer has already initiated a lock for. */
   private _buyerLockedPeers = new Set<string>();
+  private _torManualPeers: Array<{ raw: string; peerId?: PeerId; host: string; port: number }> = [];
 
   constructor(config: NodeConfig) {
     super();
@@ -372,6 +397,10 @@ export class AntseedNode extends EventEmitter {
   }
 
   async discoverPeers(model?: string): Promise<PeerInfo[]> {
+    if (this._isTorMode()) {
+      return this._discoverTorManualPeers();
+    }
+
     if (!this._peerLookup) {
       throw new Error("Node not started or not in buyer mode");
     }
@@ -630,7 +659,16 @@ export class AntseedNode extends EventEmitter {
     const identity = this._identity!;
     const dhtPort = this._config.dhtPort ?? 6881;
     const signalingPort = this._config.signalingPort ?? 6882;
-    debugLog(`[Node] Starting seller — DHT port=${dhtPort}, signaling port=${signalingPort}`);
+    const torMode = this._isTorMode();
+    const onionAddress = this._config.tor?.onionAddress?.trim().toLowerCase();
+    const configuredOnionPort = this._config.tor?.onionPort;
+    if (torMode && onionAddress && !isOnionHost(onionAddress)) {
+      throw new Error(`Invalid tor.onionAddress "${this._config.tor?.onionAddress}". Expected .onion hostname`);
+    }
+    if (torMode && configuredOnionPort !== undefined && (!Number.isInteger(configuredOnionPort) || configuredOnionPort < 1 || configuredOnionPort > 65535)) {
+      throw new Error(`Invalid tor.onionPort "${String(configuredOnionPort)}". Expected integer 1-65535`);
+    }
+    debugLog(`[Node] Starting seller — DHT port=${dhtPort}, signaling port=${signalingPort}, tor=${torMode ? "on" : "off"}`);
 
     // Initialize metering storage
     const dataDir = this._config.dataDir ?? join(homedir(), ".antseed");
@@ -650,43 +688,53 @@ export class AntseedNode extends EventEmitter {
 
     await this._initializePayments(dataDir);
 
-    // Start DHT
-    this._dht = new DHTNode(this._createDHTConfig(dhtPort, bootstrapNodes));
-    await this._dht.start();
+    if (!torMode) {
+      // Start DHT
+      this._dht = new DHTNode(this._createDHTConfig(dhtPort, bootstrapNodes));
+      await this._dht.start();
+    }
 
     // Create ConnectionManager and start listening
-    this._connectionManager = new ConnectionManager();
+    this._connectionManager = new ConnectionManager(undefined, {
+      forceTcp: torMode,
+      ...(this._config.tor?.socksProxy ? { socksProxy: this._config.tor.socksProxy } : {}),
+    });
     this._connectionManager.setLocalIdentity(identity);
     await this._connectionManager.startListening({
       peerId: identity.peerId,
       port: signalingPort,
-      host: "0.0.0.0",
+      host: torMode ? "127.0.0.1" : "0.0.0.0",
     });
 
     // Resolve actual bound port (important when port 0 is used for OS-assigned)
     const actualSignalingPort = this._connectionManager.getListeningPort() ?? signalingPort;
-    const actualDhtPort = this._dht.getPort();
+    if (!torMode) {
+      const actualDhtPort = this._dht!.getPort();
 
-    // NAT traversal: automatically map ports via UPnP/NAT-PMP
-    this._nat = new NatTraversal();
-    const natResult = await this._nat.mapPorts([
-      { port: actualSignalingPort, protocol: "TCP" },
-      { port: actualDhtPort, protocol: "UDP" },
-    ]);
+      // NAT traversal: automatically map ports via UPnP/NAT-PMP
+      this._nat = new NatTraversal();
+      const natResult = await this._nat.mapPorts([
+        { port: actualSignalingPort, protocol: "TCP" },
+        { port: actualDhtPort, protocol: "UDP" },
+      ]);
 
-    if (natResult.success) {
-      this.emit("nat:mapped", natResult);
-    } else {
-      debugWarn("[NAT] UPnP/NAT-PMP mapping failed — seller may not be reachable from the internet");
-      debugWarn("[NAT] Ensure port forwarding is configured manually, or peers on the same LAN can still connect");
-      this.emit("nat:failed");
+      if (natResult.success) {
+        this.emit("nat:mapped", natResult);
+      } else {
+        debugWarn("[NAT] UPnP/NAT-PMP mapping failed — seller may not be reachable from the internet");
+        debugWarn("[NAT] Ensure port forwarding is configured manually, or peers on the same LAN can still connect");
+        this.emit("nat:failed");
+      }
     }
 
     // Set up announcer for providers
     if (this._providers.length > 0) {
+      const announceDht = torMode
+        ? ({ announce: async () => undefined } as unknown as DHTNode)
+        : this._dht!;
       const announcerConfig: AnnouncerConfig = {
         identity,
-        dht: this._dht,
+        dht: announceDht,
         providers: this._providers.map((p) => ({
           provider: p.name,
           models: p.models,
@@ -709,7 +757,11 @@ export class AntseedNode extends EventEmitter {
         signalingPort: actualSignalingPort,
       };
       this._announcer = new PeerAnnouncer(announcerConfig);
-      this._announcer.startPeriodicAnnounce();
+      if (torMode) {
+        await this._announcer.announce();
+      } else {
+        this._announcer.startPeriodicAnnounce();
+      }
 
       // Serve metadata on the signaling port (HTTP requests are auto-detected)
       this._connectionManager!.setMetadataProvider(
@@ -722,13 +774,86 @@ export class AntseedNode extends EventEmitter {
       this._handleIncomingConnection(conn);
     });
 
-    debugLog(`[Node] Seller ready — announcing ${this._providers.length} provider(s)`);
+    if (torMode) {
+      if (onionAddress) {
+        const onionPort = configuredOnionPort ?? actualSignalingPort;
+        const manualPeer = `${identity.peerId}@${onionAddress}:${onionPort}`;
+        this.emit("tor:ready", {
+          peerId: identity.peerId,
+          onionAddress,
+          onionPort,
+          manualPeer,
+        });
+        debugLog(`[Node] Tor hidden-service endpoint ${onionAddress}:${onionPort}`);
+        debugLog(`[Node] Tor peer hint ${manualPeer}`);
+      } else {
+        debugWarn("[Node] Tor mode is enabled but tor.onionAddress is not set. Buyers must be given manual peer endpoints separately.");
+      }
+    }
+
+    debugLog(
+      torMode
+        ? `[Node] Seller ready in tor mode — providers=${this._providers.length}, listener=${actualSignalingPort}`
+        : `[Node] Seller ready — announcing ${this._providers.length} provider(s)`,
+    );
   }
 
   private async _startBuyer(bootstrapNodes: Array<{ host: string; port: number }>): Promise<void> {
     const identity = this._identity!;
+    const torMode = this._isTorMode();
     const dhtPort = this._config.dhtPort ?? 0;
-    debugLog(`[Node] Starting buyer — DHT port=${dhtPort}`);
+    debugLog(`[Node] Starting buyer — DHT port=${dhtPort}, tor=${torMode ? "on" : "off"}`);
+
+    if (torMode) {
+      // Create ConnectionManager for outbound connections (forced TCP in tor mode)
+      this._connectionManager = new ConnectionManager(undefined, {
+        forceTcp: true,
+        ...(this._config.tor?.socksProxy ? { socksProxy: this._config.tor.socksProxy } : {}),
+      });
+      this._connectionManager.setLocalIdentity(identity);
+
+      this._torManualPeers = this._parseTorManualPeers(this._config.tor?.manualPeers ?? []);
+      if (this._torManualPeers.length === 0) {
+        throw new Error("Tor mode requires at least one manual peer endpoint (tor.manualPeers)");
+      }
+
+      const hasOnionPeer = this._torManualPeers.some((entry) => isOnionHost(entry.host));
+      if (hasOnionPeer && !this._config.tor?.socksProxy) {
+        throw new Error("Tor mode with .onion peers requires tor.socksProxy");
+      }
+
+      const onionWithoutPeerId = this._torManualPeers.find((entry) => isOnionHost(entry.host) && !entry.peerId);
+      if (onionWithoutPeerId) {
+        throw new Error(
+          `Tor mode requires peerId@host:port for .onion peers. Invalid peer: ${onionWithoutPeerId.raw}`,
+        );
+      }
+
+      if (!this._config.tor?.allowDirectFallback) {
+        const nonOnion = this._torManualPeers.find((entry) => !isOnionHost(entry.host));
+        if (nonOnion) {
+          throw new Error(
+            `Tor mode only allows .onion manual peers by default. Invalid peer: ${nonOnion.raw}. Set tor.allowDirectFallback=true to override.`,
+          );
+        }
+      }
+
+      // Initialize buyer-side payment manager if payments config is provided
+      const payments = this._config.payments;
+      if (payments?.enabled && payments.rpcUrl && payments.contractAddress && payments.usdcAddress) {
+        const buyerPaymentConfig: BuyerPaymentConfig = {
+          defaultLockAmountUSDC: payments.defaultEscrowAmountUSDC ?? "1000000",
+          rpcUrl: payments.rpcUrl,
+          contractAddress: payments.contractAddress,
+          usdcAddress: payments.usdcAddress,
+        };
+        this._buyerPaymentManager = new BuyerPaymentManager(identity, buyerPaymentConfig);
+        debugLog(`[Node] Buyer payment manager initialized (wallet=${identityToEvmAddress(identity).slice(0, 10)}...)`);
+      }
+
+      debugLog(`[Node] Buyer ready in tor mode — manual peers=${this._torManualPeers.length}`);
+      return;
+    }
 
     // Start DHT with ephemeral port
     this._dht = new DHTNode(this._createDHTConfig(dhtPort, bootstrapNodes));
@@ -1844,6 +1969,118 @@ export class AntseedNode extends EventEmitter {
       trustScore: result.metadata.onChainReputation,
     };
   }
+
+  private _isTorMode(): boolean {
+    return this._config.tor?.enabled === true;
+  }
+
+  private _parseTorManualPeers(entries: string[]): Array<{ raw: string; peerId?: PeerId; host: string; port: number }> {
+    const parsed: Array<{ raw: string; peerId?: PeerId; host: string; port: number }> = [];
+    for (const entry of entries) {
+      const raw = entry.trim();
+      if (raw.length === 0) continue;
+
+      const atIndex = raw.indexOf("@");
+      const peerPart = atIndex >= 0 ? raw.slice(0, atIndex) : "";
+      const endpointPart = atIndex >= 0 ? raw.slice(atIndex + 1) : raw;
+      const endpoint = parseHostPort(endpointPart);
+      if (!endpoint) {
+        throw new Error(`Invalid tor manual peer entry "${entry}". Expected [peerId@]host:port`);
+      }
+
+      let peerId: PeerId | undefined;
+      if (peerPart.length > 0) {
+        if (!/^[0-9a-f]{64}$/i.test(peerPart)) {
+          throw new Error(`Invalid tor manual peer id in "${entry}". Expected 64 hex chars`);
+        }
+        peerId = peerPart.toLowerCase() as PeerId;
+      }
+
+      parsed.push({
+        raw,
+        ...(peerId ? { peerId } : {}),
+        host: endpoint.host,
+        port: endpoint.port,
+      });
+    }
+    return parsed;
+  }
+
+  private async _discoverTorManualPeers(): Promise<PeerInfo[]> {
+    if (!this._started) {
+      throw new Error("Node not started");
+    }
+    if (this._torManualPeers.length === 0) {
+      throw new Error("No tor manual peers configured");
+    }
+
+    const fallbackProviders = (this._config.tor?.manualPeerProviders ?? [
+      "anthropic",
+      "openai",
+      "claude-code",
+      "claude-oauth",
+      "openrouter",
+      "local-llm",
+    ])
+      .map((provider) => provider.trim().toLowerCase())
+      .filter((provider) => provider.length > 0);
+
+    const metadataResolver = new HttpMetadataResolver();
+    const peers: PeerInfo[] = [];
+    const seenPeerIds = new Set<string>();
+
+    for (const endpoint of this._torManualPeers) {
+      // HttpMetadataResolver does not route through SOCKS in phase 1.
+      // Skip metadata fetch for onion endpoints and rely on manual peer fallback data.
+      const canFetchMetadata = !isOnionHost(endpoint.host);
+      if (canFetchMetadata) {
+        const metadata = await metadataResolver.resolve({ host: endpoint.host, port: endpoint.port });
+        if (metadata) {
+          if (endpoint.peerId && endpoint.peerId !== metadata.peerId) {
+            debugWarn(
+              `[Node] Tor manual peer ${endpoint.raw} metadata peerId mismatch (expected=${endpoint.peerId.slice(0, 12)}..., got=${metadata.peerId.slice(0, 12)}...)`,
+            );
+            continue;
+          } else {
+            const fromMetadata = this._lookupResultToPeerInfo({
+              metadata,
+              host: endpoint.host,
+              port: endpoint.port,
+            });
+            if (!seenPeerIds.has(fromMetadata.peerId)) {
+              seenPeerIds.add(fromMetadata.peerId);
+              peers.push(fromMetadata);
+            }
+            continue;
+          }
+        }
+      }
+
+      const syntheticPeerId = endpoint.peerId ?? (
+        createHash("sha256")
+          .update(`${endpoint.host}:${endpoint.port}`)
+          .digest("hex")
+          .slice(0, 64) as PeerId
+      );
+
+      if (!seenPeerIds.has(syntheticPeerId)) {
+        seenPeerIds.add(syntheticPeerId);
+        peers.push({
+          peerId: syntheticPeerId,
+          lastSeen: Date.now(),
+          providers: fallbackProviders.length > 0 ? fallbackProviders : ["anthropic"],
+          publicAddress: `${endpoint.host}:${endpoint.port}`,
+          defaultInputUsdPerMillion: 0,
+          defaultOutputUsdPerMillion: 0,
+        });
+      }
+    }
+
+    for (const peer of peers) {
+      debugLog(`[Node] Tor peer ${peer.peerId.slice(0, 12)}... providers=[${peer.providers.join(",")}] addr=${peer.publicAddress ?? "?"}`);
+    }
+    return peers;
+  }
 }
 
 function concatChunks(chunks: Uint8Array[]): Uint8Array {
@@ -1858,4 +2095,33 @@ function concatChunks(chunks: Uint8Array[]): Uint8Array {
     offset += chunk.length;
   }
   return output;
+}
+
+function parseHostPort(value: string): { host: string; port: number } | null {
+  const raw = value.trim();
+  if (raw.length === 0) return null;
+
+  if (raw.startsWith("[")) {
+    const end = raw.indexOf("]");
+    if (end <= 1) return null;
+    const host = raw.slice(1, end).trim().toLowerCase();
+    const portPart = raw.slice(end + 1);
+    if (!portPart.startsWith(":")) return null;
+    const port = Number.parseInt(portPart.slice(1), 10);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+    if (host.length === 0) return null;
+    return { host, port };
+  }
+
+  const lastColon = raw.lastIndexOf(":");
+  if (lastColon <= 0) return null;
+  const host = raw.slice(0, lastColon).trim().toLowerCase();
+  const port = Number.parseInt(raw.slice(lastColon + 1), 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+  if (host.length === 0) return null;
+  return { host, port };
+}
+
+function isOnionHost(host: string): boolean {
+  return host.trim().toLowerCase().endsWith(".onion");
 }

--- a/packages/node/src/p2p/connection-manager.ts
+++ b/packages/node/src/p2p/connection-manager.ts
@@ -33,6 +33,16 @@ export interface PeerEndpoint {
   port: number;
 }
 
+export interface SocksProxyConfig {
+  host: string;
+  port: number;
+}
+
+export interface ConnectionManagerOptions {
+  forceTcp?: boolean;
+  socksProxy?: SocksProxyConfig;
+}
+
 type TransportMode = "webrtc" | "tcp";
 type InitialWireMessage =
   | {
@@ -60,6 +70,116 @@ const DATA_CHANNEL_LABEL = "antseed-data";
 const LINE_SEPARATOR = "\n";
 const INITIAL_LINE_TIMEOUT_MS = 10_000;
 const MAX_INITIAL_LINE_BYTES = 8 * 1024;
+
+function buildSocksConnectRequest(host: string, port: number): Buffer {
+  const ipVersion = net.isIP(host);
+  if (ipVersion === 4) {
+    const octets = host.split(".").map((part) => Number.parseInt(part, 10));
+    const payload = Buffer.alloc(4 + 4 + 2);
+    payload[0] = 0x05; // SOCKS5
+    payload[1] = 0x01; // CONNECT
+    payload[2] = 0x00; // reserved
+    payload[3] = 0x01; // IPv4
+    for (let i = 0; i < 4; i++) {
+      payload[4 + i] = octets[i] ?? 0;
+    }
+    payload.writeUInt16BE(port, 8);
+    return payload;
+  }
+
+  if (ipVersion === 6) {
+    const payload = Buffer.alloc(4 + 16 + 2);
+    payload[0] = 0x05;
+    payload[1] = 0x01;
+    payload[2] = 0x00;
+    payload[3] = 0x04; // IPv6
+    const segments = host.split(":");
+    const expanded: string[] = [];
+    let emptyIndex = -1;
+    for (let i = 0; i < segments.length; i++) {
+      if (segments[i] === "" && emptyIndex < 0) {
+        emptyIndex = i;
+      }
+    }
+    if (emptyIndex >= 0) {
+      const missing = 8 - (segments.length - 1);
+      for (let i = 0; i < segments.length; i++) {
+        if (i === emptyIndex) {
+          for (let j = 0; j < missing; j++) expanded.push("0");
+        } else if (segments[i] !== "") {
+          expanded.push(segments[i]!);
+        }
+      }
+    } else {
+      expanded.push(...segments);
+    }
+    for (let i = 0; i < 8; i++) {
+      const value = Number.parseInt(expanded[i] ?? "0", 16);
+      payload.writeUInt16BE(Number.isFinite(value) ? value : 0, 4 + i * 2);
+    }
+    payload.writeUInt16BE(port, 20);
+    return payload;
+  }
+
+  const hostBytes = Buffer.from(host, "utf8");
+  if (hostBytes.length === 0 || hostBytes.length > 255) {
+    throw new Error(`Invalid SOCKS target host "${host}"`);
+  }
+  const payload = Buffer.alloc(4 + 1 + hostBytes.length + 2);
+  payload[0] = 0x05;
+  payload[1] = 0x01;
+  payload[2] = 0x00;
+  payload[3] = 0x03; // domain name
+  payload[4] = hostBytes.length;
+  hostBytes.copy(payload, 5);
+  payload.writeUInt16BE(port, 5 + hostBytes.length);
+  return payload;
+}
+
+function createSocketReader(socket: Socket): { readExact: (bytes: number) => Promise<Buffer> } {
+  let buffer = Buffer.alloc(0);
+  return {
+    readExact: (bytes: number): Promise<Buffer> =>
+      new Promise<Buffer>((resolve, reject) => {
+        if (buffer.length >= bytes) {
+          const out = buffer.subarray(0, bytes);
+          buffer = buffer.subarray(bytes);
+          resolve(out);
+          return;
+        }
+
+        const onData = (chunk: Buffer): void => {
+          buffer = Buffer.concat([buffer, chunk]);
+          if (buffer.length >= bytes) {
+            cleanup();
+            const out = buffer.subarray(0, bytes);
+            buffer = buffer.subarray(bytes);
+            resolve(out);
+          }
+        };
+
+        const onError = (err: Error): void => {
+          cleanup();
+          reject(err);
+        };
+
+        const onClose = (): void => {
+          cleanup();
+          reject(new Error("SOCKET_CLOSED"));
+        };
+
+        const cleanup = (): void => {
+          socket.off("data", onData);
+          socket.off("error", onError);
+          socket.off("close", onClose);
+        };
+
+        socket.on("data", onData);
+        socket.once("error", onError);
+        socket.once("close", onClose);
+      }),
+  };
+}
 
 /** Represents a single P2P connection. */
 export class PeerConnection extends EventEmitter {
@@ -263,25 +383,27 @@ export class ConnectionManager extends EventEmitter {
   private _listenPort: number | null = null;
   private _server: net.Server | null = null;
   private _transportMode: TransportMode;
+  private _socksProxy: SocksProxyConfig | null;
   private _metadataProvider: (() => object | null) | null = null;
   private _ipConnectionCounts = new Map<string, number>();
   private readonly _introReplayGuard = new NonceReplayGuard();
   private static _knownEndpoints = new Map<PeerId, PeerEndpoint>();
   private static _detectedTransportMode: TransportMode | null = null;
 
-  constructor(iceConfig?: IceConfig) {
+  constructor(iceConfig?: IceConfig, options?: ConnectionManagerOptions) {
     super();
     this._iceConfig = iceConfig ?? getDefaultIceConfig();
-    this._transportMode = ConnectionManager._detectTransportMode();
+    this._transportMode = options?.forceTcp ? "tcp" : ConnectionManager._detectTransportMode();
+    this._socksProxy = options?.socksProxy ?? null;
   }
 
-  static async init(iceConfig?: IceConfig): Promise<ConnectionManager> {
+  static async init(iceConfig?: IceConfig, options?: ConnectionManagerOptions): Promise<ConnectionManager> {
     try {
       await loadNodeDatachannel();
     } catch {
       // node-datachannel not available — TCP fallback will be used
     }
-    return new ConnectionManager(iceConfig);
+    return new ConnectionManager(iceConfig, options);
   }
 
   get iceConfig(): IceConfig {
@@ -457,56 +579,61 @@ export class ConnectionManager extends EventEmitter {
     conn: PeerConnection,
     endpoint: PeerEndpoint,
   ): void {
-    const signalingSocket = net.connect({ host: endpoint.host, port: endpoint.port });
-    conn.attachSignalingSocket(signalingSocket);
+    void this._openOutboundSocket(endpoint)
+      .then((signalingSocket) => {
+        conn.attachSignalingSocket(signalingSocket);
 
-    let rtc: NativeRtcPeerConnection | null = null;
-    const pendingSignals: SignalingMessage[] = [];
+        let rtc: NativeRtcPeerConnection | null = null;
+        const pendingSignals: SignalingMessage[] = [];
 
-    this._attachSignalingParser(
-      signalingSocket,
-      (msg) => {
-        if (!rtc) {
-          pendingSignals.push(msg);
-          return;
+        this._attachSignalingParser(
+          signalingSocket,
+          (msg) => {
+            if (!rtc) {
+              pendingSignals.push(msg);
+              return;
+            }
+            this._applySignalToRtc(rtc, msg, conn);
+          },
+          (err) => conn.fail(err),
+          "",
+        );
+
+        this._sendLine(signalingSocket, {
+          type: "hello",
+          auth: buildConnectionAuthEnvelope(
+            "hello",
+            this._localPeerId!,
+            this._localPrivateKey!,
+          ),
+        });
+
+        rtc = this._createRtcPeer(config.remotePeerId);
+        conn.attachRtcPeer(rtc);
+        this._wireRtcPeer(conn, rtc, signalingSocket, true);
+
+        for (const signal of pendingSignals) {
+          this._applySignalToRtc(rtc, signal, conn);
         }
-        this._applySignalToRtc(rtc, msg, conn);
-      },
-      (err) => conn.fail(err),
-      "",
-    );
+        pendingSignals.length = 0;
 
-    signalingSocket.once("connect", () => {
-      this._sendLine(signalingSocket, {
-        type: "hello",
-        auth: buildConnectionAuthEnvelope(
-          "hello",
-          this._localPeerId!,
-          this._localPrivateKey!,
-        ),
+        signalingSocket.on("error", (err: Error) => {
+          if (conn.state === ConnectionState.Connecting) {
+            conn.fail(err);
+          }
+        });
+
+        signalingSocket.on("close", () => {
+          if (conn.state === ConnectionState.Connecting) {
+            conn.fail(new Error(`Signaling socket closed before connection to ${config.remotePeerId} opened`));
+          }
+        });
+      })
+      .catch((err: Error) => {
+        if (conn.state === ConnectionState.Connecting) {
+          conn.fail(err);
+        }
       });
-
-      rtc = this._createRtcPeer(config.remotePeerId);
-      conn.attachRtcPeer(rtc);
-      this._wireRtcPeer(conn, rtc, signalingSocket, true);
-
-      for (const signal of pendingSignals) {
-        this._applySignalToRtc(rtc, signal, conn);
-      }
-      pendingSignals.length = 0;
-    });
-
-    signalingSocket.on("error", (err: Error) => {
-      if (conn.state === ConnectionState.Connecting) {
-        conn.fail(err);
-      }
-    });
-
-    signalingSocket.on("close", () => {
-      if (conn.state === ConnectionState.Connecting) {
-        conn.fail(new Error(`Signaling socket closed before connection to ${config.remotePeerId} opened`));
-      }
-    });
   }
 
   private _createTcpConnection(
@@ -514,31 +641,97 @@ export class ConnectionManager extends EventEmitter {
     conn: PeerConnection,
     endpoint: PeerEndpoint,
   ): void {
-    const socket = net.connect({ host: endpoint.host, port: endpoint.port });
+    void this._openOutboundSocket(endpoint)
+      .then((socket) => {
+        this._sendLine(socket, {
+          type: "intro",
+          auth: buildConnectionAuthEnvelope(
+            "intro",
+            this._localPeerId!,
+            this._localPrivateKey!,
+          ),
+        });
+        conn.attachRawSocket(socket);
 
-    socket.once("connect", () => {
-      this._sendLine(socket, {
-        type: "intro",
-        auth: buildConnectionAuthEnvelope(
-          "intro",
-          this._localPeerId!,
-          this._localPrivateKey!,
-        ),
+        socket.on("error", (err: Error) => {
+          if (conn.state === ConnectionState.Connecting) {
+            conn.fail(err);
+          }
+        });
+
+        socket.on("close", () => {
+          if (conn.state === ConnectionState.Connecting) {
+            conn.fail(new Error(`TCP socket closed before connection to ${config.remotePeerId} opened`));
+          }
+        });
+      })
+      .catch((err: Error) => {
+        if (conn.state === ConnectionState.Connecting) {
+          conn.fail(err);
+        }
       });
-      conn.attachRawSocket(socket);
-    });
+  }
 
-    socket.on("error", (err: Error) => {
-      if (conn.state === ConnectionState.Connecting) {
-        conn.fail(err);
-      }
-    });
+  private async _openOutboundSocket(endpoint: PeerEndpoint): Promise<Socket> {
+    if (!this._socksProxy) {
+      return this._openDirectSocket(endpoint.host, endpoint.port);
+    }
+    return this._openSocketViaSocksProxy(endpoint);
+  }
 
-    socket.on("close", () => {
-      if (conn.state === ConnectionState.Connecting) {
-        conn.fail(new Error(`TCP socket closed before connection to ${config.remotePeerId} opened`));
-      }
+  private _openDirectSocket(host: string, port: number): Promise<Socket> {
+    return new Promise<Socket>((resolve, reject) => {
+      const socket = net.connect({ host, port });
+      const onError = (err: Error): void => {
+        socket.off("connect", onConnect);
+        reject(err);
+      };
+      const onConnect = (): void => {
+        socket.off("error", onError);
+        resolve(socket);
+      };
+      socket.once("error", onError);
+      socket.once("connect", onConnect);
     });
+  }
+
+  private async _openSocketViaSocksProxy(endpoint: PeerEndpoint): Promise<Socket> {
+    const proxy = this._socksProxy!;
+    const socket = await this._openDirectSocket(proxy.host, proxy.port);
+    const reader = createSocketReader(socket);
+
+    socket.write(Buffer.from([0x05, 0x01, 0x00])); // SOCKS5 + 1 auth method + no-auth
+    const greeting = await reader.readExact(2);
+    if (greeting[0] !== 0x05 || greeting[1] !== 0x00) {
+      socket.destroy();
+      throw new Error("SOCKS5 proxy does not support no-auth mode");
+    }
+
+    socket.write(buildSocksConnectRequest(endpoint.host, endpoint.port));
+    const responseHead = await reader.readExact(4);
+    if (responseHead[0] !== 0x05) {
+      socket.destroy();
+      throw new Error("Invalid SOCKS5 response version");
+    }
+    if (responseHead[1] !== 0x00) {
+      socket.destroy();
+      throw new Error(`SOCKS5 connect failed with code ${String(responseHead[1])}`);
+    }
+
+    const atyp = responseHead[3];
+    if (atyp === 0x01) {
+      await reader.readExact(4 + 2); // IPv4 + port
+    } else if (atyp === 0x03) {
+      const domainLen = (await reader.readExact(1))[0] ?? 0;
+      await reader.readExact(domainLen + 2); // domain + port
+    } else if (atyp === 0x04) {
+      await reader.readExact(16 + 2); // IPv6 + port
+    } else {
+      socket.destroy();
+      throw new Error("Unsupported SOCKS5 address type");
+    }
+
+    return socket;
   }
 
   private _handleInboundSocket(socket: Socket): void {

--- a/packages/node/tests/tor-guardrails.test.ts
+++ b/packages/node/tests/tor-guardrails.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AntseedNode } from '../src/node.js';
+
+const BUYER_PEER_ID = 'a'.repeat(64);
+const SELLER_PEER_ID = 'b'.repeat(64);
+const OTHER_PEER_ID = 'c'.repeat(64);
+
+function attachIdentity(node: AntseedNode, peerId = BUYER_PEER_ID): void {
+  (node as unknown as {
+    _identity: {
+      peerId: string;
+      privateKey: Uint8Array;
+      publicKey: Uint8Array;
+    };
+  })._identity = {
+    peerId,
+    privateKey: new Uint8Array(32),
+    publicKey: new Uint8Array(32),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('Tor guardrails (buyer)', () => {
+  it('rejects onion manual peers when socks proxy is not configured', async () => {
+    const node = new AntseedNode({
+      role: 'buyer',
+      tor: {
+        enabled: true,
+        manualPeers: [`${SELLER_PEER_ID}@abcdefghijklmnop.onion:80`],
+      },
+    });
+    attachIdentity(node);
+
+    await expect(
+      (node as unknown as { _startBuyer: (bootstrap: Array<{ host: string; port: number }>) => Promise<void> })
+        ._startBuyer([])
+    ).rejects.toThrow(/requires tor\.socksProxy/i);
+  });
+
+  it('rejects onion manual peers without explicit peerId', async () => {
+    const node = new AntseedNode({
+      role: 'buyer',
+      tor: {
+        enabled: true,
+        manualPeers: ['abcdefghijklmnop.onion:80'],
+        socksProxy: { host: '127.0.0.1', port: 9050 },
+      },
+    });
+    attachIdentity(node);
+
+    await expect(
+      (node as unknown as { _startBuyer: (bootstrap: Array<{ host: string; port: number }>) => Promise<void> })
+        ._startBuyer([])
+    ).rejects.toThrow(/requires peerId@host:port/i);
+  });
+
+  it('rejects non-onion peers unless allowDirectFallback=true', async () => {
+    const node = new AntseedNode({
+      role: 'buyer',
+      tor: {
+        enabled: true,
+        manualPeers: [`${SELLER_PEER_ID}@127.0.0.1:6882`],
+      },
+    });
+    attachIdentity(node);
+
+    await expect(
+      (node as unknown as { _startBuyer: (bootstrap: Array<{ host: string; port: number }>) => Promise<void> })
+        ._startBuyer([])
+    ).rejects.toThrow(/only allows \.onion manual peers/i);
+  });
+
+  it('starts buyer in tor mode with valid onion manual peer + socks proxy', async () => {
+    const node = new AntseedNode({
+      role: 'buyer',
+      tor: {
+        enabled: true,
+        manualPeers: [`${SELLER_PEER_ID}@abcdefghijklmnop.onion:80`],
+        socksProxy: { host: '127.0.0.1', port: 9050 },
+      },
+    });
+    attachIdentity(node);
+
+    await expect(
+      (node as unknown as { _startBuyer: (bootstrap: Array<{ host: string; port: number }>) => Promise<void> })
+        ._startBuyer([])
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('Tor manual discovery', () => {
+  it('skips mismatched metadata peerId instead of falling back to synthetic peer', async () => {
+    const node = new AntseedNode({
+      role: 'buyer',
+      tor: {
+        enabled: true,
+        manualPeerProviders: ['anthropic'],
+      },
+    });
+
+    const mutableNode = node as unknown as {
+      _started: boolean;
+      _torManualPeers: Array<{ raw: string; peerId?: string; host: string; port: number }>;
+      _discoverTorManualPeers: () => Promise<Array<{ peerId: string }>>;
+    };
+    mutableNode._started = true;
+    mutableNode._torManualPeers = [
+      {
+        raw: `${SELLER_PEER_ID}@127.0.0.1:6882`,
+        peerId: SELLER_PEER_ID,
+        host: '127.0.0.1',
+        port: 6882,
+      },
+    ];
+
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          peerId: OTHER_PEER_ID,
+          version: 2,
+          providers: [
+            {
+              provider: 'anthropic',
+              models: ['claude-3-opus'],
+              defaultPricing: { inputUsdPerMillion: 1, outputUsdPerMillion: 2 },
+              maxConcurrency: 4,
+              currentLoad: 0,
+            },
+          ],
+          region: 'test',
+          timestamp: Date.now(),
+          signature: 'd'.repeat(128),
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const peers = await mutableNode._discoverTorManualPeers();
+    expect(peers).toHaveLength(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attempt metadata HTTP fetch for onion endpoints', async () => {
+    const node = new AntseedNode({
+      role: 'buyer',
+      tor: {
+        enabled: true,
+        manualPeerProviders: ['anthropic', 'openai'],
+      },
+    });
+
+    const mutableNode = node as unknown as {
+      _started: boolean;
+      _torManualPeers: Array<{ raw: string; peerId?: string; host: string; port: number }>;
+      _discoverTorManualPeers: () => Promise<
+        Array<{ peerId: string; providers: string[]; publicAddress?: string }>
+      >;
+    };
+    mutableNode._started = true;
+    mutableNode._torManualPeers = [
+      {
+        raw: `${SELLER_PEER_ID}@abcdefghijklmnop.onion:80`,
+        peerId: SELLER_PEER_ID,
+        host: 'abcdefghijklmnop.onion',
+        port: 80,
+      },
+    ];
+
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const peers = await mutableNode._discoverTorManualPeers();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(peers).toHaveLength(1);
+    expect(peers[0]?.peerId).toBe(SELLER_PEER_ID);
+    expect(peers[0]?.providers).toEqual(['anthropic', 'openai']);
+    expect(peers[0]?.publicAddress).toBe('abcdefghijklmnop.onion:80');
+  });
+});

--- a/tor mode guardrails/CONTEXT.md
+++ b/tor mode guardrails/CONTEXT.md
@@ -1,0 +1,60 @@
+# Tor Mode Guardrails - Session Context
+
+Last updated: 2026-02-26
+Repo: /Users/eylon/Claude/antseed-monorepo
+Branch: main
+
+## Goal
+Build a Tor hidden-service mode for AntSeed so inbound seller connections do not expose direct IP addresses.
+
+## Work Completed
+1. Researched current networking behavior in `@antseed/node`.
+2. Confirmed blockers for Tor-only privacy in current implementation:
+   - seller listens publicly (`0.0.0.0`),
+   - NAT mapping is enabled,
+   - discovery/announce relies on UDP DHT,
+   - buyer resolves and connects to direct host:port.
+3. Wrote PRD:
+   - `docs/tor-hidden-service-prd.md`
+4. Installed and validated Babysitter tooling:
+   - `@a5c-ai/babysitter`, `@a5c-ai/babysitter-sdk`, `@a5c-ai/babysitter-breakpoints`
+   - `babysitter version` => `0.0.169`
+5. Ran a Babysitter planning/approval flow for this feature:
+   - runId: `01KJCJE1NSS20DA2SWG08KWJW5`
+   - output state: `ready-for-implementation`
+   - run artifacts: `/tmp/antseed-babysitter-runs/01KJCJE1NSS20DA2SWG08KWJW5`
+6. Implemented Phase 1 Tor MVP guardrails in code:
+   - seller tor mode: loopback bind, no DHT startup, no NAT traversal
+   - buyer tor mode: manual peers, no DHT lookup, forced TCP transport
+   - SOCKS5 outbound dialing support in connection manager
+   - tor config schema/defaults/validation and CLI tor flags
+   - tests updated and passing
+7. Ran Babysitter subagent-style implementation tracking with 3 streams:
+   - runId: `01KJCJYMXX8AYCGFD4AR44V8V6`
+   - streams: `node`, `cli`, `tests`
+   - output state: `phase1-implemented`
+   - run artifacts: `/tmp/antseed-babysitter-runs/01KJCJYMXX8AYCGFD4AR44V8V6`
+
+## Repo State
+- Uncommitted docs/module artifacts:
+  - `docs/tor-hidden-service-prd.md`
+  - `tor mode guardrails/CONTEXT.md`
+  - `tor mode guardrails/SESSION_START_PROMPT.md`
+  - `tor mode guardrails/babysitter/phase1-process.mjs`
+  - `tor mode guardrails/babysitter/phase1-inputs.json`
+  - `tor mode guardrails/babysitter/README.md`
+- Uncommitted Phase 1 implementation changes are present in `apps/cli` and `packages/node`.
+
+## Critical Constraints
+- Tor mode must fail closed by default (no silent direct-IP fallback).
+- Keep public mode behavior unchanged.
+- Do not merge protocol-v3 endpoint format until Phase 2 unless explicitly scoped.
+
+## Key References
+- PRD: `docs/tor-hidden-service-prd.md`
+- Node entry: `packages/node/src/node.ts`
+- Connection manager: `packages/node/src/p2p/connection-manager.ts`
+- Discovery DHT: `packages/node/src/discovery/dht-node.ts`
+- Seed command: `apps/cli/src/cli/commands/seed.ts`
+- Connect command: `apps/cli/src/cli/commands/connect.ts`
+- Babysitter module: `tor mode guardrails/babysitter/`

--- a/tor mode guardrails/SESSION_START_PROMPT.md
+++ b/tor mode guardrails/SESSION_START_PROMPT.md
@@ -1,0 +1,17 @@
+# New Session Prompt
+
+Use this prompt in a fresh session:
+
+---
+Read and load context from:
+1. `/Users/eylon/Claude/antseed-monorepo/tor mode guardrails/CONTEXT.md`
+2. `/Users/eylon/Claude/antseed-monorepo/docs/tor-hidden-service-prd.md`
+3. `/Users/eylon/Claude/antseed-monorepo/tor mode guardrails/babysitter/README.md`
+
+Then continue from current state:
+- validate current uncommitted Phase 1 changes
+- prepare commit/PR split (docs/module vs code)
+- or start **Phase 2** only if explicitly requested (metadata v3 endpoint signing + endpoint source abstraction)
+
+Keep public mode unchanged. Show concise diff summaries and test results.
+---


### PR DESCRIPTION
## Summary
This PR introduces the **core Tor hidden-service guardrails and runtime plumbing** for AntSeed.

### Included
- `@antseed/node` Tor mode guardrails:
  - Seller: loopback bind in Tor mode, DHT/NAT disabled, `tor:ready` hint emission.
  - Buyer: Tor manual peers, fail-closed `.onion` policy by default, forced TCP.
  - SOCKS5 outbound dialing support in `ConnectionManager` for `.onion` routes.
- CLI Tor runtime flags + config projection:
  - `seed`: `--tor`, `--tor-onion`
  - `connect`: `--tor`, `--tor-peer`, `--tor-socks`
  - Config schema/defaults/validation updates for `network.tor.*`.
- Coverage:
  - Unit tests for Tor guardrails.
  - Tor hidden-service e2e test scenario.
  - E2E CLI runtime override bootstrap fix.
  - Local-chain full-flow script and README alignment updates.
- Product/docs prep:
  - Tor hidden-service PRD and session context docs.

## Tor Hidden-Service Dependencies
- **Required runtime dependency**: `tor` daemon (0.4.x+) reachable via SOCKS (default `127.0.0.1:9050`).
- **No new npm package dependency for Tor transport**: SOCKS5 connect is implemented directly in `@antseed/node`.
- **For local-chain flow validation only**: Foundry (`anvil`, `forge`, `cast`) plus Node.js/pnpm workspace toolchain.

## Validation
- `pnpm run build` (workspace): pass
- `pnpm run test:e2e`: pass (`11/11` files, `51/51` tests)
- `@antseed/node` tests: pass (`259/259`)
- Local-chain flow script (`flow:local-chain`): pass
- Live smoke (real Tor hidden service + SOCKS): pass in local environment

## Notes
- Tor mode is **fail-closed** by default (no silent direct fallback unless explicitly enabled).
- Public mode behavior remains default/unchanged.
