### PR TITLE
fix(buyer-proxy): bypass router cooldown when no alternative peers exist

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -1584,7 +1584,7 @@ export class BuyerProxy {
 
       if (!selectedPeer) {
         selectedPeer = router
-          ? router.selectPeer(serializedReq, availableCandidates)
+          ? (router.selectPeer(serializedReq, availableCandidates) ?? availableCandidates[0] ?? null)
           : availableCandidates[0] ?? null
       }
 


### PR DESCRIPTION
## Summary
- When the router rejects all candidates due to cooldown, the final fallback now falls through to `availableCandidates[0]` directly instead of returning null
- Prevents healthy peers from being permanently blocked after recovery when they're the only available candidate

Closes #74

## Test plan
- [ ] Simulate: single peer hits cooldown (3 failures) → peer recovers → next request still dispatches instead of returning "Router could not select a suitable peer"
- [ ] Multi-peer: router cooldown still correctly prefers non-cooled-down peers when alternatives exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)