### PR TITLE
chore: bump all packages to v0.1.4 (cli v0.1.5)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/dashboard",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Antseed Network web dashboard — monitoring and configuration UI",
   "type": "module",
   "files": [

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/node",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Antseed Network protocol SDK — P2P inference marketplace",
   "type": "module",
   "files": [

--- a/packages/provider-core/package.json
+++ b/packages/provider-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Shared provider infrastructure for Antseed plugins",
   "type": "module",
   "files": [

--- a/packages/router-core/package.json
+++ b/packages/router-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/router-core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Shared router infrastructure for Antseed plugins",
   "type": "module",
   "files": [

--- a/plugins/provider-anthropic/package.json
+++ b/plugins/provider-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-anthropic",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Anthropic API key provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/provider-claude-code/package.json
+++ b/plugins/provider-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-claude-code",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Claude Code keychain provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/provider-claude-oauth/package.json
+++ b/plugins/provider-claude-oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-claude-oauth",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Third-party Anthropic Claude provider with OAuth authentication",
   "type": "module",
   "files": [

--- a/plugins/provider-local-llm/package.json
+++ b/plugins/provider-local-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-local-llm",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Local LLM provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/provider-openai/package.json
+++ b/plugins/provider-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-openai",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OpenAI-compatible provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/router-local/package.json
+++ b/plugins/router-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/router-local",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Antseed local router plugin — Claude Code, Aider, Continue.dev",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- Patch bump all publishable packages after recent feature merges
- All 11 packages already published to npm

## Packages
- `@antseed/node@0.1.4`
- `@antseed/provider-core@0.1.4`
- `@antseed/router-core@0.1.4`
- `@antseed/provider-anthropic@0.1.4`
- `@antseed/provider-claude-code@0.1.4`
- `@antseed/provider-claude-oauth@0.1.4`
- `@antseed/provider-openai@0.1.4`
- `@antseed/provider-local-llm@0.1.4`
- `@antseed/router-local@0.1.4`
- `@antseed/dashboard@0.1.4`
- `@antseed/cli@0.1.5`