### PR TITLE
feat: manual peer selection via --peer flag and x-antseed-pin-peer header

### DIFF
--- a/apps/cli/src/cli/commands/connect.ts
+++ b/apps/cli/src/cli/commands/connect.ts
@@ -148,9 +148,17 @@ export function registerConnectCommand(program: Command): void {
     .option('--instance <id>', 'use a configured plugin instance by ID')
     .option('--max-input-usd-per-million <number>', 'runtime-only max input pricing override in USD per 1M tokens', parseFloat)
     .option('--max-output-usd-per-million <number>', 'runtime-only max output pricing override in USD per 1M tokens', parseFloat)
+    .option('--peer <peerId>', 'pin all requests to a specific peer ID (64-char hex), bypassing the router')
     .action(async (options) => {
       const globalOpts = getGlobalOptions(program)
       const config = await loadConfig(globalOpts.config)
+
+      const pinnedPeerId = options.peer as string | undefined
+      if (pinnedPeerId !== undefined && !/^[0-9a-f]{64}$/i.test(pinnedPeerId)) {
+        console.error(chalk.red('Error: --peer must be a 64-character hex peer ID.'))
+        process.exit(1)
+      }
+
       const runtimeOverrides = buildBuyerRuntimeOverridesFromFlags({
         port: options.port as number | undefined,
         maxInputUsdPerMillion: options.maxInputUsdPerMillion as number | undefined,
@@ -257,6 +265,9 @@ export function registerConnectCommand(program: Command): void {
       )
       console.log(chalk.dim(`  min peer reputation: ${effectiveBuyerConfig.minPeerReputation}`))
       console.log(chalk.dim(`  proxy port: ${effectiveBuyerConfig.proxyPort}`))
+      if (pinnedPeerId) {
+        console.log(chalk.yellow(`  pinned peer: ${pinnedPeerId} (router bypassed)`))
+      }
       console.log('')
 
       const node = new AntseedNode({
@@ -304,6 +315,7 @@ export function registerConnectCommand(program: Command): void {
       const proxy = new BuyerProxy({
         port: proxyPort,
         node,
+        pinnedPeerId,
       })
 
       try {

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -26,6 +26,12 @@ export interface BuyerProxyConfig {
   node: AntseedNode
   /** How long to cache discovered peers before re-querying DHT (ms). Default: 30000 */
   peerCacheTtlMs?: number
+  /**
+   * Pin all requests to a specific peer ID for this session.
+   * The router is bypassed; the named peer is used directly if it is available
+   * and protocol-compatible. A 502 is returned if the peer cannot be reached.
+   */
+  pinnedPeerId?: string
 }
 
 const DAEMON_STATE_FILE = join(homedir(), '.antseed', 'daemon.state.json')
@@ -70,6 +76,16 @@ export type CandidatePeerRouteSelection = {
 function getExplicitProviderOverride(request: SerializedHttpRequest): string | null {
   const provider = request.headers['x-antseed-provider']?.trim().toLowerCase()
   return provider && provider.length > 0 ? provider : null
+}
+
+function getExplicitPeerIdOverride(
+  request: SerializedHttpRequest,
+  sessionPinnedPeerId: string | undefined,
+): string | null {
+  // Per-request header takes priority over session pin
+  const header = request.headers['x-antseed-pin-peer']?.trim().toLowerCase()
+  if (header && header.length > 0) return header
+  return sessionPinnedPeerId?.toLowerCase() ?? null
 }
 
 function getPeerProviderProtocols(
@@ -536,6 +552,7 @@ export class BuyerProxy {
   private readonly _node: AntseedNode
   private readonly _port: number
   private readonly _peerCacheTtlMs: number
+  private readonly _pinnedPeerId: string | undefined
 
   private _cachedPeers: PeerInfo[] = []
   private _cacheTimestamp = 0
@@ -544,6 +561,7 @@ export class BuyerProxy {
     this._node = config.node
     this._port = config.port
     this._peerCacheTtlMs = config.peerCacheTtlMs ?? 30_000
+    this._pinnedPeerId = config.pinnedPeerId?.toLowerCase()
     this._server = createServer((req, res) => {
       this._handleRequest(req, res).catch((err) => {
         log('Unhandled error:', err)
@@ -727,6 +745,7 @@ export class BuyerProxy {
     const requestProtocol = detectRequestModelApiProtocol(serializedReq)
     const requestedModel = extractRequestedModel(serializedReq)
     const explicitProvider = getExplicitProviderOverride(serializedReq)
+    const explicitPeerId = getExplicitPeerIdOverride(serializedReq, this._pinnedPeerId)
     const {
       candidatePeers,
       routePlanByPeerId,
@@ -745,32 +764,45 @@ export class BuyerProxy {
       return
     }
 
-    // Use router to select peer
+    // Select peer: explicit pin bypasses the router
     const router = this._node.router
-    const localPeers = candidatePeers.filter((peer) => isLoopbackPeer(peer))
     let selectedPeer: PeerInfo | null = null
 
-    if (localPeers.length > 0) {
-      selectedPeer = router
-        ? router.selectPeer(serializedReq, localPeers)
-        : localPeers[0] ?? null
-      if (selectedPeer) {
-        log(`Preferring local peer ${selectedPeer.peerId.slice(0, 12)}... @ ${selectedPeer.publicAddress ?? 'unknown'}`)
+    if (explicitPeerId) {
+      selectedPeer = candidatePeers.find((p) => p.peerId.toLowerCase() === explicitPeerId) ?? null
+      if (!selectedPeer) {
+        const source = serializedReq.headers['x-antseed-pin-peer'] ? 'x-antseed-pin-peer header' : '--peer flag'
+        log(`Pinned peer ${explicitPeerId.slice(0, 12)}... not found in candidate list (${source})`)
+        res.writeHead(502, { 'content-type': 'text/plain' })
+        res.end(`Pinned peer ${explicitPeerId.slice(0, 12)}... is not available or does not support this request.`)
+        return
       }
-    }
+      log(`Using pinned peer ${selectedPeer.peerId.slice(0, 12)}...`)
+    } else {
+      const localPeers = candidatePeers.filter((peer) => isLoopbackPeer(peer))
 
-    if (!selectedPeer) {
-      selectedPeer = router
-        ? router.selectPeer(serializedReq, candidatePeers)
-        : candidatePeers[0] ?? null
-    }
+      if (localPeers.length > 0) {
+        selectedPeer = router
+          ? router.selectPeer(serializedReq, localPeers)
+          : localPeers[0] ?? null
+        if (selectedPeer) {
+          log(`Preferring local peer ${selectedPeer.peerId.slice(0, 12)}... @ ${selectedPeer.publicAddress ?? 'unknown'}`)
+        }
+      }
 
-    if (!selectedPeer) {
-      const diagnostics = this._formatPeerSelectionDiagnostics(candidatePeers)
-      log('Router could not select a peer.', diagnostics)
-      res.writeHead(502, { 'content-type': 'text/plain' })
-      res.end(`Router could not select a suitable peer. ${diagnostics}`)
-      return
+      if (!selectedPeer) {
+        selectedPeer = router
+          ? router.selectPeer(serializedReq, candidatePeers)
+          : candidatePeers[0] ?? null
+      }
+
+      if (!selectedPeer) {
+        const diagnostics = this._formatPeerSelectionDiagnostics(candidatePeers)
+        log('Router could not select a peer.', diagnostics)
+        res.writeHead(502, { 'content-type': 'text/plain' })
+        res.end(`Router could not select a suitable peer. ${diagnostics}`)
+        return
+      }
     }
 
     const selectedRoutePlan = routePlanByPeerId.get(selectedPeer.peerId)
@@ -783,10 +815,11 @@ export class BuyerProxy {
       return
     }
 
+    const { 'x-antseed-pin-peer': _pinPeer, ...headersForPeer } = serializedReq.headers
     let requestForPeer: SerializedHttpRequest = {
       ...serializedReq,
       headers: {
-        ...serializedReq.headers,
+        ...headersForPeer,
         'x-antseed-provider': selectedRoutePlan.provider,
       },
     }


### PR DESCRIPTION
## Summary

Adds two complementary ways to bypass the router and pin requests to a specific peer:

- **`antseed connect --peer <peerId>`** — pins all requests for the session to the given 64-char hex peer ID. Displayed in effective settings at startup with a warning that the router is bypassed.
- **`x-antseed-pin-peer: <peerId>` HTTP header** — per-request override, takes priority over the `--peer` flag. Stripped before forwarding to the seller.

In both cases the pinned peer still goes through `selectCandidatePeersForRouting` for protocol compatibility. If the peer is unavailable or doesn't support the request, a `502` is returned with a clear message.

## Test plan

- [ ] `antseed connect --peer <valid-64-char-hex>` starts and shows `pinned peer: <id> (router bypassed)`
- [ ] `antseed connect --peer abc` exits immediately with a format error
- [ ] Requests routed to the pinned peer while it's online succeed
- [ ] Requests return `502 Pinned peer ... is not available` when peer is offline
- [ ] `x-antseed-pin-peer` header on an individual request overrides the session pin
- [ ] `x-antseed-pin-peer` header is stripped and not forwarded to the seller

🤖 Generated with [Claude Code](https://claude.com/claude-code)