### PR TITLE
Use model max token budget in AntStation chat

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,6 +18,7 @@
     "build": "npm run build:main && npm run build:renderer",
     "build:main": "tsc -p tsconfig.main.json",
     "build:renderer": "vite build",
+    "test": "npm run build:main && node --test dist/main/*.test.js",
     "typecheck:renderer": "tsc -p tsconfig.renderer.json --noEmit",
     "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:main\" \"npm:dev:electron\"",
     "dev:debug": "concurrently -k \"npm:dev:renderer\" \"npm:dev:main\" \"npm:dev:electron:debug\"",

--- a/apps/desktop/src/main/chat-request-budget.test.ts
+++ b/apps/desktop/src/main/chat-request-budget.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { DEFAULT_MAX_TOKENS, resolveRequestMaxTokens } from './chat-request-budget.js';
+
+test('resolveRequestMaxTokens prefers explicit stream option override', () => {
+  const value = resolveRequestMaxTokens(
+    { maxTokens: 16_384 },
+    { maxTokens: 32_000 },
+  );
+
+  assert.equal(value, 32_000);
+});
+
+test('resolveRequestMaxTokens falls back to model maxTokens', () => {
+  const value = resolveRequestMaxTokens(
+    { maxTokens: 16_384 },
+    undefined,
+  );
+
+  assert.equal(value, 16_384);
+});
+
+test('resolveRequestMaxTokens falls back to default when neither source is usable', () => {
+  const value = resolveRequestMaxTokens(
+    { maxTokens: 0 },
+    { maxTokens: -1 },
+  );
+
+  assert.equal(value, DEFAULT_MAX_TOKENS);
+});

--- a/apps/desktop/src/main/chat-request-budget.ts
+++ b/apps/desktop/src/main/chat-request-budget.ts
@@ -1,0 +1,20 @@
+import type { Model, StreamOptions } from '@mariozechner/pi-ai';
+
+export const DEFAULT_MAX_TOKENS = 16_384;
+
+export function resolveRequestMaxTokens(
+  model: Pick<Model<any>, 'maxTokens'>,
+  options?: Pick<StreamOptions, 'maxTokens'>,
+): number {
+  const requested = Number(options?.maxTokens);
+  if (Number.isFinite(requested) && requested > 0) {
+    return Math.floor(requested);
+  }
+
+  const modelMaxTokens = Number(model.maxTokens);
+  if (Number.isFinite(modelMaxTokens) && modelMaxTokens > 0) {
+    return Math.floor(modelMaxTokens);
+  }
+
+  return DEFAULT_MAX_TOKENS;
+}

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -37,6 +37,7 @@ import type {
   Usage,
 } from '@mariozechner/pi-ai';
 import { createAssistantMessageEventStream } from '@mariozechner/pi-ai';
+import { resolveRequestMaxTokens } from './chat-request-budget.js';
 
 type TextBlock = { type: 'text'; text: string };
 type ThinkingBlock = { type: 'thinking'; thinking: string };
@@ -364,7 +365,6 @@ const CHAT_WORKSPACE_DIR = path.join(ANTSEED_HOME_DIR, 'projects');
 const CHAT_AGENT_DIR = path.join(CHAT_DATA_DIR, 'pi-agent');
 const DEFAULT_PROXY_PORT = 8377;
 const DEFAULT_CHAT_MODEL = 'claude-sonnet-4-20250514';
-const DEFAULT_MAX_TOKENS = 4096;
 const PROXY_PROVIDER_ID = 'antseed-proxy';
 const PROXY_RUNTIME_API_KEY = 'antseed-local';
 const CHAT_SYSTEM_PROMPT_ENV = 'ANTSEED_CHAT_SYSTEM_PROMPT';
@@ -1653,7 +1653,7 @@ function createBuyerProxyStreamFn(
       const url = `${String(model.baseUrl).replace(/\/+$/, '')}/v1/messages`;
       const requestBody = {
         model: model.id,
-        max_tokens: Number(options?.maxTokens) > 0 ? Math.floor(Number(options?.maxTokens)) : DEFAULT_MAX_TOKENS,
+        max_tokens: resolveRequestMaxTokens(model, options),
         stream: true,
         ...(context.systemPrompt ? { system: context.systemPrompt } : {}),
         ...(context.tools ? { tools: convertToolsToAnthropic(context.tools) } : {}),


### PR DESCRIPTION
## Summary
- stop falling back to a hard-coded 4096 output budget in AntStation chat requests
- resolve  from the model budget unless a per-request override is provided
- add focused tests for request token-budget resolution

## Testing
- pnpm --filter @antseed/desktop build:main
- node --test apps/desktop/dist/main/chat-request-budget.test.js