### PR TITLE
fix(desktop): apply markdown styles to user messages

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -12,56 +12,8 @@
   border: 0;
 
   /* ===================================================================
-     User message (own)
+     Shared markdown styles (apply to both user and assistant bubbles)
      =================================================================== */
-
-  &.own {
-    width: fit-content;
-    margin-left: auto;
-    margin-right: max(0px, calc((100% - 640px) / 2));
-    background: var(--chat-user-bubble);
-    border: 1px solid var(--chat-user-bubble-border);
-    color: var(--text-primary);
-    border-radius: var(--radius);
-    padding: 9px 17px;
-    margin-bottom: 32px;
-    margin-top: 16px;
-
-    .chat-bubble-meta {
-      margin-bottom: 4px;
-      text-align: left;
-      justify-content: flex-start;
-      font-size: 11px;
-    }
-
-    :global {
-      .chat-bubble-content {
-        line-height: 1.7;
-      }
-
-      .chat-image-preview {
-        max-width: 280px;
-        max-height: 200px;
-        border-radius: var(--radius-sm);
-        margin-bottom: 6px;
-        display: block;
-        object-fit: contain;
-      }
-    }
-  }
-
-  /* ===================================================================
-     Assistant message (other)
-     =================================================================== */
-
-  &.other {
-    align-self: stretch;
-    background: transparent;
-    color: var(--text-primary);
-    border-left: 0;
-    border-radius: 0;
-    width: 100%;
-    padding: 0 16px;
 
   :global {
     .chat-bubble-content {
@@ -248,7 +200,57 @@
       display: inline-block;
       margin: 6px 0;
     }
+  }
 
+  /* ===================================================================
+     User message (own)
+     =================================================================== */
+
+  &.own {
+    width: fit-content;
+    margin-left: auto;
+    margin-right: max(0px, calc((100% - 640px) / 2));
+    background: var(--chat-user-bubble);
+    border: 1px solid var(--chat-user-bubble-border);
+    color: var(--text-primary);
+    border-radius: var(--radius);
+    padding: 9px 17px;
+    margin-bottom: 32px;
+    margin-top: 16px;
+
+    .chat-bubble-meta {
+      margin-bottom: 4px;
+      text-align: left;
+      justify-content: flex-start;
+      font-size: 11px;
+    }
+
+    :global {
+      .chat-image-preview {
+        max-width: 280px;
+        max-height: 200px;
+        border-radius: var(--radius-sm);
+        margin-bottom: 6px;
+        display: block;
+        object-fit: contain;
+      }
+    }
+  }
+
+  /* ===================================================================
+     Assistant message (other)
+     =================================================================== */
+
+  &.other {
+    align-self: stretch;
+    background: transparent;
+    color: var(--text-primary);
+    border-left: 0;
+    border-radius: 0;
+    width: 100%;
+    padding: 0 16px;
+
+  :global {
     /* Tool group */
     .tool-group {
       margin: 10px 0 12px;


### PR DESCRIPTION
## Summary

- Move shared markdown CSS rules (headings, lists, code blocks, tables, blockquotes, images) from assistant-only scope to the shared `.chat-bubble` scope
- User messages now render markdown with proper styling

## Test plan

- [ ] Send a user message containing markdown (bold, lists, inline code, code blocks)
- [ ] Verify the formatting matches assistant message styling
- [ ] Verify assistant message styling is unchanged

Closes #86