### PR TITLE
feat(website): add JSON-LD SoftwareApplication schema for GEO

### DIFF
--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -125,7 +125,7 @@ const config: Config = {
           'Desktop app (AntStation)',
           'Agent-to-agent commerce support',
         ],
-        downloadUrl: 'https://antseed.com/docs',
+        downloadUrl: 'https://github.com/AntSeed/antseed/releases',
         softwareVersion: '0.1.25',
         license: 'https://github.com/AntSeed/antseed/blob/main/LICENSE',
       }),


### PR DESCRIPTION
## JSON-LD Structured Data — GEO

Adds a `SoftwareApplication` JSON-LD schema to the homepage `<head>` via Docusaurus `headTags`.

### What it does

Tells Google, Perplexity, ChatGPT, and other AI crawlers exactly what AntSeed is — in unambiguous machine-readable format:

```json
{
  "@type": "SoftwareApplication",
  "name": "AntSeed",
  "applicationCategory": "DeveloperApplication",
  "operatingSystem": "macOS, Linux, Windows",
  "featureList": [
    "P2P inference routing via DHT",
    "OpenAI Responses API compatible",
    "Reputation-based provider scoring",
    "TEE attestation",
    ...
  ]
}
```

### Why it matters

- **Rich results in Google** — enables app category, download links, and star ratings directly in search listings
- **Knowledge graph eligibility** — structured data is how Google builds the info panel for a brand
- **AI answer accuracy** — when someone asks Perplexity/ChatGPT "what is AntSeed?", they get facts from this schema instead of guessing from marketing copy
- **Zero performance cost** — static JSON in `<head>`, no runtime overhead

### Implementation

Uses Docusaurus `headTags` config (the correct Docusaurus way to inject arbitrary `<head>` tags globally). The schema is inlined as `application/ld+json`.