### PR TITLE
Harden node frame decoding and stream buffer limits

### DIFF
--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -111,6 +111,10 @@ export interface NodeConfig {
   signalingPort?: number;     // Default: 6882 for seller
   bootstrapNodes?: Array<{ host: string; port: number }>;
   requestTimeoutMs?: number;  // Default: 30000
+  /** Maximum buffered body size (bytes) while reconstructing streaming responses. Default: 16 MiB. */
+  maxStreamBufferBytes?: number;
+  /** Maximum wall time allowed for a streaming response. Default: 5 minutes. */
+  maxStreamDurationMs?: number;
   /** Allow private/loopback IPs in DHT lookups. Default: false. Set true for local testing. */
   allowPrivateIPs?: boolean;
   /** Optional seller-side payment runtime wiring. */
@@ -456,12 +460,16 @@ export class AntseedNode extends EventEmitter {
     const startTime = Date.now();
     return new Promise<SerializedHttpResponse>((resolve, reject) => {
       const timeoutMs = this._config.requestTimeoutMs ?? 30_000;
+      const maxStreamBufferBytes = Math.max(1, this._config.maxStreamBufferBytes ?? 16 * 1024 * 1024);
+      const maxStreamDurationMs = Math.max(1, this._config.maxStreamDurationMs ?? 5 * 60_000);
       // Idle timeout for streaming: resets on each chunk so long-running
       // streams (thinking models, large outputs) stay alive as long as
       // data keeps flowing.
       const streamIdleTimeoutMs = Math.max(timeoutMs, 60_000);
       let settled = false;
       let streamStarted = false;
+      let streamStartedAtMs = 0;
+      let streamBufferedBytes = 0;
       let streamStartResponse: SerializedHttpResponse | null = null;
       const streamChunks: Uint8Array[] = [];
       let activeTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -499,8 +507,11 @@ export class AntseedNode extends EventEmitter {
       mux.sendProxyRequest(
         req,
         (response: SerializedHttpResponse, metadata) => {
+          if (settled) return;
           if (metadata.streamingStart) {
             streamStarted = true;
+            streamStartedAtMs = Date.now();
+            streamBufferedBytes = 0;
             streamStartResponse = this._stripStreamingHeader(response);
             // Switch to streaming idle timeout: resets on each chunk.
             resetTimeout(streamIdleTimeoutMs);
@@ -512,10 +523,27 @@ export class AntseedNode extends EventEmitter {
           finish(response);
         },
         (chunk) => {
+          if (settled) return;
           if (!streamStarted) return;
 
           // Reset idle timeout on each chunk so streaming stays alive.
           resetTimeout(streamIdleTimeoutMs);
+
+          if (Date.now() - streamStartedAtMs > maxStreamDurationMs) {
+            mux.cancelProxyRequest(req.requestId);
+            fail(new Error(`Stream ${req.requestId} exceeded max duration (${maxStreamDurationMs}ms)`));
+            return;
+          }
+
+          if (chunk.data.length > 0) {
+            const nextBufferedBytes = streamBufferedBytes + chunk.data.length;
+            if (nextBufferedBytes > maxStreamBufferBytes) {
+              mux.cancelProxyRequest(req.requestId);
+              fail(new Error(`Stream ${req.requestId} exceeded max buffered size (${maxStreamBufferBytes} bytes)`));
+              return;
+            }
+            streamBufferedBytes = nextBufferedBytes;
+          }
 
           callbacks?.onResponseChunk?.(chunk);
 
@@ -594,7 +622,15 @@ export class AntseedNode extends EventEmitter {
   private _wireConnection(conn: PeerConnection, peerId: PeerId): void {
     const decoder = new FrameDecoder();
     conn.on("message", (data: Uint8Array) => {
-      const frames = decoder.feed(data);
+      let frames: ReturnType<typeof decoder.feed>;
+      try {
+        frames = decoder.feed(data);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        debugWarn(`[Node] Failed to decode frame from ${peerId.slice(0, 12)}...: ${message}`);
+        conn.fail(err instanceof Error ? err : new Error(message));
+        return;
+      }
       const proxyMux = this._muxes.get(peerId);
       const paymentMux = this._paymentMuxes.get(peerId);
       for (const frame of frames) {

--- a/packages/node/src/p2p/message-protocol.ts
+++ b/packages/node/src/p2p/message-protocol.ts
@@ -55,7 +55,7 @@ export function decodeFrame(
   const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
   const rawType = view.getUint8(0);
   if (!isValidMessageType(rawType)) {
-    return null;
+    throw new Error(`Invalid message type: 0x${rawType.toString(16).padStart(2, "0")}`);
   }
   const type = rawType as MessageType;
   const messageId = view.getUint32(1);
@@ -101,9 +101,9 @@ export class FrameDecoder {
       let result: ReturnType<typeof decodeFrame>;
       try {
         result = decodeFrame(this._buffer);
-      } catch {
+      } catch (err) {
         this._buffer = new Uint8Array(0);
-        break;
+        throw err;
       }
       if (!result) break;
 

--- a/packages/node/tests/message-protocol.test.ts
+++ b/packages/node/tests/message-protocol.test.ts
@@ -82,6 +82,15 @@ describe('encodeFrame / decodeFrame', () => {
     expect(() => decodeFrame(buf)).toThrow('exceeds maximum');
   });
 
+  it('should throw for invalid message type', () => {
+    const buf = new Uint8Array(FRAME_HEADER_SIZE);
+    const view = new DataView(buf.buffer);
+    view.setUint8(0, 0x99);
+    view.setUint32(1, 1);
+    view.setUint32(5, 0);
+    expect(() => decodeFrame(buf)).toThrow('Invalid message type');
+  });
+
   it('should handle all message types', () => {
     for (const type of Object.values(MessageType).filter((v) => typeof v === 'number') as MessageType[]) {
       const msg: FramedMessage = { type, messageId: 1, payload: new Uint8Array(0) };
@@ -150,6 +159,18 @@ describe('FrameDecoder', () => {
     decoder.feed(new Uint8Array(5)); // partial data
     expect(decoder.bufferedBytes).toBe(5);
     decoder.reset();
+    expect(decoder.bufferedBytes).toBe(0);
+  });
+
+  it('should clear buffered data and throw on invalid frame type', () => {
+    const decoder = new FrameDecoder();
+    const buf = new Uint8Array(FRAME_HEADER_SIZE);
+    const view = new DataView(buf.buffer);
+    view.setUint8(0, 0x99);
+    view.setUint32(1, 1);
+    view.setUint32(5, 0);
+
+    expect(() => decoder.feed(buf)).toThrow('Invalid message type');
     expect(decoder.bufferedBytes).toBe(0);
   });
 });

--- a/packages/node/tests/node-stream-security.test.ts
+++ b/packages/node/tests/node-stream-security.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AntseedNode, type NodeConfig } from '../src/node.js';
+import {
+  ANTSEED_STREAMING_RESPONSE_HEADER,
+  type SerializedHttpRequest,
+  type SerializedHttpResponse,
+  type SerializedHttpResponseChunk,
+} from '../src/types/http.js';
+import type { PeerInfo } from '../src/types/peer.js';
+
+interface StreamingHarness {
+  readonly mux: { cancelProxyRequest: ReturnType<typeof vi.fn> };
+  waitUntilRegistered: () => Promise<void>;
+  emitStreamingStart: () => void;
+  emitChunk: (chunk: SerializedHttpResponseChunk) => void;
+}
+
+function createNode(config: Partial<NodeConfig>): AntseedNode {
+  const node = new AntseedNode({
+    role: 'buyer',
+    ...config,
+  });
+
+  (node as any)._identity = {
+    peerId: 'a'.repeat(64),
+    privateKey: new Uint8Array(32),
+    publicKey: new Uint8Array(32),
+  };
+  (node as any)._connectionManager = {};
+  return node;
+}
+
+function setupStreamingHarness(node: AntseedNode, requestId: string): StreamingHarness {
+  let onResponse: ((response: SerializedHttpResponse, metadata: { streamingStart: boolean }) => void) | null = null;
+  let onChunk: ((chunk: SerializedHttpResponseChunk) => void) | null = null;
+  let resolveRegistered: (() => void) | null = null;
+  const registered = new Promise<void>((resolve) => {
+    resolveRegistered = resolve;
+  });
+
+  const mux = {
+    sendProxyRequest: vi.fn(
+      (
+        _request: SerializedHttpRequest,
+        responseHandler: (response: SerializedHttpResponse, metadata: { streamingStart: boolean }) => void,
+        chunkHandler: (chunk: SerializedHttpResponseChunk) => void,
+      ) => {
+        onResponse = responseHandler;
+        onChunk = chunkHandler;
+        resolveRegistered?.();
+      },
+    ),
+    cancelProxyRequest: vi.fn(),
+  };
+
+  (node as any)._getOrCreateConnection = vi.fn(async () => ({ state: 'open' }));
+  (node as any)._getOrCreateMux = vi.fn(() => mux);
+
+  return {
+    mux,
+    waitUntilRegistered: () => registered,
+    emitStreamingStart: () => {
+      if (!onResponse) throw new Error('stream response handler is not registered');
+      onResponse(
+        {
+          requestId,
+          statusCode: 200,
+          headers: {
+            [ANTSEED_STREAMING_RESPONSE_HEADER]: '1',
+            'content-type': 'text/event-stream',
+          },
+          body: new Uint8Array(0),
+        },
+        { streamingStart: true },
+      );
+    },
+    emitChunk: (chunk) => {
+      if (!onChunk) throw new Error('stream chunk handler is not registered');
+      onChunk(chunk);
+    },
+  };
+}
+
+describe('AntseedNode streaming security guards', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('rejects streaming responses that exceed max buffered size', async () => {
+    const requestId = 'stream-size-limit';
+    const node = createNode({
+      maxStreamBufferBytes: 4,
+      maxStreamDurationMs: 60_000,
+    });
+    const harness = setupStreamingHarness(node, requestId);
+    const peer = { peerId: 'b'.repeat(64) } as PeerInfo;
+    const request: SerializedHttpRequest = {
+      requestId,
+      method: 'POST',
+      path: '/v1/messages',
+      headers: { accept: 'text/event-stream' },
+      body: new Uint8Array(0),
+    };
+
+    const promise = (node as any)._sendRequestInternal(peer, request, {});
+    await harness.waitUntilRegistered();
+    harness.emitStreamingStart();
+    harness.emitChunk({
+      requestId,
+      data: new Uint8Array([1, 2, 3, 4, 5]),
+      done: false,
+    });
+
+    await expect(promise).rejects.toThrow('exceeded max buffered size');
+    expect(harness.mux.cancelProxyRequest).toHaveBeenCalledWith(requestId);
+  });
+
+  it('rejects streaming responses that exceed max stream duration', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const requestId = 'stream-duration-limit';
+    const node = createNode({
+      maxStreamBufferBytes: 1024,
+      maxStreamDurationMs: 100,
+    });
+    const harness = setupStreamingHarness(node, requestId);
+    const peer = { peerId: 'b'.repeat(64) } as PeerInfo;
+    const request: SerializedHttpRequest = {
+      requestId,
+      method: 'POST',
+      path: '/v1/messages',
+      headers: { accept: 'text/event-stream' },
+      body: new Uint8Array(0),
+    };
+
+    const promise = (node as any)._sendRequestInternal(peer, request, {});
+    await harness.waitUntilRegistered();
+    harness.emitStreamingStart();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.200Z'));
+    harness.emitChunk({
+      requestId,
+      data: new Uint8Array([1]),
+      done: false,
+    });
+
+    await expect(promise).rejects.toThrow('exceeded max duration');
+    expect(harness.mux.cancelProxyRequest).toHaveBeenCalledWith(requestId);
+  });
+
+  it('still reconstructs streamed responses under configured limits', async () => {
+    const requestId = 'stream-success';
+    const node = createNode({
+      maxStreamBufferBytes: 1024,
+      maxStreamDurationMs: 60_000,
+    });
+    const harness = setupStreamingHarness(node, requestId);
+    const peer = { peerId: 'b'.repeat(64) } as PeerInfo;
+    const request: SerializedHttpRequest = {
+      requestId,
+      method: 'POST',
+      path: '/v1/messages',
+      headers: { accept: 'text/event-stream' },
+      body: new Uint8Array(0),
+    };
+
+    const promise = (node as any)._sendRequestInternal(peer, request, {});
+    await harness.waitUntilRegistered();
+    harness.emitStreamingStart();
+    harness.emitChunk({
+      requestId,
+      data: new Uint8Array([1, 2]),
+      done: false,
+    });
+    harness.emitChunk({
+      requestId,
+      data: new Uint8Array([3]),
+      done: true,
+    });
+
+    const response = await promise;
+    expect([...response.body]).toEqual([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
## Summary
- fail fast on invalid frame message types in FrameDecoder and terminate the offending connection in AntseedNode
- add streaming safeguards in sendRequestInternal with configurable maxStreamBufferBytes and maxStreamDurationMs
- add tests for invalid frame handling and new stream guard behavior

## Scope
- non-payment changes only

## Verification
- pnpm --filter @antseed/node typecheck
- pnpm --filter @antseed/node test