### PR TITLE
feat: provider middleware — inject MD skill files into LLM requests

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -116,6 +116,35 @@ Pricing is configured in USD per 1M tokens with role-specific defaults and optio
 
 Model categories are normalized to lowercase tags. Recommended tags include: `privacy`, `legal`, `uncensored`, `coding`, `finance`, `tee` (custom tags are also allowed).
 
+### Seller Middleware
+
+Providers can inject Markdown files into every LLM request using `seller.middleware`. This is the primary mechanism for adding system prompts, skill instructions, persona definitions, and output-format rules — buyers only see the LLM's natural response, never the injected content.
+
+```json
+{
+  "seller": {
+    "middleware": [
+      { "file": "./skills/coding-expert.md", "position": "system-prepend" },
+      { "file": "./skills/output-format.md",  "position": "system-append" },
+      { "file": "./skills/reminder.md",       "position": "append", "role": "user" }
+    ]
+  }
+}
+```
+
+**`file`** — path to a `.md` file, relative to the config file directory (or absolute).
+
+**`position`** — where to inject the content:
+
+| position | effect |
+|---|---|
+| `system-prepend` | Prepend to the Anthropic `system` field; or insert a system-role message at the top of OpenAI messages |
+| `system-append`  | Append to the `system` field; or insert after the last system message in OpenAI messages |
+| `prepend`        | Insert as the first message in the `messages` array |
+| `append`         | Insert as the last message in the `messages` array |
+
+**`role`** — only used for `prepend`/`append` positions; defaults to `'user'`.
+
 Role-first config examples:
 
 ```bash

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@antseed/node": "workspace:*",
+    "@antseed/provider-core": "workspace:*",
     "@antseed/dashboard": "workspace:*",
     "chalk": "^5.6.2",
     "cli-table3": "^0.6.5",

--- a/apps/cli/src/cli/commands/seed.ts
+++ b/apps/cli/src/cli/commands/seed.ts
@@ -1,8 +1,8 @@
 import type { Command } from 'commander'
 import chalk from 'chalk'
 import ora from 'ora'
-import { writeFile, unlink } from 'node:fs/promises'
-import { join } from 'node:path'
+import { writeFile, unlink, readFile } from 'node:fs/promises'
+import { join, resolve, isAbsolute, dirname } from 'node:path'
 import { homedir } from 'node:os'
 import { getGlobalOptions } from './types.js'
 import { loadConfig } from '../../config/loader.js'
@@ -13,7 +13,8 @@ import { parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery'
 import { setupShutdownHandler } from '../shutdown.js'
 import { loadProviderPlugin, buildPluginConfig } from '../../plugins/loader.js'
 import { resolveEffectiveSellerConfig, type SellerRuntimeOverrides } from '../../config/effective.js'
-import type { SellerCLIConfig } from '../../config/types.js'
+import type { SellerCLIConfig, SellerMiddlewareConfig } from '../../config/types.js'
+import { MiddlewareProvider, type ProviderMiddleware } from '@antseed/provider-core'
 
 function getStateFile(dataDir: string): string {
   return join(dataDir, 'daemon.state.json')
@@ -166,6 +167,19 @@ function parseRuntimeModelCategoriesJson(raw: string | undefined): Record<string
   } catch {
     return undefined
   }
+}
+
+async function loadMiddlewareFiles(
+  configs: SellerMiddlewareConfig[],
+  baseDir: string,
+): Promise<ProviderMiddleware[]> {
+  return Promise.all(
+    configs.map(async (entry) => {
+      const filePath = isAbsolute(entry.file) ? entry.file : resolve(baseDir, entry.file)
+      const content = await readFile(filePath, 'utf-8')
+      return { content, position: entry.position, role: entry.role } as ProviderMiddleware
+    }),
+  )
 }
 
 export function registerSeedCommand(program: Command): void {
@@ -335,6 +349,20 @@ export function registerSeedCommand(program: Command): void {
           paymentConfig,
         },
       })
+
+      // Wrap provider with middleware if configured
+      const middlewareConfigs = effectiveSellerConfig.middleware ?? []
+      if (middlewareConfigs.length > 0) {
+        const baseDir = globalOpts.config ? dirname(resolve(globalOpts.config)) : process.cwd()
+        try {
+          const middleware = await loadMiddlewareFiles(middlewareConfigs, baseDir)
+          provider = new MiddlewareProvider(provider, middleware)
+          console.log(chalk.dim(`  middleware: ${middlewareConfigs.length} file(s) loaded`))
+        } catch (err) {
+          console.error(chalk.red(`Failed to load middleware: ${(err as Error).message}`))
+          process.exit(1)
+        }
+      }
 
       node.registerProvider(provider)
 

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -58,6 +58,23 @@ export interface SellerModelCategoryConfig {
 }
 
 /**
+ * Injection position for a middleware entry.
+ */
+export type MiddlewarePosition = 'system-prepend' | 'system-append' | 'prepend' | 'append';
+
+/**
+ * A single middleware entry referencing a Markdown file on disk.
+ */
+export interface SellerMiddlewareConfig {
+  /** Path to the .md file (relative to the config file's directory, or absolute). */
+  file: string;
+  /** Where to inject the content in the LLM request. */
+  position: MiddlewarePosition;
+  /** Role for 'prepend'/'append' positions. Defaults to 'user'. */
+  role?: string;
+}
+
+/**
  * Seller-specific configuration within the Antseed config.
  */
 export interface SellerCLIConfig {
@@ -71,6 +88,8 @@ export interface SellerCLIConfig {
   pricing: HierarchicalPricingConfig;
   /** Optional provider/model category tags announced in peer metadata */
   modelCategories?: SellerModelCategoryConfig;
+  /** Optional middleware files to inject into every LLM request. */
+  middleware?: SellerMiddlewareConfig[];
 }
 
 /**

--- a/docs/protocol/templates/provider-plugin/README.md
+++ b/docs/protocol/templates/provider-plugin/README.md
@@ -85,6 +85,25 @@ configSchema: [
 
 The CLI reads matching environment variables and passes them to `createProvider(config)`.
 
+## Adding Skills via Middleware
+
+Providers can inject Markdown files (system prompts, persona definitions, skill instructions) into every buyer request without buyers seeing the additions. The CLI handles this automatically — no plugin code required.
+
+In your `antseed.config.json`:
+
+```json
+{
+  "seller": {
+    "middleware": [
+      { "file": "./skills/coding-expert.md", "position": "system-prepend" },
+      { "file": "./skills/output-format.md",  "position": "append", "role": "user" }
+    ]
+  }
+}
+```
+
+Buyers receive only the LLM's natural response. The injected content is applied server-side before the upstream call and is never visible in conversation history. See the [`@antseed/cli` README](../../../apps/cli/README.md) for full position reference.
+
 ## Publishing
 
 ```bash

--- a/packages/provider-core/README.md
+++ b/packages/provider-core/README.md
@@ -44,6 +44,35 @@ const provider = new BaseProvider({
 - **`OAuthTokenProvider`** -- Manages OAuth access/refresh token pairs with automatic renewal.
 - **`createTokenProvider()`** -- Factory that creates the right provider based on auth type.
 
+### MiddlewareProvider
+
+A decorator that wraps any `Provider` to inject Markdown file content into every LLM request before it reaches the upstream API. Use it to add system prompts, persona files, skill instructions, or output-format rules — without buyers seeing the injected content (standard LLM APIs never echo input in their responses).
+
+```ts
+import { MiddlewareProvider } from '@antseed/provider-core';
+
+const provider = new MiddlewareProvider(innerProvider, [
+  { content: systemPromptMd,   position: 'system-prepend' },
+  { content: outputFormatMd,   position: 'system-append' },
+  { content: reminderMd,       position: 'append', role: 'user' },
+]);
+```
+
+**Injection positions:**
+
+| position | effect |
+|---|---|
+| `system-prepend` | Prepend to the Anthropic `system` field; or insert a `{role:'system'}` message at the top of an OpenAI messages array |
+| `system-append`  | Append to the `system` field; or insert after the last system message in an OpenAI messages array |
+| `prepend`        | Insert as the first element of the `messages` array |
+| `append`         | Insert as the last element of the `messages` array |
+
+The request path is used to auto-detect format: paths containing `/chat/completions` are treated as OpenAI format; all others as Anthropic format.
+
+`role` is only used for `prepend`/`append` positions and defaults to `'user'`.
+
+In practice the CLI configures `MiddlewareProvider` automatically — see the `seller.middleware` config option in `@antseed/cli`.
+
 ### Utilities
 
 - **`swapAuthHeader()`** -- Injects/replaces authentication headers on outgoing requests.

--- a/packages/provider-core/src/index.ts
+++ b/packages/provider-core/src/index.ts
@@ -3,3 +3,5 @@ export { swapAuthHeader, validateRequestModel, KNOWN_AUTH_HEADERS } from './auth
 export { StaticTokenProvider, OAuthTokenProvider, createTokenProvider, type AuthType } from './token-providers.js';
 export type { TokenProvider, TokenProviderState } from './token-providers.js';
 export { BaseProvider, type BaseProviderConfig } from './base-provider.js';
+export { MiddlewareProvider } from './middleware-provider.js';
+export { applyMiddleware, type ProviderMiddleware, type MiddlewarePosition } from './middleware.js';

--- a/packages/provider-core/src/middleware-provider.ts
+++ b/packages/provider-core/src/middleware-provider.ts
@@ -1,0 +1,59 @@
+import type {
+  Provider,
+  SerializedHttpRequest,
+  SerializedHttpResponse,
+  ProviderStreamCallbacks,
+} from '@antseed/node';
+import { type ProviderMiddleware, applyMiddleware } from './middleware.js';
+
+/**
+ * Wraps any Provider to inject middleware (MD files) into each request before
+ * forwarding to the upstream LLM. The buyer never sees the injected content —
+ * standard LLM APIs return only the assistant's generated text, so no response
+ * stripping is necessary.
+ */
+export class MiddlewareProvider implements Provider {
+  constructor(
+    private readonly _inner: Provider,
+    private readonly _middleware: ProviderMiddleware[],
+  ) {}
+
+  get name() { return this._inner.name; }
+  get models() { return this._inner.models; }
+  get pricing(): Provider['pricing'] { return this._inner.pricing; }
+  get maxConcurrency() { return this._inner.maxConcurrency; }
+
+  get modelCategories() { return this._inner.modelCategories; }
+  set modelCategories(v: Record<string, string[]> | undefined) { this._inner.modelCategories = v; }
+
+  get modelApiProtocols() { return this._inner.modelApiProtocols; }
+
+  getCapacity() { return this._inner.getCapacity(); }
+
+  async init() { return this._inner.init?.(); }
+
+  async handleRequest(req: SerializedHttpRequest): Promise<SerializedHttpResponse> {
+    return this._inner.handleRequest(this._augment(req));
+  }
+
+  get handleRequestStream():
+    | ((req: SerializedHttpRequest, callbacks: ProviderStreamCallbacks) => Promise<SerializedHttpResponse>)
+    | undefined {
+    if (!this._inner.handleRequestStream) return undefined;
+    return (req: SerializedHttpRequest, callbacks: ProviderStreamCallbacks) =>
+      this._inner.handleRequestStream!(this._augment(req), callbacks);
+  }
+
+  private _augment(req: SerializedHttpRequest): SerializedHttpRequest {
+    if (!this._middleware.length) return req;
+    let body: Record<string, unknown>;
+    try {
+      body = JSON.parse(new TextDecoder().decode(req.body)) as Record<string, unknown>;
+    } catch {
+      return req; // not JSON — leave unchanged
+    }
+    const format = req.path?.includes('/chat/completions') ? 'openai' : 'anthropic';
+    const augmented = applyMiddleware(body, this._middleware, format);
+    return { ...req, body: new TextEncoder().encode(JSON.stringify(augmented)) };
+  }
+}

--- a/packages/provider-core/src/middleware.test.ts
+++ b/packages/provider-core/src/middleware.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { applyMiddleware, type ProviderMiddleware } from './middleware.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mw(content: string, position: ProviderMiddleware['position'], role?: string): ProviderMiddleware {
+  return role ? { content, position, role } : { content, position };
+}
+
+// ---------------------------------------------------------------------------
+// Anthropic format — top-level `system` string
+// ---------------------------------------------------------------------------
+
+describe('system-prepend (Anthropic string system)', () => {
+  it('prepends to existing system string', () => {
+    const body = { system: 'original', messages: [] };
+    const result = applyMiddleware(body, [mw('injected', 'system-prepend')]);
+    expect(result.system).toBe('injected\n\noriginal');
+  });
+
+  it('creates system field when absent', () => {
+    const body = { messages: [] };
+    const result = applyMiddleware(body, [mw('injected', 'system-prepend')]);
+    expect(result.system).toBe('injected');
+  });
+});
+
+describe('system-append (Anthropic string system)', () => {
+  it('appends to existing system string', () => {
+    const body = { system: 'original', messages: [] };
+    const result = applyMiddleware(body, [mw('injected', 'system-append')]);
+    expect(result.system).toBe('original\n\ninjected');
+  });
+
+  it('creates system field when null', () => {
+    const body = { system: null, messages: [] };
+    const result = applyMiddleware(body, [mw('injected', 'system-append')]);
+    expect(result.system).toBe('injected');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anthropic format — top-level `system` array of content blocks
+// ---------------------------------------------------------------------------
+
+describe('system-prepend (Anthropic array system)', () => {
+  it('prepends a text block to the array', () => {
+    const existing = [{ type: 'text', text: 'original' }];
+    const body = { system: existing, messages: [] };
+    const result = applyMiddleware(body, [mw('injected', 'system-prepend')]);
+    expect(result.system).toEqual([{ type: 'text', text: 'injected' }, ...existing]);
+  });
+});
+
+describe('system-append (Anthropic array system)', () => {
+  it('appends a text block to the array', () => {
+    const existing = [{ type: 'text', text: 'original' }];
+    const body = { system: existing, messages: [] };
+    const result = applyMiddleware(body, [mw('injected', 'system-append')]);
+    expect(result.system).toEqual([...existing, { type: 'text', text: 'injected' }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenAI format — system prompt lives inside `messages` array
+// ---------------------------------------------------------------------------
+
+describe('system-prepend (OpenAI messages format)', () => {
+  it('inserts a system message at index 0 when no system present', () => {
+    const body = { messages: [{ role: 'user', content: 'hello' }] };
+    const result = applyMiddleware(body, [mw('injected', 'system-prepend')], 'openai');
+    const msgs = result.messages as { role: string; content: string }[];
+    expect(msgs[0]).toEqual({ role: 'system', content: 'injected' });
+    expect(msgs[1]).toEqual({ role: 'user', content: 'hello' });
+  });
+
+  it('inserts before existing system messages', () => {
+    const body = { messages: [{ role: 'system', content: 'existing' }, { role: 'user', content: 'hi' }] };
+    const result = applyMiddleware(body, [mw('injected', 'system-prepend')], 'openai');
+    const msgs = result.messages as { role: string; content: string }[];
+    expect(msgs[0]).toEqual({ role: 'system', content: 'injected' });
+    expect(msgs[1]).toEqual({ role: 'system', content: 'existing' });
+  });
+});
+
+describe('system-append (OpenAI messages format)', () => {
+  it('inserts after the last system message', () => {
+    const body = {
+      messages: [
+        { role: 'system', content: 'sys1' },
+        { role: 'user', content: 'hi' },
+      ],
+    };
+    const result = applyMiddleware(body, [mw('injected', 'system-append')], 'openai');
+    const msgs = result.messages as { role: string; content: string }[];
+    expect(msgs[0]).toEqual({ role: 'system', content: 'sys1' });
+    expect(msgs[1]).toEqual({ role: 'system', content: 'injected' });
+    expect(msgs[2]).toEqual({ role: 'user', content: 'hi' });
+  });
+
+  it('appends at end when no system message exists', () => {
+    const body = { messages: [{ role: 'user', content: 'hi' }] };
+    const result = applyMiddleware(body, [mw('injected', 'system-append')], 'openai');
+    const msgs = result.messages as { role: string; content: string }[];
+    expect(msgs[0]).toEqual({ role: 'user', content: 'hi' });
+    expect(msgs[1]).toEqual({ role: 'system', content: 'injected' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// messages prepend / append
+// ---------------------------------------------------------------------------
+
+describe('prepend position', () => {
+  it('inserts as first message with default user role', () => {
+    const body = { messages: [{ role: 'user', content: 'hello' }] };
+    const result = applyMiddleware(body, [mw('skill content', 'prepend')]);
+    const msgs = result.messages as { role: string; content: string }[];
+    expect(msgs[0]).toEqual({ role: 'user', content: 'skill content' });
+  });
+
+  it('respects custom role', () => {
+    const body = { messages: [{ role: 'user', content: 'hello' }] };
+    const result = applyMiddleware(body, [mw('sys hint', 'prepend', 'system')]);
+    const msgs = result.messages as { role: string; content: string }[];
+    expect(msgs[0].role).toBe('system');
+  });
+});
+
+describe('append position', () => {
+  it('inserts as last message with default user role', () => {
+    const body = { messages: [{ role: 'user', content: 'hello' }] };
+    const result = applyMiddleware(body, [mw('reminder', 'append')]);
+    const msgs = result.messages as { role: string; content: string }[];
+    expect(msgs[msgs.length - 1]).toEqual({ role: 'user', content: 'reminder' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple middleware applied in order
+// ---------------------------------------------------------------------------
+
+describe('multiple middleware', () => {
+  it('applies all in sequence', () => {
+    const body = { system: 'base', messages: [] };
+    const result = applyMiddleware(body, [
+      mw('first', 'system-prepend'),
+      mw('last', 'system-append'),
+    ]);
+    expect(result.system).toBe('first\n\nbase\n\nlast');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No-op
+// ---------------------------------------------------------------------------
+
+describe('empty middleware list', () => {
+  it('returns the original body reference unchanged', () => {
+    const body = { system: 'x', messages: [] };
+    const result = applyMiddleware(body, []);
+    expect(result).toBe(body);
+  });
+});

--- a/packages/provider-core/src/middleware.ts
+++ b/packages/provider-core/src/middleware.ts
@@ -1,0 +1,108 @@
+export type MiddlewarePosition =
+  | 'system-prepend'   // Prepend to Anthropic system field; or inject system-role msg at top of OpenAI messages
+  | 'system-append'    // Append to Anthropic system field; or at end of OpenAI system messages
+  | 'prepend'          // Insert as first element of messages array
+  | 'append';          // Insert as last element of messages array
+
+export interface ProviderMiddleware {
+  /** Markdown content to inject. */
+  content: string;
+  position: MiddlewarePosition;
+  /** Role for 'prepend'/'append' positions. Default: 'user'. */
+  role?: string;
+}
+
+/**
+ * Inject middleware content into an already-parsed request body.
+ * Handles both Anthropic format (top-level `system` string) and
+ * OpenAI format (system role inside `messages` array).
+ *
+ * @param format - 'anthropic' (default) for Anthropic-style requests, 'openai' for
+ *                 OpenAI-compatible requests where system prompts live inside `messages`.
+ */
+export function applyMiddleware(
+  body: Record<string, unknown>,
+  middlewares: ProviderMiddleware[],
+  format: 'anthropic' | 'openai' = 'anthropic',
+): Record<string, unknown> {
+  if (!middlewares.length) return body;
+
+  let result: Record<string, unknown> = { ...body };
+
+  for (const mw of middlewares) {
+    if (mw.position === 'system-prepend' || mw.position === 'system-append') {
+      result = applySystemMiddleware(result, mw, format);
+    } else {
+      result = applyMessagesMiddleware(result, mw);
+    }
+  }
+
+  return result;
+}
+
+function applySystemMiddleware(
+  body: Record<string, unknown>,
+  mw: ProviderMiddleware,
+  format: 'anthropic' | 'openai',
+): Record<string, unknown> {
+  const prepend = mw.position === 'system-prepend';
+
+  if (format !== 'openai') {
+    // Anthropic format: top-level `system` string or array of content blocks
+    if (typeof body.system === 'string') {
+      return {
+        ...body,
+        system: prepend
+          ? `${mw.content}\n\n${body.system}`
+          : `${body.system}\n\n${mw.content}`,
+      };
+    }
+
+    if (Array.isArray(body.system)) {
+      const block = { type: 'text', text: mw.content };
+      return {
+        ...body,
+        system: prepend
+          ? [block, ...body.system]
+          : [...body.system, block],
+      };
+    }
+
+    // No system field yet — create one
+    return { ...body, system: mw.content };
+  }
+
+  // OpenAI format: system prompt lives inside the messages array
+  const messages = Array.isArray(body.messages) ? [...(body.messages as unknown[])] : [];
+  const systemMsg = { role: 'system', content: mw.content };
+  if (prepend) {
+    // Insert before existing system messages (at index 0)
+    messages.unshift(systemMsg);
+  } else {
+    // Insert after the last existing system message, or at the end
+    const lastSystem = messages.reduceRight<number>(
+      (acc, msg, i) => acc === -1 && (msg as Record<string, unknown>).role === 'system' ? i : acc,
+      -1,
+    );
+    if (lastSystem === -1) {
+      messages.push(systemMsg);
+    } else {
+      messages.splice(lastSystem + 1, 0, systemMsg);
+    }
+  }
+  return { ...body, messages };
+}
+
+function applyMessagesMiddleware(
+  body: Record<string, unknown>,
+  mw: ProviderMiddleware,
+): Record<string, unknown> {
+  const messages = Array.isArray(body.messages) ? [...(body.messages as unknown[])] : [];
+  const injected = { role: mw.role ?? 'user', content: mw.content };
+  if (mw.position === 'prepend') {
+    messages.unshift(injected);
+  } else {
+    messages.push(injected);
+  }
+  return { ...body, messages };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@antseed/node':
         specifier: workspace:*
         version: link:../../packages/node
+      '@antseed/provider-core':
+        specifier: workspace:*
+        version: link:../../packages/provider-core
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -92,10 +95,10 @@ importers:
         version: 11.2.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@mariozechner/pi-ai':
         specifier: ^0.54.2
-        version: 0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@mariozechner/pi-coding-agent':
         specifier: ^0.54.2
-        version: 0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@noble/ed25519':
         specifier: ^2.1.0
         version: 2.3.0
@@ -12833,9 +12836,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@mariozechner/pi-agent-core@0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
-      '@mariozechner/pi-ai': 0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@mariozechner/pi-ai': 0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -12845,7 +12848,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@mariozechner/pi-ai@0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.996.0
@@ -12855,7 +12858,7 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       chalk: 5.6.2
-      openai: 6.10.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.10.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       undici: 7.22.0
@@ -12869,11 +12872,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@mariozechner/pi-coding-agent@0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
-      '@mariozechner/pi-ai': 0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@mariozechner/pi-agent-core': 0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@mariozechner/pi-ai': 0.54.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@mariozechner/pi-tui': 0.54.2
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -19512,9 +19515,9 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.10.0(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
+  openai@6.10.0(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     optionalDependencies:
-      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
 
   opener@1.5.2: {}


### PR DESCRIPTION
## Summary

- Providers can now enrich every buyer request with system prompts, skill instructions, and persona definitions stored as Markdown files
- Buyers receive only the LLM's natural response — injected content is applied server-side and never visible in conversation history
- Zero changes to `AntseedNode`, `HttpRelay`, `BaseProvider`, or the plugin interface (pure decorator pattern)

### New: `seller.middleware` config

```json
{
  "seller": {
    "middleware": [
      { "file": "./skills/coding-expert.md", "position": "system-prepend" },
      { "file": "./skills/output-format.md",  "position": "system-append" },
      { "file": "./skills/reminder.md",       "position": "append", "role": "user" }
    ]
  }
}
```

### Injection positions

| position | effect |
|---|---|
| `system-prepend` | Prepend to Anthropic `system` field; or insert system-role message at top of OpenAI messages |
| `system-append`  | Append to `system` field; or after last system message in OpenAI messages |
| `prepend`        | Insert as first element of `messages` array |
| `append`         | Insert as last element of `messages` array |

Format (Anthropic vs OpenAI) is auto-detected from the request path (`/chat/completions` → openai).

### Files changed

- `packages/provider-core/src/middleware.ts` — new: `applyMiddleware`, `ProviderMiddleware`, `MiddlewarePosition`
- `packages/provider-core/src/middleware-provider.ts` — new: `MiddlewareProvider` decorator
- `packages/provider-core/src/middleware.test.ts` — 15 tests, all positions × both formats
- `packages/provider-core/src/index.ts` — exports added
- `apps/cli/src/config/types.ts` — `SellerMiddlewareConfig` + `middleware?` on `SellerCLIConfig`
- `apps/cli/src/cli/commands/seed.ts` — `loadMiddlewareFiles()` + wraps provider before `registerProvider()`
- `apps/cli/package.json` — added `@antseed/provider-core` dependency
- Docs updated: provider-core README, CLI README, provider-plugin template

## Test plan

- [x] `pnpm --filter @antseed/provider-core test` — 40 tests pass (15 new middleware tests)
- [x] `pnpm --filter @antseed/provider-core build` — clean
- [x] `pnpm --filter @antseed/cli build` — clean
- [ ] Manual: create a `.md` skill file, add `seller.middleware` to config, run `antseed seed`, verify LLM responds with skill context applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)