### PR TITLE
feat(bound-agent): add OpenAI Responses API format

### DIFF
--- a/packages/bound-agent/src/agent-loop.ts
+++ b/packages/bound-agent/src/agent-loop.ts
@@ -68,6 +68,12 @@ function chunkHasMessageStart(data: Uint8Array): boolean {
   return text.includes('event: message_start') || text.includes('"type":"message_start"') || text.includes('"type": "message_start"');
 }
 
+/** Check if an SSE chunk contains a Responses API response.created event. */
+function chunkHasResponseCreated(data: Uint8Array): boolean {
+  const text = decoder.decode(data);
+  return text.includes('event: response.created');
+}
+
 
 /**
  * Check if an SSE chunk contains an internal (antseed_*) tool call.
@@ -87,7 +93,7 @@ function chunkHasInternalToolCall(data: Uint8Array, format: RequestFormat): bool
       } catch { /* ignore */ }
     }
   } else {
-    // Anthropic: look for content_block_start with tool_use type and antseed_ name
+    // Anthropic & Responses API: look for antseed_ name in content blocks or output items
     if (text.includes(`"name":"${TOOL_PREFIX}`) || text.includes(`"name": "${TOOL_PREFIX}`)) return true;
   }
   return false;
@@ -244,6 +250,10 @@ export async function runAgentLoopStream(
               if (messageStartSent) return;
               messageStartSent = true;
             }
+            if (format === 'openai-responses' && chunkHasResponseCreated(chunk.data)) {
+              if (messageStartSent) return;
+              messageStartSent = true;
+            }
           }
           callbacks.onResponseChunk(chunk);
         },
@@ -316,9 +326,11 @@ export async function runAgentLoopStream(
       }
     },
     onResponseChunk: (chunk) => {
-      // Anthropic: suppress message_start if we already sent one (continuing the envelope)
-      if (format === 'anthropic' && messageStartSent && !chunk.done && chunk.data.length > 0 && chunkHasMessageStart(chunk.data)) {
-        return;
+      if (!chunk.done && chunk.data.length > 0) {
+        // Anthropic: suppress message_start if we already sent one (continuing the envelope)
+        if (format === 'anthropic' && messageStartSent && chunkHasMessageStart(chunk.data)) return;
+        // Responses API: suppress response.created if we already sent one
+        if (format === 'openai-responses' && messageStartSent && chunkHasResponseCreated(chunk.data)) return;
       }
       callbacks.onResponseChunk(chunk);
     },

--- a/packages/bound-agent/src/provider.test.ts
+++ b/packages/bound-agent/src/provider.test.ts
@@ -55,6 +55,29 @@ function makeOpenAIToolCallResponse(toolName: string, toolId: string, args: unkn
   });
 }
 
+function makeResponsesTextResponse(text: string): Uint8Array {
+  return makeBody({
+    id: 'resp-1',
+    object: 'response',
+    output: [{ type: 'message', role: 'assistant', content: [{ type: 'output_text', text }] }],
+    status: 'completed',
+  });
+}
+
+function makeResponsesFunctionCallResponse(toolName: string, callId: string, args: unknown): Uint8Array {
+  return makeBody({
+    id: 'resp-1',
+    object: 'response',
+    output: [{
+      type: 'function_call',
+      call_id: callId,
+      name: toolName,
+      arguments: JSON.stringify(args),
+    }],
+    status: 'completed',
+  });
+}
+
 // ─── Mock provider ──────────────────────────────────────────────
 
 interface MockProviderOptions {
@@ -494,6 +517,149 @@ describe('BoundAgentProvider — agent loop (OpenAI)', () => {
     const result = parseBody(res.body);
     const choices = result.choices as { message: { tool_calls: { function: { name: string } }[] } }[];
     expect(choices[0]!.message.tool_calls[0]!.function.name).toBe('search_web');
+  });
+});
+
+describe('BoundAgentProvider — agent loop (OpenAI Responses)', () => {
+  it('tool call → execute → text response', async () => {
+    const inner = mockProvider({
+      responses: [
+        makeResponsesFunctionCallResponse('antseed_load_knowledge', 'call-1', { name: 'linkedin-posting' }),
+        makeResponsesTextResponse('LinkedIn tips here.'),
+      ],
+    });
+    const agent = new BoundAgentProvider(inner, agentWithKnowledge());
+
+    const req = makeReq(
+      { input: [{ role: 'user', content: 'LinkedIn help' }] },
+      '/v1/responses',
+    );
+    const res = await agent.handleRequest(req);
+
+    expect(inner.callCount()).toBe(2);
+
+    // First call should have tools injected (flat function format)
+    const firstBody = inner.requestBodies()[0]!;
+    const tools = firstBody.tools as { type: string; name: string }[];
+    expect(tools.some(t => t.name === 'antseed_load_knowledge')).toBe(true);
+    expect(tools[0]!.type).toBe('function');
+    // Should NOT have nested function property (flat Responses API format)
+    expect((tools[0] as Record<string, unknown>).function).toBeUndefined();
+
+    // Instructions should have persona
+    const instructions = firstBody.instructions as string;
+    expect(instructions).toContain('You are a social media expert.');
+
+    // Second call should have function_call + function_call_output in input
+    const secondBody = inner.requestBodies()[1]!;
+    const input = secondBody.input as Record<string, unknown>[];
+    const funcOutput = input.find(i => i.type === 'function_call_output');
+    expect(funcOutput).toBeDefined();
+    expect((funcOutput as Record<string, unknown>).output).toContain('LinkedIn Posting');
+
+    // Response content
+    const result = parseBody(res.body);
+    const output = result.output as { type: string; content?: { type: string; text: string }[] }[];
+    expect(output[0]!.content![0]!.text).toBe('LinkedIn tips here.');
+  });
+
+  it('text only response — single call, no loop', async () => {
+    const inner = mockProvider({
+      responses: [makeResponsesTextResponse('Simple answer.')],
+    });
+    const agent = new BoundAgentProvider(inner, agentWithKnowledge());
+
+    await agent.handleRequest(makeReq(
+      { input: 'What time is it?' },
+      '/v1/responses',
+    ));
+    expect(inner.callCount()).toBe(1);
+  });
+
+  it('buyer function call only — returned as-is', async () => {
+    const buyerFuncCall = makeBody({
+      id: 'resp-1',
+      object: 'response',
+      output: [{ type: 'function_call', call_id: 'call-1', name: 'search_web', arguments: '{"q":"test"}' }],
+      status: 'completed',
+    });
+    const inner = mockProvider({ responses: [buyerFuncCall] });
+    const agent = new BoundAgentProvider(inner, agentWithKnowledge());
+
+    const req = makeReq(
+      {
+        input: [{ role: 'user', content: 'search for me' }],
+        tools: [{ type: 'function', name: 'search_web', description: 'Search', parameters: { type: 'object' } }],
+      },
+      '/v1/responses',
+    );
+    const res = await agent.handleRequest(req);
+
+    expect(inner.callCount()).toBe(1);
+    const result = parseBody(res.body);
+    const output = result.output as { type: string; name: string }[];
+    expect(output[0]!.name).toBe('search_web');
+  });
+
+  it('mixed antseed + buyer function calls → treated as done', async () => {
+    const mixedResponse = makeBody({
+      id: 'resp-1',
+      object: 'response',
+      output: [
+        { type: 'function_call', call_id: 'call-1', name: 'antseed_load_knowledge', arguments: '{"name":"linkedin-posting"}' },
+        { type: 'function_call', call_id: 'call-2', name: 'search_web', arguments: '{"q":"linkedin"}' },
+      ],
+    });
+    const inner = mockProvider({ responses: [mixedResponse] });
+    const agent = new BoundAgentProvider(inner, agentWithKnowledge());
+
+    const req = makeReq(
+      {
+        input: [{ role: 'user', content: 'help' }],
+        tools: [{ type: 'function', name: 'search_web', description: 'Search', parameters: { type: 'object' } }],
+      },
+      '/v1/responses',
+    );
+    const res = await agent.handleRequest(req);
+
+    expect(inner.callCount()).toBe(1);
+    const body = parseBody(res.body);
+    const output = body.output as { type: string; name: string }[];
+    // Internal calls stripped, only buyer call remains
+    const functionCalls = output.filter(i => i.type === 'function_call');
+    expect(functionCalls).toHaveLength(1);
+    expect(functionCalls[0]!.name).toBe('search_web');
+  });
+
+  it('wraps buyer instructions as client context', async () => {
+    const inner = mockProvider({ responses: [makeResponsesTextResponse('ok')] });
+    const agent = new BoundAgentProvider(inner, personaOnlyAgent());
+
+    await agent.handleRequest(makeReq(
+      {
+        input: 'hi',
+        instructions: 'Buyer instructions here',
+      },
+      '/v1/responses',
+    ));
+
+    const body = inner.requestBodies()[0]!;
+    const instructions = body.instructions as string;
+    expect(instructions).toContain('You are a helpful social media advisor.');
+    expect(instructions).toContain('<client-context>\nBuyer instructions here\n</client-context>');
+  });
+
+  it('string input is preserved (not wrapped in array)', async () => {
+    const inner = mockProvider({ responses: [makeResponsesTextResponse('ok')] });
+    const agent = new BoundAgentProvider(inner, personaOnlyAgent());
+
+    await agent.handleRequest(makeReq(
+      { input: 'hello there' },
+      '/v1/responses',
+    ));
+
+    const body = inner.requestBodies()[0]!;
+    expect(body.input).toBe('hello there');
   });
 });
 

--- a/packages/bound-agent/src/sse-parser.ts
+++ b/packages/bound-agent/src/sse-parser.ts
@@ -178,6 +178,105 @@ function parseAnthropicSSE(sseText: string): Record<string, unknown> {
 }
 
 /**
+ * Parse OpenAI Responses API SSE format into a non-streaming response object.
+ *
+ * Responses SSE uses named events:
+ *   event: response.created / response.output_item.added /
+ *          response.output_text.delta / response.function_call_arguments.delta /
+ *          response.output_item.done / response.completed
+ */
+function parseOpenAIResponsesSSE(sseText: string): Record<string, unknown> {
+  let id = '';
+  let model = '';
+  let status = 'completed';
+  const outputItems: Record<string, unknown>[] = [];
+
+  // Track in-progress output items by index
+  const builders: Map<number, Record<string, unknown>> = new Map();
+
+  const lines = sseText.split('\n');
+  let currentEvent = '';
+
+  for (const line of lines) {
+    if (line.startsWith('event: ')) {
+      currentEvent = line.slice(7).trim();
+      continue;
+    }
+    if (!line.startsWith('data: ') || line === 'data: [DONE]') continue;
+
+    let data: Record<string, unknown>;
+    const event = currentEvent;
+    currentEvent = '';
+    try {
+      data = JSON.parse(line.slice(6).trimEnd()) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    if (event === 'response.created' || event === 'response.completed') {
+      if (data.id) id = data.id as string;
+      if (data.model) model = data.model as string;
+      if (data.status) status = data.status as string;
+      // If response.completed has output, use it directly
+      if (event === 'response.completed' && Array.isArray(data.output)) {
+        return data;
+      }
+    } else if (event === 'response.output_item.added') {
+      const idx = data.output_index as number;
+      const item = data.item as Record<string, unknown>;
+      if (item) {
+        builders.set(idx, { ...item });
+      }
+    } else if (event === 'response.output_text.delta') {
+      const idx = data.output_index as number;
+      const builder = builders.get(idx);
+      if (builder && typeof data.delta === 'string') {
+        // Accumulate text in the message's content part
+        const content = builder.content as { type: string; text: string }[] | undefined;
+        if (content && content.length > 0) {
+          const part = content[content.length - 1]!;
+          part.text = (part.text ?? '') + data.delta;
+        }
+      }
+    } else if (event === 'response.content_part.added') {
+      const idx = data.output_index as number;
+      const builder = builders.get(idx);
+      const part = data.part as Record<string, unknown>;
+      if (builder && part) {
+        if (!Array.isArray(builder.content)) builder.content = [];
+        (builder.content as unknown[]).push({ ...part });
+      }
+    } else if (event === 'response.function_call_arguments.delta') {
+      const idx = data.output_index as number;
+      const builder = builders.get(idx);
+      if (builder && typeof data.delta === 'string') {
+        builder.arguments = ((builder.arguments as string) ?? '') + data.delta;
+      }
+    } else if (event === 'response.output_item.done') {
+      const idx = data.output_index as number;
+      const item = data.item as Record<string, unknown>;
+      if (item) {
+        outputItems[idx] = item;
+        builders.delete(idx);
+      }
+    }
+  }
+
+  // Fill in any remaining builders that didn't get a done event
+  for (const [idx, builder] of builders) {
+    if (!outputItems[idx]) outputItems[idx] = builder;
+  }
+
+  return {
+    id,
+    object: 'response',
+    model,
+    output: outputItems.filter(Boolean),
+    status,
+  };
+}
+
+/**
  * Parse raw SSE bytes into a structured response object.
  */
 export function parseSSEResponse(
@@ -197,6 +296,7 @@ export function parseSSEResponse(
     }
   }
 
+  if (format === 'openai-responses') return parseOpenAIResponsesSSE(text);
   return format === 'openai' ? parseOpenAISSE(text) : parseAnthropicSSE(text);
 }
 

--- a/packages/bound-agent/src/system-prompt.ts
+++ b/packages/bound-agent/src/system-prompt.ts
@@ -50,6 +50,15 @@ export function injectSystemPrompt(
   systemContent: string,
   format: RequestFormat,
 ): Record<string, unknown> {
+  if (format === 'openai-responses') {
+    const existing = typeof body.instructions === 'string' ? body.instructions : '';
+    if (existing.includes(INJECTION_MARKER)) return body;
+    return {
+      ...body,
+      instructions: existing ? `${systemContent}\n\n${wrapClientContext(existing)}` : systemContent,
+    };
+  }
+
   if (format === 'openai') {
     const messages = Array.isArray(body.messages) ? [...(body.messages as unknown[])] : [];
 

--- a/packages/bound-agent/src/tools.test.ts
+++ b/packages/bound-agent/src/tools.test.ts
@@ -114,6 +114,15 @@ describe('injectTools', () => {
     const fn = tools[0].function as Record<string, unknown>;
     expect(fn.name).toBe('antseed_load_knowledge');
   });
+
+  it('uses OpenAI Responses format (flat function)', () => {
+    const body = { input: 'hello' };
+    const result = injectTools(body, testTools, 'openai-responses');
+    const tools = result.tools as Record<string, unknown>[];
+    expect(tools[0].type).toBe('function');
+    expect(tools[0].name).toBe('antseed_load_knowledge');
+    expect(tools[0].function).toBeUndefined(); // flat, not nested
+  });
 });
 
 describe('inspectResponse', () => {
@@ -186,6 +195,48 @@ describe('inspectResponse', () => {
       }],
     };
     expect(inspectResponse(response, 'openai').type).toBe('done');
+  });
+
+  it('returns done for text-only response (Responses)', () => {
+    const response = {
+      output: [{ type: 'message', content: [{ type: 'output_text', text: 'hi' }] }],
+    };
+    expect(inspectResponse(response, 'openai-responses').type).toBe('done');
+  });
+
+  it('returns continue for antseed_* calls (Responses)', () => {
+    const response = {
+      output: [{
+        type: 'function_call',
+        call_id: 'call-1',
+        name: 'antseed_load_knowledge',
+        arguments: '{"name":"pricing"}',
+      }],
+    };
+    const action = inspectResponse(response, 'openai-responses');
+    expect(action.type).toBe('continue');
+    if (action.type === 'continue') {
+      expect(action.internalCalls).toHaveLength(1);
+      expect(action.internalCalls[0].id).toBe('call-1');
+      expect(action.internalCalls[0].arguments).toEqual({ name: 'pricing' });
+    }
+  });
+
+  it('returns done for buyer-only function calls (Responses)', () => {
+    const response = {
+      output: [{ type: 'function_call', call_id: 'call-1', name: 'search_web', arguments: '{}' }],
+    };
+    expect(inspectResponse(response, 'openai-responses').type).toBe('done');
+  });
+
+  it('returns done when mixed — buyer calls prevent re-prompt (Responses)', () => {
+    const response = {
+      output: [
+        { type: 'function_call', call_id: 'call-1', name: 'search_web', arguments: '{}' },
+        { type: 'function_call', call_id: 'call-2', name: 'antseed_load_knowledge', arguments: '{"name":"faq"}' },
+      ],
+    };
+    expect(inspectResponse(response, 'openai-responses').type).toBe('done');
   });
 });
 
@@ -277,6 +328,21 @@ describe('appendToolLoop', () => {
     expect(msgs).toHaveLength(3);
     expect(msgs[2]).toEqual({ role: 'tool', tool_call_id: 'tc1', content: 'Price is $10/mo' });
   });
+
+  it('appends correctly in Responses format', () => {
+    const body = { input: [{ role: 'user', content: 'hello' }] };
+    const assistantResponse = {
+      output: [
+        { type: 'function_call', call_id: 'call-1', name: 'antseed_load_knowledge', arguments: '{"name":"pricing"}' },
+      ],
+    };
+    const results = [{ id: 'call-1', content: 'Price is $10/mo', isError: false }];
+    const updated = appendToolLoop(body, assistantResponse, results, 'openai-responses');
+    const input = updated.input as Record<string, unknown>[];
+    expect(input).toHaveLength(3); // original + function_call + function_call_output
+    expect(input[1]).toEqual(assistantResponse.output[0]);
+    expect(input[2]).toEqual({ type: 'function_call_output', call_id: 'call-1', output: 'Price is $10/mo' });
+  });
 });
 
 describe('stripInternalToolCalls', () => {
@@ -347,5 +413,30 @@ describe('stripInternalToolCalls', () => {
     };
     const stripped = stripInternalToolCalls(response, 'anthropic');
     expect(stripped.stop_reason).toBe('end_turn');
+  });
+
+  it('strips antseed_* calls, keeps buyer calls (Responses)', () => {
+    const response = {
+      output: [
+        { type: 'message', content: [{ type: 'output_text', text: 'Here you go' }] },
+        { type: 'function_call', call_id: 'call-1', name: 'search_web', arguments: '{}' },
+        { type: 'function_call', call_id: 'call-2', name: 'antseed_load_knowledge', arguments: '{}' },
+      ],
+    };
+    const stripped = stripInternalToolCalls(response, 'openai-responses');
+    const output = stripped.output as Record<string, unknown>[];
+    expect(output).toHaveLength(2);
+    expect((output[1] as Record<string, unknown>).name).toBe('search_web');
+  });
+
+  it('sets status to completed when all function_calls removed (Responses)', () => {
+    const response = {
+      output: [{ type: 'function_call', call_id: 'call-1', name: 'antseed_load_knowledge', arguments: '{}' }],
+      status: 'requires_action',
+    };
+    const stripped = stripInternalToolCalls(response, 'openai-responses');
+    const output = stripped.output as unknown[];
+    expect(output).toHaveLength(0);
+    expect(stripped.status).toBe('completed');
   });
 });

--- a/packages/bound-agent/src/tools.ts
+++ b/packages/bound-agent/src/tools.ts
@@ -1,9 +1,11 @@
 import type { KnowledgeModule } from './loader.js';
 
-export type RequestFormat = 'anthropic' | 'openai';
+export type RequestFormat = 'anthropic' | 'openai' | 'openai-responses';
 
 export function detectRequestFormat(path?: string): RequestFormat {
-  return path?.includes('/chat/completions') ? 'openai' : 'anthropic';
+  if (path?.includes('/chat/completions')) return 'openai';
+  if (path?.includes('/responses')) return 'openai-responses';
+  return 'anthropic';
 }
 
 export const TOOL_PREFIX = 'antseed_';
@@ -88,6 +90,9 @@ function toApiFormat(tool: BoundAgentTool, format: RequestFormat): Record<string
   if (format === 'openai') {
     return { type: 'function', function: { name: prefixedName, description: tool.description, parameters: tool.parameters } };
   }
+  if (format === 'openai-responses') {
+    return { type: 'function', name: prefixedName, description: tool.description, parameters: tool.parameters };
+  }
   return { name: prefixedName, description: tool.description, input_schema: tool.parameters };
 }
 
@@ -150,6 +155,25 @@ function extractToolCalls(
         }
       }
     }
+  } else if (format === 'openai-responses') {
+    const output = body.output as {
+      type: string;
+      call_id?: string;
+      name?: string;
+      arguments?: string;
+    }[] | undefined;
+    if (output) {
+      for (const item of output) {
+        if (item.type === 'function_call' && item.call_id && item.name) {
+          try {
+            const args = JSON.parse(item.arguments ?? '{}') as Record<string, unknown>;
+            calls.push({ id: item.call_id, name: item.name, arguments: args });
+          } catch {
+            calls.push({ id: item.call_id, name: item.name, arguments: {} });
+          }
+        }
+      }
+    }
   } else {
     const content = body.content as {
       type: string;
@@ -207,6 +231,26 @@ export function appendToolLoop(
   results: ToolResult[],
   format: RequestFormat,
 ): Record<string, unknown> {
+  if (format === 'openai-responses') {
+    const input = Array.isArray(body.input) ? [...(body.input as unknown[])] : [];
+    // Append the function_call items from the response output
+    const output = assistantResponse.output as { type: string }[] | undefined;
+    if (output) {
+      for (const item of output) {
+        if (item.type === 'function_call') input.push(item);
+      }
+    }
+    // Append function_call_output items for each result
+    for (const result of results) {
+      input.push({
+        type: 'function_call_output',
+        call_id: result.id,
+        output: result.content,
+      });
+    }
+    return { ...body, input };
+  }
+
   const messages = Array.isArray(body.messages) ? [...(body.messages as unknown[])] : [];
 
   if (format === 'openai') {
@@ -260,6 +304,21 @@ export function stripInternalToolCalls(
       return { ...choice, message: msg };
     });
     return { ...responseBody, choices: cleaned };
+  }
+
+  if (format === 'openai-responses') {
+    const output = responseBody.output as { type: string; name?: string }[] | undefined;
+    if (!output) return responseBody;
+    const filtered = output.filter(
+      item => !(item.type === 'function_call' && item.name?.startsWith(TOOL_PREFIX)),
+    );
+    const wasStripped = filtered.length < output.length;
+    const hasRemainingFunctionCall = filtered.some(i => i.type === 'function_call');
+    return {
+      ...responseBody,
+      output: filtered,
+      ...(wasStripped && !hasRemainingFunctionCall ? { status: 'completed' } : {}),
+    };
   }
 
   const content = responseBody.content as { type: string; name?: string }[] | undefined;


### PR DESCRIPTION
## Summary
- Add `openai-responses` as a third `RequestFormat` alongside `anthropic` and `openai`
- Detect `/v1/responses` paths and handle the Responses API conventions: `input`/`instructions` fields, flat `{ type: "function", name, ... }` tool format, `output[]` with `function_call` items, `function_call_output` for tool results
- SSE parser handles Responses streaming events (`response.created`, `response.output_item.added`, `response.output_text.delta`, `response.function_call_arguments.delta`, `response.completed`, etc.)
- Streaming envelope continuity: suppress `response.created` on non-first iterations, suppress chunks with internal tool calls

## Files changed
- `packages/bound-agent/src/tools.ts` — format detection, tool injection, extraction, appending, stripping
- `packages/bound-agent/src/sse-parser.ts` — `parseOpenAIResponsesSSE()`
- `packages/bound-agent/src/agent-loop.ts` — `chunkHasResponseCreated()`, streaming suppression
- `packages/bound-agent/src/system-prompt.ts` — `instructions` field injection
- `packages/bound-agent/src/tools.test.ts` — 8 new tests
- `packages/bound-agent/src/provider.test.ts` — 7 new integration tests

## Test plan
- [x] All existing tests pass (409 total)
- [x] TypeScript compiles cleanly
- [ ] Manual test with `provider-openai-responses` plugin + bound agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)