### PR TITLE
docs: document displayName and modelCategories metadata

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -72,10 +72,13 @@ Initialize a new config:
 antseed config init
 ```
 
-Pricing is configured in USD per 1M tokens with role-specific defaults and optional provider/model overrides:
+Pricing is configured in USD per 1M tokens with role-specific defaults and optional provider/model overrides. You can also set node `displayName` and optional per-model category tags announced in discovery metadata:
 
 ```json
 {
+  "identity": {
+    "displayName": "Acme Inference - us-east-1"
+  },
   "seller": {
     "pricing": {
       "defaults": {
@@ -92,6 +95,11 @@ Pricing is configured in USD per 1M tokens with role-specific defaults and optio
           }
         }
       }
+    },
+    "modelCategories": {
+      "anthropic": {
+        "claude-sonnet-4-5-20250929": ["coding", "privacy"]
+      }
     }
   },
   "buyer": {
@@ -106,15 +114,23 @@ Pricing is configured in USD per 1M tokens with role-specific defaults and optio
 }
 ```
 
+Model categories are normalized to lowercase tags. Recommended tags include: `privacy`, `legal`, `uncensored`, `coding`, `finance`, `tee` (custom tags are also allowed).
+
 Role-first config examples:
 
 ```bash
+# Identity / metadata display name
+antseed config set identity.displayName "Acme Inference - us-east-1"
+
 # Seller defaults
 antseed config seller set pricing.defaults.inputUsdPerMillion 12
 antseed config seller set pricing.defaults.outputUsdPerMillion 36
 
 # Seller per-model override for a provider
 antseed config seller set pricing.providers.anthropic.models '{"claude-sonnet-4-5-20250929":{"inputUsdPerMillion":14,"outputUsdPerMillion":42}}'
+
+# Seller per-model category tags announced in metadata
+antseed config seller set modelCategories.anthropic.claude-sonnet-4-5-20250929 '["coding","legal"]'
 
 # Buyer preferences and max pricing
 antseed config buyer set preferredProviders '["anthropic","openai"]'

--- a/apps/website/docs/getting-started/configuration.md
+++ b/apps/website/docs/getting-started/configuration.md
@@ -19,7 +19,8 @@ Ready to connect
 
 ## Identity
 
-Your node identity is an Ed25519 keypair. The private key seed is stored as 64 hex characters in `~/.antseed/identity.key` with `0600` permissions. Your PeerId is the hex-encoded 32-byte public key (64 lowercase hex characters).
+Your node identity is an Ed25519 keypair. The private key seed is stored as 64 hex characters in `~/.antseed/identity.key` with `0600` permissions. Your PeerId is the hex-encoded 32-byte public key (64 lowercase hex characters).  
+Set `identity.displayName` in config to control the human-readable name announced in peer metadata.
 
 ## Selling AI Services
 
@@ -57,11 +58,39 @@ Configuration is stored at `~/.antseed/config.json`. Key sections:
 |---|---|
 | `identity` | Display name and wallet address |
 | `providers` | Configured provider API keys and endpoints |
-| `seller` | Reserve floor, max concurrent buyers, pricing, enabled providers |
+| `seller` | Reserve floor, max concurrent buyers, pricing, enabled providers, model category tags |
 | `buyer` | Preferred providers, max pricing, min peer reputation, proxy port |
 | `payments` | Payment method, platform fee rate, chain config (Base) |
 | `network` | Bootstrap nodes |
 | `plugins` | Installed plugin packages |
+
+## Metadata Fields
+
+Use config to control metadata advertised to buyers:
+
+```json title="config example"
+{
+  "identity": {
+    "displayName": "Acme Inference - us-east-1"
+  },
+  "seller": {
+    "modelCategories": {
+      "anthropic": {
+        "claude-sonnet-4-5-20250929": ["coding", "privacy"]
+      }
+    }
+  }
+}
+```
+
+- `identity.displayName`: optional node label shown in browse/discovery results.
+- `seller.modelCategories`: optional provider/model -> tag array map announced in peer metadata.
+- Recommended category tags: `privacy`, `legal`, `uncensored`, `coding`, `finance`, `tee` (custom tags are allowed).
+
+```bash title="set metadata fields"
+antseed config set identity.displayName "Acme Inference - us-east-1"
+antseed config seller set modelCategories.anthropic.claude-sonnet-4-5-20250929 '["coding","privacy"]'
+```
 
 ## Authentication
 

--- a/apps/website/docs/plugins/provider-plugin.md
+++ b/apps/website/docs/plugins/provider-plugin.md
@@ -7,7 +7,7 @@ hide_title: true
 
 # Provider Plugin
 
-Provider plugins expose AI services to the network. They advertise models, capabilities, Skills, and pricing via the DHT, and handle incoming requests from buyers.
+Provider plugins expose AI services to the network. They advertise models, pricing, optional model categories, capabilities, and Skills via discovery metadata, and handle incoming requests from buyers.
 
 :::warning Provider Compliance
 AntSeed is designed for providers who build differentiated services — such as TEE-secured inference, domain-specific skills or agents, fine-tuned models, or managed product experiences. Simply reselling raw API access or subscription credentials is not the intended use and may violate your upstream provider's terms of service. Providers are solely responsible for complying with their upstream API provider's terms.
@@ -29,6 +29,7 @@ interface Provider {
       outputUsdPerMillion: number
     }>
   }
+  modelCategories?: Record<string, string[]>
   maxConcurrency: number
   capabilities?: ProviderCapability[]
 
@@ -62,6 +63,9 @@ export default {
       outputUsdPerMillion: 15
     }
   },
+  modelCategories: {
+    "claude-sonnet-4-6": ["coding", "privacy"]
+  },
   maxConcurrency: 5,
 
   getCapacity: () => ({ current: 0, max: 10 }),
@@ -83,6 +87,8 @@ export default {
   }
 } satisfies Provider
 ```
+
+`modelCategories` is optional and is announced in peer metadata for discovery filtering. Recommended tags include `privacy`, `legal`, `uncensored`, `coding`, `finance`, and `tee` (custom tags are allowed).
 
 ## Peer Offering
 

--- a/apps/website/docs/protocol/discovery.md
+++ b/apps/website/docs/protocol/discovery.md
@@ -32,19 +32,19 @@ Sellers announce themselves under a topic derived from their provider name. The 
 
 ## Metadata Endpoint
 
-Each seller runs an HTTP server exposing `GET /metadata` which returns JSON-serialized `PeerMetadata` including capabilities and Skills. The metadata URL is constructed as `http://{host}:{port + 1}/metadata`.
+Each seller runs an HTTP server exposing `GET /metadata` which returns JSON-serialized `PeerMetadata` with pricing, capacity, and optional metadata tags.  
+By default, metadata is fetched from `http://{host}:{port}/metadata` (`metadataPortOffset = 0`).
 
 ## PeerMetadata
 
 ```json title="metadata structure"
 {
   "peerId": "a1b2c3d4...64 hex chars",
-  "version": 2,
+  "version": 3,
+  "displayName": "Acme Inference - us-east-1",
   "providers": [{
     "provider": "anthropic",
     "models": ["claude-sonnet-4-6", "claude-haiku-4-5"],
-    "capabilities": ["inference", "skill", "agent"],
-    "skills": ["legal-research", "security-audit"],
     "defaultPricing": {
       "inputUsdPerMillion": 3,
       "outputUsdPerMillion": 15
@@ -52,6 +52,9 @@ Each seller runs an HTTP server exposing `GET /metadata` which returns JSON-seri
     "modelPricing": {
       "claude-sonnet-4-6": { "inputUsdPerMillion": 3, "outputUsdPerMillion": 15 },
       "claude-haiku-4-5": { "inputUsdPerMillion": 1, "outputUsdPerMillion": 5 }
+    },
+    "modelCategories": {
+      "claude-sonnet-4-6": ["coding", "privacy"]
     },
     "maxConcurrency": 5,
     "currentLoad": 2
@@ -61,6 +64,8 @@ Each seller runs an HTTP server exposing `GET /metadata` which returns JSON-seri
   "signature": "ed25519...128 hex chars"
 }
 ```
+
+Recommended category tags: `privacy`, `legal`, `uncensored`, `coding`, `finance`, `tee` (custom tags are allowed).
 
 ## Peer Scoring
 

--- a/docs/protocol/spec/01-discovery.md
+++ b/docs/protocol/spec/01-discovery.md
@@ -60,7 +60,7 @@ Custom bootstrap nodes can be supplied and are merged (deduplicated by `host:por
 **Source:** `node/src/discovery/peer-metadata.ts`
 
 ```
-METADATA_VERSION = 2
+METADATA_VERSION = 3
 ```
 
 ### Data Structures
@@ -70,7 +70,8 @@ METADATA_VERSION = 2
 | Field       | Type                    | Description                             |
 |-------------|-------------------------|-----------------------------------------|
 | peerId      | PeerId (string)         | 64 hex chars (32-byte Ed25519 public key) |
-| version     | number                  | Must equal `METADATA_VERSION` (2)       |
+| version     | number                  | Must equal `METADATA_VERSION` (3)       |
+| displayName | string                  | Optional human-readable node label      |
 | providers   | ProviderAnnouncement[]  | List of provider offerings              |
 | region      | string                  | Geographic region identifier            |
 | timestamp   | number                  | Unix epoch milliseconds                 |
@@ -84,6 +85,7 @@ METADATA_VERSION = 2
 | models           | string[] | List of model identifiers                                    |
 | defaultPricing   | object   | Default `{ inputUsdPerMillion, outputUsdPerMillion }`       |
 | modelPricing     | object   | Optional per-model map `{ [model]: { inputUsdPerMillion, outputUsdPerMillion } }` |
+| modelCategories  | object   | Optional per-model map `{ [model]: string[] }` with lowercase tags |
 | maxConcurrency   | number   | Maximum concurrent requests (>= 1)                           |
 | currentLoad      | number   | Current number of active requests                            |
 
@@ -117,8 +119,25 @@ Per provider (repeated providerCount times):
     [model      : N bytes  UTF-8  ]
     [inputUsdPerMillion  : 4 bytes  float32 big-endian ]
     [outputUsdPerMillion : 4 bytes  float32 big-endian ]
+  [modelCategoryCount         : 1 byte   uint8 ]      // v3+
+  Per model category entry (repeated modelCategoryCount times):
+    [modelLen   : 1 byte   uint8 ]
+    [model      : N bytes  UTF-8  ]
+    [categoryCount : 1 byte uint8 ]
+    Per category (repeated categoryCount times):
+      [categoryLen : 1 byte uint8 ]
+      [category    : N bytes UTF-8 ]
   [maxConcurrency: 2 bytes  uint16  big-endian ]
   [currentLoad   : 2 bytes  uint16  big-endian ]
+
+Post-provider sections:
+  [displayNameFlag:1]                             // v3+
+  if displayNameFlag == 1:
+    [displayNameLen:1][displayName:N]
+  [offeringCount:2]                               // uint16
+  [offeringEntries...]
+  [evmAddressFlag:1] + [evmAddress:20 if present]
+  [onChainReputationFlag:1] + [reputationData:10 if present]
 
 Trailer:
   [signature     : 64 bytes        ]   // Ed25519 signature
@@ -137,16 +156,24 @@ The body (everything except the trailing 64-byte signature) is the data that is 
 | MAX_MODELS_PER_PROVIDER   | 20    | Maximum models per provider entry           |
 | MAX_MODEL_NAME_LENGTH     | 64    | Maximum model name length in characters     |
 | MAX_REGION_LENGTH         | 32    | Maximum region string length in characters  |
+| MAX_DISPLAY_NAME_LENGTH   | 64    | Maximum display name length in characters   |
+| MAX_MODEL_CATEGORIES_PER_MODEL | 8 | Maximum categories per model               |
+| MAX_MODEL_CATEGORY_LENGTH | 32    | Maximum category length in characters       |
 
 Additional validation rules enforced by `validateMetadata()`:
 
-- `version` must equal `METADATA_VERSION` (2).
+- `version` must equal `METADATA_VERSION` (3).
 - `peerId` must be exactly 64 lowercase hex characters.
 - `region` must not be empty.
+- `displayName` is optional, but when present it must be non-empty and <= 64 chars.
 - `timestamp` must be a positive finite number.
 - At least one provider must be present.
 - `defaultPricing.inputUsdPerMillion` and `defaultPricing.outputUsdPerMillion` must be non-negative.
 - Each `modelPricing[model].inputUsdPerMillion` and `modelPricing[model].outputUsdPerMillion` (if present) must be non-negative.
+- `modelCategories` (if present) must reference models listed in `providers[].models`.
+- Each category must be lowercase alphanumeric or hyphen: `^[a-z0-9][a-z0-9-]*$`.
+- Categories must be non-empty, unique per model, and within per-model/per-tag limits above.
+- Recommended category tags: `privacy`, `legal`, `uncensored`, `coding`, `finance`, `tee` (not enforced; custom tags allowed).
 - `maxConcurrency` must be at least 1.
 - `currentLoad` must be non-negative and must not exceed `maxConcurrency`.
 - `signature` must be exactly 128 lowercase hex characters (64 bytes).
@@ -222,7 +249,7 @@ The `PeerLookup` class orchestrates the full discovery flow:
 The `PeerAnnouncer` class handles the seller-side announcement lifecycle:
 
 1. Build a `PeerMetadata` object from the configured providers, current pricing, current load, and region.
-2. Set `version` to `METADATA_VERSION` (2) and `timestamp` to `Date.now()`.
+2. Set `version` to `METADATA_VERSION` (3) and `timestamp` to `Date.now()`.
 3. Encode the body (without signature) via `encodeMetadataForSigning()`.
 4. Sign the body with the seller's Ed25519 private key.
 5. For each provider in the metadata, compute `infoHash = SHA1("antseed:" + lowercase(provider))` and announce on the DHT at the configured signaling port.

--- a/docs/protocol/spec/README.md
+++ b/docs/protocol/spec/README.md
@@ -1,6 +1,6 @@
 # Antseed Network Protocol Specification
 
-**Version:** 1.0 (matches `METADATA_VERSION = 1` in current code)
+**Version:** 1.0 (current discovery metadata format uses `METADATA_VERSION = 3`)
 
 ## Overview
 

--- a/docs/protocol/templates/provider-plugin/README.md
+++ b/docs/protocol/templates/provider-plugin/README.md
@@ -50,6 +50,7 @@ export class MyProvider implements Provider {
       outputUsdPerMillion: 2,
     },
   };
+  readonly modelCategories = { 'my-model-v1': ['coding'] };
   readonly maxConcurrency = 10;
 
   private _current = 0;
@@ -111,6 +112,7 @@ npm run verify
 | `pricing.defaults.inputUsdPerMillion` | `number` | Default input pricing in USD per 1M tokens |
 | `pricing.defaults.outputUsdPerMillion` | `number` | Default output pricing in USD per 1M tokens |
 | `pricing.models?` | `Record<string, { inputUsdPerMillion; outputUsdPerMillion }>` | Optional per-model pricing overrides |
+| `modelCategories?` | `Record<string, string[]>` | Optional per-model discovery tags (e.g. `coding`, `privacy`) |
 | `maxConcurrency` | `number` | Max concurrent requests |
 | `handleRequest(req)` | `Promise<SerializedHttpResponse>` | Handle an inference request |
 | `getCapacity()` | `{ current: number; max: number }` | Current / max concurrency |

--- a/e2e/tests/cli-runtime-overrides.test.ts
+++ b/e2e/tests/cli-runtime-overrides.test.ts
@@ -10,7 +10,7 @@ import { promisify } from 'node:util';
 const execFile = promisify(execFileCallback);
 const currentDir = fileURLToPath(new URL('.', import.meta.url));
 const repoRoot = resolve(currentDir, '..', '..');
-const cliDir = resolve(repoRoot, 'cli');
+const cliDir = resolve(repoRoot, 'apps', 'cli');
 const cliEntry = resolve(cliDir, 'dist', 'cli', 'index.js');
 
 const baselineConfig = {
@@ -51,7 +51,11 @@ async function ensureCliBuilt(): Promise<void> {
   try {
     await access(cliEntry, fsConstants.R_OK);
   } catch {
-    await execFile('npm', ['run', 'build'], { cwd: cliDir });
+    try {
+      await execFile('pnpm', ['run', 'build'], { cwd: cliDir });
+    } catch {
+      await execFile('npm', ['run', 'build'], { cwd: cliDir });
+    }
   }
 }
 

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -34,6 +34,9 @@ const myProvider: Provider = {
       outputUsdPerMillion: 10,
     },
   },
+  modelCategories: {
+    'my-model-v1': ['coding', 'privacy'],
+  },
   maxConcurrency: 10,
   async handleRequest(req: SerializedHttpRequest): Promise<SerializedHttpResponse> {
     // Forward the request to your LLM backend and return the response
@@ -96,6 +99,7 @@ if (peers.length > 0) {
 ```ts
 interface NodeConfig {
   role: 'seller' | 'buyer';
+  displayName?: string;       // Optional human-readable name announced in metadata
   dataDir?: string;           // Default: ~/.antseed
   dhtPort?: number;           // Default: 6881 for seller, 0 (OS-assigned) for buyer
   signalingPort?: number;     // Default: 6882 for seller
@@ -115,6 +119,7 @@ interface NodeConfig {
 | Option | Default | Description |
 |---|---|---|
 | `role` | (required) | `'seller'` to serve requests, `'buyer'` to consume them |
+| `displayName` | unset | Optional node label included in discovery metadata |
 | `dataDir` | `~/.antseed` | Directory for identity keys, metering DB, and config |
 | `dhtPort` | `6881` / `0` | UDP port for DHT. Seller defaults to 6881, buyer uses OS-assigned |
 | `signalingPort` | `6882` | TCP port for P2P signaling and incoming connections (seller only) |
@@ -224,6 +229,9 @@ interface Provider {
     defaults: { inputUsdPerMillion: number; outputUsdPerMillion: number };
     models?: Record<string, { inputUsdPerMillion: number; outputUsdPerMillion: number }>;
   };
+
+  /** Optional per-model discovery tags (e.g., coding/privacy/legal) */
+  modelCategories?: Record<string, string[]>;
 
   /** Maximum concurrent requests this provider can handle */
   maxConcurrency: number;

--- a/packages/provider-core/README.md
+++ b/packages/provider-core/README.md
@@ -23,6 +23,7 @@ const provider = new BaseProvider({
   name: 'my-provider',
   models: ['model-a', 'model-b'],
   pricing: { defaults: { inputUsdPerMillion: 10, outputUsdPerMillion: 10 } },
+  modelCategories: { 'model-a': ['coding'] },
   relay: {
     baseUrl: 'https://api.example.com',
     authHeaderName: 'Authorization',

--- a/plugins/provider-claude-oauth/src/index.test.ts
+++ b/plugins/provider-claude-oauth/src/index.test.ts
@@ -7,7 +7,7 @@ describe('provider-claude-oauth plugin manifest', () => {
     expect(plugin.displayName).toBe('Claude (OAuth)');
     expect(plugin.version).toBe('0.1.0');
     expect(plugin.type).toBe('provider');
-    expect(plugin.description).toBe('Anthropic Claude with OAuth authentication (third-party example)');
+    expect(plugin.description).toBe('Claude OAuth provider (testing and development only)');
   });
 
   it('exposes configSchema with required fields', () => {


### PR DESCRIPTION
Summary
- document identity.displayName and seller.modelCategories in CLI and website configuration docs
- update discovery protocol docs to metadata version 3 and include displayName plus modelCategories
- update provider interface/template docs to include optional modelCategories
- fix two stale tests encountered while running full workspace tests (provider-claude-oauth description expectation and e2e CLI build path plus runner fallback)

Validation
- pnpm run test