### PR TITLE
fix(desktop): skip node binaries below v20 when resolving CLI runtime

### DIFF
--- a/apps/desktop/src/main/process-manager.ts
+++ b/apps/desktop/src/main/process-manager.ts
@@ -249,12 +249,14 @@ function resolveNodeBinary(targetArch: string): string {
     }
     const majorVersion = detectNodeMajorVersion(candidate);
     const meetsMinVersion = majorVersion !== null && majorVersion >= MIN_NODE_MAJOR_VERSION;
-    if (meetsMinVersion && !firstCompatible) {
-      firstCompatible = candidate;
-    }
-    const arch = detectNodeArch(candidate);
-    if (arch === targetArch && meetsMinVersion) {
-      return candidate;
+    if (meetsMinVersion) {
+      if (!firstCompatible) {
+        firstCompatible = candidate;
+      }
+      const arch = detectNodeArch(candidate);
+      if (arch === targetArch) {
+        return candidate;
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

When a user has an old Node.js version installed via NVM (e.g. v14), the desktop app's `resolveNodeBinary` would fall back to it as `firstExisting` whenever no arch-matching candidate was found. Node 14 doesn't support logical-assignment operators (`??=`) used in the bundled CLI, causing an immediate `SyntaxError` at startup — surfaced to the user as a misleading "Error creating WebGL context" message in the UI.

Example log:
```
Started connect with "/Users/.../.nvm/versions/node/v14.18.1/bin/node"
SyntaxError: Unexpected token '??='
```

## Fix

- Add `MIN_NODE_MAJOR_VERSION = 20` constant (matches the project's stated `Node.js >=20` runtime requirement)
- Add `detectNodeMajorVersion()` helper to probe a binary's major version
- Track `firstCompatible` (first candidate meeting v20+) alongside `firstExisting`
- Require candidates to meet the minimum version in addition to arch match
- Fall back to `firstCompatible` before `firstExisting`, so an old-but-existing node is skipped in favour of a compatible one

## Test plan

- [ ] User with only NVM v14 installed: app should skip it and fall back to a compatible system node or report a clear error
- [ ] User with NVM v20+ installed: should be selected as before
- [ ] User with `/opt/homebrew/bin/node` (v20+, arm64): should be preferred as the best match