### PR TITLE
fix(desktop): resolve intermittent 0 peers display issue

### DIFF
--- a/apps/desktop/src/renderer/modules/dashboard-api.ts
+++ b/apps/desktop/src/renderer/modules/dashboard-api.ts
@@ -27,6 +27,8 @@ export function initDashboardApiModule({
   defaultDashboardPort = 3117,
 }: DashboardApiOptions) {
   let refreshHooks: RefreshHooks | null = null;
+  let dashboardReady = false;
+  let lastDashboardCheck = 0;
 
   function getDashboardPort(): number {
     const port = safeNumber(uiState.dashboardPortValue, defaultDashboardPort);
@@ -45,21 +47,21 @@ export function initDashboardApiModule({
     if (!bridge) return dashboardBridgeError('Desktop bridge unavailable');
 
     if (!bridge.getDashboardData) {
-      if (endpoint === 'network' && bridge.getNetwork) {
+      // Always try legacy fallback for network/peers if new API is unavailable
+      if ((endpoint === 'network' || endpoint === 'peers') && bridge.getNetwork) {
         const legacyNetwork = await bridge.getNetwork(getDashboardPort());
         if (!legacyNetwork.ok) return dashboardBridgeError(legacyNetwork.error ?? 'Failed to query network endpoint');
-        return { ok: true, data: legacyNetwork, error: null, status: 200 };
-      }
-
-      if (endpoint === 'peers' && bridge.getNetwork) {
-        const legacyNetwork = await bridge.getNetwork(getDashboardPort());
-        if (!legacyNetwork.ok) return dashboardBridgeError(legacyNetwork.error ?? 'Failed to query peers endpoint');
-        return {
-          ok: true,
-          data: { peers: safeArray(legacyNetwork.peers), total: safeArray(legacyNetwork.peers).length, degraded: false },
-          error: null,
-          status: 200,
-        };
+        
+        if (endpoint === 'network') {
+          return { ok: true, data: legacyNetwork, error: null, status: 200 };
+        } else {
+          return {
+            ok: true,
+            data: { peers: safeArray(legacyNetwork.peers), total: safeArray(legacyNetwork.peers).length, degraded: false },
+            error: null,
+            status: 200,
+          };
+        }
       }
 
       return dashboardBridgeError('Dashboard data bridge unavailable');
@@ -71,12 +73,44 @@ export function initDashboardApiModule({
       const message = err instanceof Error ? err.message : String(err);
 
       if (message.includes("No handler registered for 'runtime:get-dashboard-data'")) {
-        if (endpoint === 'network' && bridge.getNetwork) {
+        // Consistent legacy fallback for both network and peers
+        if ((endpoint === 'network' || endpoint === 'peers') && bridge.getNetwork) {
           const legacyNetwork = await bridge.getNetwork(getDashboardPort());
           if (!legacyNetwork.ok) return dashboardBridgeError(legacyNetwork.error ?? 'Failed to query network endpoint');
-          return { ok: true, data: legacyNetwork, error: null, status: 200 };
+          
+          if (endpoint === 'network') {
+            return { ok: true, data: legacyNetwork, error: null, status: 200 };
+          } else {
+            return {
+              ok: true,
+              data: { peers: safeArray(legacyNetwork.peers), total: safeArray(legacyNetwork.peers).length, degraded: false },
+              error: null,
+              status: 200,
+            };
+          }
         }
         return dashboardBridgeError('Desktop main process is outdated. Fully quit and relaunch AntSeed Desktop.');
+      }
+
+      // On any API error, try legacy fallback for network/peers data
+      if ((endpoint === 'network' || endpoint === 'peers') && bridge.getNetwork) {
+        try {
+          const legacyNetwork = await bridge.getNetwork(getDashboardPort());
+          if (legacyNetwork.ok) {
+            if (endpoint === 'network') {
+              return { ok: true, data: legacyNetwork, error: null, status: 200 };
+            } else {
+              return {
+                ok: true,
+                data: { peers: safeArray(legacyNetwork.peers), total: safeArray(legacyNetwork.peers).length, degraded: false },
+                error: null,
+                status: 200,
+              };
+            }
+          }
+        } catch {
+          // If legacy fallback also fails, return original error
+        }
       }
 
       return dashboardBridgeError(message);
@@ -110,6 +144,25 @@ export function initDashboardApiModule({
     }
   }
 
+  async function ensureDashboardReady(): Promise<boolean> {
+    const now = Date.now();
+    // Cache readiness check for 5 seconds to avoid hammering the API
+    if (dashboardReady && now - lastDashboardCheck < 5000) {
+      return true;
+    }
+
+    try {
+      const result = await getDashboardData('status');
+      dashboardReady = result.ok;
+      lastDashboardCheck = now;
+      return dashboardReady;
+    } catch {
+      dashboardReady = false;
+      lastDashboardCheck = now;
+      return false;
+    }
+  }
+
   function setRefreshHooks(hooks: RefreshHooks): void {
     refreshHooks = hooks;
   }
@@ -120,11 +173,40 @@ export function initDashboardApiModule({
     const { renderDashboardData, setDashboardRefreshState, refreshChatConversations, refreshChatProxyStatus } =
       refreshHooks;
 
-    setDashboardRefreshState?.(true, 'Refreshing peers and network status...');
+    setDashboardRefreshState?.(true, 'Checking dashboard readiness...');
 
     try {
+      // Ensure dashboard is ready before attempting data fetch
+      const ready = await ensureDashboardReady();
+      if (!ready) {
+        setDashboardRefreshState?.(true, 'Waiting for dashboard service...');
+        // Wait a bit longer for dashboard to start
+        await new Promise(resolve => setTimeout(resolve, 2000));
+        const retryReady = await ensureDashboardReady();
+        if (!retryReady) {
+          // Fall back to showing offline state
+          setDashboardRefreshState?.(false, 'Dashboard service unavailable');
+          return;
+        }
+      }
+
+      // First attempt: Load network and peers data
       setDashboardRefreshState?.(true, 'Loading network and peers...');
-      const [network, peers] = await Promise.all([getDashboardData('network'), getDashboardData('peers')]);
+      let network = await getDashboardData('network');
+      let peers = await getDashboardData('peers');
+
+      // If both network and peers failed, retry once after a short delay
+      if (!network.ok && !peers.ok) {
+        setDashboardRefreshState?.(true, 'Retrying peer discovery...');
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        
+        const retryResults = await Promise.all([
+          getDashboardData('network'),
+          getDashboardData('peers')
+        ]);
+        network = retryResults[0];
+        peers = retryResults[1];
+      }
 
       setDashboardRefreshState?.(true, 'Loading runtime status and settings...');
       const [status, dataSources, config] = await Promise.all([
@@ -150,5 +232,6 @@ export function initDashboardApiModule({
     scanDhtNow,
     setRefreshHooks,
     refreshDashboardData,
+    ensureDashboardReady,
   };
 }

--- a/apps/desktop/src/renderer/modules/dashboard-render.ts
+++ b/apps/desktop/src/renderer/modules/dashboard-render.ts
@@ -52,6 +52,17 @@ function normalizeNetworkData(
       ? { ...defaultNetworkStats(), ...(rawStats as Record<string, unknown>) }
       : defaultNetworkStats();
 
+  // Debug logging to help diagnose peer visibility issues
+  if (typeof console !== 'undefined' && console.debug) {
+    console.debug('[AntSeed] Normalizing network data:', {
+      networkPeersCount: networkPeers.length,
+      daemonPeersCount: daemonPeers.length,
+      networkDataPresent: !!networkData,
+      peersDataPresent: !!peersData,
+      statsPresent: !!rawStats
+    });
+  }
+
   const merged = new Map<string, PeerEntry>();
 
   for (const peer of networkPeers) {
@@ -119,7 +130,9 @@ function normalizeNetworkData(
   }
 
   const peers = Array.from(merged.values())
-    .filter((peer) => peer.services.length > 0)
+    // Don't filter out peers without services - they might still be valid
+    // Only filter out peers with obviously invalid data
+    .filter((peer) => peer.peerId.length > 0 && (peer.host.length > 0 || peer.services.length > 0))
     .sort((a, b) => {
       if (b.reputation !== a.reputation) return b.reputation - a.reputation;
       return b.lastSeen - a.lastSeen;
@@ -134,6 +147,17 @@ function normalizeNetworkData(
         services.add(normalized);
       }
     }
+  }
+
+  // Debug logging for peer count issues
+  if (typeof console !== 'undefined' && console.debug) {
+    console.debug('[AntSeed] Peer processing result:', {
+      mergedPeersCount: merged.size,
+      filteredPeersCount: peers.length,
+      serviceCount: services.size,
+      peersWithServices: peers.filter(p => p.services.length > 0).length,
+      peersWithoutServices: peers.filter(p => p.services.length === 0).length
+    });
   }
 
   stats.totalPeers = peers.length;
@@ -182,6 +206,17 @@ export function initDashboardRenderModule({
     config: { ok: boolean; data: unknown; error?: string | null };
   }): void {
     const networkOk = results.network.ok || results.peers.ok;
+    
+    // Enhanced error logging for debugging
+    if (!networkOk && typeof console !== 'undefined' && console.warn) {
+      console.warn('[AntSeed] Both network and peers endpoints failed:', {
+        networkError: results.network.error,
+        peersError: results.peers.error,
+        networkOk: results.network.ok,
+        peersOk: results.peers.ok
+      });
+    }
+    
     const normalizedNetwork = normalizeNetworkData(
       results.network.ok ? (results.network.data as Record<string, unknown> | null) : null,
       results.peers.ok ? (results.peers.data as Record<string, unknown> | null) : null,

--- a/apps/desktop/test-peer-discovery.md
+++ b/apps/desktop/test-peer-discovery.md
@@ -1,0 +1,67 @@
+# Testing Peer Discovery Fix
+
+## Steps to Verify the Fix
+
+1. **Start the AntSeed Desktop app**
+   ```bash
+   cd antseed/apps/desktop
+   pnpm dev
+   ```
+
+2. **Monitor the Console for Debug Messages**
+   - Open Developer Tools (Cmd+Option+I / Ctrl+Shift+I)
+   - Look for debug messages with `[AntSeed]` prefix
+   - These will show peer discovery status and data flow
+
+3. **Test Scenarios**
+
+   **Scenario A: Normal Operation**
+   - Start the app fresh
+   - Navigate to the Peers tab
+   - Should see peers (if any) within 10-15 seconds
+   - Console should show peer count info
+
+   **Scenario B: Refresh Testing**  
+   - Click "Refresh" button multiple times quickly
+   - Should not cause peer count to flicker to 0
+   - Each refresh should maintain peer visibility
+
+   **Scenario C: Dashboard Restart**
+   - Stop dashboard service manually if possible
+   - Start it again
+   - App should recover and show peers again
+
+## Debug Output to Look For
+
+```
+[AntSeed] Normalizing network data: {
+  networkPeersCount: X,
+  daemonPeersCount: Y,
+  networkDataPresent: true/false,
+  peersDataPresent: true/false,
+  statsPresent: true/false
+}
+
+[AntSeed] Peer processing result: {
+  mergedPeersCount: X,
+  filteredPeersCount: Y,
+  serviceCount: Z,
+  peersWithServices: A,
+  peersWithoutServices: B
+}
+```
+
+## Expected Behavior After Fix
+
+- ✅ Peers should appear consistently, not flicker to 0
+- ✅ Retry logic should recover from temporary API failures  
+- ✅ Peers without services should still be displayed
+- ✅ Dashboard readiness checks prevent premature requests
+- ✅ Enhanced fallback to legacy network API when needed
+
+## If Issues Persist
+
+1. Check the console warnings about endpoint failures
+2. Verify dashboard service is running on expected port (3117)
+3. Look for network connectivity or timing issues
+4. Consider increasing retry delays in dashboard-api.ts if needed


### PR DESCRIPTION
## Fix intermittent "0 peers" display in desktop app

### Problem
The desktop app would sometimes show 0 peers even when peers were available on the network. This happened particularly during:
- App startup and initialization
- Manual refresh cycles
- Dashboard service restarts

### Root Cause
1. **Race conditions** during data fetching from dashboard API
2. **Overly strict peer filtering** that excluded peers without service announcements
3. **Insufficient fallback handling** when dashboard endpoints failed
4. **Missing readiness checks** before attempting API calls

### Solution
- ✅ Added consistent fallback to legacy network API when dashboard endpoints fail
- ✅ Implemented retry logic with proper dashboard readiness checks  
- ✅ Relaxed peer filtering to include peers without service announcements
- ✅ Added debug logging to trace peer discovery data flow
- ✅ Improved error handling and recovery during API failures

### Testing
See `apps/desktop/test-peer-discovery.md` for comprehensive testing scenarios and debug output examples.

### Files Changed
- `apps/desktop/src/renderer/modules/dashboard-api.ts` - Enhanced API reliability
- `apps/desktop/src/renderer/modules/dashboard-render.ts` - Fixed filtering & debugging  
- `apps/desktop/test-peer-discovery.md` - Testing documentation

### Verification
- [ ] Peers display consistently without flickering to 0
- [ ] App recovers gracefully from dashboard API failures
- [ ] Debug console shows peer discovery flow clearly
- [ ] Manual refresh maintains peer visibility

Fixes issue where desktop app would intermittently show 0 peers even when peers were available on the network.