### PR TITLE
fix: enforce explicit provider routing and harden metadata model keys

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -21,7 +21,7 @@
     "start:connect": "node dist/cli/index.js connect",
     "start:dashboard": "node dist/cli/index.js dashboard",
     "typecheck": "tsc --noEmit",
-    "test": "npm run build && node --test dist/config/*.test.js dist/cli/commands/*.test.js"
+    "test": "npm run build && node --test dist/config/*.test.js dist/cli/commands/*.test.js dist/proxy/*.test.js"
   },
   "dependencies": {
     "@antseed/node": "workspace:*",

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { PeerInfo } from '@antseed/node'
+import { selectCandidatePeersForRouting } from './buyer-proxy.js'
+
+function makePeer(seed: string, providers: string[]): PeerInfo {
+  const repeated = (seed.repeat(64) + 'a'.repeat(64)).slice(0, 64)
+  return {
+    peerId: repeated as PeerInfo['peerId'],
+    lastSeen: Date.now(),
+    providers,
+  }
+}
+
+test('selectCandidatePeersForRouting enforces explicit provider overrides even without request protocol', () => {
+  const peers = [
+    makePeer('a', ['anthropic']),
+    makePeer('b', ['openai']),
+  ]
+
+  const result = selectCandidatePeersForRouting(peers, null, null, 'openai')
+  assert.equal(result.candidatePeers.length, 1)
+  assert.equal(result.candidatePeers[0]?.peerId, peers[1]?.peerId)
+  assert.equal(result.routePlanByPeerId.get(peers[1]!.peerId)?.provider, 'openai')
+  assert.equal(result.routePlanByPeerId.get(peers[1]!.peerId)?.selection, null)
+})
+
+test('selectCandidatePeersForRouting returns no candidates when explicit provider is unavailable', () => {
+  const peers = [
+    makePeer('a', ['anthropic']),
+    makePeer('b', ['local-llm']),
+  ]
+
+  const result = selectCandidatePeersForRouting(peers, null, null, 'openai')
+  assert.equal(result.candidatePeers.length, 0)
+  assert.equal(result.routePlanByPeerId.size, 0)
+})
+
+test('selectCandidatePeersForRouting keeps all peers when no protocol or provider override is set', () => {
+  const peers = [
+    makePeer('a', ['anthropic']),
+    makePeer('b', ['openai']),
+  ]
+
+  const result = selectCandidatePeersForRouting(peers, null, null, null)
+  assert.deepEqual(result.candidatePeers.map((peer) => peer.peerId), peers.map((peer) => peer.peerId))
+  assert.equal(result.routePlanByPeerId.size, 0)
+})

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -62,6 +62,11 @@ type PeerProtocolRoutePlan = {
   selection: TargetProtocolSelection | null
 }
 
+export type CandidatePeerRouteSelection = {
+  candidatePeers: PeerInfo[]
+  routePlanByPeerId: Map<string, PeerProtocolRoutePlan>
+}
+
 function getExplicitProviderOverride(request: SerializedHttpRequest): string | null {
   const provider = request.headers['x-antseed-provider']?.trim().toLowerCase()
   return provider && provider.length > 0 ? provider : null
@@ -132,6 +137,33 @@ function resolvePeerRoutePlan(
   }
 
   return transformedFallback
+}
+
+export function selectCandidatePeersForRouting(
+  peers: PeerInfo[],
+  requestProtocol: ModelApiProtocol | null,
+  requestedModel: string | null,
+  explicitProvider: string | null,
+): CandidatePeerRouteSelection {
+  const routePlanByPeerId = new Map<string, PeerProtocolRoutePlan>()
+  if (!requestProtocol && !explicitProvider) {
+    return {
+      candidatePeers: peers,
+      routePlanByPeerId,
+    }
+  }
+
+  const candidatePeers = peers.filter((peer) => {
+    const plan = resolvePeerRoutePlan(peer, requestProtocol, requestedModel, explicitProvider)
+    if (!plan) return false
+    routePlanByPeerId.set(peer.peerId, plan)
+    return true
+  })
+
+  return {
+    candidatePeers,
+    routePlanByPeerId,
+  }
 }
 
 function parseTokenCount(value: unknown): number {
@@ -695,25 +727,22 @@ export class BuyerProxy {
     const requestProtocol = detectRequestModelApiProtocol(serializedReq)
     const requestedModel = extractRequestedModel(serializedReq)
     const explicitProvider = getExplicitProviderOverride(serializedReq)
-    const routePlanByPeerId = new Map<string, PeerProtocolRoutePlan>()
+    const {
+      candidatePeers,
+      routePlanByPeerId,
+    } = selectCandidatePeersForRouting(peers, requestProtocol, requestedModel, explicitProvider)
 
-    let candidatePeers = peers
-    if (requestProtocol) {
-      candidatePeers = peers.filter((peer) => {
-        const plan = resolvePeerRoutePlan(peer, requestProtocol, requestedModel, explicitProvider)
-        if (!plan) return false
-        routePlanByPeerId.set(peer.peerId, plan)
-        return true
-      })
-
-      if (candidatePeers.length === 0) {
+    if (candidatePeers.length === 0) {
+      const diagnostics = this._formatPeerSelectionDiagnostics(peers)
+      res.writeHead(502, { 'content-type': 'text/plain' })
+      if (requestProtocol) {
         const protocolLabel = requestProtocol
         const providerLabel = explicitProvider ? ` for provider "${explicitProvider}"` : ''
-        const diagnostics = this._formatPeerSelectionDiagnostics(peers)
-        res.writeHead(502, { 'content-type': 'text/plain' })
         res.end(`No peers support ${protocolLabel}${providerLabel}. ${diagnostics}`)
-        return
+      } else {
+        res.end(`No peers advertise provider "${explicitProvider}". ${diagnostics}`)
       }
+      return
     }
 
     // Use router to select peer

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -200,10 +200,11 @@ export class PeerAnnouncer {
       return undefined;
     }
 
+    const hasWildcardModels = supportedModels.length === 0;
     const supportedModelSet = new Set(supportedModels);
     const normalized: Record<string, string[]> = {};
     for (const [model, categories] of Object.entries(modelCategories)) {
-      if (!supportedModelSet.has(model)) {
+      if (!hasWildcardModels && !supportedModelSet.has(model)) {
         continue;
       }
       const deduped = Array.from(
@@ -230,10 +231,11 @@ export class PeerAnnouncer {
       return undefined;
     }
 
+    const hasWildcardModels = supportedModels.length === 0;
     const supportedModelSet = new Set(supportedModels);
     const normalized: Record<string, ModelApiProtocol[]> = {};
     for (const [model, protocols] of Object.entries(modelApiProtocols)) {
-      if (!supportedModelSet.has(model)) {
+      if (!hasWildcardModels && !supportedModelSet.has(model)) {
         continue;
       }
       const deduped = Array.from(

--- a/packages/node/src/discovery/metadata-validator.ts
+++ b/packages/node/src/discovery/metadata-validator.ts
@@ -127,6 +127,12 @@ export function validateMetadata(metadata: PeerMetadata): ValidationError[] {
     // model pricing (optional)
     if (p.modelPricing !== undefined) {
       for (const [modelName, modelPricing] of Object.entries(p.modelPricing)) {
+        if (modelName.length > MAX_MODEL_NAME_LENGTH) {
+          errors.push({
+            field: `providers[${i}].modelPricing.${modelName}`,
+            message: `Model name length ${modelName.length} exceeds max ${MAX_MODEL_NAME_LENGTH}`,
+          });
+        }
         if (!modelPricing || !Number.isFinite(modelPricing.inputUsdPerMillion) || modelPricing.inputUsdPerMillion < 0) {
           errors.push({
             field: `providers[${i}].modelPricing.${modelName}.inputUsdPerMillion`,
@@ -144,6 +150,12 @@ export function validateMetadata(metadata: PeerMetadata): ValidationError[] {
 
     if (p.modelCategories !== undefined) {
       for (const [modelName, categories] of Object.entries(p.modelCategories)) {
+        if (modelName.length > MAX_MODEL_NAME_LENGTH) {
+          errors.push({
+            field: `providers[${i}].modelCategories.${modelName}`,
+            message: `Model name length ${modelName.length} exceeds max ${MAX_MODEL_NAME_LENGTH}`,
+          });
+        }
         if (!hasWildcardModels && !p.models.includes(modelName)) {
           errors.push({
             field: `providers[${i}].modelCategories.${modelName}`,
@@ -199,6 +211,12 @@ export function validateMetadata(metadata: PeerMetadata): ValidationError[] {
 
     if (p.modelApiProtocols !== undefined) {
       for (const [modelName, protocols] of Object.entries(p.modelApiProtocols)) {
+        if (modelName.length > MAX_MODEL_NAME_LENGTH) {
+          errors.push({
+            field: `providers[${i}].modelApiProtocols.${modelName}`,
+            message: `Model name length ${modelName.length} exceeds max ${MAX_MODEL_NAME_LENGTH}`,
+          });
+        }
         if (!hasWildcardModels && !p.models.includes(modelName)) {
           errors.push({
             field: `providers[${i}].modelApiProtocols.${modelName}`,

--- a/packages/node/tests/announcer-load.test.ts
+++ b/packages/node/tests/announcer-load.test.ts
@@ -66,4 +66,35 @@ describe('PeerAnnouncer live load metadata', () => {
     );
     expect(valid).toBe(true);
   });
+
+  it('preserves wildcard model metadata entries when provider models are wildcard', async () => {
+    const { config } = await makeConfig();
+    config.providers = [
+      {
+        provider: 'openai',
+        models: [],
+        modelCategories: {
+          'gpt-4.1': [' Coding ', 'coding'],
+        },
+        modelApiProtocols: {
+          'gpt-4.1': ['openai-chat-completions', 'OPENAI-CHAT-COMPLETIONS' as any, 'invalid-protocol' as any],
+        },
+        maxConcurrency: 5,
+      },
+    ];
+    config.pricing = new Map([
+      ['openai', { defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 1 } }],
+    ]);
+
+    const announcer = new PeerAnnouncer(config);
+    await announcer.refreshMetadata();
+    const refreshed = announcer.getLatestMetadata();
+    expect(refreshed).not.toBeNull();
+    expect(refreshed!.providers[0]!.modelCategories).toEqual({
+      'gpt-4.1': ['coding'],
+    });
+    expect(refreshed!.providers[0]!.modelApiProtocols).toEqual({
+      'gpt-4.1': ['openai-chat-completions'],
+    });
+  });
 });

--- a/packages/node/tests/metadata-validator.test.ts
+++ b/packages/node/tests/metadata-validator.test.ts
@@ -137,6 +137,33 @@ describe('validateMetadata', () => {
     expect(errors.some((e) => e.field.includes('models'))).toBe(true);
   });
 
+  it('should reject modelPricing entries with model names exceeding max length', () => {
+    const longModelName = 'x'.repeat(MAX_MODEL_NAME_LENGTH + 1);
+    const errors = validateMetadata(
+      validMetadata({
+        providers: [
+          {
+            provider: 'test',
+            models: ['m'],
+            defaultPricing: {
+              inputUsdPerMillion: 1,
+              outputUsdPerMillion: 1,
+            },
+            modelPricing: {
+              [longModelName]: {
+                inputUsdPerMillion: 2,
+                outputUsdPerMillion: 3,
+              },
+            },
+            maxConcurrency: 1,
+            currentLoad: 0,
+          },
+        ],
+      })
+    );
+    expect(errors.some((e) => e.field.includes('modelPricing'))).toBe(true);
+  });
+
   it('should reject negative default input price', () => {
     const errors = validateMetadata(
       validMetadata({
@@ -325,6 +352,28 @@ describe('validateMetadata', () => {
     expect(errors.some((e) => e.field.includes('modelCategories.m1'))).toBe(true);
   });
 
+  it('should reject model category entries with model names exceeding max length', () => {
+    const longModelName = 'x'.repeat(MAX_MODEL_NAME_LENGTH + 1);
+    const errors = validateMetadata(validMetadata({
+      providers: [
+        {
+          provider: 'test',
+          models: [],
+          defaultPricing: {
+            inputUsdPerMillion: 1,
+            outputUsdPerMillion: 1,
+          },
+          modelCategories: {
+            [longModelName]: ['privacy'],
+          },
+          maxConcurrency: 1,
+          currentLoad: 0,
+        },
+      ],
+    }));
+    expect(errors.some((e) => e.field.includes('modelCategories'))).toBe(true);
+  });
+
   it('should reject model API protocols for a model not listed by provider', () => {
     const errors = validateMetadata(validMetadata({
       providers: [
@@ -409,6 +458,28 @@ describe('validateMetadata', () => {
       ],
     }));
     expect(errors.some((e) => e.field.includes('modelApiProtocols.m1'))).toBe(true);
+  });
+
+  it('should reject model API protocol entries with model names exceeding max length', () => {
+    const longModelName = 'x'.repeat(MAX_MODEL_NAME_LENGTH + 1);
+    const errors = validateMetadata(validMetadata({
+      providers: [
+        {
+          provider: 'test',
+          models: [],
+          defaultPricing: {
+            inputUsdPerMillion: 1,
+            outputUsdPerMillion: 1,
+          },
+          modelApiProtocols: {
+            [longModelName]: ['openai-chat-completions'],
+          },
+          maxConcurrency: 1,
+          currentLoad: 0,
+        },
+      ],
+    }));
+    expect(errors.some((e) => e.field.includes('modelApiProtocols'))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- enforce explicit provider override filtering in buyer proxy even when request protocol detection is null
- preserve wildcard model metadata (categories + API protocols) when providers advertise wildcard models (models=[])
- validate model-name length for model-map keys in metadata fields modelPricing, modelCategories, and modelApiProtocols to prevent invalid binary metadata encoding/decoding
- add regression tests for proxy candidate selection, announcer wildcard metadata behavior, and metadata validator key-length guards
- include proxy tests in the CLI test runner

## Validation
- pnpm run test
- pnpm run typecheck