### PR TITLE
feat(dashboard): add display name and model list to peer discovery

### DIFF
--- a/apps/dashboard/src/api/routes.ts
+++ b/apps/dashboard/src/api/routes.ts
@@ -46,7 +46,9 @@ function computeReadiness(
 /** PeerInfo type for API responses */
 export interface PeerInfo {
   peerId: string;
+  displayName: string | null;
   providers: string[];
+  models: string[];
   capacityMsgPerHour: number;
   inputUsdPerMillion: number;
   outputUsdPerMillion: number;
@@ -225,9 +227,11 @@ export async function registerApiRoutes(
       // Convert daemon peers to NetworkPeer format for merging
       const allPeers: NetworkPeer[] = daemonResult.peers.map((p) => ({
         peerId: p.peerId,
+        displayName: p.displayName,
         host: '',
         port: 0,
         providers: p.providers,
+        models: p.models,
         inputUsdPerMillion: p.inputUsdPerMillion,
         outputUsdPerMillion: p.outputUsdPerMillion,
         capacityMsgPerHour: p.capacityMsgPerHour,
@@ -236,13 +240,25 @@ export async function registerApiRoutes(
         source: 'daemon' as const,
       }));
 
-      // Add DHT peers, deduplicating by peerId
-      const seen = new Set(allPeers.map((p) => p.peerId));
+      // Add DHT peers, deduplicating by peerId while preserving daemon values.
+      const byPeerId = new Map(allPeers.map((p) => [p.peerId, p]));
       for (const dp of dhtPeers) {
-        if (!seen.has(dp.peerId)) {
-          allPeers.push(dp);
-          seen.add(dp.peerId);
+        const existing = byPeerId.get(dp.peerId);
+        if (existing) {
+          if ((!existing.displayName || existing.displayName.trim().length === 0) && dp.displayName) {
+            existing.displayName = dp.displayName;
+          }
+          if ((existing.models?.length ?? 0) === 0 && (dp.models?.length ?? 0) > 0) {
+            existing.models = dp.models;
+          }
+          if (existing.host.trim().length === 0 && dp.host.trim().length > 0) {
+            existing.host = dp.host;
+            existing.port = dp.port;
+          }
+          continue;
         }
+        allPeers.push(dp);
+        byPeerId.set(dp.peerId, dp);
       }
 
       return reply.send({
@@ -337,23 +353,71 @@ function mergePeers(daemonPeers: PeerInfo[], dhtPeers: NetworkPeer[]): PeerInfo[
     merged.set(p.peerId, { ...p, source: 'daemon' });
   }
 
-  // DHT peers, skip duplicates
+  // DHT peers, enrich daemon entries and add missing ones.
   for (const dp of dhtPeers) {
-    if (!merged.has(dp.peerId)) {
-      merged.set(dp.peerId, {
-        peerId: dp.peerId,
-        providers: dp.providers,
-        capacityMsgPerHour: dp.capacityMsgPerHour,
-        inputUsdPerMillion: dp.inputUsdPerMillion,
-        outputUsdPerMillion: dp.outputUsdPerMillion,
-        reputation: dp.reputation,
-        location: null,
-        source: 'dht',
-      });
+    const existing = merged.get(dp.peerId);
+    if (existing) {
+      if ((!existing.displayName || existing.displayName.trim().length === 0) && dp.displayName) {
+        existing.displayName = dp.displayName;
+      }
+      if ((existing.models?.length ?? 0) === 0 && (dp.models?.length ?? 0) > 0) {
+        existing.models = dp.models;
+      }
+      continue;
     }
+    merged.set(dp.peerId, {
+      peerId: dp.peerId,
+      displayName: dp.displayName ?? null,
+      providers: dp.providers,
+      models: dp.models ?? [],
+      capacityMsgPerHour: dp.capacityMsgPerHour,
+      inputUsdPerMillion: dp.inputUsdPerMillion,
+      outputUsdPerMillion: dp.outputUsdPerMillion,
+      reputation: dp.reputation,
+      location: null,
+      source: 'dht',
+    });
   }
 
   return Array.from(merged.values());
+}
+
+function collectPeerModels(peer: Record<string, unknown>): string[] {
+  const models = new Set<string>();
+
+  const explicitModels = peer.models;
+  if (Array.isArray(explicitModels)) {
+    for (const model of explicitModels) {
+      if (typeof model !== 'string') {
+        continue;
+      }
+      const normalized = model.trim();
+      if (normalized.length > 0) {
+        models.add(normalized);
+      }
+    }
+  }
+
+  const providerPricing = peer.providerPricing;
+  if (providerPricing && typeof providerPricing === 'object') {
+    for (const providerEntry of Object.values(providerPricing as Record<string, unknown>)) {
+      if (!providerEntry || typeof providerEntry !== 'object') {
+        continue;
+      }
+      const modelPricing = (providerEntry as Record<string, unknown>).models;
+      if (!modelPricing || typeof modelPricing !== 'object') {
+        continue;
+      }
+      for (const modelName of Object.keys(modelPricing as Record<string, unknown>)) {
+        const normalized = modelName.trim();
+        if (normalized.length > 0) {
+          models.add(normalized);
+        }
+      }
+    }
+  }
+
+  return Array.from(models);
 }
 
 async function getPeerList(): Promise<{ peers: PeerInfo[]; degraded: boolean }> {
@@ -363,10 +427,18 @@ async function getPeerList(): Promise<{ peers: PeerInfo[]; degraded: boolean }> 
     const state = JSON.parse(raw) as Record<string, unknown>;
     const rawPeers = Array.isArray(state.peers) ? state.peers : [];
     const peers: PeerInfo[] = rawPeers.map((p) => {
-      const peer = p as Partial<PeerInfo>;
+      const peer = p as Record<string, unknown>;
+      const rawDisplayName = typeof peer.displayName === 'string' ? peer.displayName.trim() : '';
+      const fallbackDisplayName = typeof peer.publicAddress === 'string' && peer.publicAddress.trim().length > 0
+        ? peer.publicAddress.trim()
+        : (typeof peer.peerId === 'string' && peer.peerId.trim().length > 0
+          ? peer.peerId.trim().slice(0, 12)
+          : '');
       return {
-        peerId: peer.peerId ?? '',
-        providers: Array.isArray(peer.providers) ? peer.providers : [],
+        peerId: typeof peer.peerId === 'string' ? peer.peerId : '',
+        displayName: (rawDisplayName.length > 0 ? rawDisplayName : fallbackDisplayName) || null,
+        providers: Array.isArray(peer.providers) ? peer.providers.filter((provider): provider is string => typeof provider === 'string') : [],
+        models: collectPeerModels(peer),
         capacityMsgPerHour: typeof peer.capacityMsgPerHour === 'number' ? peer.capacityMsgPerHour : 0,
         inputUsdPerMillion: typeof peer.inputUsdPerMillion === 'number' ? peer.inputUsdPerMillion : 0,
         outputUsdPerMillion: typeof peer.outputUsdPerMillion === 'number' ? peer.outputUsdPerMillion : 0,

--- a/apps/dashboard/src/dht-query-service.test.ts
+++ b/apps/dashboard/src/dht-query-service.test.ts
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { resolveDiscoveryProviders, resolveMetadataSummaryPricing, resolveNetworkPeerProviders } from './dht-query-service.js';
+import {
+  resolveDiscoveryProviders,
+  resolveMetadataSummaryPricing,
+  resolveNetworkPeerModels,
+  resolveNetworkPeerProviders,
+} from './dht-query-service.js';
 
 test('metadata default pricing maps to input/output USD per million', () => {
   const pricing = resolveMetadataSummaryPricing({
@@ -97,4 +102,28 @@ test('network peer providers fallback accumulates inferred topics when metadata 
   );
 
   assert.deepEqual(providers, ['openai']);
+});
+
+test('network peer models are extracted from metadata announcements', () => {
+  const models = resolveNetworkPeerModels(
+    {
+      providers: [
+        {
+          provider: 'anthropic',
+          models: ['claude-sonnet-4.6', 'claude-opus-4.1'],
+          defaultPricing: { inputUsdPerMillion: 0, outputUsdPerMillion: 0 },
+          maxConcurrency: 1,
+          currentLoad: 0,
+        },
+      ],
+    } as any,
+    ['legacy-model'],
+  );
+
+  assert.deepEqual(models, ['claude-sonnet-4.6', 'claude-opus-4.1']);
+});
+
+test('network peer models fallback keeps existing model list when metadata is unavailable', () => {
+  const models = resolveNetworkPeerModels(null, ['claude-sonnet-4.6', 'gpt-4.1']);
+  assert.deepEqual(models, ['claude-sonnet-4.6', 'gpt-4.1']);
 });

--- a/apps/dashboard/src/dht-query-service.ts
+++ b/apps/dashboard/src/dht-query-service.ts
@@ -11,9 +11,11 @@ import type { PeerMetadata } from '@antseed/node';
 
 export interface NetworkPeer {
   peerId: string;
+  displayName: string | null;
   host: string;
   port: number;
   providers: string[];
+  models: string[];
   inputUsdPerMillion: number;
   outputUsdPerMillion: number;
   capacityMsgPerHour: number;
@@ -124,6 +126,28 @@ function providerNamesFromMetadata(
   return Array.from(providers);
 }
 
+function modelNamesFromMetadata(
+  metadata: Pick<PeerMetadata, 'providers'> | null | undefined,
+): string[] {
+  if (!metadata?.providers || metadata.providers.length === 0) {
+    return [];
+  }
+
+  const models = new Set<string>();
+  for (const provider of metadata.providers) {
+    for (const model of provider.models ?? []) {
+      if (typeof model !== 'string') {
+        continue;
+      }
+      const normalized = model.trim();
+      if (normalized.length > 0) {
+        models.add(normalized);
+      }
+    }
+  }
+  return Array.from(models);
+}
+
 export function resolveNetworkPeerProviders(
   metadata: Pick<PeerMetadata, 'providers'> | null | undefined,
   existingProviders: string[] | undefined,
@@ -148,6 +172,29 @@ export function resolveNetworkPeerProviders(
     providers.add(normalizedTopic);
   }
   return Array.from(providers);
+}
+
+export function resolveNetworkPeerModels(
+  metadata: Pick<PeerMetadata, 'providers'> | null | undefined,
+  existingModels: string[] | undefined,
+): string[] {
+  // Prefer metadata models whenever available.
+  const fromMetadata = modelNamesFromMetadata(metadata);
+  if (fromMetadata.length > 0) {
+    return fromMetadata;
+  }
+
+  const models = new Set<string>();
+  for (const model of existingModels ?? []) {
+    if (typeof model !== 'string') {
+      continue;
+    }
+    const normalized = model.trim();
+    if (normalized.length > 0) {
+      models.add(normalized);
+    }
+  }
+  return Array.from(models);
 }
 
 export function resolveMetadataSummaryPricing(
@@ -283,6 +330,10 @@ export class DHTQueryService {
 
           const existing = discoveredPeers.get(peerId);
           const providers = resolveNetworkPeerProviders(metadata, existing?.providers, name);
+          const models = resolveNetworkPeerModels(metadata, existing?.models);
+          const displayName = typeof metadata?.displayName === 'string' && metadata.displayName.trim().length > 0
+            ? metadata.displayName.trim()
+            : (existing?.displayName ?? `${ep.host}:${ep.port}`);
 
           // Extract summary pricing and capacity from metadata
           const summaryPricing = this.resolveSummaryPricing(metadata);
@@ -295,9 +346,11 @@ export class DHTQueryService {
 
           discoveredPeers.set(peerId, {
             peerId,
+            displayName,
             host: ep.host,
             port: ep.port,
             providers,
+            models,
             inputUsdPerMillion: existing?.inputUsdPerMillion || summaryPricing.inputUsdPerMillion,
             outputUsdPerMillion: existing?.outputUsdPerMillion || summaryPricing.outputUsdPerMillion,
             capacityMsgPerHour: existing?.capacityMsgPerHour || capacityMsgPerHour,


### PR DESCRIPTION
## Summary
- Add `displayName` and `models` fields to `PeerInfo` and `NetworkPeer` interfaces
- Extract model names from DHT metadata provider announcements
- Merge DHT peer data into daemon entries instead of skipping duplicates (enriches displayName, models, host/port)
- Collect models from both explicit model lists and provider pricing metadata in daemon state
- Add tests for model extraction from metadata

## Test plan
- [ ] Verify dashboard network page shows peer display names and model lists
- [ ] Verify DHT-discovered peers enrich existing daemon peer entries
- [ ] Run `pnpm --filter antseed-dashboard run test` — new model extraction tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)