### PR TITLE
fix: emit input_json_delta for tool_use in synthetic Anthropic SSE streams

### DIFF
--- a/apps/cli/src/proxy/model-api-adapter.ts
+++ b/apps/cli/src/proxy/model-api-adapter.ts
@@ -307,7 +307,7 @@ function buildAnthropicStreamFromMessage(message: {
       index,
       content_block: block.type === 'text'
         ? { type: 'text', text: '' }
-        : { type: 'tool_use', id: block.id, name: block.name, input: block.input },
+        : { type: 'tool_use', id: block.id, name: block.name, input: {} },
     })
 
     if (block.type === 'text' && block.text.length > 0) {
@@ -317,6 +317,17 @@ function buildAnthropicStreamFromMessage(message: {
         delta: {
           type: 'text_delta',
           text: block.text,
+        },
+      })
+    }
+
+    if (block.type === 'tool_use') {
+      pushEvent('content_block_delta', {
+        type: 'content_block_delta',
+        index,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: JSON.stringify(block.input),
         },
       })
     }

--- a/packages/node/src/proxy/model-api-adapter.ts
+++ b/packages/node/src/proxy/model-api-adapter.ts
@@ -292,7 +292,7 @@ function buildAnthropicStreamFromMessage(message: {
       index,
       content_block: block.type === 'text'
         ? { type: 'text', text: '' }
-        : { type: 'tool_use', id: block.id, name: block.name, input: block.input },
+        : { type: 'tool_use', id: block.id, name: block.name, input: {} },
     });
 
     if (block.type === 'text' && block.text.length > 0) {
@@ -302,6 +302,17 @@ function buildAnthropicStreamFromMessage(message: {
         delta: {
           type: 'text_delta',
           text: block.text,
+        },
+      });
+    }
+
+    if (block.type === 'tool_use') {
+      pushEvent('content_block_delta', {
+        type: 'content_block_delta',
+        index,
+        delta: {
+          type: 'input_json_delta',
+          partial_json: JSON.stringify(block.input),
         },
       });
     }

--- a/packages/node/tests/model-api-adapter.test.ts
+++ b/packages/node/tests/model-api-adapter.test.ts
@@ -167,4 +167,42 @@ describe('transformOpenAIChatResponseToAnthropicMessage', () => {
     expect(sseText).toContain('event: content_block_start');
     expect(sseText).toContain('event: message_stop');
   });
+
+  it('emits input_json_delta for tool_use blocks in SSE stream', () => {
+    const transformed = transformOpenAIChatResponseToAnthropicMessage(makeOpenAIResponse(), {
+      streamRequested: true,
+      fallbackModel: 'fallback-model',
+    });
+    const sseText = new TextDecoder().decode(transformed.body);
+
+    // Parse SSE events
+    const events: Array<{ event: string; data: Record<string, unknown> }> = [];
+    for (const chunk of sseText.split('\n\n')) {
+      const lines = chunk.split('\n').filter((l) => l.length > 0);
+      if (lines.length < 2) continue;
+      const event = lines[0].replace('event: ', '');
+      const data = JSON.parse(lines[1].replace('data: ', '')) as Record<string, unknown>;
+      events.push({ event, data });
+    }
+
+    // Find content_block_start for tool_use
+    const toolStart = events.find(
+      (e) => e.event === 'content_block_start'
+        && (e.data.content_block as Record<string, unknown>)?.type === 'tool_use',
+    );
+    expect(toolStart).toBeDefined();
+    // input should be empty in content_block_start per Anthropic spec
+    expect((toolStart!.data.content_block as Record<string, unknown>).input).toEqual({});
+
+    // Find input_json_delta for tool_use arguments
+    const toolDelta = events.find(
+      (e) => e.event === 'content_block_delta'
+        && (e.data.delta as Record<string, unknown>)?.type === 'input_json_delta',
+    );
+    expect(toolDelta).toBeDefined();
+    const delta = toolDelta!.data.delta as Record<string, unknown>;
+    expect(delta.type).toBe('input_json_delta');
+    const parsedArgs = JSON.parse(delta.partial_json as string) as Record<string, unknown>;
+    expect(parsedArgs).toEqual({ path: 'hello.txt' });
+  });
 });


### PR DESCRIPTION
## Summary
- When converting OpenAI Chat Completions responses to Anthropic Messages SSE stream format, tool_use content blocks placed their full `input` in `content_block_start` but never emitted `input_json_delta` delta events
- Standard Anthropic SDK/client parsers (e.g. OpenClaw) build tool input from `input_json_delta` events, not from `content_block_start.input`, causing tool arguments to arrive as empty `{}` — e.g. `read` tool calls missing the `path` parameter
- Fix: set `input: {}` in `content_block_start` per the Anthropic streaming spec, and emit an `input_json_delta` `content_block_delta` with the serialized arguments
- Applied to both `packages/node` and `apps/cli` copies of the adapter
- Added test verifying `input_json_delta` is emitted with correct arguments

## Test plan
- [x] Existing model-api-adapter tests pass (10/10)
- [x] New test verifies `content_block_start` has empty `input: {}` for tool_use
- [x] New test verifies `input_json_delta` delta is emitted with correct parsed arguments
- [ ] Deploy to production and verify OpenClaw tool calls work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)