### PR TITLE
fix(desktop): preserve tool pane when returning to active chat

### DIFF
--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -2762,6 +2762,10 @@ export function registerPiChatHandlers({
     },
   );
 
+  ipcMain.handle('chat:ai-is-stream-active', (_event, conversationId: string) => {
+    return { ok: true, active: activeRunsByConversation.has(conversationId) };
+  });
+
   ipcMain.handle('chat:ai-abort', async () => {
     const activeRuns = Array.from(activeRunsByConversation.values());
     if (activeRuns.length === 0) {

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -172,6 +172,9 @@ const api = {
   chatAiAbort(): Promise<{ ok: boolean }> {
     return ipcRenderer.invoke('chat:ai-abort');
   },
+  chatAiIsStreamActive(conversationId: string): Promise<{ ok: boolean; active: boolean }> {
+    return ipcRenderer.invoke('chat:ai-is-stream-active', conversationId);
+  },
   chatAiGetProxyStatus(): Promise<{ ok: boolean; data: { running: boolean; port: number } }> {
     return ipcRenderer.invoke('chat:ai-get-proxy-status');
   },

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -508,6 +508,9 @@ export function initChatModule({
     });
   }
 
+  // Per-conversation cache so the streaming message survives navigation.
+  const streamingMessageCache = new Map<string, ChatMessage>();
+
   function cloneStreamingMessage(message: ChatMessage): ChatMessage {
     return {
       ...message,
@@ -871,6 +874,12 @@ export function initChatModule({
   async function openConversation(convId: string): Promise<void> {
     if (!bridge || !bridge.chatAiGetConversation) return;
 
+    // Save the current streaming message so it survives navigation.
+    const previousConvId = uiState.chatActiveConversation;
+    if (previousConvId && uiState.chatStreamingMessage) {
+      streamingMessageCache.set(previousConvId, cloneStreamingMessage(uiState.chatStreamingMessage));
+    }
+
     uiState.chatActiveConversation = convId;
     setStreamingMessage(null);
 
@@ -897,6 +906,26 @@ export function initChatModule({
 
         updateThreadMeta(conv);
         uiState.chatError = null;
+
+        // Restore the cached streaming message if the stream is still active
+        // and the cached turn hasn't already been committed to disk.
+        const cached = streamingMessageCache.get(convId);
+        if (cached) {
+          streamingMessageCache.delete(convId);
+          if (bridge.chatAiIsStreamActive) {
+            const { active } = await bridge.chatAiIsStreamActive(convId);
+            if (active) {
+              const lastAssistant = uiState.chatMessages
+                .findLast((m: ChatMessage) => m.role === 'assistant');
+              const isStale = lastAssistant &&
+                Number(lastAssistant.createdAt) >= Number(cached.createdAt);
+              if (!isStale && !uiState.chatStreamingMessage) {
+                setStreamingMessage(cached);
+              }
+            }
+          }
+        }
+
         notifyUiStateChanged();
       } else {
         reportChatError(result.error, 'Failed to open conversation');
@@ -1654,6 +1683,7 @@ export function initChatModule({
 
     if (bridge.onChatAiStreamDone) {
       bridge.onChatAiStreamDone((data) => {
+        streamingMessageCache.delete(data.conversationId);
         if (data.conversationId !== uiState.chatActiveConversation) return;
 
         cancelThinkingRaf();
@@ -1687,6 +1717,7 @@ export function initChatModule({
 
     if (bridge.onChatAiStreamError) {
       bridge.onChatAiStreamError((data) => {
+        streamingMessageCache.delete(data.conversationId);
         if (data.conversationId !== uiState.chatActiveConversation) return;
 
         cancelThinkingRaf();

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -120,6 +120,7 @@ export type DesktopBridge = {
   chatAiSend?: (conversationId: string, message: string, model?: string, provider?: string, imageBase64?: string, imageMimeType?: string) => Promise<{ ok: boolean; error?: string }>;
   chatAiSendStream?: (conversationId: string, message: string, model?: string, provider?: string, imageBase64?: string, imageMimeType?: string) => Promise<{ ok: boolean; error?: string }>;
   chatAiAbort?: () => Promise<{ ok: boolean }>;
+  chatAiIsStreamActive?: (conversationId: string) => Promise<{ ok: boolean; active: boolean }>;
   chatAiGetProxyStatus?: () => Promise<{ ok: boolean; data: { running: boolean; port: number } }>;
   onChatAiDone?: (handler: (data: { conversationId: string; message: { role: string; content: unknown; createdAt?: number; meta?: Record<string, unknown> } }) => void) => () => void;
   onChatAiError?: (handler: (data: { conversationId: string; error: string }) => void) => () => void;

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -466,9 +466,10 @@ function CopyResponseButton({ content }: { content: unknown }) {
 type ChatBubbleProps = {
   message: ChatMessage;
   streaming?: boolean;
+  hideActions?: boolean;
 };
 
-export function ChatBubble({ message, streaming = false }: ChatBubbleProps) {
+export function ChatBubble({ message, streaming = false, hideActions = false }: ChatBubbleProps) {
   const [metaExpanded, setMetaExpanded] = useState(false);
   const metaParts = useMemo(() => buildChatMetaParts(message), [message]);
 
@@ -514,7 +515,7 @@ export function ChatBubble({ message, streaming = false }: ChatBubbleProps) {
     <div className={`${styles.chatBubble} ${message.role === 'user' ? styles.own : styles.other}`}>
       {bubbleMeta}
       <div>{content}</div>
-      {message.role !== 'user' && !streaming ? (
+      {message.role !== 'user' && !streaming && !hideActions ? (
         <div className={styles.messageActions}>
           <CopyResponseButton content={message.content} />
         </div>

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -255,7 +255,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
               </div>
             ) : (
               visibleMessages.map((msg, i) => (
-                <ChatBubble key={getMessageKey(msg, i)} message={msg} />
+                <ChatBubble key={getMessageKey(msg, i)} message={msg} hideActions={Boolean(snap.chatStreamingMessage) && i === visibleMessages.length - 1} />
               ))
             )}
             {snap.chatStreamingMessage ? (


### PR DESCRIPTION
## Summary

- Skip clearing the streaming message when re-opening the same conversation that already has an active stream
- In-progress tool calls now remain visible after navigating away and back

## Test plan

- [ ] Start a chat that triggers a tool call (e.g. code execution)
- [ ] While the tool is running, navigate to another conversation or screen
- [ ] Navigate back to the original chat
- [ ] Verify the tool pane is still visible with its running state

Closes #85