### PR TITLE
Guard large desktop write tool payloads

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
     "build": "npm run build:main && npm run build:renderer",
     "build:main": "tsc -p tsconfig.main.json",
     "build:renderer": "vite build",
+    "test": "npm run build:main && node --test dist/main/*.test.js",
     "typecheck:renderer": "tsc -p tsconfig.renderer.json --noEmit",
     "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:main\" \"npm:dev:electron\"",
     "dev:debug": "concurrently -k \"npm:dev:renderer\" \"npm:dev:main\" \"npm:dev:electron:debug\"",

--- a/apps/desktop/src/main/chat-system-prompt.ts
+++ b/apps/desktop/src/main/chat-system-prompt.ts
@@ -55,6 +55,7 @@ Tool guidelines:
 - Use web_fetch for any public URL — it handles both static and JS-rendered pages. Never use curl or bash for web fetching.
 - Use read to inspect files before editing. You must use this tool instead of cat or sed.
 - Use edit for precise modifications when the existing text can be matched exactly.
-- Use write only for new files or full rewrites.
+- Use write only for new files or short full rewrites.
+- If a file body is large, do not send it in one write call. Create a short stub first, then use edit in small chunks.
 - Only use tools when they materially help with the user's request.
 - When summarizing your work, respond in plain text directly. Do not use tools just to print a summary.`;

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -21,7 +21,6 @@ import {
   readTool,
   SessionManager,
   SettingsManager,
-  writeTool,
 } from '@mariozechner/pi-coding-agent';
 import type {
   AssistantMessage,
@@ -37,6 +36,7 @@ import type {
   Usage,
 } from '@mariozechner/pi-ai';
 import { createAssistantMessageEventStream } from '@mariozechner/pi-ai';
+import { createManagedWriteTool } from './write-tool-policy.js';
 
 type TextBlock = { type: 'text'; text: string };
 type ThinkingBlock = { type: 'thinking'; thinking: string };
@@ -2364,6 +2364,7 @@ export function registerPiChatHandlers({
       systemPrompt: userSystemPrompt ?? ANTSTATION_SYSTEM_PROMPT,
     });
     await resourceLoader.reload();
+    const managedWriteTool = createManagedWriteTool(CHAT_WORKSPACE_DIR);
 
     const { session } = await createAgentSession({
       cwd: CHAT_WORKSPACE_DIR,
@@ -2376,7 +2377,7 @@ export function registerPiChatHandlers({
         readTool,
         bashTool,
         editTool,
-        writeTool,
+        managedWriteTool,
         grepTool,
         findTool,
         lsTool,

--- a/apps/desktop/src/main/write-tool-policy.test.ts
+++ b/apps/desktop/src/main/write-tool-policy.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createManagedWriteTool, MAX_DIRECT_WRITE_CHARS } from './write-tool-policy.js';
+
+test('createManagedWriteTool writes small payloads', async () => {
+  const writes: Array<{ path: string; content: string }> = [];
+  const mkdirs: string[] = [];
+  const tool = createManagedWriteTool('/workspace', {
+    operations: {
+      async writeFile(path, content) {
+        writes.push({ path, content });
+      },
+      async mkdir(dir) {
+        mkdirs.push(dir);
+      },
+    },
+  });
+
+  const result = await tool.execute('tool-1', {
+    path: 'index.html',
+    content: '<h1>Hello</h1>',
+  }, undefined, undefined);
+
+  assert.equal(mkdirs.length, 1);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0]?.path, '/workspace/index.html');
+  assert.equal(writes[0]?.content, '<h1>Hello</h1>');
+  const firstBlock = result.content[0];
+  const text = firstBlock && firstBlock.type === 'text' ? firstBlock.text : '';
+  assert.match(text, /Successfully wrote 14 bytes/);
+});
+
+test('createManagedWriteTool rejects oversized payloads before touching the filesystem', async () => {
+  const writes: Array<{ path: string; content: string }> = [];
+  const mkdirs: string[] = [];
+  const tool = createManagedWriteTool('/workspace', {
+    operations: {
+      async writeFile(path, content) {
+        writes.push({ path, content });
+      },
+      async mkdir(dir) {
+        mkdirs.push(dir);
+      },
+    },
+  });
+
+  await assert.rejects(
+    () => tool.execute('tool-2', {
+      path: 'large.txt',
+      content: 'x'.repeat(MAX_DIRECT_WRITE_CHARS + 1),
+    }, undefined, undefined),
+    /Direct write payload too large/,
+  );
+
+  assert.equal(mkdirs.length, 0);
+  assert.equal(writes.length, 0);
+});

--- a/apps/desktop/src/main/write-tool-policy.ts
+++ b/apps/desktop/src/main/write-tool-policy.ts
@@ -1,0 +1,44 @@
+import {
+  createWriteTool,
+  type WriteOperations,
+  type WriteToolInput,
+  type WriteToolOptions,
+} from '@mariozechner/pi-coding-agent';
+
+export const MAX_DIRECT_WRITE_CHARS = 8_000;
+
+export function buildDirectWriteLimitMessage(contentLength: number): string {
+  return [
+    `Direct write payload too large (${contentLength} chars).`,
+    `To avoid provider-side tool-call truncation, keep write content at or below ${MAX_DIRECT_WRITE_CHARS} chars.`,
+    'For larger files, create a short stub first and then use edit in small chunks.',
+  ].join(' ');
+}
+
+export function createManagedWriteTool(
+  cwd: string,
+  options?: WriteToolOptions & { maxChars?: number },
+): ReturnType<typeof createWriteTool> {
+  const maxChars = Math.max(1, options?.maxChars ?? MAX_DIRECT_WRITE_CHARS);
+  const operations: WriteOperations | undefined = options?.operations;
+  const baseTool = createWriteTool(cwd, operations ? { operations } : undefined);
+
+  return {
+    ...baseTool,
+    description:
+      `Write small files or short full rewrites (up to ${maxChars} chars). `
+      + 'For larger files, create a short stub and then use edit in small chunks.',
+    async execute(
+      toolCallId: string,
+      params: WriteToolInput,
+      signal?: AbortSignal,
+      onUpdate?: Parameters<typeof baseTool.execute>[3],
+    ) {
+      const typedParams = params as WriteToolInput;
+      if (typedParams.content.length > maxChars) {
+        throw new Error(buildDirectWriteLimitMessage(typedParams.content.length));
+      }
+      return baseTool.execute(toolCallId, typedParams, signal, onUpdate);
+    },
+  };
+}


### PR DESCRIPTION
## Summary\n- add a desktop-only managed write tool that rejects oversized direct writes with actionable guidance\n- wire the desktop chat session to use the managed write tool instead of the raw write tool\n- update the default AntStation prompt to prefer stub-plus-edit chunking for large files\n- add Node-based tests for the small-write and oversized-write paths\n\n## Testing\n- pnpm --filter @antseed/desktop test