### PR TITLE
fix(provider): preserve final streaming with agent skills

### DIFF
--- a/apps/cli/src/cli/commands/seed.ts
+++ b/apps/cli/src/cli/commands/seed.ts
@@ -1,8 +1,8 @@
 import type { Command } from 'commander'
 import chalk from 'chalk'
 import ora from 'ora'
-import { writeFile, unlink, readFile } from 'node:fs/promises'
-import { join, resolve, isAbsolute, dirname } from 'node:path'
+import { writeFile, unlink } from 'node:fs/promises'
+import { join, resolve, dirname, isAbsolute } from 'node:path'
 import { homedir } from 'node:os'
 import { getGlobalOptions } from './types.js'
 import { loadConfig } from '../../config/loader.js'
@@ -13,8 +13,9 @@ import { parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery'
 import { setupShutdownHandler } from '../shutdown.js'
 import { loadProviderPlugin, buildPluginConfig } from '../../plugins/loader.js'
 import { resolveEffectiveSellerConfig, type SellerRuntimeOverrides } from '../../config/effective.js'
-import type { SellerCLIConfig, SellerMiddlewareConfig } from '../../config/types.js'
-import { MiddlewareProvider, AgentProvider, SkillRegistry, type ProviderMiddleware } from '@antseed/provider-core'
+import type { SellerCLIConfig } from '../../config/types.js'
+import { MiddlewareProvider, AgentProvider, SkillRegistry } from '@antseed/provider-core'
+import { loadMiddlewareFiles } from '../provider-files.js'
 
 function getStateFile(dataDir: string): string {
   return join(dataDir, 'daemon.state.json')
@@ -167,22 +168,6 @@ function parseRuntimeServiceCategoriesJson(raw: string | undefined): Record<stri
   } catch {
     return undefined
   }
-}
-
-async function loadMiddlewareFiles(
-  configs: SellerMiddlewareConfig[],
-  baseDir: string,
-): Promise<ProviderMiddleware[]> {
-  return Promise.all(
-    configs.map(async (entry) => {
-      if (entry.services !== undefined && entry.services.length === 0) {
-        throw new Error(`Middleware entry "${entry.file}" has an empty services list — remove the field to apply globally or list at least one service ID.`)
-      }
-      const filePath = isAbsolute(entry.file) ? entry.file : resolve(baseDir, entry.file)
-      const content = await readFile(filePath, 'utf-8')
-      return { content, position: entry.position, role: entry.role, services: entry.services } as ProviderMiddleware
-    }),
-  )
 }
 
 export function registerSeedCommand(program: Command): void {

--- a/apps/cli/src/cli/commands/serve-agent.ts
+++ b/apps/cli/src/cli/commands/serve-agent.ts
@@ -1,0 +1,307 @@
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { resolve } from 'node:path';
+import type {
+  Provider,
+  ProviderStreamCallbacks,
+  SerializedHttpRequest,
+  SerializedHttpResponse,
+} from '@antseed/node';
+import { ANTSEED_STREAMING_RESPONSE_HEADER } from '@antseed/node';
+import {
+  AgentProvider,
+  MiddlewareProvider,
+  SkillRegistry,
+  type ProviderMiddleware,
+} from '@antseed/provider-core';
+import { setupShutdownHandler } from '../shutdown.js';
+import { buildPluginConfig, loadProviderPlugin } from '../../plugins/loader.js';
+import { loadMiddlewareDirectory, loadMiddlewareFiles } from '../provider-files.js';
+import type { MiddlewarePosition, SellerMiddlewareConfig } from '../../config/types.js';
+
+const DEFAULT_PORT = 4020;
+const DEFAULT_HOST = '127.0.0.1';
+
+const DEBUG = () =>
+  ['1', 'true', 'yes', 'on'].includes((process.env['ANTSEED_DEBUG'] ?? '').trim().toLowerCase());
+
+function log(...args: unknown[]): void {
+  if (DEBUG()) console.log('[serve-agent]', ...args);
+}
+
+function collectList(value: string, previous: string[] = []): string[] {
+  previous.push(value);
+  return previous;
+}
+
+function isValidMiddlewarePosition(value: string): value is MiddlewarePosition {
+  return value === 'system-prepend' || value === 'system-append' || value === 'prepend' || value === 'append';
+}
+
+function parseJsonObject(body: Uint8Array): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(body)) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function serializeRequest(req: IncomingMessage, body: Uint8Array): SerializedHttpRequest {
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (typeof value === 'string') {
+      headers[key] = value;
+    } else if (Array.isArray(value)) {
+      headers[key] = value.join(', ');
+    }
+  }
+  delete headers.host;
+  headers['content-length'] = String(body.length);
+
+  return {
+    requestId: randomUUID(),
+    method: req.method ?? 'POST',
+    path: req.url ?? '/',
+    headers,
+    body,
+  };
+}
+
+function isStreamRequested(request: SerializedHttpRequest): boolean {
+  const accept = request.headers.accept?.toLowerCase() ?? '';
+  if (accept.includes('text/event-stream')) {
+    return true;
+  }
+  return parseJsonObject(request.body)?.stream === true;
+}
+
+function toNodeHeaders(headers: Record<string, string>, bodyLength?: number): Record<string, string> {
+  const next = { ...headers };
+  delete next[ANTSEED_STREAMING_RESPONSE_HEADER];
+  if (bodyLength === undefined) {
+    delete next['content-length'];
+  } else {
+    next['content-length'] = String(bodyLength);
+  }
+  return next;
+}
+
+function encodeJson(value: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(value));
+}
+
+function writeBufferedResponse(res: ServerResponse, response: SerializedHttpResponse): void {
+  res.writeHead(response.statusCode, toNodeHeaders(response.headers, response.body.length));
+  res.end(Buffer.from(response.body));
+}
+
+function writeJson(res: ServerResponse, statusCode: number, value: unknown): void {
+  const body = encodeJson(value);
+  res.writeHead(statusCode, {
+    'content-type': 'application/json',
+    'content-length': String(body.length),
+  });
+  res.end(Buffer.from(body));
+}
+
+function buildOpenAIModelsResponse(provider: Provider): Uint8Array {
+  return encodeJson({
+    object: 'list',
+    data: provider.services.map((service) => ({
+      id: service,
+      object: 'model',
+      created: 0,
+      owned_by: provider.name,
+    })),
+  });
+}
+
+async function readIncomingBody(req: IncomingMessage): Promise<Uint8Array> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  return new Uint8Array(Buffer.concat(chunks));
+}
+
+async function buildProviderStack(options: {
+  providerName: string;
+  skillsDir?: string;
+  middlewareFiles: string[];
+  middlewareDirs: string[];
+  middlewarePosition: MiddlewarePosition;
+  middlewareRole?: string;
+  middlewareServices: string[];
+  middlewareConfidentialityPrompt?: string;
+}): Promise<Provider> {
+  const plugin = await loadProviderPlugin(options.providerName);
+  const providerConfig = buildPluginConfig(plugin.configSchema ?? plugin.configKeys ?? [], {});
+  let provider = await plugin.createProvider(providerConfig);
+  if (provider.init) {
+    await provider.init();
+  }
+
+  const middlewareServices = options.middlewareServices.length > 0 ? options.middlewareServices : undefined;
+  const middlewareConfigs: SellerMiddlewareConfig[] = options.middlewareFiles.map((file) => ({
+    file,
+    position: options.middlewarePosition,
+    ...(options.middlewareRole !== undefined ? { role: options.middlewareRole } : {}),
+    ...(middlewareServices !== undefined ? { services: middlewareServices } : {}),
+  }));
+  const middlewareEntries: ProviderMiddleware[] = [];
+  if (middlewareConfigs.length > 0) {
+    middlewareEntries.push(...await loadMiddlewareFiles(middlewareConfigs, process.cwd()));
+  }
+  for (const directory of options.middlewareDirs) {
+    middlewareEntries.push(...await loadMiddlewareDirectory(directory, {
+      position: options.middlewarePosition,
+      ...(options.middlewareRole !== undefined ? { role: options.middlewareRole } : {}),
+      ...(middlewareServices !== undefined ? { services: middlewareServices } : {}),
+    }));
+  }
+
+  if (middlewareEntries.length > 0) {
+    provider = new MiddlewareProvider(provider, middlewareEntries, options.middlewareConfidentialityPrompt);
+  }
+
+  if (options.skillsDir) {
+    const registry = new SkillRegistry();
+    await registry.loadDirectory(options.skillsDir);
+    provider = new AgentProvider(provider, registry);
+  }
+
+  return provider;
+}
+
+export function registerServeAgentCommand(program: Command): void {
+  program
+    .command('serve-agent')
+    .description('Run a local standalone agent service backed by a provider plugin')
+    .option('-p, --port <number>', 'local listen port', (value) => parseInt(value, 10), DEFAULT_PORT)
+    .option('--host <host>', 'local listen host', DEFAULT_HOST)
+    .option('--provider <name>', 'provider plugin name', 'openai')
+    .option('--skills-dir <path>', 'directory of skill subdirectories containing SKILL.md')
+    .option('--middleware-file <path>', 'middleware markdown file (repeatable)', collectList, [])
+    .option('--middleware-dir <path>', 'directory of middleware markdown files (repeatable)', collectList, [])
+    .option('--middleware-position <position>', 'middleware insertion position', 'system-prepend')
+    .option('--middleware-role <role>', 'role for prepend/append middleware')
+    .option('--middleware-service <service>', 'restrict middleware to service IDs (repeatable)', collectList, [])
+    .option('--middleware-confidentiality-prompt <text>', 'override the middleware confidentiality prompt')
+    .action(async (options) => {
+      if (!isValidMiddlewarePosition(options.middlewarePosition as string)) {
+        console.error(chalk.red(`Invalid --middleware-position "${String(options.middlewarePosition)}"`));
+        process.exit(1);
+      }
+
+      const spinner = ora(`Loading provider stack "${String(options.provider)}"...`).start();
+      let provider: Provider;
+      try {
+        provider = await buildProviderStack({
+          providerName: options.provider as string,
+          skillsDir: options.skillsDir ? resolve(options.skillsDir as string) : undefined,
+          middlewareFiles: (options.middlewareFile as string[]).map((value) => resolve(value)),
+          middlewareDirs: (options.middlewareDir as string[]).map((value) => resolve(value)),
+          middlewarePosition: options.middlewarePosition as MiddlewarePosition,
+          middlewareRole: options.middlewareRole as string | undefined,
+          middlewareServices: (options.middlewareService as string[]).map((value) => value.trim()).filter((value) => value.length > 0),
+          middlewareConfidentialityPrompt: options.middlewareConfidentialityPrompt as string | undefined,
+        });
+      } catch (error) {
+        spinner.fail(chalk.red(`Failed to load provider stack: ${(error as Error).message}`));
+        process.exit(1);
+      }
+
+      spinner.succeed(chalk.green(`Provider "${provider.name}" ready`));
+
+      const server = createServer(async (req, res) => {
+        try {
+          const method = req.method ?? 'GET';
+          const path = req.url ?? '/';
+
+          if (method === 'GET' && path === '/health') {
+            writeJson(res, 200, { ok: true });
+            return;
+          }
+
+          if (method === 'GET' && path === '/v1/models') {
+            const body = buildOpenAIModelsResponse(provider);
+            res.writeHead(200, {
+              'content-type': 'application/json',
+              'content-length': String(body.length),
+            });
+            res.end(Buffer.from(body));
+            return;
+          }
+
+          if (method !== 'POST') {
+            writeJson(res, 400, { error: { message: 'Only POST is supported for this endpoint', type: 'invalid_request_error' } });
+            return;
+          }
+
+          const body = await readIncomingBody(req);
+          const serializedReq = serializeRequest(req, body);
+          const streamRequested = isStreamRequested(serializedReq);
+
+          if (!serializedReq.path.startsWith('/v1/')) {
+            writeJson(res, 400, { error: { message: `Unsupported path "${serializedReq.path}"`, type: 'invalid_request_error' } });
+            return;
+          }
+
+          log(`${serializedReq.method} ${serializedReq.path} stream=${streamRequested}`);
+
+          if (streamRequested && provider.handleRequestStream) {
+            let started = false;
+            const callbacks: ProviderStreamCallbacks = {
+              onResponseStart: (response) => {
+                res.writeHead(response.statusCode, toNodeHeaders(response.headers));
+                started = true;
+              },
+              onResponseChunk: (chunk) => {
+                if (chunk.data.length > 0) {
+                  res.write(Buffer.from(chunk.data));
+                }
+                if (chunk.done && !res.writableEnded) {
+                  res.end();
+                }
+              },
+            };
+
+            const response = await provider.handleRequestStream(serializedReq, callbacks);
+            if (!started) {
+              writeBufferedResponse(res, response);
+            }
+            return;
+          }
+
+          const response = await provider.handleRequest(serializedReq);
+          writeBufferedResponse(res, response);
+        } catch (error) {
+          writeJson(res, 500, { error: { message: (error as Error).message, type: 'server_error' } });
+        }
+      });
+
+      server.listen(options.port as number, options.host as string, () => {
+        console.log(chalk.green(`Local agent service listening on http://${String(options.host)}:${String(options.port)}`));
+        console.log(chalk.dim('Native provider endpoints are forwarded unchanged, plus /v1/models and /health.'));
+      });
+
+      setupShutdownHandler(async () => {
+        await new Promise<void>((resolveClose, rejectClose) => {
+          server.close((error) => {
+            if (error) {
+              rejectClose(error);
+              return;
+            }
+            resolveClose();
+          });
+        });
+      });
+    });
+}

--- a/apps/cli/src/cli/index.ts
+++ b/apps/cli/src/cli/index.ts
@@ -17,6 +17,7 @@ import { registerWithdrawCommand } from './commands/withdraw.js';
 import { registerBalanceCommand } from './commands/balance.js';
 import { registerBootstrapCommand } from './commands/bootstrap.js';
 import { registerConnectionCommand } from './commands/connection.js';
+import { registerServeAgentCommand } from './commands/serve-agent.js';
 
 loadEnvFromFiles();
 
@@ -49,5 +50,6 @@ registerWithdrawCommand(program);
 registerBalanceCommand(program);
 registerBootstrapCommand(program);
 registerConnectionCommand(program);
+registerServeAgentCommand(program);
 
 program.parse(process.argv);

--- a/apps/cli/src/cli/provider-files.ts
+++ b/apps/cli/src/cli/provider-files.ts
@@ -1,0 +1,38 @@
+import { readdir, readFile } from 'node:fs/promises';
+import { isAbsolute, resolve } from 'node:path';
+import type { SellerMiddlewareConfig } from '../config/types.js';
+import type { ProviderMiddleware } from '@antseed/provider-core';
+
+export async function loadMiddlewareFiles(
+  configs: SellerMiddlewareConfig[],
+  baseDir: string,
+): Promise<ProviderMiddleware[]> {
+  return Promise.all(
+    configs.map(async (entry) => {
+      if (entry.services !== undefined && entry.services.length === 0) {
+        throw new Error(`Middleware entry "${entry.file}" has an empty services list — remove the field to apply globally or list at least one service ID.`);
+      }
+      const filePath = isAbsolute(entry.file) ? entry.file : resolve(baseDir, entry.file);
+      const content = await readFile(filePath, 'utf-8');
+      return { content, position: entry.position, role: entry.role, services: entry.services } as ProviderMiddleware;
+    }),
+  );
+}
+
+export async function loadMiddlewareDirectory(
+  directory: string,
+  defaults: Omit<SellerMiddlewareConfig, 'file'>,
+): Promise<ProviderMiddleware[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const configs = entries
+    .filter((entry) => entry.isFile() && entry.name.toLowerCase().endsWith('.md'))
+    .map((entry) => ({
+      file: resolve(directory, entry.name),
+      position: defaults.position,
+      ...(defaults.role !== undefined ? { role: defaults.role } : {}),
+      ...(defaults.services !== undefined ? { services: defaults.services } : {}),
+    }))
+    .sort((a, b) => a.file.localeCompare(b.file));
+
+  return loadMiddlewareFiles(configs, directory);
+}

--- a/packages/api-adapter/src/anthropic.ts
+++ b/packages/api-adapter/src/anthropic.ts
@@ -1,9 +1,11 @@
 import type { SerializedHttpRequest, SerializedHttpResponse } from './types.js';
 import {
+  adaptBufferedSseResponse,
   createChatStreamParser,
   encodeJson,
   encodeText,
   encodeSseEvents,
+  isBufferedSseResponse,
   makeStreamingStartResponse,
   mapFinishReasonToAnthropicStopReason,
   parseChatCompletionResponse,
@@ -247,6 +249,12 @@ export function transformOpenAIChatResponseToAnthropicMessage(
   options: { streamRequested: boolean; fallbackModel?: string | null },
 ): SerializedHttpResponse {
   const parsed = parseJsonObject(response.body);
+  if (!parsed && options.streamRequested && response.statusCode < 400 && isBufferedSseResponse(response)) {
+    return adaptBufferedSseResponse(
+      response,
+      createOpenAIChatToAnthropicStreamingAdapter({ fallbackModel: options.fallbackModel }),
+    );
+  }
   if (!parsed) return response;
 
   if (response.statusCode >= 400) {

--- a/packages/api-adapter/src/openai-responses.ts
+++ b/packages/api-adapter/src/openai-responses.ts
@@ -1,9 +1,11 @@
 import type { SerializedHttpRequest, SerializedHttpResponse } from './types.js';
 import {
+  adaptBufferedSseResponse,
   createChatStreamParser,
   encodeJson,
   encodeText,
   encodeSseEvents,
+  isBufferedSseResponse,
   makeStreamingStartResponse,
   parseChatCompletionResponse,
   parseJsonObject,
@@ -282,6 +284,12 @@ export function transformOpenAIChatResponseToOpenAIResponses(
   options: { fallbackModel?: string | null; streamRequested?: boolean },
 ): SerializedHttpResponse {
   const parsed = parseJsonObject(response.body);
+  if (!parsed && options.streamRequested && response.statusCode < 400 && isBufferedSseResponse(response)) {
+    return adaptBufferedSseResponse(
+      response,
+      createOpenAIChatToResponsesStreamingAdapter({ fallbackModel: options.fallbackModel }),
+    );
+  }
   if (!parsed) return response;
 
   if (response.statusCode >= 400) {

--- a/packages/api-adapter/src/utils.ts
+++ b/packages/api-adapter/src/utils.ts
@@ -136,6 +136,50 @@ export function encodeSseEvents(events: Array<{ event?: string; data: unknown | 
   return encoder.encode(chunks.join(''));
 }
 
+export function isBufferedSseResponse(response: SerializedHttpResponse): boolean {
+  const contentType = (response.headers['content-type'] ?? response.headers['Content-Type'] ?? '').toLowerCase();
+  if (contentType.includes('text/event-stream')) {
+    return true;
+  }
+  if (!response.body || response.body.length === 0) {
+    return false;
+  }
+  const previewLength = Math.min(response.body.length, 256);
+  const preview = decoder.decode(response.body.slice(0, previewLength));
+  const trimmed = preview.trimStart();
+  return trimmed.startsWith('data:') || trimmed.startsWith('event:');
+}
+
+export function concatUint8Arrays(chunks: Uint8Array[]): Uint8Array {
+  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const merged = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return merged;
+}
+
+export function adaptBufferedSseResponse(
+  response: SerializedHttpResponse,
+  adapter: StreamingResponseAdapter,
+): SerializedHttpResponse {
+  const startResponse = adapter.adaptStart({ ...response, body: new Uint8Array(0) });
+  const adaptedChunks = adapter.adaptChunk({
+    requestId: response.requestId,
+    data: response.body,
+    done: true,
+  });
+  return {
+    ...startResponse,
+    body: concatUint8Arrays([
+      startResponse.body,
+      ...adaptedChunks.map((chunk) => chunk.data),
+    ]),
+  };
+}
+
 export function makeStreamingStartResponse(response: SerializedHttpResponse): SerializedHttpResponse {
   return {
     ...response,

--- a/packages/api-adapter/tests/adapter.test.ts
+++ b/packages/api-adapter/tests/adapter.test.ts
@@ -1,20 +1,20 @@
 import { describe, it, expect } from 'vitest';
 import type { SerializedHttpRequest, SerializedHttpResponse } from '../src/types.js';
 import {
+  detectRequestServiceApiProtocol,
+  inferProviderDefaultServiceApiProtocols,
+  selectTargetProtocolForRequest,
+} from '../src/detect.js';
+import {
   createOpenAIChatToAnthropicStreamingAdapter,
   transformAnthropicMessagesRequestToOpenAIChat,
   transformOpenAIChatResponseToAnthropicMessage,
 } from '../src/anthropic.js';
 import {
   createOpenAIChatToResponsesStreamingAdapter,
-  transformOpenAIChatResponseToOpenAIResponses,
   transformOpenAIResponsesRequestToOpenAIChat,
+  transformOpenAIChatResponseToOpenAIResponses,
 } from '../src/openai-responses.js';
-import {
-  detectRequestServiceApiProtocol,
-  inferProviderDefaultServiceApiProtocols,
-  selectTargetProtocolForRequest,
-} from '../src/detect.js';
 
 function makeRequest(overrides?: Partial<SerializedHttpRequest>): SerializedHttpRequest {
   return {
@@ -87,6 +87,34 @@ function makeOpenAIResponse(overrides?: Partial<SerializedHttpResponse>): Serial
         completion_tokens: 5,
       },
     })),
+    ...overrides,
+  };
+}
+
+function makeBufferedOpenAIStreamResponse(overrides?: Partial<SerializedHttpResponse>): SerializedHttpResponse {
+  return {
+    requestId: 'req-stream-1',
+    statusCode: 200,
+    headers: {
+      'content-type': 'text/event-stream',
+    },
+    body: new TextEncoder().encode(
+      'data: {"id":"chatcmpl-stream","model":"gpt-4.1","choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n'
+      + 'data: {"usage":{"prompt_tokens":5,"completion_tokens":3},"choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}\n\n'
+      + 'data: [DONE]\n\n',
+    ),
+    ...overrides,
+  };
+}
+
+function makePlainTextDataResponse(overrides?: Partial<SerializedHttpResponse>): SerializedHttpResponse {
+  return {
+    requestId: 'req-text-1',
+    statusCode: 400,
+    headers: {
+      'content-type': 'text/plain',
+    },
+    body: new TextEncoder().encode('Bad request data: missing field'),
     ...overrides,
   };
 }
@@ -191,6 +219,29 @@ describe('transformOpenAIChatResponseToAnthropicMessage', () => {
     expect(sseText).toContain('event: message_start');
     expect(sseText).toContain('event: content_block_start');
     expect(sseText).toContain('event: message_stop');
+  });
+
+  it('adapts buffered SSE bodies when stream is requested', () => {
+    const transformed = transformOpenAIChatResponseToAnthropicMessage(makeBufferedOpenAIStreamResponse(), {
+      streamRequested: true,
+      fallbackModel: 'fallback-model',
+    });
+    expect(transformed.headers['content-type']).toBe('text/event-stream');
+    const sseText = new TextDecoder().decode(transformed.body);
+    expect(sseText).toContain('event: message_start');
+    expect(sseText).toContain('event: content_block_delta');
+    expect(sseText).toContain('"text":"Hello"');
+    expect(sseText).toContain('"text":" world"');
+    expect(sseText).toContain('event: message_stop');
+  });
+
+  it('does not misclassify plain text bodies containing "data:" as SSE', () => {
+    const response = makePlainTextDataResponse();
+    const transformed = transformOpenAIChatResponseToAnthropicMessage(response, {
+      streamRequested: true,
+      fallbackModel: 'fallback-model',
+    });
+    expect(transformed).toEqual(response);
   });
 
   it('emits input_json_delta for tool_use blocks in SSE stream', () => {
@@ -724,6 +775,40 @@ describe('transformOpenAIChatResponseToOpenAIResponses', () => {
         output_text: 'Hello!',
       },
     });
+  });
+
+  it('adapts buffered SSE bodies into responses SSE when streamRequested is true', () => {
+    const result = transformOpenAIChatResponseToOpenAIResponses(makeBufferedOpenAIStreamResponse(), {
+      fallbackModel: 'fallback',
+      streamRequested: true,
+    });
+    expect(result.headers['content-type']).toBe('text/event-stream');
+    const sseText = new TextDecoder().decode(result.body);
+    const events = parseSseEvents(sseText);
+    const deltas = events.filter((event) => event.event === 'response.output_text.delta');
+    const completed = events.find((event) => event.event === 'response.completed');
+
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(JSON.parse(deltas[0]!.data)).toMatchObject({
+      type: 'response.output_text.delta',
+      delta: 'Hello',
+    });
+    expect(completed).toBeDefined();
+    expect(JSON.parse(completed!.data)).toMatchObject({
+      type: 'response.completed',
+      response: {
+        output_text: 'Hello world',
+      },
+    });
+  });
+
+  it('does not misclassify plain text bodies containing "data:" for responses SSE', () => {
+    const response = makePlainTextDataResponse();
+    const result = transformOpenAIChatResponseToOpenAIResponses(response, {
+      fallbackModel: 'fallback',
+      streamRequested: true,
+    });
+    expect(result).toEqual(response);
   });
 
   it('emits correlated function call SSE events', () => {

--- a/packages/node/tests/service-api-adapter.test.ts
+++ b/packages/node/tests/service-api-adapter.test.ts
@@ -87,6 +87,34 @@ function makeOpenAIResponse(overrides?: Partial<SerializedHttpResponse>): Serial
   };
 }
 
+function makeBufferedOpenAIStreamResponse(overrides?: Partial<SerializedHttpResponse>): SerializedHttpResponse {
+  return {
+    requestId: 'req-stream-1',
+    statusCode: 200,
+    headers: {
+      'content-type': 'text/event-stream',
+    },
+    body: new TextEncoder().encode(
+      'data: {"id":"chatcmpl-stream","model":"gpt-4.1","choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n'
+      + 'data: {"usage":{"prompt_tokens":5,"completion_tokens":3},"choices":[{"delta":{"content":" world"},"finish_reason":"stop"}]}\n\n'
+      + 'data: [DONE]\n\n',
+    ),
+    ...overrides,
+  };
+}
+
+function makePlainTextDataResponse(overrides?: Partial<SerializedHttpResponse>): SerializedHttpResponse {
+  return {
+    requestId: 'req-text-1',
+    statusCode: 400,
+    headers: {
+      'content-type': 'text/plain',
+    },
+    body: new TextEncoder().encode('Bad request data: missing field'),
+    ...overrides,
+  };
+}
+
 function parseSseEvents(sseText: string): Array<{ event: string | null; data: string }> {
   return sseText
     .trim()
@@ -187,6 +215,29 @@ describe('transformOpenAIChatResponseToAnthropicMessage', () => {
     expect(sseText).toContain('event: message_start');
     expect(sseText).toContain('event: content_block_start');
     expect(sseText).toContain('event: message_stop');
+  });
+
+  it('adapts buffered SSE bodies when stream is requested', () => {
+    const transformed = transformOpenAIChatResponseToAnthropicMessage(makeBufferedOpenAIStreamResponse(), {
+      streamRequested: true,
+      fallbackModel: 'fallback-model',
+    });
+    expect(transformed.headers['content-type']).toBe('text/event-stream');
+    const sseText = new TextDecoder().decode(transformed.body);
+    expect(sseText).toContain('event: message_start');
+    expect(sseText).toContain('event: content_block_delta');
+    expect(sseText).toContain('"text":"Hello"');
+    expect(sseText).toContain('"text":" world"');
+    expect(sseText).toContain('event: message_stop');
+  });
+
+  it('does not misclassify plain text bodies containing \"data:\" as SSE', () => {
+    const response = makePlainTextDataResponse();
+    const transformed = transformOpenAIChatResponseToAnthropicMessage(response, {
+      streamRequested: true,
+      fallbackModel: 'fallback-model',
+    });
+    expect(transformed).toEqual(response);
   });
 
   it('emits input_json_delta for tool_use blocks in SSE stream', () => {
@@ -720,6 +771,40 @@ describe('transformOpenAIChatResponseToOpenAIResponses', () => {
         output_text: 'Hello!',
       },
     });
+  });
+
+  it('adapts buffered SSE bodies into responses SSE when streamRequested is true', () => {
+    const result = transformOpenAIChatResponseToOpenAIResponses(makeBufferedOpenAIStreamResponse(), {
+      fallbackModel: 'fallback',
+      streamRequested: true,
+    });
+    expect(result.headers['content-type']).toBe('text/event-stream');
+    const sseText = new TextDecoder().decode(result.body);
+    const events = parseSseEvents(sseText);
+    const deltas = events.filter((event) => event.event === 'response.output_text.delta');
+    const completed = events.find((event) => event.event === 'response.completed');
+
+    expect(deltas.length).toBeGreaterThan(0);
+    expect(JSON.parse(deltas[0]!.data)).toMatchObject({
+      type: 'response.output_text.delta',
+      delta: 'Hello',
+    });
+    expect(completed).toBeDefined();
+    expect(JSON.parse(completed!.data)).toMatchObject({
+      type: 'response.completed',
+      response: {
+        output_text: 'Hello world',
+      },
+    });
+  });
+
+  it('does not misclassify plain text bodies containing \"data:\" for responses SSE', () => {
+    const response = makePlainTextDataResponse();
+    const result = transformOpenAIChatResponseToOpenAIResponses(response, {
+      fallbackModel: 'fallback',
+      streamRequested: true,
+    });
+    expect(result).toEqual(response);
   });
 
   it('emits correlated function call SSE events', () => {

--- a/packages/provider-core/src/agent-provider.test.ts
+++ b/packages/provider-core/src/agent-provider.test.ts
@@ -38,6 +38,10 @@ function makeAnthropicTextResponse(text: string): Uint8Array {
   ]);
 }
 
+function makeRawTextResponse(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
 function makeOpenAIResponse(message: Record<string, unknown>): Uint8Array {
   return makeBody({
     choices: [{ message, finish_reason: 'stop' }],
@@ -156,7 +160,12 @@ describe('AgentProvider — pass-through', () => {
   });
 
   it('passes through when LLM responds with text (no tool calls)', async () => {
-    const inner = mockProvider({ responses: [makeAnthropicTextResponse('just text'), makeAnthropicTextResponse('just text')] });
+    const inner = mockProvider({
+      responses: [
+        makeAnthropicTextResponse('just text'),
+        makeAnthropicTextResponse('just text'),
+      ],
+    });
     const agent = new AgentProvider(inner, makeRegistry());
 
     const req = makeReq({ messages: [{ role: 'user', content: 'hi' }] });
@@ -164,6 +173,8 @@ describe('AgentProvider — pass-through', () => {
 
     expect(res.statusCode).toBe(200);
     expect(inner.callCount()).toBe(2);
+    const finalBody = inner.requestBodies()[1]!;
+    expect(finalBody.tools).toBeUndefined();
     const responseBody = parseBody(res.body);
     expect(responseBody.content).toEqual([{ type: 'text', text: 'just text' }]);
   });
@@ -223,7 +234,7 @@ describe('AgentProvider — Anthropic format', () => {
         makeAnthropicToolUseResponse('antseed_load', 'tool-1', { name: 'visual-explainer' }),
         // Second call: LLM responds with text (skill is now in context)
         makeAnthropicTextResponse('Here is your diagram.'),
-        // Final clean request
+        // Third call: final clean request without internal tool history
         makeAnthropicTextResponse('Here is your diagram.'),
       ],
     });
@@ -232,7 +243,7 @@ describe('AgentProvider — Anthropic format', () => {
     const req = makeReq({ messages: [{ role: 'user', content: 'create a diagram' }] });
     const res = await agent.handleRequest(req);
 
-    // Preflight tool load + post-tool response + clean final request
+    // Preflight load + post-load response + final clean request
     expect(inner.callCount()).toBe(3);
 
     // Second request should contain the tool result with skill content
@@ -248,6 +259,31 @@ describe('AgentProvider — Anthropic format', () => {
     const toolResultContent = toolResultMsg.content as { type: string; content: string }[];
     expect(toolResultContent[0]!.type).toBe('tool_result');
     expect(toolResultContent[0]!.content).toContain('Visual Explainer');
+
+    // Final clean request should strip the injected tool and internal tool history
+    const finalBody = inner.requestBodies()[2]!;
+    expect(finalBody.tools).toBeUndefined();
+    const finalMessages = finalBody.messages as Record<string, unknown>[];
+    expect(
+      finalMessages.some(
+        (message) =>
+          message.role === 'assistant' &&
+          Array.isArray(message.content) &&
+          (message.content as Record<string, unknown>[]).some(
+            (block) => block.type === 'tool_use' && block.name === 'antseed_load',
+          ),
+      ),
+    ).toBe(false);
+    expect(
+      finalMessages.some(
+        (message) =>
+          message.role === 'user' &&
+          Array.isArray(message.content) &&
+          (message.content as Record<string, unknown>[]).some(
+            (block) => block.type === 'tool_result',
+          ),
+      ),
+    ).toBe(false);
 
     // Final response should be the text response
     const responseBody = parseBody(res.body);
@@ -281,6 +317,10 @@ describe('AgentProvider — Anthropic format', () => {
     const thirdBody = inner.requestBodies()[2]!;
     const thirdTools = thirdBody.tools as { name: string }[];
     expect(thirdTools.some((t) => t.name === 'antseed_load')).toBe(true);
+
+    // Final request should be clean
+    const finalBody = inner.requestBodies()[3]!;
+    expect(finalBody.tools).toBeUndefined();
   });
 
   it('returns error tool_result when skill is not found', async () => {
@@ -302,6 +342,38 @@ describe('AgentProvider — Anthropic format', () => {
     const toolResultContent = toolResultMsg.content as { type: string; content: string; is_error: boolean }[];
     expect(toolResultContent[0]!.is_error).toBe(true);
     expect(toolResultContent[0]!.content).toContain('not found');
+    const finalBody = inner.requestBodies()[2]!;
+    expect(finalBody.tools).toBeUndefined();
+  });
+
+  it('strips internal tool history from mixed anthropic assistant messages', async () => {
+    const inner = mockProvider({
+      responses: [
+        makeAnthropicResponse([
+          { type: 'text', text: 'Let me look that up.' },
+          { type: 'tool_use', id: 'tool-1', name: 'antseed_load', input: { name: 'visual-explainer' } },
+        ]),
+        makeAnthropicTextResponse('Here is your diagram.'),
+        makeAnthropicTextResponse('Here is your diagram.'),
+      ],
+    });
+    const agent = new AgentProvider(inner, makeRegistry());
+
+    await agent.handleRequest(makeReq({ messages: [{ role: 'user', content: 'create a diagram' }] }));
+
+    const finalBody = inner.requestBodies()[2]!;
+    const finalMessages = finalBody.messages as Record<string, unknown>[];
+    const assistantMessage = finalMessages.find((message) => message.role === 'assistant');
+    expect(assistantMessage).toBeDefined();
+    expect(assistantMessage!.content).toEqual([{ type: 'text', text: 'Let me look that up.' }]);
+    expect(
+      finalMessages.some(
+        (message) =>
+          message.role === 'user' &&
+          Array.isArray(message.content) &&
+          (message.content as Record<string, unknown>[]).some((block) => block.type === 'tool_result'),
+      ),
+    ).toBe(false);
   });
 
   it('respects maxIterations limit', async () => {
@@ -426,6 +498,28 @@ describe('AgentProvider — OpenAI format', () => {
     expect(toolResultMsg!.tool_call_id).toBe('call-1');
     expect(toolResultMsg!.content).toContain('Code Review');
 
+    const finalBody = inner.requestBodies()[2]!;
+    expect(finalBody.tools).toBeUndefined();
+    const finalMessages = finalBody.messages as Record<string, unknown>[];
+    expect(
+      finalMessages.some(
+        (message) =>
+          message.role === 'assistant' &&
+          Array.isArray(message.tool_calls) &&
+          (message.tool_calls as Record<string, unknown>[]).some((toolCall) => {
+            const fn = toolCall.function as Record<string, unknown> | undefined;
+            return fn?.name === 'antseed_load';
+          }),
+      ),
+    ).toBe(false);
+    expect(
+      finalMessages.some(
+        (message) =>
+          message.role === 'tool' &&
+          typeof message.tool_call_id === 'string',
+      ),
+    ).toBe(false);
+
     const responseBody = parseBody(res.body);
     const choices = responseBody.choices as { message: { content: string } }[];
     expect(choices[0]!.message.content).toBe('Here is the code review.');
@@ -523,7 +617,7 @@ describe('AgentProvider — OpenAI format', () => {
     const res = await agent.handleRequest(req);
 
     // Verify antseed_load was NOT injected into the request
-    const sentBody = inner.requestBodies()[0]!;
+    const sentBody = parseBody(inner.lastRequest()!.body);
     const tools = sentBody.tools as { function?: { name: string }; name?: string }[];
     const hasAntseedTool = tools.some(
       (t) => t.name === 'antseed_load' || t.function?.name === 'antseed_load',
@@ -536,12 +630,14 @@ describe('AgentProvider — OpenAI format', () => {
 });
 
 describe('AgentProvider — streaming', () => {
-  it('streams the buffered response without extra LLM call', async () => {
+  it('uses a real final stream after hidden skill-loading iterations', async () => {
     const inner = mockProvider({
       responses: [
         // First call (buffered): LLM requests a skill
         makeAnthropicToolUseResponse('antseed_load', 'tool-1', { name: 'visual-explainer' }),
-        // Second call (buffered): LLM responds with text — streamed via callbacks
+        // Second call (buffered): LLM produces the final answer once the skill is loaded
+        makeAnthropicTextResponse('Here is your diagram.'),
+        // Third call (streamed): buyer-visible final answer
         makeAnthropicTextResponse('Here is your diagram.'),
       ],
     });
@@ -558,11 +654,126 @@ describe('AgentProvider — streaming', () => {
 
     expect(streamStarted).toBe(true);
     expect(res.statusCode).toBe(200);
-    // Should only make 2 calls (loop + text), NOT 3 (loop + text + stream)
-    expect(inner.callCount()).toBe(2);
-    // The streamed response should contain the final text
+    expect(inner.callCount()).toBe(3);
+    const finalBody = inner.requestBodies()[2]!;
+    expect(finalBody.tools).toBeUndefined();
+    const system = finalBody.system as string | undefined;
+    if (system) {
+      expect(system).not.toContain('ANTSEED_CATALOG_START');
+    }
+    const finalMessages = finalBody.messages as Record<string, unknown>[];
+    expect(finalMessages.some((message) => message.role === 'tool')).toBe(false);
+    expect(
+      finalMessages.some(
+        (message) =>
+          message.role === 'assistant' &&
+          Array.isArray(message.tool_calls),
+      ),
+    ).toBe(false);
     const responseBody = parseBody(res.body);
     expect(responseBody.content).toEqual([{ type: 'text', text: 'Here is your diagram.' }]);
+    const streamedText = chunks.map((chunk) => new TextDecoder().decode(chunk)).join('');
+    expect(streamedText).toContain('Here is your diagram.');
+  });
+
+  it('emits a loading-status chunk on openai streams while fetching more context', async () => {
+    const inner = mockProvider({
+      responses: [
+        makeOpenAIToolCallResponse('antseed_load', 'call-1', { name: 'code-review' }),
+        makeOpenAITextResponse('Here is the review.'),
+        makeOpenAITextResponse('Here is the review.'),
+      ],
+    });
+    const agent = new AgentProvider(inner, makeRegistry());
+
+    const chunks: Uint8Array[] = [];
+    const req = makeReq(
+      { messages: [{ role: 'user', content: 'review this code' }] },
+      '/v1/chat/completions',
+    );
+
+    await agent.handleRequestStream!(req, {
+      onResponseStart: () => {},
+      onResponseChunk: (chunk) => { chunks.push(chunk.data); },
+    });
+
+    const streamedText = chunks.map((chunk) => new TextDecoder().decode(chunk)).join('');
+    expect(streamedText).toContain('Loading additional context: code-review');
+    expect(streamedText).toContain('Here is the review.');
+  });
+
+  it('keeps openai SSE valid when buyer-visible tool calls appear after loading status', async () => {
+    const inner = mockProvider({
+      responses: [
+        makeOpenAIToolCallResponse('antseed_load', 'call-1', { name: 'code-review' }),
+        new TextEncoder().encode(JSON.stringify({
+          id: 'chatcmpl-2',
+          model: 'gpt-4.1',
+          choices: [
+            {
+              index: 0,
+              finish_reason: 'tool_calls',
+              message: {
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                  {
+                    id: 'call-2',
+                    type: 'function',
+                    function: {
+                      name: 'search',
+                      arguments: '{"q":"test"}',
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        })),
+      ],
+    });
+    const agent = new AgentProvider(inner, makeRegistry());
+
+    const chunks: Uint8Array[] = [];
+    const req = makeReq(
+      { messages: [{ role: 'user', content: 'review and search' }] },
+      '/v1/chat/completions',
+    );
+
+    await agent.handleRequestStream!(req, {
+      onResponseStart: () => {},
+      onResponseChunk: (chunk) => { chunks.push(chunk.data); },
+    });
+
+    const streamedText = chunks.map((chunk) => new TextDecoder().decode(chunk)).join('');
+    expect(streamedText).toContain('Loading additional context: code-review');
+    expect(streamedText).toContain('"tool_calls"');
+    expect(streamedText).toContain('"search"');
+    expect(streamedText).toContain('data: [DONE]');
+  });
+
+  it('emits the buffered response when an intermediate pass is not JSON', async () => {
+    const inner = mockProvider({
+      responses: [
+        makeAnthropicToolUseResponse('antseed_load', 'tool-1', { name: 'visual-explainer' }),
+        makeRawTextResponse('streamed plain text'),
+      ],
+    });
+    const agent = new AgentProvider(inner, makeRegistry());
+
+    let streamStarted = false;
+    const chunks: Uint8Array[] = [];
+
+    const req = makeReq({ messages: [{ role: 'user', content: 'create a diagram' }] });
+    const res = await agent.handleRequestStream!(req, {
+      onResponseStart: () => { streamStarted = true; },
+      onResponseChunk: (chunk) => { chunks.push(chunk.data); },
+    });
+
+    expect(streamStarted).toBe(true);
+    expect(inner.callCount()).toBe(2);
+    expect(new TextDecoder().decode(res.body)).toBe('streamed plain text');
+    expect(new TextDecoder().decode(chunks[0]!)).toBe('streamed plain text');
   });
 
   it('streams directly when no skills registered', async () => {

--- a/packages/provider-core/src/agent-provider.ts
+++ b/packages/provider-core/src/agent-provider.ts
@@ -41,6 +41,8 @@ const CATALOG_END_MARKER = '<!-- ANTSEED_CATALOG_END -->';
 const CONFIDENTIALITY_INSTRUCTION =
   'You have access to a resource loading system. ' +
   'Do not mention the antseed_load tool, the resource catalog, or the loading mechanism to the user. ' +
+  'Before emitting any user-visible output, decide whether you need to call antseed_load. ' +
+  'If you need more context, call antseed_load before producing visible text. ' +
   'When you load a resource, use its instructions naturally as if you always had this knowledge. ' +
   'Never reveal that you loaded additional instructions.';
 
@@ -159,7 +161,7 @@ export class AgentProvider implements Provider {
           return response;
         }
         this._debug(req, 'no antseed_load calls detected; issuing final buffered request without catalog');
-        const finalBody = this._stripCatalogAndTool(body, format);
+        const finalBody = this._stripInternalToolHistory(this._stripCatalogAndTool(body, format), format);
         return this._inner.handleRequest({
           ...req,
           body: encoder.encode(JSON.stringify(finalBody)),
@@ -183,7 +185,7 @@ export class AgentProvider implements Provider {
 
     // Max iterations reached — final request without antseed_load
     this._debug(req, `max iterations (${this._maxIterations}) reached; issuing final buffered request without antseed_load`);
-    body = this._stripCatalogAndTool(body, format);
+    body = this._stripInternalToolHistory(this._stripCatalogAndTool(body, format), format);
     const finalReq = {
       ...req,
       body: encoder.encode(JSON.stringify(body)),
@@ -212,7 +214,11 @@ export class AgentProvider implements Provider {
         return this._inner.handleRequestStream!(req, callbacks);
       }
 
-      let lastResponse: SerializedHttpResponse | null = null;
+      const streamState: StreamStatusState = {
+        started: false,
+        format,
+        model: typeof body.model === 'string' && body.model.trim().length > 0 ? body.model : null,
+      };
 
       for (let i = 0; i < this._maxIterations; i++) {
         this._debug(req, `loop iteration ${i + 1}/${this._maxIterations} (stream preflight)`);
@@ -220,7 +226,7 @@ export class AgentProvider implements Provider {
 
         const augmentedReq = {
           ...req,
-          body: encoder.encode(JSON.stringify(body)),
+          body: encoder.encode(JSON.stringify(this._setStreamFlag(body, false))),
         };
 
         const response = await this._inner.handleRequest(augmentedReq);
@@ -229,44 +235,55 @@ export class AgentProvider implements Provider {
         try {
           responseBody = JSON.parse(decoder.decode(response.body)) as Record<string, unknown>;
         } catch {
-          lastResponse = response;
-          break;
+          this._debug(req, 'buffered preflight response was not JSON; returning upstream response as-is');
+          this._emitBufferedResponse(response, callbacks, streamState);
+          return response;
         }
 
         const antseedCalls = extractAntseedLoadCalls(responseBody, format);
         if (antseedCalls.length === 0) {
-          lastResponse = response;
-          break;
+          if (hasNonAntseedToolCalls(responseBody, format)) {
+            this._debug(req, 'no antseed_load calls detected and response contains buyer-visible tool calls; returning buffered response');
+            this._emitBufferedResponse(response, callbacks, streamState);
+            return response;
+          }
+          this._debug(req, 'no antseed_load calls detected; switching to real final upstream stream');
+          const finalBody = this._setStreamFlag(this._stripInternalToolHistory(this._stripCatalogAndTool(body, format), format), true);
+          return this._inner.handleRequestStream!(
+            {
+              ...req,
+              body: encoder.encode(JSON.stringify(finalBody)),
+            },
+            this._wrapFinalStreamCallbacks(callbacks, streamState),
+          );
         }
         this._debug(req, `detected ${antseedCalls.length} antseed_load call(s): ${this._formatLoadNames(antseedCalls)}`);
         if (hasNonAntseedToolCalls(responseBody, format)) {
           this._debug(req, 'response also contains buyer-visible tool calls; stripping antseed_load blocks and returning buffered response');
           const cleaned = stripAntseedLoadFromResponse(responseBody, format);
-          lastResponse = { ...response, body: encoder.encode(JSON.stringify(cleaned)) };
-          break;
+          const finalResponse = { ...response, body: encoder.encode(JSON.stringify(cleaned)) };
+          this._emitBufferedResponse(finalResponse, callbacks, streamState);
+          return finalResponse;
         }
 
+        this._emitLoadingStatus(req, antseedCalls, callbacks, streamState);
         const toolResults = this._resolveLoads(antseedCalls);
         this._debug(req, `resolved ${toolResults.length} skill load(s): ${this._formatToolResults(antseedCalls, toolResults)}`);
         body = this._stripCatalogAndTool(body, format);
         body = this._appendToolLoop(body, responseBody, toolResults, format);
       }
 
-      if (lastResponse) {
-        // Stream the already-received response through callbacks
-        callbacks.onResponseStart(lastResponse);
-        callbacks.onResponseChunk({ requestId: req.requestId, data: lastResponse.body, done: true });
-        return lastResponse;
-      }
-
       // Max iterations reached — stream the final request
       this._debug(req, `max iterations (${this._maxIterations}) reached; issuing final upstream stream without antseed_load`);
-      body = this._stripCatalogAndTool(body, format);
+      body = this._setStreamFlag(
+        this._stripInternalToolHistory(this._stripCatalogAndTool(body, format), format),
+        true,
+      );
       const finalReq = {
         ...req,
         body: encoder.encode(JSON.stringify(body)),
       };
-      return this._inner.handleRequestStream!(finalReq, callbacks);
+      return this._inner.handleRequestStream!(finalReq, this._wrapFinalStreamCallbacks(callbacks, streamState));
     };
   }
 
@@ -285,6 +302,188 @@ export class AgentProvider implements Provider {
       const name = calls[index]?.resourceName || '<unnamed>';
       return `${name}:${result.isError ? 'miss' : 'hit'}`;
     }).join(', ');
+  }
+
+  private _emitBufferedResponse(
+    response: SerializedHttpResponse,
+    callbacks: ProviderStreamCallbacks,
+    streamState?: StreamStatusState,
+  ): void {
+    if (streamState?.started) {
+      if (streamState.format === 'openai') {
+        const adapted = this._adaptBufferedOpenAIResponseToSse(response, streamState.model);
+        if (adapted) {
+          callbacks.onResponseChunk({
+            requestId: response.requestId,
+            data: adapted,
+            done: true,
+          });
+          return;
+        }
+      }
+      callbacks.onResponseChunk({
+        requestId: response.requestId,
+        data: response.body,
+        done: true,
+      });
+      return;
+    }
+    callbacks.onResponseStart({ ...response, body: new Uint8Array(0) });
+    callbacks.onResponseChunk({
+      requestId: response.requestId,
+      data: response.body,
+      done: true,
+    });
+  }
+
+  private _setStreamFlag(body: Record<string, unknown>, stream: boolean): Record<string, unknown> {
+    return { ...body, stream };
+  }
+
+  private _emitLoadingStatus(
+    req: SerializedHttpRequest,
+    antseedCalls: AntseedLoadCall[],
+    callbacks: ProviderStreamCallbacks,
+    streamState: StreamStatusState,
+  ): void {
+    if (streamState.format !== 'openai') {
+      return;
+    }
+    if (!streamState.started) {
+      callbacks.onResponseStart({
+        requestId: req.requestId,
+        statusCode: 200,
+        headers: {
+          'content-type': 'text/event-stream',
+          'cache-control': 'no-cache',
+        },
+        body: new Uint8Array(0),
+      });
+      streamState.started = true;
+    }
+
+    const resourceNames = antseedCalls
+      .map((call) => call.resourceName.trim())
+      .filter((name) => name.length > 0)
+      .join(', ');
+    const message = resourceNames.length > 0
+      ? `Loading additional context: ${resourceNames}`
+      : 'Loading additional context';
+
+    callbacks.onResponseChunk({
+      requestId: req.requestId,
+      data: this._encodeOpenAIReasoningStatusChunk(req.requestId, streamState.model, message),
+      done: false,
+    });
+  }
+
+  private _wrapFinalStreamCallbacks(
+    callbacks: ProviderStreamCallbacks,
+    streamState: StreamStatusState,
+  ): ProviderStreamCallbacks {
+    if (!streamState.started) {
+      return {
+        onResponseStart: (response) => {
+          streamState.started = true;
+          callbacks.onResponseStart(response);
+        },
+        onResponseChunk: callbacks.onResponseChunk,
+      };
+    }
+
+    return {
+      onResponseStart: () => {},
+      onResponseChunk: callbacks.onResponseChunk,
+    };
+  }
+
+  private _encodeOpenAIReasoningStatusChunk(
+    requestId: string,
+    model: string | null,
+    message: string,
+  ): Uint8Array {
+    const payload = {
+      id: `${requestId}-agent-status`,
+      object: 'chat.completion.chunk',
+      created: Math.floor(Date.now() / 1000),
+      model: model ?? 'antseed-agent',
+      choices: [
+        {
+          index: 0,
+          delta: {
+            reasoning: `${message}\n`,
+          },
+          finish_reason: null,
+        },
+      ],
+    };
+    return new TextEncoder().encode(`data: ${JSON.stringify(payload)}\n\n`);
+  }
+
+  private _adaptBufferedOpenAIResponseToSse(
+    response: SerializedHttpResponse,
+    fallbackModel: string | null,
+  ): Uint8Array | null {
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(decoder.decode(response.body)) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+
+    const id = typeof parsed.id === 'string' && parsed.id.length > 0 ? parsed.id : response.requestId;
+    const model = typeof parsed.model === 'string' && parsed.model.length > 0
+      ? parsed.model
+      : (fallbackModel ?? 'unknown');
+    const created = typeof parsed.created === 'number' ? parsed.created : Math.floor(Date.now() / 1000);
+    const choices = Array.isArray(parsed.choices) ? parsed.choices : [];
+    const firstChoice = choices[0] && typeof choices[0] === 'object'
+      ? (choices[0] as Record<string, unknown>)
+      : null;
+    const message = firstChoice?.message && typeof firstChoice.message === 'object'
+      ? (firstChoice.message as Record<string, unknown>)
+      : null;
+    const finishReason = typeof firstChoice?.finish_reason === 'string' ? firstChoice.finish_reason : 'stop';
+
+    const chunks: string[] = [];
+    const pushChunk = (delta: Record<string, unknown>, chunkFinishReason: string | null = null): void => {
+      chunks.push(`data: ${JSON.stringify({
+        id,
+        object: 'chat.completion.chunk',
+        created,
+        model,
+        choices: [
+          {
+            index: 0,
+            delta,
+            finish_reason: chunkFinishReason,
+          },
+        ],
+      })}\n\n`);
+    };
+
+    if (typeof message?.content === 'string' && message.content.length > 0) {
+      pushChunk({ content: message.content });
+    }
+
+    if (Array.isArray(message?.tool_calls)) {
+      for (const [index, toolCall] of (message.tool_calls as Array<Record<string, unknown>>).entries()) {
+        pushChunk({
+          tool_calls: [
+            {
+              index,
+              id: toolCall.id,
+              type: toolCall.type ?? 'function',
+              function: toolCall.function,
+            },
+          ],
+        });
+      }
+    }
+
+    pushChunk({}, finishReason);
+    chunks.push('data: [DONE]\n\n');
+    return encoder.encode(chunks.join(''));
   }
 
   private _injectCatalogAndTool(
@@ -376,6 +575,87 @@ export class AgentProvider implements Provider {
     return body;
   }
 
+  private _stripInternalToolHistory(
+    body: Record<string, unknown>,
+    format: RequestFormat,
+  ): Record<string, unknown> {
+    if (!Array.isArray(body.messages)) {
+      return body;
+    }
+
+    const messages = body.messages as Record<string, unknown>[];
+    if (format === 'openai') {
+      const removedToolIds = new Set<string>();
+      const filtered = messages.flatMap((message) => {
+        if (message.role === 'assistant' && Array.isArray(message.tool_calls)) {
+          const toolCalls = message.tool_calls as Array<Record<string, unknown>>;
+          const retainedToolCalls: Array<Record<string, unknown>> = [];
+          for (const toolCall of toolCalls) {
+            const fn = toolCall.function as Record<string, unknown> | undefined;
+            if (fn?.name === ANTSEED_LOAD_TOOL_NAME) {
+              if (typeof toolCall.id === 'string' && toolCall.id.length > 0) {
+                removedToolIds.add(toolCall.id);
+              }
+              continue;
+            }
+            retainedToolCalls.push(toolCall);
+          }
+          if (retainedToolCalls.length === 0 && (message.content === null || message.content === undefined || message.content === '')) {
+            return [];
+          }
+          return [{ ...message, tool_calls: retainedToolCalls.length > 0 ? retainedToolCalls : undefined }];
+        }
+        if (
+          message.role === 'tool' &&
+          typeof message.tool_call_id === 'string' &&
+          removedToolIds.has(message.tool_call_id)
+        ) {
+          return [];
+        }
+        return [message];
+      });
+      return { ...body, messages: filtered };
+    }
+
+    const removedToolIds = new Set<string>();
+    const filtered = messages.flatMap((message) => {
+      if (message.role === 'assistant' && Array.isArray(message.content)) {
+        const content = message.content as Array<Record<string, unknown>>;
+        const retainedContent: Array<Record<string, unknown>> = [];
+        for (const block of content) {
+          if (block.type === 'tool_use' && block.name === ANTSEED_LOAD_TOOL_NAME) {
+            if (typeof block.id === 'string' && block.id.length > 0) {
+              removedToolIds.add(block.id);
+            }
+            continue;
+          }
+          retainedContent.push(block);
+        }
+        if (retainedContent.length === 0) {
+          return [];
+        }
+        return [{ ...message, content: retainedContent }];
+      }
+      if (message.role === 'user' && Array.isArray(message.content)) {
+        const content = message.content as Array<Record<string, unknown>>;
+        const retainedContent = content.filter(
+          (block) =>
+            !(
+              block.type === 'tool_result' &&
+              typeof block.tool_use_id === 'string' &&
+              removedToolIds.has(block.tool_use_id)
+            ),
+        );
+        if (retainedContent.length === 0) {
+          return [];
+        }
+        return [{ ...message, content: retainedContent }];
+      }
+      return [message];
+    });
+    return { ...body, messages: filtered };
+  }
+
   private _resolveLoads(toolCalls: AntseedLoadCall[]): ToolResult[] {
     return toolCalls.map((call) => {
       const skill = this._registry.get(call.resourceName);
@@ -444,6 +724,12 @@ interface ToolResult {
   id: string;
   content: string;
   isError: boolean;
+}
+
+interface StreamStatusState {
+  started: boolean;
+  format: RequestFormat;
+  model: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- keep agent skill-loading iterations buffered but use a real final upstream stream for the buyer-visible response
- adapt buffered SSE bodies into Anthropic and Responses streaming formats when the seller returns a buffered stream body
- add regression tests for both the agent-provider streaming path and buffered SSE protocol adaptation

## Verification
- pnpm --filter @antseed/provider-core exec vitest run src/agent-provider.test.ts
- pnpm --filter @antseed/node run test -- service-api-adapter.test.ts
- pnpm run build:tier0 && pnpm run build:tier1 && pnpm --filter @antseed/cli run build