### PR TITLE
refactor(buyer-proxy): rename rewriteModelInBody → rewriteServiceInBody

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import type { PeerInfo } from '@antseed/node'
-import { selectCandidatePeersForRouting, rewriteModelInBody } from './buyer-proxy.js'
+import { selectCandidatePeersForRouting, rewriteServiceInBody } from './buyer-proxy.js'
 
 function makePeer(seed: string, providers: string[]): PeerInfo {
   const repeated = (seed.repeat(64) + 'a'.repeat(64)).slice(0, 64)
@@ -91,7 +91,7 @@ test('selectCandidatePeersForRouting can still include peers without service pro
   assert.equal(result.candidatePeers[0]?.peerId, peerWithoutMetadata.peerId)
 })
 
-// rewriteModelInBody tests
+// rewriteServiceInBody tests
 
 function makeJsonBody(obj: Record<string, unknown>): Uint8Array {
   return new TextEncoder().encode(JSON.stringify(obj))
@@ -103,50 +103,55 @@ function parseJsonBody(body: Uint8Array): Record<string, unknown> {
 
 const jsonHeaders: Record<string, string> = { 'content-type': 'application/json' }
 
-test('rewriteModelInBody replaces existing model field', () => {
+test('rewriteServiceInBody replaces existing model field and sets service', () => {
   const body = makeJsonBody({ model: 'claude-sonnet-4-5', messages: [] })
-  const result = rewriteModelInBody(body, jsonHeaders, 'claude-opus-4-6')
-  assert.equal(parseJsonBody(result.body)['model'], 'claude-opus-4-6')
-})
-
-test('rewriteModelInBody adds model field when absent', () => {
-  const body = makeJsonBody({ messages: [] })
-  const result = rewriteModelInBody(body, jsonHeaders, 'claude-opus-4-6')
-  assert.equal(parseJsonBody(result.body)['model'], 'claude-opus-4-6')
-})
-
-test('rewriteModelInBody preserves all other fields', () => {
-  const body = makeJsonBody({ model: 'old', messages: [{ role: 'user', content: 'hi' }], max_tokens: 1024 })
-  const result = rewriteModelInBody(body, jsonHeaders, 'new-model')
+  const result = rewriteServiceInBody(body, jsonHeaders, 'claude-opus-4-6')
   const parsed = parseJsonBody(result.body)
+  assert.equal(parsed['service'], 'claude-opus-4-6')
+  assert.equal(parsed['model'], 'claude-opus-4-6')
+})
+
+test('rewriteServiceInBody adds service and model fields when absent', () => {
+  const body = makeJsonBody({ messages: [] })
+  const result = rewriteServiceInBody(body, jsonHeaders, 'claude-opus-4-6')
+  const parsed = parseJsonBody(result.body)
+  assert.equal(parsed['service'], 'claude-opus-4-6')
+  assert.equal(parsed['model'], 'claude-opus-4-6')
+})
+
+test('rewriteServiceInBody preserves all other fields', () => {
+  const body = makeJsonBody({ model: 'old', messages: [{ role: 'user', content: 'hi' }], max_tokens: 1024 })
+  const result = rewriteServiceInBody(body, jsonHeaders, 'new-model')
+  const parsed = parseJsonBody(result.body)
+  assert.equal(parsed['service'], 'new-model')
   assert.equal(parsed['model'], 'new-model')
   assert.deepEqual(parsed['messages'], [{ role: 'user', content: 'hi' }])
   assert.equal(parsed['max_tokens'], 1024)
 })
 
-test('rewriteModelInBody updates content-length header when present', () => {
+test('rewriteServiceInBody updates content-length header when present', () => {
   const original = makeJsonBody({ model: 'a', messages: [] })
   const headers = { 'content-type': 'application/json', 'content-length': String(original.length) }
-  const result = rewriteModelInBody(original, headers, 'claude-opus-4-6-20251201')
+  const result = rewriteServiceInBody(original, headers, 'claude-opus-4-6-20251201')
   assert.equal(result.headers['content-length'], String(result.body.length))
 })
 
-test('rewriteModelInBody returns original when body is not JSON content-type', () => {
+test('rewriteServiceInBody returns original when body is not JSON content-type', () => {
   const body = makeJsonBody({ model: 'old' })
   const headers = { 'content-type': 'text/plain' }
-  const result = rewriteModelInBody(body, headers, 'new-model')
+  const result = rewriteServiceInBody(body, headers, 'new-model')
   assert.equal(result.body, body)
   assert.equal(result.headers, headers)
 })
 
-test('rewriteModelInBody returns original when body is empty', () => {
+test('rewriteServiceInBody returns original when body is empty', () => {
   const body = new Uint8Array(0)
-  const result = rewriteModelInBody(body, jsonHeaders, 'new-model')
+  const result = rewriteServiceInBody(body, jsonHeaders, 'new-model')
   assert.equal(result.body, body)
 })
 
-test('rewriteModelInBody returns original when body is not a JSON object', () => {
+test('rewriteServiceInBody returns original when body is not a JSON object', () => {
   const body = new TextEncoder().encode('"just a string"')
-  const result = rewriteModelInBody(body, jsonHeaders, 'new-model')
+  const result = rewriteServiceInBody(body, jsonHeaders, 'new-model')
   assert.equal(result.body, body)
 })

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -785,15 +785,15 @@ function isLoopbackPeer(peer: PeerInfo): boolean {
 }
 
 /**
- * Rewrite the `model` field in a JSON request body.
+ * Rewrite the `service` (and `model` for upstream LLM API compat) fields in a JSON request body.
  * Also updates `content-length` if present in headers.
  * Returns the original body/headers unchanged if the body is not JSON,
  * is empty, or cannot be parsed.
  */
-export function rewriteModelInBody(
+export function rewriteServiceInBody(
   body: Uint8Array,
   headers: Record<string, string>,
-  model: string,
+  service: string,
 ): { body: Uint8Array; headers: Record<string, string> } {
   const contentType = (headers['content-type'] ?? headers['Content-Type'] ?? '').toLowerCase()
   if (!contentType.includes('application/json') || body.length === 0) {
@@ -805,7 +805,8 @@ export function rewriteModelInBody(
       return { body, headers }
     }
     const obj = parsed as Record<string, unknown>
-    obj['model'] = model
+    obj['service'] = service
+    obj['model'] = service
     const rewritten = new TextEncoder().encode(JSON.stringify(obj))
     const updatedHeaders = { ...headers }
     if ('content-length' in updatedHeaders) {
@@ -1228,7 +1229,7 @@ export class BuyerProxy {
     const effectivePinnedService = this._pinnedService
     const effectivePinnedPeer = this._pinnedPeer
     if (effectivePinnedService) {
-      const { body: rewrittenBody, headers: rewrittenHeaders } = rewriteModelInBody(
+      const { body: rewrittenBody, headers: rewrittenHeaders } = rewriteServiceInBody(
         serializedReq.body,
         serializedReq.headers,
         effectivePinnedService,


### PR DESCRIPTION
## Summary

- Renames `rewriteModelInBody` → `rewriteServiceInBody` in `buyer-proxy.ts` and its test file
- The rewrite function now sets **both** `service` and `model` fields in the outgoing JSON body, ensuring sellers receive the service ID regardless of which field name their upstream LLM API expects
- Updates all test names and assertions to cover the new `service` field
- `connection.ts` was already updated on main (no changes needed there)

## Test plan

- [x] All 12 buyer-proxy unit tests pass (`rewriteServiceInBody` + `selectCandidatePeersForRouting`)