### PR TITLE
feat(desktop): add runtime tab and tor hidden-service relaunch controls

### DIFF
--- a/apps/desktop/src/main/process-manager.ts
+++ b/apps/desktop/src/main/process-manager.ts
@@ -23,6 +23,12 @@ export interface StartOptions {
   configPath?: string;
   verbose?: boolean;
   env?: Record<string, string>;
+  tor?: {
+    enabled?: boolean;
+    socksProxy?: string;
+    onion?: string;
+    peer?: string;
+  };
 }
 
 export interface DaemonStateSnapshot {
@@ -303,6 +309,10 @@ function resolveCliExecution(): CliExecution {
 
 function resolveCommandArgs(opts: StartOptions): string[] {
   const args: string[] = [];
+  const torEnabled = opts.tor?.enabled === true;
+  const torSocksProxy = opts.tor?.socksProxy?.trim();
+  const torOnion = opts.tor?.onion?.trim();
+  const torPeer = opts.tor?.peer?.trim();
 
   if (opts.verbose) {
     args.push('--verbose');
@@ -315,10 +325,25 @@ function resolveCommandArgs(opts: StartOptions): string[] {
     case 'seed':
       args.push('--data-dir', DESKTOP_SEED_DATA_DIR);
       args.push('seed', '--provider', normalizeProviderIdentifier(opts.provider));
+      if (torEnabled) {
+        args.push('--tor');
+        if (torOnion && torOnion.length > 0) {
+          args.push('--tor-onion', torOnion);
+        }
+      }
       break;
     case 'connect':
       args.push('--data-dir', DESKTOP_CONNECT_DATA_DIR);
       args.push('connect', '--router', normalizeRouterIdentifier(opts.router));
+      if (torEnabled) {
+        args.push('--tor');
+        if (torPeer && torPeer.length > 0) {
+          args.push('--tor-peer', torPeer);
+        }
+        if (torSocksProxy && torSocksProxy.length > 0) {
+          args.push('--tor-socks', torSocksProxy);
+        }
+      }
       break;
     case 'dashboard':
       args.push('dashboard', '--port', String(opts.dashboardPort ?? DEFAULT_DASHBOARD_PORT), '--no-open');
@@ -376,6 +401,12 @@ export class ProcessManager {
     for (const [key, value] of Object.entries(opts.env ?? {})) {
       if (typeof key === 'string' && key.trim().length > 0) {
         childEnv[key] = String(value);
+      }
+    }
+    if (opts.tor?.enabled === true) {
+      const torSocksProxy = opts.tor.socksProxy?.trim();
+      if (torSocksProxy && !childEnv['ANTSEED_TOR_SOCKS']) {
+        childEnv['ANTSEED_TOR_SOCKS'] = torSocksProxy;
       }
     }
     delete childEnv['ELECTRON_RUN_AS_NODE'];

--- a/apps/desktop/src/renderer/app.ts
+++ b/apps/desktop/src/renderer/app.ts
@@ -13,6 +13,7 @@ const POLL_INTERVAL_MS = 5000;
 const SEED_AUTH_PREFS_KEY = 'antseed-seed-auth-prefs';
 const DEFAULT_PROVIDER_RUNTIME = 'anthropic';
 const DEFAULT_ROUTER_RUNTIME = 'local-proxy';
+const ONION_HOST_RE = /^([a-z2-7]{16}|[a-z2-7]{56})\.onion$/;
 
 const PROVIDER_PACKAGE_ALIASES: Record<string, string> = {
   anthropic: '@antseed/provider-anthropic',
@@ -114,6 +115,48 @@ function safeObject(value) {
     return value;
   }
   return null;
+}
+
+function parseHostPort(rawValue: string): { host: string; port: number } | null {
+  const raw = safeString(rawValue, '').trim();
+  if (raw.length === 0) return null;
+
+  if (raw.startsWith('[')) {
+    const end = raw.indexOf(']');
+    if (end <= 1) return null;
+    const host = raw.slice(1, end).trim();
+    const portPart = raw.slice(end + 1);
+    if (!portPart.startsWith(':')) return null;
+    const port = Number.parseInt(portPart.slice(1), 10);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+    return { host, port };
+  }
+
+  const sep = raw.lastIndexOf(':');
+  if (sep <= 0) return null;
+  const host = raw.slice(0, sep).trim();
+  const port = Number.parseInt(raw.slice(sep + 1), 10);
+  if (!host || !Number.isInteger(port) || port < 1 || port > 65535) return null;
+  return { host, port };
+}
+
+function normalizeTorOnion(rawValue: string): string | null {
+  const raw = safeString(rawValue, '').trim().toLowerCase();
+  if (raw.length === 0) return null;
+
+  let host = raw;
+  let port: number | null = null;
+  const sep = raw.lastIndexOf(':');
+  if (sep > 0) {
+    host = raw.slice(0, sep).trim();
+    port = Number.parseInt(raw.slice(sep + 1), 10);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      return null;
+    }
+  }
+
+  if (!ONION_HOST_RE.test(host)) return null;
+  return port ? `${host}:${port}` : host;
 }
 
 function formatClock(timestamp) {
@@ -452,10 +495,13 @@ function updatePluginHintFromLog(event) {
 }
 
 function renderPluginSetupState() {
+  const expectedProvider = uiState.pluginHints.provider || expectedProviderPluginPackage();
   const expectedRouter = uiState.pluginHints.router || expectedRouterPluginPackage();
 
+  const installedProvider = uiState.installedPlugins.has(expectedProvider);
   const installedRouter = uiState.installedPlugins.has(expectedRouter);
   const missing: string[] = [];
+  if (!installedProvider) missing.push(expectedProvider);
   if (!installedRouter) missing.push(expectedRouter);
 
   if (elements.pluginSetupStatus) {
@@ -464,6 +510,13 @@ function renderPluginSetupState() {
     } else {
       elements.pluginSetupStatus.textContent = `Missing plugin${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}`;
     }
+  }
+
+  if (elements.installSeedPluginBtn) {
+    elements.installSeedPluginBtn.textContent = installedProvider
+      ? `Seller Ready (${expectedProvider})`
+      : `Install ${expectedProvider}`;
+    elements.installSeedPluginBtn.disabled = uiState.pluginInstallBusy || installedProvider || !bridge?.pluginsInstall;
   }
 
   if (elements.installConnectPluginBtn) {
@@ -527,6 +580,12 @@ const elements = {
   seedAuthValue: byId('seedAuthValue'),
   seedAuthValueLabel: byId('seedAuthValueLabel'),
   connectRouter: byId('connectRouter'),
+  torEnabledToggle: byId('torEnabledToggle'),
+  torSocks: byId('torSocks'),
+  torOnion: byId('torOnion'),
+  torPeer: byId('torPeer'),
+  relaunchTorBtn: byId('relaunchTorBtn'),
+  torRelaunchStatus: byId('torRelaunchStatus'),
   pluginSetupCard: byId('pluginSetupCard'),
   pluginSetupStatus: byId('pluginSetupStatus'),
   refreshPluginsBtn: byId('refreshPluginsBtn'),
@@ -648,16 +707,67 @@ function setConnectWarning(message: string | null): void {
   elements.connectWarning.hidden = false;
 }
 
+function setTorRelaunchStatus(message: string): void {
+  if (!elements.torRelaunchStatus) return;
+  elements.torRelaunchStatus.textContent = message;
+}
+
+function syncTorControlState(): void {
+  const enabled = Boolean(elements.torEnabledToggle?.checked);
+  const torInputs = [elements.torSocks, elements.torOnion, elements.torPeer];
+  for (const input of torInputs) {
+    if (input) {
+      input.disabled = !enabled;
+    }
+  }
+  setTorRelaunchStatus(enabled ? 'Tor relaunch is enabled.' : 'Tor relaunch is disabled.');
+}
+
+function getTorRelaunchOptions(): { enabled: boolean; socksProxy: string; onion: string; peer?: string } {
+  const enabled = Boolean(elements.torEnabledToggle?.checked);
+  if (!enabled) {
+    throw new Error('Enable Tor relaunch first.');
+  }
+
+  const socksRaw = safeString(elements.torSocks?.value, '').trim();
+  if (!parseHostPort(socksRaw)) {
+    throw new Error('Invalid SOCKS proxy. Expected host:port (example: 127.0.0.1:9050).');
+  }
+
+  const onionRaw = safeString(elements.torOnion?.value, '').trim();
+  const onion = normalizeTorOnion(onionRaw);
+  if (!onion) {
+    throw new Error('Invalid onion endpoint. Expected .onion or .onion:port.');
+  }
+
+  const peerRaw = safeString(elements.torPeer?.value, '').trim();
+  return {
+    enabled: true,
+    socksProxy: socksRaw,
+    onion,
+    ...(peerRaw ? { peer: peerRaw } : {}),
+  };
+}
+
 const navButtons = Array.from(document.querySelectorAll<HTMLElement>('.sidebar-btn[data-view]'));
 const views = Array.from(document.querySelectorAll<HTMLElement>('.view'));
 
-const TOOLBAR_VIEWS = new Set<string>();
+const TOOLBAR_VIEWS = new Set<string>([
+  'chat',
+  'overview',
+  'peers',
+  'sessions',
+  'connection',
+  'config',
+  'desktop',
+]);
 
 const {
   setActiveView,
   getActiveView,
   setAppMode,
   initNavigation,
+  getSavedAppMode,
 } = initNavigationModule({
   uiState,
   navButtons,
@@ -850,6 +960,56 @@ function bindControls() {
     await installPluginPackage(packageName);
   }, { refreshAfter: false });
 
+  bindAction('relaunchTorBtn', async () => {
+    const tor = getTorRelaunchOptions();
+    setTorRelaunchStatus('Stopping existing runtimes...');
+    await bridge.stop('connect');
+    await bridge.stop('seed');
+
+    setTorRelaunchStatus('Starting seller in Tor mode...');
+    uiState.pluginHints.provider = null;
+    saveSeedAuthPrefs();
+    await bridge.start({
+      mode: 'seed',
+      provider: normalizeProviderRuntime(elements.seedProvider?.value),
+      env: buildSeedRuntimeEnv(),
+      tor: {
+        enabled: true,
+        socksProxy: tor.socksProxy,
+        onion: tor.onion,
+      },
+    });
+
+    await refreshAll();
+
+    let peerHint = tor.peer;
+    if (!peerHint) {
+      const daemonSnapshot = safeObject(uiState.daemonState);
+      const daemonState = safeObject(daemonSnapshot?.state);
+      peerHint = safeString(daemonState?.torPeerHint, '').trim();
+    }
+    if (!peerHint) {
+      throw new Error('Tor peer hint unavailable. Set Buyer Peer manually or verify onion settings.');
+    }
+    if (elements.torPeer && elements.torPeer.value.trim().length === 0) {
+      elements.torPeer.value = peerHint;
+    }
+
+    setTorRelaunchStatus('Starting buyer in Tor mode...');
+    uiState.pluginHints.router = null;
+    await bridge.start({
+      mode: 'connect',
+      router: normalizeRouterRuntime(elements.connectRouter?.value),
+      tor: {
+        enabled: true,
+        socksProxy: tor.socksProxy,
+        peer: peerHint,
+      },
+    });
+    setConnectWarning(null);
+    setTorRelaunchStatus(`Tor relaunch active via ${peerHint}`);
+  });
+
   elements.seedProvider?.addEventListener('input', () => {
     uiState.pluginHints.provider = null;
     renderPluginSetupState();
@@ -858,6 +1018,10 @@ function bindControls() {
     uiState.pluginHints.router = null;
     renderPluginSetupState();
   });
+  elements.torEnabledToggle?.addEventListener('change', () => {
+    syncTorControlState();
+  });
+  syncTorControlState();
 }
 
 function initializeBridge() {
@@ -1010,7 +1174,7 @@ function initPeriodToggle() {
 
 initNavigation();
 setActiveView('chat');
-setAppMode('connect');
+setAppMode(getSavedAppMode() ?? 'connect');
 
 renderPluginSetupState();
 initSeedAuthControls();

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -19,9 +19,16 @@
           <p class="sidebar-version">Desktop Runtime Console</p>
           <p id="runtimeSummary" class="sidebar-status">No active services</p>
           <p id="connectWarning" class="sidebar-warning" hidden></p>
+          <div class="mode-switcher" role="tablist" aria-label="Runtime mode">
+            <button class="mode-btn active" data-appmode="connect" role="tab" aria-selected="true">Buyer</button>
+            <button class="mode-btn" data-appmode="seeder" role="tab" aria-selected="false">Seller</button>
+          </div>
         </div>
 
         <ul class="sidebar-nav" role="tablist" aria-label="Dashboard Views">
+          <li class="sidebar-nav-label">Runtime</li>
+          <li data-mode="both"><button class="sidebar-btn" data-view="runtime" role="tab">Runtime</button></li>
+          <li class="sidebar-nav-divider" aria-hidden="true"></li>
           <li class="sidebar-nav-label">Chat Interface</li>
           <li data-mode="connect"><button class="sidebar-btn active" data-view="chat" role="tab">AI Chat</button></li>
           <li class="sidebar-nav-divider" aria-hidden="true"></li>
@@ -43,43 +50,97 @@
       </aside>
 
       <main class="main-content">
-        <section class="runtime-toolbar" data-mode="seeder">
-          <div class="toolbar-header">
-            <h2>Buyer Runtime</h2>
-            <div class="toolbar-actions">
-              <button id="startAllBtn">Start Connect</button>
-              <button id="stopAllBtn" class="danger">Stop Connect</button>
-              <button id="scanNetworkBtn" class="secondary">Scan DHT</button>
-              <button id="refreshBtn" class="secondary">Refresh</button>
-              <button id="clearLogsBtn" class="danger">Clear Logs</button>
-            </div>
-          </div>
-
-          <div class="runtime-grid">
-            <article class="control-card" data-mode="connect">
-              <h3>Buyer Runtime</h3>
-              <label>Router<input id="connectRouter" value="local-proxy" /></label>
-              <div class="row">
-                <button id="connectStartBtn">Start</button>
-                <button id="connectStopBtn" class="danger">Stop</button>
-              </div>
-              <p id="connectState" class="state status-stopped">Unknown</p>
-            </article>
-          </div>
-
-          <article id="pluginSetupCard" class="plugin-setup-card">
-            <div class="plugin-setup-head">
-              <h3>Plugin Setup</h3>
-              <button id="refreshPluginsBtn" class="secondary">Recheck</button>
-            </div>
-            <p id="pluginSetupStatus" class="plugin-setup-status">Checking plugin availability...</p>
-            <div class="plugin-setup-actions">
-              <button id="installConnectPluginBtn" class="secondary">Install Buyer Plugin</button>
-            </div>
-          </article>
-        </section>
-
         <section class="view-host">
+          <section id="view-runtime" class="view" role="tabpanel">
+            <section class="runtime-controls" data-mode="both">
+              <div class="toolbar-header">
+                <h2>Runtime Controls</h2>
+                <div class="toolbar-actions">
+                  <button id="startAllBtn">Start Buyer</button>
+                  <button id="stopAllBtn" class="danger">Stop Buyer</button>
+                  <button id="scanNetworkBtn" class="secondary">Scan DHT</button>
+                  <button id="refreshBtn" class="secondary">Refresh</button>
+                  <button id="clearLogsBtn" class="danger">Clear Logs</button>
+                </div>
+              </div>
+
+              <div class="runtime-grid">
+                <article class="control-card" data-mode="seeder">
+                  <h3>Seller Runtime</h3>
+                  <label>Provider
+                    <select id="seedProvider">
+                      <option value="anthropic">anthropic</option>
+                      <option value="openrouter">openrouter</option>
+                      <option value="local-llm">local-llm</option>
+                      <option value="claude-code">claude-code</option>
+                      <option value="claude-oauth">claude-oauth</option>
+                    </select>
+                  </label>
+                  <label>Auth Type
+                    <select id="seedAuthType">
+                      <option value="apikey">apikey</option>
+                      <option value="oauth">oauth</option>
+                      <option value="claude-code">claude-code</option>
+                    </select>
+                  </label>
+                  <label id="seedAuthValueLabel">API Key
+                    <input id="seedAuthValue" type="password" autocomplete="off" placeholder="Paste API key" />
+                  </label>
+                  <div class="row">
+                    <button id="seedStartBtn">Start</button>
+                    <button id="seedStopBtn" class="danger">Stop</button>
+                  </div>
+                  <p id="seedState" class="state status-stopped">Unknown</p>
+                </article>
+
+                <article class="control-card" data-mode="connect">
+                  <h3>Buyer Runtime</h3>
+                  <label>Router<input id="connectRouter" value="local-proxy" /></label>
+                  <div class="row">
+                    <button id="connectStartBtn">Start</button>
+                    <button id="connectStopBtn" class="danger">Stop</button>
+                  </div>
+                  <p id="connectState" class="state status-stopped">Unknown</p>
+                </article>
+              </div>
+
+              <article id="pluginSetupCard" class="plugin-setup-card">
+                <div class="plugin-setup-head">
+                  <h3>Plugin Setup</h3>
+                  <button id="refreshPluginsBtn" class="secondary">Recheck</button>
+                </div>
+                <p id="pluginSetupStatus" class="plugin-setup-status">Checking plugin availability...</p>
+                <div class="plugin-setup-actions">
+                  <button id="installSeedPluginBtn" class="secondary" data-mode="seeder">Install Seller Plugin</button>
+                  <button id="installConnectPluginBtn" class="secondary">Install Buyer Plugin</button>
+                </div>
+              </article>
+
+              <article class="plugin-setup-card">
+                <div class="plugin-setup-head">
+                  <h3>Tor Hidden Service</h3>
+                </div>
+                <label>
+                  <span>Enable Tor Relaunch</span>
+                  <input id="torEnabledToggle" type="checkbox" />
+                </label>
+                <label>SOCKS Proxy (host:port)
+                  <input id="torSocks" value="127.0.0.1:9050" />
+                </label>
+                <label>Seller Onion Endpoint (.onion:port)
+                  <input id="torOnion" placeholder="abcdefghijklmnop.onion:80" />
+                </label>
+                <label>Buyer Peer (optional override)
+                  <input id="torPeer" placeholder="peerId@abcdefghijklmnop.onion:80" />
+                </label>
+                <div class="plugin-setup-actions">
+                  <button id="relaunchTorBtn">Relaunch Through Tor</button>
+                </div>
+                <p id="torRelaunchStatus" class="plugin-setup-status">Tor relaunch is disabled.</p>
+              </article>
+            </section>
+          </section>
+
           <section id="view-overview" class="view" role="tabpanel">
             <div class="page-header">
               <h2>Overview</h2>

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -268,12 +268,14 @@ select {
   grid-template-rows: auto minmax(0, 1fr);
 }
 
-.runtime-toolbar.hidden {
+.runtime-toolbar.hidden,
+.runtime-controls.hidden {
   display: none;
 }
 
 /* Desktop-only runtime toolbar */
-.runtime-toolbar {
+.runtime-toolbar,
+.runtime-controls {
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -75,6 +75,12 @@ export type StartOptions = {
   router?: string;
   dashboardPort?: number;
   env?: Record<string, string>;
+  tor?: {
+    enabled?: boolean;
+    socksProxy?: string;
+    onion?: string;
+    peer?: string;
+  };
 };
 
 export type DesktopBridge = {


### PR DESCRIPTION
## Summary
This PR adds a dedicated **Runtime** tab in the desktop app and introduces an in-app **"Relaunch Through Tor"** workflow.

### Included
- Left sidebar: new `Runtime` tab.
- Runtime controls moved into a dedicated Runtime view.
- Added Tor Hidden Service control panel in Runtime tab:
  - Enable Tor relaunch toggle
  - SOCKS proxy input
  - Seller onion endpoint input
  - Optional buyer peer override
  - `Relaunch Through Tor` action
- End-to-end desktop relaunch orchestration:
  - Stop seller + buyer
  - Start seller in Tor mode with onion endpoint
  - Resolve/auto-fill buyer peer hint
  - Start buyer in Tor mode with SOCKS + peer
- Process manager + bridge updates to carry Tor runtime options to CLI invocations.

## Tor Hidden-Service Dependencies
- **Required runtime dependency**: `tor` daemon (0.4.x+) running locally with:
  - SOCKS listener (`host:port`)
  - Hidden service mapped to seller signaling port
- Desktop forwards Tor runtime options into CLI flags/env; no additional npm Tor transport dependency added in desktop.

## Validation
- `pnpm --filter=@antseed/desktop run build`: pass

## Depends On
- Depends on core Tor runtime support introduced in:
  - **#3** (`feat(core): add tor hidden-service guardrails, CLI flags, and e2e coverage`)
- This PR is intentionally scoped to desktop UX/process wiring.
