### PR TITLE
feat(desktop): HTML preview split panel with artifact cards

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1607,6 +1607,19 @@ ipcMain.handle('desktop:set-debug-logs', (_event, enabled: boolean) => {
   return { ok: true };
 });
 
+ipcMain.handle('desktop:open-html-in-browser', async (_event, html: string) => {
+  try {
+    const tmpDir = path.join(app.getPath('temp'), 'antseed-html-preview');
+    await mkdir(tmpDir, { recursive: true });
+    const filePath = path.join(tmpDir, `preview-${Date.now()}.html`);
+    await writeFile(filePath, html, 'utf-8');
+    await shell.openExternal(`file://${filePath}`);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+});
+
 ipcMain.handle('runtime:open-dashboard', async (_event, port?: number) => {
   const openPort = dashboardRuntime.running ? dashboardRuntime.port : toSafeDashboardPort(port);
   await shell.openExternal(`http://127.0.0.1:${openPort}`);

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -272,6 +272,9 @@ const api = {
   setDebugLogs(enabled: boolean): Promise<{ ok: true }> {
     return ipcRenderer.invoke('desktop:set-debug-logs', enabled) as Promise<{ ok: true }>;
   },
+  openHtmlInBrowser(html: string): Promise<{ ok: boolean }> {
+    return ipcRenderer.invoke('desktop:open-html-in-browser', html) as Promise<{ ok: boolean }>;
+  },
 };
 
 contextBridge.exposeInMainWorld('antseedDesktop', api);

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -139,4 +139,5 @@ export type DesktopBridge = {
   onAppSetupStep?: (handler: (data: { step: string; label: string }) => void) => () => void;
   onAppSetupComplete?: (handler: () => void) => () => void;
   setDebugLogs?: (enabled: boolean) => Promise<{ ok: true }>;
+  openHtmlInBrowser?: (html: string) => Promise<{ ok: boolean }>;
 };

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -839,3 +839,80 @@
 .tool-result-msg {
   display: none;
 }
+
+/* ===================================================================
+   HTML Artifact card
+   =================================================================== */
+
+.html-artifact-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 12px 0 4px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card-alt);
+}
+
+.html-artifact-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.html-artifact-icon {
+  font-family: var(--font-mono);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.html-artifact-label {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.html-artifact-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.html-artifact-type {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.html-artifact-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.html-artifact-btn {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  white-space: nowrap;
+
+  &:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+}

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -4,7 +4,9 @@ import { HugeiconsIcon } from '@hugeicons/react';
 import { Copy01Icon, Tick02Icon } from '@hugeicons/core-free-icons';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import type { ReactNode } from 'react';
-import { MarkdownContent } from './chat-utils.js';
+import { Lexer } from 'marked';
+import { MarkdownContent, isHtmlContent } from './chat-utils.js';
+import { useHtmlPreview } from './HtmlPreviewContext';
 import styles from './ChatBubble.module.scss';
 import type { ChatMessage, ContentBlock } from './chat-shared';
 import {
@@ -356,6 +358,90 @@ function ToolGroupView({ blocks }: { blocks: ContentBlock[] }) {
   );
 }
 
+function HtmlArtifactCard({ code, label }: { code: string; label?: string }) {
+  const { onPreviewHtml } = useHtmlPreview();
+
+  const handleOpenInBrowser = (): void => {
+    const bridge = (window as unknown as { antseedDesktop?: { openHtmlInBrowser?: (html: string) => Promise<{ ok: boolean }> } }).antseedDesktop;
+    if (bridge?.openHtmlInBrowser) {
+      void bridge.openHtmlInBrowser(code);
+    }
+  };
+
+  return (
+    <div className={styles.htmlArtifactCard}>
+      <div className={styles.htmlArtifactInfo}>
+        <span className={styles.htmlArtifactIcon}>{'</>'}</span>
+        <div className={styles.htmlArtifactLabel}>
+          <span className={styles.htmlArtifactName}>{label || 'HTML'}</span>
+          <span className={styles.htmlArtifactType}>Code · HTML</span>
+        </div>
+      </div>
+      <div className={styles.htmlArtifactActions}>
+        <button type="button" className={styles.htmlArtifactBtn} onClick={() => onPreviewHtml(code)}>
+          Preview
+        </button>
+        <button type="button" className={styles.htmlArtifactBtn} onClick={handleOpenInBrowser}>
+          Open in Browser
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** Extract HTML code blocks from markdown text using the marked lexer */
+function collectHtmlCodeBlocksFromText(text: string): { code: string; lang?: string }[] {
+  const htmlBlocks: { code: string; lang?: string }[] = [];
+  const tokens = Lexer.lex(text, { gfm: true, breaks: true });
+  for (const token of tokens) {
+    if (token.type === 'code' && typeof token.text === 'string') {
+      const lang = (token as { lang?: string }).lang;
+      if (isHtmlContent(token.text, lang)) {
+        htmlBlocks.push({ code: token.text, lang });
+      }
+    }
+  }
+  return htmlBlocks;
+}
+
+/** Check if a tool_use block wrote/edited an HTML file */
+function extractHtmlFromToolUse(block: ContentBlock): string | null {
+  if (block.type !== 'tool_use') return null;
+  const kind = getToolKind(block.name);
+  // Write tool: input.content contains the full file content
+  if (kind === 'write' && block.input) {
+    const filePath = String(block.input.file_path || block.input.path || '');
+    const content = String(block.input.content || '');
+    if (
+      (filePath.endsWith('.html') || filePath.endsWith('.htm')) &&
+      content.trim().length > 0
+    ) {
+      return content;
+    }
+    // Also detect HTML even without .html extension if content looks like HTML
+    if (content.trim().length > 0 && isHtmlContent(content)) {
+      return content;
+    }
+  }
+  return null;
+}
+
+/** Extract HTML code blocks from a message's content blocks */
+function collectHtmlCodeBlocks(blocks: ContentBlock[]): { code: string; lang?: string }[] {
+  const htmlBlocks: { code: string; lang?: string }[] = [];
+  for (const block of blocks) {
+    if (block.type === 'text' && typeof block.text === 'string') {
+      htmlBlocks.push(...collectHtmlCodeBlocksFromText(block.text));
+    }
+    // Also check tool_use blocks that write HTML files
+    const toolHtml = extractHtmlFromToolUse(block);
+    if (toolHtml) {
+      htmlBlocks.push({ code: toolHtml, lang: 'html' });
+    }
+  }
+  return htmlBlocks;
+}
+
 function renderAssistantBlocks(blocks: ContentBlock[], streaming = false, messagePrefix = ''): ReactNode[] {
   const nodes: ReactNode[] = [];
   let toolGroup: ContentBlock[] = [];
@@ -381,6 +467,16 @@ function renderAssistantBlocks(blocks: ContentBlock[], streaming = false, messag
   });
 
   flushToolGroup();
+
+  // Append artifact cards for any HTML code blocks or tool-written HTML.
+  // Show them even during streaming so the user can preview partial results.
+  const htmlBlocks = collectHtmlCodeBlocks(blocks);
+  htmlBlocks.forEach((hb, i) => {
+    nodes.push(
+      <HtmlArtifactCard key={`${messagePrefix}-html-artifact-${i}`} code={hb.code} />
+    );
+  });
+
   return nodes;
 }
 
@@ -520,11 +616,26 @@ export function ChatBubble({ message, streaming = false }: ChatBubbleProps) {
       if (Array.isArray(message.content)) {
         return renderAssistantBlocks(message.content as ContentBlock[], isStreamingBubble, messagePrefix);
       }
-      return <MarkdownContent text={String(message.content)} />;
+      // String content from assistant — check for HTML code blocks
+      const text = String(message.content);
+      const nodes: ReactNode[] = [<MarkdownContent key="md" text={text} />];
+      if (!isStreamingBubble) {
+        const htmlBlocks = collectHtmlCodeBlocksFromText(text);
+        htmlBlocks.forEach((hb, i) => {
+          nodes.push(<HtmlArtifactCard key={`html-artifact-${i}`} code={hb.code} />);
+        });
+      }
+      return nodes;
     }
 
     if (typeof message.content === 'string') {
-      return <MarkdownContent text={message.content} />;
+      // User messages — check for HTML code blocks (e.g. uploaded HTML files)
+      const nodes: ReactNode[] = [<MarkdownContent key="md" text={message.content} />];
+      const htmlBlocks = collectHtmlCodeBlocksFromText(message.content);
+      htmlBlocks.forEach((hb, i) => {
+        nodes.push(<HtmlArtifactCard key={`html-artifact-${i}`} code={hb.code} />);
+      });
+      return nodes;
     }
 
     if (Array.isArray(message.content)) {

--- a/apps/desktop/src/renderer/ui/components/chat/HtmlPreviewContext.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/HtmlPreviewContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+type HtmlPreviewContextType = {
+  onPreviewHtml: (html: string) => void;
+};
+
+export const HtmlPreviewContext = createContext<HtmlPreviewContextType>({
+  onPreviewHtml: () => {},
+});
+
+export function useHtmlPreview(): HtmlPreviewContextType {
+  return useContext(HtmlPreviewContext);
+}

--- a/apps/desktop/src/renderer/ui/components/chat/chat-utils.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-utils.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useState } from 'react';
+import React, { Fragment, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { Lexer } from 'marked';
 import type { ChatMessage } from './chat-shared';
@@ -157,24 +157,38 @@ function renderListItemContent(token: MarkdownToken, key: string): ReactNode {
   return normalizeText(token.text ?? token.raw);
 }
 
-function CodeBlock({ code, lang }: { code: string; lang?: string }) {
-  const [copied, setCopied] = useState(false);
-  const langLabel = normalizeText(lang).trim() || 'code';
+export function isHtmlContent(code: string, lang?: string): boolean {
+  const l = normalizeText(lang).trim().toLowerCase();
+  if (l === 'html' || l === 'htm') return true;
+  if (!l || l === 'code') {
+    return /^\s*<!doctype\s+html/i.test(code) || /^\s*<html[\s>]/i.test(code);
+  }
+  return false;
+}
 
+function CopyButton({ code }: { code: string }) {
+  const [copied, setCopied] = React.useState(false);
   const handleCopy = (): void => {
     void navigator.clipboard.writeText(code).then(() => {
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);
     });
   };
+  return (
+    <button className="chat-code-copy-btn" type="button" onClick={handleCopy}>
+      {copied ? 'Copied!' : 'Copy'}
+    </button>
+  );
+}
+
+function CodeBlock({ code, lang }: { code: string; lang?: string }) {
+  const langLabel = normalizeText(lang).trim() || 'code';
 
   return (
     <div className="chat-code-container">
       <div className="chat-code-header">
         <span className="code-lang">{langLabel}</span>
-        <button className="chat-code-copy-btn" type="button" onClick={handleCopy}>
-          {copied ? 'Copied!' : 'Copy'}
-        </button>
+        <CopyButton code={code} />
       </div>
       <pre>
         <code>{code}</code>

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
@@ -52,6 +52,115 @@
   overflow: hidden;
 }
 
+.chat-container-split {
+  .chat-main {
+    flex: none;
+    min-width: 0;
+  }
+}
+
+/* ===================================================================
+   Resize handle between chat and preview panel
+   =================================================================== */
+
+.chat-resize-handle {
+  width: 6px;
+  flex-shrink: 0;
+  cursor: col-resize;
+  background: transparent;
+  position: relative;
+  z-index: 10;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 2px;
+    width: 2px;
+    background: var(--border);
+    transition: background 0.15s;
+  }
+
+  &:hover::after {
+    background: var(--accent-green);
+  }
+}
+
+/* ===================================================================
+   HTML Preview split panel
+   =================================================================== */
+
+.chat-preview-panel {
+  flex: none;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border);
+  background: var(--bg-primary);
+}
+
+.chat-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+}
+
+.chat-preview-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.chat-preview-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.chat-preview-action-btn {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+
+  &:hover {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+  }
+}
+
+.chat-preview-close-btn {
+  appearance: none;
+  border: none;
+  background: none;
+  color: var(--text-muted);
+  font-size: 14px;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: var(--radius-sm);
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+}
+
+.chat-preview-iframe {
+  flex: 1;
+  width: 100%;
+  border: 0;
+  background: #fff;
+}
+
 .chat-main {
   display: flex;
   flex-direction: column;
@@ -144,6 +253,26 @@
   object-fit: cover;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
+}
+
+.chat-html-attach-preview {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 17px 8px;
+}
+
+.chat-html-attach-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
 }
 
 .chat-image-remove-btn {

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -8,6 +8,7 @@ import { useUiSnapshot } from '../../hooks/useUiSnapshot';
 import { useActions } from '../../hooks/useActions';
 import { ChatBubble } from '../chat/ChatBubble';
 import { isToolResultOnlyMessage } from '../chat/chat-utils.js';
+import { HtmlPreviewContext } from '../chat/HtmlPreviewContext';
 import { WalkingAnt } from '../chat/WalkingAnt';
 import { ServiceDropdown } from '../chat/ServiceDropdown';
 import { AntStationStackedLogo } from '../AntStationLogo';
@@ -53,7 +54,11 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   const actions = useActions();
   const [inputValue, setInputValue] = useState('');
   const [attachedImage, setAttachedImage] = useState<{ base64: string; mimeType: string; previewUrl: string } | null>(null);
+  const [attachedHtml, setAttachedHtml] = useState<{ name: string; content: string } | null>(null);
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null);
+  const [previewWidthPct, setPreviewWidthPct] = useState(50);
   const [isDragOver, setIsDragOver] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -101,16 +106,20 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
 
   const handleSend = useCallback(() => {
     const text = inputValue.trim();
-    if (!text && !attachedImage) return;
+    if (!text && !attachedImage && !attachedHtml) return;
+    const finalText = attachedHtml
+      ? `${text ? text + '\n\n' : ''}Here is the HTML file "${attachedHtml.name}":\n\n\`\`\`html\n${attachedHtml.content}\n\`\`\``
+      : text;
     setInputValue('');
     setAttachedImage(null);
+    setAttachedHtml(null);
     if (inputRef.current) {
       inputRef.current.style.height = 'auto';
       inputRef.current.style.overflowY = 'hidden';
       inputRef.current.focus();
     }
-    actions.sendMessage(text, attachedImage?.base64, attachedImage?.mimeType);
-  }, [inputValue, attachedImage, actions]);
+    actions.sendMessage(finalText, attachedImage?.base64, attachedImage?.mimeType);
+  }, [inputValue, attachedImage, attachedHtml, actions]);
 
   const ALLOWED_PASTE_MIME_TYPES = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
 
@@ -125,16 +134,29 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     reader.readAsDataURL(file);
   }, []);
 
-  const handleImageAttach = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileAttach = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    attachImageFile(file);
+    if (file.name.endsWith('.html') || file.name.endsWith('.htm') || file.type === 'text/html') {
+      const reader = new FileReader();
+      reader.onload = () => {
+        setAttachedHtml({ name: file.name, content: reader.result as string });
+      };
+      reader.readAsText(file);
+    } else {
+      attachImageFile(file);
+    }
     // Reset so the same file can be re-attached
     e.target.value = '';
   }, [attachImageFile]);
 
   const handleRemoveImage = useCallback(() => {
     setAttachedImage(null);
+    if (inputRef.current) inputRef.current.focus();
+  }, []);
+
+  const handleRemoveHtml = useCallback(() => {
+    setAttachedHtml(null);
     if (inputRef.current) inputRef.current.focus();
   }, []);
 
@@ -192,6 +214,56 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     }
   }, []);
 
+  const handlePreviewHtml = useCallback((html: string) => {
+    setPreviewHtml(html);
+  }, []);
+
+  const handleOpenPreviewInBrowser = useCallback(() => {
+    if (!previewHtml) return;
+    const bridge = (window as unknown as { antseedDesktop?: { openHtmlInBrowser?: (html: string) => Promise<{ ok: boolean }> } }).antseedDesktop;
+    if (bridge?.openHtmlInBrowser) {
+      void bridge.openHtmlInBrowser(previewHtml);
+    }
+  }, [previewHtml]);
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    const container = containerRef.current;
+    if (!container) return;
+
+    const startX = e.clientX;
+    const containerRect = container.getBoundingClientRect();
+    const containerWidth = containerRect.width;
+    const startChatPct = 100 - previewWidthPct;
+
+    const onMouseMove = (ev: MouseEvent): void => {
+      const dx = ev.clientX - startX;
+      const newChatPct = Math.min(80, Math.max(20, startChatPct + (dx / containerWidth) * 100));
+      setPreviewWidthPct(100 - newChatPct);
+    };
+
+    const onMouseUp = (): void => {
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      // Un-block pointer events on the iframe
+      const iframe = container.querySelector('iframe');
+      if (iframe) iframe.style.pointerEvents = '';
+    };
+
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    // Block pointer events on the iframe so mousemove events aren't swallowed
+    const iframe = container.querySelector('iframe');
+    if (iframe) iframe.style.pointerEvents = 'none';
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, [previewWidthPct]);
+
+  const previewContextValue = useMemo(() => ({ onPreviewHtml: handlePreviewHtml }), [handlePreviewHtml]);
+
   const showWelcome =
     snap.chatConversationsLoaded &&
     !snap.chatActiveConversation &&
@@ -231,100 +303,134 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
         </button>
       )}
 
-      <div className={styles.chatContainer}>
-        <div
-          className={styles.chatMain}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
-        >
-          {isDragOver && (
-            <div className={styles.chatDropOverlay}>
-              <div className={styles.chatDropOverlayInner}>
-                <span>Drop image here</span>
+      <HtmlPreviewContext.Provider value={previewContextValue}>
+        <div ref={containerRef} className={`${styles.chatContainer}${previewHtml ? ` ${styles.chatContainerSplit}` : ''}`}>
+          <div
+            className={styles.chatMain}
+            style={previewHtml ? { width: `${100 - previewWidthPct}%` } : undefined}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+          >
+            {isDragOver && (
+              <div className={styles.chatDropOverlay}>
+                <div className={styles.chatDropOverlayInner}>
+                  <span>Drop image here</span>
+                </div>
+              </div>
+            )}
+            <div className={styles.chatMessages} ref={scrollRef} data-chat-scroll>
+              {showWelcome ? (
+                <div className={styles.chatWelcome}>
+                  <AntStationStackedLogo height={72} />
+                  <div className={styles.chatWelcomeSubtitle}>
+                    Start typing. Best provider auto-selected by reputation.
+                  </div>
+                </div>
+              ) : (
+                visibleMessages.map((msg, i) => (
+                  <ChatBubble key={getMessageKey(msg, i)} message={msg} />
+                ))
+              )}
+              {snap.chatStreamingMessage ? (
+                <ChatBubble
+                  key={`streaming:${snap.chatActiveConversation || 'new'}`}
+                  message={snap.chatStreamingMessage as ChatMessage}
+                  streaming
+                />
+              ) : null}
+              {snap.chatSending && snap.chatSendingConversationId === snap.chatActiveConversation && (
+                <WalkingAnt elapsedMs={snap.chatThinkingElapsedMs} />
+              )}
+            </div>
+
+            <div className={styles.chatInputArea}>
+              {attachedImage && (
+                <div className={styles.chatImageAttachPreview}>
+                  <img src={attachedImage.previewUrl} alt="Attached" className={styles.chatImageAttachThumb} />
+                  <button className={styles.chatImageRemoveBtn} onClick={handleRemoveImage} title="Remove image">✕</button>
+                </div>
+              )}
+              {attachedHtml && (
+                <div className={styles.chatHtmlAttachPreview}>
+                  <span className={styles.chatHtmlAttachChip}>{attachedHtml.name}</span>
+                  <button className={styles.chatImageRemoveBtn} onClick={handleRemoveHtml} title="Remove HTML">✕</button>
+                </div>
+              )}
+              <div className={styles.chatInputRow}>
+                <input
+                  ref={fileInputRef}
+                  id={fileInputId}
+                  type="file"
+                  accept="image/jpeg,image/png,image/gif,image/webp,.html,.htm"
+                  style={{ display: 'none' }}
+                  onChange={handleFileAttach}
+                />
+                <textarea
+                  ref={inputRef}
+                  className={styles.chatTextInput}
+                  placeholder="Type a message... (Shift+Enter for newline)"
+                  rows={1}
+                  disabled={snap.chatInputDisabled}
+                  value={inputValue}
+                  onChange={(e) => setInputValue(e.target.value)}
+                  onInput={handleInput}
+                  onKeyDown={handleKeyDown}
+                  onPaste={handlePaste}
+                />
+                <div className={styles.chatInputBottom}>
+                  <div className={styles.chatInputBottomLeft}>
+                    <button
+                      className={styles.chatAttachBtn}
+                      title="Attach file"
+                      disabled={snap.chatInputDisabled}
+                      onClick={() => fileInputRef.current?.click()}
+                    >
+                      <HugeiconsIcon icon={Add01Icon} size={18} strokeWidth={2} />
+                    </button>
+                  </div>
+                  {snap.chatAbortVisible ? (
+                    <button className={styles.chatAbortBtn} onClick={() => void actions.abortChat()}>
+                      Stop
+                    </button>
+                  ) : (
+                    <button className={styles.chatSendBtn} disabled={snap.chatSendDisabled && !attachedImage && !attachedHtml} onClick={handleSend}>
+                      <HugeiconsIcon icon={ArrowUp02Icon} size={18} strokeWidth={2.5} />
+                    </button>
+                  )}
+                </div>
               </div>
             </div>
+
+            {snap.chatError && <div className={styles.chatError}>{snap.chatError}</div>}
+          </div>
+
+          {previewHtml && (
+            <>
+            <div className={styles.chatResizeHandle} onMouseDown={handleResizeStart} />
+            <div className={styles.chatPreviewPanel} style={{ width: `${previewWidthPct}%` }}>
+              <div className={styles.chatPreviewHeader}>
+                <span className={styles.chatPreviewTitle}>HTML Preview</span>
+                <div className={styles.chatPreviewActions}>
+                  <button type="button" className={styles.chatPreviewActionBtn} onClick={handleOpenPreviewInBrowser}>
+                    Open in Browser
+                  </button>
+                  <button type="button" className={styles.chatPreviewCloseBtn} onClick={() => setPreviewHtml(null)} aria-label="Close preview">
+                    ✕
+                  </button>
+                </div>
+              </div>
+              <iframe
+                className={styles.chatPreviewIframe}
+                sandbox="allow-scripts"
+                srcDoc={previewHtml}
+                title="HTML Preview"
+              />
+            </div>
+            </>
           )}
-          <div className={styles.chatMessages} ref={scrollRef} data-chat-scroll>
-            {showWelcome ? (
-              <div className={styles.chatWelcome}>
-                <AntStationStackedLogo height={72} />
-                <div className={styles.chatWelcomeSubtitle}>
-                  Start typing. Best provider auto-selected by reputation.
-                </div>
-              </div>
-            ) : (
-              visibleMessages.map((msg, i) => (
-                <ChatBubble key={getMessageKey(msg, i)} message={msg} />
-              ))
-            )}
-            {snap.chatStreamingMessage ? (
-              <ChatBubble
-                key={`streaming:${snap.chatActiveConversation || 'new'}`}
-                message={snap.chatStreamingMessage as ChatMessage}
-                streaming
-              />
-            ) : null}
-            {snap.chatSending && snap.chatSendingConversationId === snap.chatActiveConversation && (
-              <WalkingAnt elapsedMs={snap.chatThinkingElapsedMs} />
-            )}
-          </div>
-
-          <div className={styles.chatInputArea}>
-            {attachedImage && (
-              <div className={styles.chatImageAttachPreview}>
-                <img src={attachedImage.previewUrl} alt="Attached" className={styles.chatImageAttachThumb} />
-                <button className={styles.chatImageRemoveBtn} onClick={handleRemoveImage} title="Remove image">✕</button>
-              </div>
-            )}
-            <div className={styles.chatInputRow}>
-              <input
-                ref={fileInputRef}
-                id={fileInputId}
-                type="file"
-                accept="image/jpeg,image/png,image/gif,image/webp"
-                style={{ display: 'none' }}
-                onChange={handleImageAttach}
-              />
-              <textarea
-                ref={inputRef}
-                className={styles.chatTextInput}
-                placeholder="Type a message... (Shift+Enter for newline)"
-                rows={1}
-                disabled={snap.chatInputDisabled}
-                value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
-                onInput={handleInput}
-                onKeyDown={handleKeyDown}
-                onPaste={handlePaste}
-              />
-              <div className={styles.chatInputBottom}>
-                <div className={styles.chatInputBottomLeft}>
-                  <button
-                    className={styles.chatAttachBtn}
-                    title="Attach image"
-                    disabled={snap.chatInputDisabled}
-                    onClick={() => fileInputRef.current?.click()}
-                  >
-                    <HugeiconsIcon icon={Add01Icon} size={18} strokeWidth={2} />
-                  </button>
-                </div>
-                {snap.chatAbortVisible ? (
-                  <button className={styles.chatAbortBtn} onClick={() => void actions.abortChat()}>
-                    Stop
-                  </button>
-                ) : (
-                  <button className={styles.chatSendBtn} disabled={snap.chatSendDisabled && !attachedImage} onClick={handleSend}>
-                    <HugeiconsIcon icon={ArrowUp02Icon} size={18} strokeWidth={2.5} />
-                  </button>
-                )}
-              </div>
-            </div>
-          </div>
-
-          {snap.chatError && <div className={styles.chatError}>{snap.chatError}</div>}
         </div>
-      </div>
+      </HtmlPreviewContext.Provider>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- **Split-screen HTML preview panel**: Click "Preview" on any HTML artifact to render it in a right-side panel with an iframe (sandboxed with allow-scripts). The panel is **resizable** via a drag handle, clamped between 20-80% width.
- **Artifact cards**: Compact cards with "Preview" and "Open in Browser" buttons appear at the bottom of messages containing HTML -- from code blocks, uploaded .html files, and AI Write tool responses.
- **HTML file upload**: Attach .html/.htm files via the + button, displayed as a compact chip (not raw code). The full HTML is sent to the AI as context in a code fence.
- **Open in Browser**: Opens HTML content in the system default browser via a temp file + Electron shell.openExternal.

## Files changed
- main.ts -- IPC handler for desktop:open-html-in-browser
- preload.cts -- Context bridge openHtmlInBrowser method
- bridge.ts -- Type definition
- HtmlPreviewContext.tsx -- New React context
- ChatBubble.tsx -- HtmlArtifactCard, HTML detection from text and tool_use blocks
- chat-utils.tsx -- Exported isHtmlContent helper
- ChatView.tsx -- Split layout, preview state, resize handle, HTML upload
- ChatView.module.scss -- Split panel and resize handle styles
- ChatBubble.module.scss -- Artifact card styles

## Test plan
- [ ] Upload an HTML file -- compact chip shown, not raw code
- [ ] Send message with HTML file -- AI receives the HTML content
- [ ] AI generates HTML code block -- artifact card appears below the message
- [ ] AI uses Write tool to create an HTML file -- artifact card appears
- [ ] Click Preview -- split panel opens with rendered HTML
- [ ] Drag resize handle left/right -- panels resize (clamped 20-80%)
- [ ] Click Open in Browser -- opens in default browser
- [ ] Click X -- preview panel closes, chat returns to full width

Generated with [Claude Code](https://claude.com/claude-code)