### PR TITLE
feat(website): blog post — The Permissionless OpenRouter Alternative

### DIFF
--- a/apps/website/blog/2026-03-27-the-permissionless-openrouter-alternative/index.md
+++ b/apps/website/blog/2026-03-27-the-permissionless-openrouter-alternative/index.md
@@ -1,0 +1,133 @@
+---
+slug: the-permissionless-openrouter-alternative
+title: "AntSeed: The Permissionless OpenRouter Alternative"
+authors: [antseed]
+tags: [decentralized-ai, P2P AI, OpenRouter alternative, AI infrastructure, permissionless, AI agents, AI marketplace]
+description: OpenRouter decides what you're allowed to route to. AntSeed doesn't. A permissionless, peer-to-peer AI network with the same OpenAI-compatible interface — no gatekeeper, no platform fee, no single point of failure.
+keywords: [OpenRouter alternative, permissionless AI, decentralized AI inference, P2P LLM routing, AI API gateway alternative, OpenRouter vs AntSeed, decentralized AI marketplace, AI agent marketplace, permissionless AI marketplace, Bittensor alternative]
+image: /og-image.jpg
+date: 2026-03-27
+---
+
+AntSeed is a peer-to-peer AI services network — like OpenRouter, but permissionless. Same OpenAI-compatible interface, no central gatekeeper, no editorial control over what you can route to.
+
+OpenRouter solved a real problem. Developers don't want to manage API keys for ten different model providers. They want one endpoint, one billing relationship, and access to everything.
+
+That insight was correct. The architecture wasn't.
+
+<!-- truncate -->
+
+## The Gatekeeping Problem
+
+OpenRouter doesn't just route requests. It decides what you're allowed to route to.
+
+Which models are available? OpenRouter decides. Which providers can list? OpenRouter decides. Which workflows are permitted? OpenRouter decides. Which companies get access, which technologies get supported, which content policies apply — all filtered through one company's corporate rules.
+
+That's not an API gateway. It's an editorial layer with an API attached.
+
+When OpenRouter removes a model, you lose access. When they layer moderation on top of a provider's own policies — even for users who bring their own API keys — they're not protecting you. They're asserting control. Every model, every workflow, every provider on the platform exists because OpenRouter approved it. The moment they disapprove, it's gone.
+
+This is the fundamental problem with centralized routing: the company that sits in the middle gets to shape the market that flows through it. Your access to AI runs through someone else's judgement about what's acceptable, what's profitable, and what's compliant with their own corporate obligations.
+
+## Where Centralized Routing Breaks
+
+Beyond gatekeeping, the architecture has structural costs:
+
+**The tax compounds.** OpenRouter charges 5.5% on every dollar of credit purchased. On $10K/month that's $6,600/year. On $100K/month, $66,000. You're paying a platform fee on top of inference costs, indefinitely, for the privilege of routing.
+
+**You can't see inside the black box.** Which provider handled your request? Why was it routed there? What's the actual latency distribution? OpenRouter's routing decisions are opaque. You're trusting a company to optimize for your interests when their incentive is to optimize for their own margins.
+
+**The compliance surface is wrong.** Every request passes through a third-party proxy. That's an extra hop your data takes, an extra company that handles it, an extra set of terms that govern it. For teams with GDPR, HIPAA, or data residency requirements, adding a centralized proxy between you and inference makes compliance harder, not easier.
+
+**It's a single point of failure.** When OpenRouter goes down, every app built on it goes dark. Contractual SLAs don't change the topology.
+
+## Decentralized Projects: Right Direction, Different Problem
+
+Projects like Bittensor, Akash, and Render are doing important work. Bittensor is building an incentive layer for machine intelligence with real subnet economics and a growing ecosystem. Akash created a functioning decentralized compute marketplace. Render proved that distributed GPU networks can serve production workloads at scale. These projects pushed the industry forward and demonstrated that AI infrastructure doesn't have to live inside three cloud providers.
+
+But they're solving a different problem. They're decentralizing compute — the raw GPU layer. None of them are a drop-in replacement for your API gateway. You can't point your OpenAI-compatible client at Bittensor and get a response. You can't upload a specialized workflow to Akash and have buyers discover it through an open marketplace. The developer experience gap between these networks and what OpenRouter offers is still wide.
+
+More importantly, none of them are truly peer-to-peer at the application layer. They each require their own tokens, staking mechanisms, or marketplace structures. That's fine for what they do. But the gap they leave open is the one AntSeed fills: a permissionless, OpenAI-compatible network where anyone can serve any AI capability — not just raw compute — and anyone can consume it.
+
+## AntSeed: Same Interface, No Gatekeeper
+
+AntSeed is a peer-to-peer network for AI services. Not just inference — expertise. Providers offer what they build. Buyers route requests to the best available provider. No central server sits between them. No one decides what's allowed.
+
+The interface is OpenAI-compatible. If your app works with OpenRouter today, it works with AntSeed. One endpoint, all models, automatic routing. The developer experience is the same.
+
+The architecture is completely different.
+
+**Permissionless on both sides.** Anyone can join as a provider. Anyone can connect as a buyer. No application process, no partnership agreement, no platform approval. You run a node and you're in.
+
+**Three layers, built on each other.** The foundation is the unstoppable P2P network — discovery via BitTorrent DHT, transport via WebRTC, no central point that can be shut down. On top sits an open marketplace where any AI service can be offered and proven through on-chain stats. On top of that emerge Ant Agents — domain experts who package their knowledge as always-on services. A lawyer's contract expertise available at 3am. A security researcher's threat model, queryable by anyone. A trading analyst running 24/7, earning per delivery.
+
+Ant Agents are the unit of value on the network. You wrap your expertise in AI, set your price, and the network handles discovery, payments, and reputation. How you deliver is your business — pick any model, any workflow, any stack. The protocol only measures the quality of what comes back.
+
+**Direct settlement, minimal fees.** Buyers pay providers directly — in USDC or by card. A 2% protocol fee is distributed back to the network, not extracted by a platform. Providers set their own prices. Markets clear through open competition.
+
+**Reputation is on-chain and provider-sovereign.** Every delivery builds a track record that belongs to your wallet, not a platform that can revoke it. A provider with thousands of verified deliveries charges more than a new entrant. That premium is earned through work, and it compounds.
+
+**Privacy by architecture.** There is no central server to log requests. No accounts, no logging. TEE-secured providers where not even the operator sees your data. This isn't a privacy policy — it's a consequence of peer-to-peer transport.
+
+**Resilience without SLAs.** If a provider goes offline, the network routes around it automatically. There's no central point that can fail. Uptime is a structural property of the network, not a contractual promise from a company.
+
+## How It Actually Works
+
+AntSeed's protocol has five layers, each handling a piece of what centralized gateways do behind closed doors:
+
+**Discovery** uses a BitTorrent-style DHT. Providers announce their capabilities — models, skills, agents, pricing, capacity, latency. Buyers query the DHT to find providers that match their needs. No central registry required.
+
+**Transport** runs on WebRTC data channels with TCP fallback. Connections are direct, peer-to-peer, with Ed25519 authentication. Every connection is cryptographically verified.
+
+**Metering** tracks token usage with provider-signed receipts. Each request generates a receipt with exact token counts, costs, and a cryptographic signature. Both sides have proof of what happened.
+
+**Payments** settle in USDC through on-chain escrow on Base, or via card through integrated fiat on-ramps. Bilateral payment channels between each buyer-seller pair. Disputes resolve automatically within defined thresholds. No invoicing, no billing cycles.
+
+**Reputation** aggregates real performance data — success rates, latency percentiles, token accuracy, uptime — recorded as on-chain stats. Any buyer can build their own reputation and access rules on top. The best providers earn more traffic because the data proves they deserve it.
+
+## The Comparison
+
+| | OpenRouter | Decentralized Compute | AntSeed |
+|---|---|---|---|
+| Architecture | Centralized gateway | Blockchain + subnets | Peer-to-peer |
+| What it routes | Model inference | Raw compute | AI services + expertise |
+| Permission to join | Company approval | Stake tokens | None required |
+| What you can serve | What they allow | What fits their framework | Anything |
+| API compatibility | OpenAI-compatible | Custom protocols | OpenAI-compatible |
+| Fees | 5.5% (extracted) | Token economics | 2% (returned to network) |
+| Payment methods | Card | Crypto wallets + tokens | USDC or Card |
+| Content policy | Platform-enforced | Varies | Provider-level |
+| Data privacy | Third-party proxy | Varies | P2P, no intermediary |
+| Single point of failure | Yes | No | No |
+
+## Who This Is For
+
+AntSeed is for people who care about having the option to choose. Not a curated menu of models that one company approved — but the full variety of what providers actually build, ranked by reputation earned through real deliveries.
+
+It's for people who care about privacy — not as a feature toggle, but as a structural property of the network they use. No accounts, no logging, no third-party proxy sitting between you and inference.
+
+It's for providers who want to monetize what they know without asking anyone for permission. Wrap your expertise in AI, set your price, build a reputation that compounds with every delivery. The network handles the rest.
+
+And it's for agents — software that doesn't care about brands or polished UIs, that just needs the best available service at the best price with verifiable quality. On those axes, an open P2P network wins every time.
+
+**Permissionless AI. Anyone can serve. Anyone can build. Anyone can earn.**
+
+---
+
+## Frequently Asked Questions
+
+**Is AntSeed free to use?**
+There's a 2% protocol fee per request, distributed back to the network. No subscription, no account, no platform rake on top of that.
+
+**Does AntSeed work with my existing tools?**
+Yes. Claude Code, Cursor, Aider, Continue.dev, and any app using the OpenAI SDK work without modification — just point them at AntSeed instead of your current endpoint.
+
+**How is AntSeed different from Bittensor for AI inference?**
+Bittensor decentralizes the compute layer with its own subnet economy and token. AntSeed is a peer-to-peer layer for AI services and expertise — OpenAI-compatible, no separate token required to participate as a buyer or provider.
+
+**Can I use AntSeed without crypto knowledge?**
+Yes. Providers and buyers can pay and settle in USDC or by card. The protocol handles the on-chain mechanics automatically.
+
+---
+
+[Read the lightpaper](/docs/lightpaper) · [Get started in one command](/docs/install)


### PR DESCRIPTION
## Summary

- Adds new blog post: **AntSeed: The Permissionless OpenRouter Alternative**
- Opens with a clear definitional sentence for AI search engines (Perplexity, ChatGPT, Gemini)
- Comparison table: OpenRouter vs Decentralized Compute vs AntSeed
- FAQ section targeting Google People Also Ask and generative search engines
- Covers: gatekeeping problem, structural costs of centralised routing, Bittensor/Akash/Render positioning, AntSeed protocol layers, Ant Agents

## Test plan
- [ ] Blog renders at /blog/the-permissionless-openrouter-alternative
- [ ] Appears in blog index at /blog
- [ ] Comparison table renders correctly
- [ ] FAQ section renders correctly
- [ ] CTAs link to /docs/lightpaper and /docs/install

Generated with Claude Code