### PR TITLE
fix(cli): retry with another peer on provider errors

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -785,7 +785,12 @@ export class BuyerProxy {
         return
       }
       log(`Using pinned peer ${selectedPeer.peerId.slice(0, 12)}...`)
-      await this._dispatchToPeer(res, serializedReq, selectedPeer, routePlanByPeerId, requestProtocol, requestedModel, explicitProvider, router, RETRYABLE_STATUS_CODES)
+      const result = await this._dispatchToPeer(res, serializedReq, selectedPeer, routePlanByPeerId, requestProtocol, requestedModel, explicitProvider, router, RETRYABLE_STATUS_CODES)
+      if (!result.done) {
+        // Pinned peer returned a retryable error, but we don't retry — send error to client
+        res.writeHead(result.statusCode, result.responseHeaders)
+        res.end(result.responseBody)
+      }
       return
     }
 


### PR DESCRIPTION
## Summary

- When a provider returns a retryable error (400, 404, 408, 429, 500-504), the buyer proxy now automatically tries another peer instead of passing the error through
- Up to 3 total attempts with already-tried peers excluded from subsequent rounds
- Pinned peers (`--peer` flag) skip retry — respects explicit peer choice
- Streaming requests only retry if response headers haven't been written yet
- Fixes failure classification: 400 errors now trigger router failure tracking/cooldown (previously treated as success via `statusCode < 500`)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — all 32 existing tests pass
- [ ] Manual: start provider with broken model, verify buyer retries with another provider
- [ ] Verify logs show retry attempts and peer exclusion
- [ ] Verify pinned peers don't retry on error