### PR TITLE
feat(desktop): add Discover sidebar entry for model discovery screen

### DIFF
--- a/apps/desktop/src/renderer/ui/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/ui/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import { CommandLineIcon } from '@hugeicons/core-free-icons';
 import { MoreVerticalIcon } from '@hugeicons/core-free-icons';
 import { Add01Icon } from '@hugeicons/core-free-icons';
 import { ComputerTerminal01Icon } from '@hugeicons/core-free-icons';
+import { DiscoverCircleIcon } from '@hugeicons/core-free-icons';
 import type { ViewName } from '../types';
 import { useUiSnapshot } from '../hooks/useUiSnapshot';
 import { useActions } from '../hooks/useActions';
@@ -29,6 +30,7 @@ type NavEntry = {
 
 const baseEntries: NavEntry[] = [
   { label: 'New Chat', view: 'chat', icon: Add01Icon, action: 'new-chat' },
+  { label: 'Discover', view: 'discover', icon: DiscoverCircleIcon },
   { label: 'Network', view: 'overview', icon: HierarchySquare03Icon },
   { label: 'External Clients', view: 'external-clients', icon: ComputerTerminal01Icon },
   { label: 'Settings', view: 'config', icon: Settings02Icon },

--- a/apps/desktop/src/renderer/ui/components/ViewHost.tsx
+++ b/apps/desktop/src/renderer/ui/components/ViewHost.tsx
@@ -3,6 +3,7 @@ import { ChatView } from './views/ChatView';
 import { ConfigView } from './views/ConfigView';
 import { ConnectionView } from './views/ConnectionView';
 import { DesktopView } from './views/DesktopView';
+import { DiscoverView } from './views/DiscoverView';
 import { ExternalClientsView } from './views/ExternalClientsView';
 import { OverviewView } from './views/OverviewView';
 import { PeersView } from './views/PeersView';
@@ -22,6 +23,7 @@ export function ViewHost({ activeView, onSelectView }: ViewHostProps) {
       <ConfigView active={activeView === 'config'} />
       <DesktopView active={activeView === 'desktop'} />
       <ExternalClientsView active={activeView === 'external-clients'} />
+      <DiscoverView active={activeView === 'discover'} onSelectView={onSelectView} />
     </section>
   );
 }

--- a/apps/desktop/src/renderer/ui/components/views/DiscoverView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/DiscoverView.tsx
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+import { useUiSnapshot } from '../../hooks/useUiSnapshot';
+import { useActions } from '../../hooks/useActions';
+import { DiscoverWelcome } from '../chat/DiscoverWelcome';
+import type { ViewName } from '../../types';
+
+type DiscoverViewProps = {
+  active: boolean;
+  onSelectView: (view: ViewName) => void;
+};
+
+export function DiscoverView({ active, onSelectView }: DiscoverViewProps) {
+  const snap = useUiSnapshot();
+  const actions = useActions();
+
+  const handleStartChatting = useCallback(
+    (modelValue: string) => {
+      actions.handleModelChange(modelValue);
+      actions.startNewChat();
+      onSelectView('chat');
+    },
+    [actions, onSelectView],
+  );
+
+  return (
+    <section className={`view${active ? ' active' : ''}`} role="tabpanel">
+      <DiscoverWelcome
+        modelOptions={snap.chatModelOptions}
+        onStartChatting={handleStartChatting}
+      />
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/ui/types.ts
+++ b/apps/desktop/src/renderer/ui/types.ts
@@ -1,3 +1,3 @@
-export const VIEW_NAMES = ['chat', 'overview', 'peers', 'connection', 'config', 'desktop', 'external-clients'] as const;
+export const VIEW_NAMES = ['chat', 'overview', 'peers', 'connection', 'config', 'desktop', 'external-clients', 'discover'] as const;
 
 export type ViewName = (typeof VIEW_NAMES)[number];


### PR DESCRIPTION
## Summary

- Adds a "Discover" nav entry to the main sidebar (positioned after "New Chat"), using `DiscoverCircleIcon` from `@hugeicons/core-free-icons`
- Introduces a new `'discover'` view name in the `VIEW_NAMES` tuple and a thin `DiscoverView` wrapper component that renders the existing `DiscoverWelcome` component as a full-panel view
- Wires `ViewHost` to mount `DiscoverView`, with clicking a model card selecting that model and navigating to the chat view

Closes #66

## Test plan

- [ ] Click "Discover" in the sidebar — the model discovery screen renders as a full panel
- [ ] Filter pills and model cards function normally in the new view
- [ ] Clicking a model card selects the model and navigates to the Chat view
- [ ] Other sidebar entries (New Chat, Network, External Clients, Settings) continue to work as before
- [ ] Dev-mode entries are unaffected