### PR TITLE
feat(node): inject buyer peer ID header

### DIFF
--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -886,6 +886,8 @@ export class AntseedNode extends EventEmitter {
       // in-flight work immediately (not only after metering persistence).
       this._getOrCreateSellerSession(buyerPeerId, provider.name);
 
+      request.headers['x-antseed-buyer-peer-id'] = buyerPeerId;
+
       debugLog(`[Node] Routing to provider "${provider.name}"`);
       const startTime = Date.now();
       let statusCode = 500;


### PR DESCRIPTION
## Summary

- Injects `x-antseed-buyer-peer-id` header into `SerializedHttpRequest` before dispatching to `provider.handleRequest()`
- One-line addition in `_handleIncomingConnection` callback
- Enables providers to identify the connecting buyer peer (e.g., for allowlists in `openclaw-channel-antseed`)

## Test plan

- [x] Type-checks pass
- [x] Header is set from `conn.remotePeerId` which is already available in scope
- [x] No breaking changes — adds a new header, existing providers ignore unknown headers