### PR TITLE
fix: persist peers across DHT scans

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -85,6 +85,8 @@ export interface BuyerProxyConfig {
 
 const BUYER_STATE_FILE = join(homedir(), '.antseed', 'buyer.state.json')
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504])
+/** Max age for carrying forward peers not seen in the latest DHT scan. */
+const CARRY_FORWARD_TTL_MS = 30 * 60_000
 
 type TransformResult = { request: SerializedHttpRequest; streamRequested: boolean; requestedModel: string | null }
 type AdaptResponseMeta = { streamRequested: boolean; fallbackModel: string | null }
@@ -324,8 +326,6 @@ export class BuyerProxy {
     // Carry forward previously known peers that are missing from this scan,
     // preserving their lastSeen timestamp. A missed DHT scan doesn't mean
     // the peer is unavailable — it just wasn't discovered this time.
-    // Drop peers older than 30 minutes to prevent unbounded growth.
-    const CARRY_FORWARD_TTL_MS = 30 * 60_000
     const merged = [...incoming]
     for (const prev of this._cachedPeers) {
       if (!incomingById.has(prev.peerId) && now - prev.lastSeen < CARRY_FORWARD_TTL_MS) {

--- a/apps/desktop/src/main/peer-cache.ts
+++ b/apps/desktop/src/main/peer-cache.ts
@@ -170,6 +170,12 @@ export async function refreshPeerCache(): Promise<void> {
     // File doesn't exist yet — buyer runtime may not be running.
   }
 
+  // Re-derive online for every cached peer so evicted / un-filed peers
+  // also transition to offline once their lastSeen TTL expires.
+  for (const peer of peerCache.values()) {
+    peer.online = now - peer.lastSeen < PEER_ONLINE_TTL_MS;
+  }
+
   emitIfChanged();
 }
 


### PR DESCRIPTION
## Summary
- Peers missing from a DHT scan are no longer removed from the buyer state — they're carried forward with their original `lastSeen` preserved
- Desktop derives `online` status from `lastSeen` vs 5-minute TTL instead of tracking file snapshot membership
- Eviction on actual connection failure now persists to state file immediately

## Test plan
- [ ] Run buyer, observe peers appearing in dashboard
- [ ] Stop a provider peer, verify it stays in dashboard but shows as offline after 5 minutes
- [ ] Restart the provider, verify it comes back online with updated `lastSeen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)