### PR TITLE
refactor(contracts): weekly epoch emissions model

### DIFF
--- a/packages/contracts/AntseedEmissions.sol
+++ b/packages/contracts/AntseedEmissions.sol
@@ -47,6 +47,7 @@ contract AntseedEmissions is Ownable, Pausable, ReentrancyGuard {
 
     // ─── Reserve ───
     uint256 public reserveAccumulated;
+    mapping(uint256 => bool) public epochReserveAccounted;
 
     // ─── Events ───
     event SellerPointsAccrued(address indexed seller, uint256 indexed epoch, uint256 pointsDelta);
@@ -57,7 +58,6 @@ contract AntseedEmissions is Ownable, Pausable, ReentrancyGuard {
     // ─── Custom Errors ───
     error NotAuthorized();
     error EpochNotFinalized();
-    error EpochAlreadyClaimed();
     error InvalidShareSum();
     error NoProtocolReserve();
     error NoReserve();
@@ -144,10 +144,16 @@ contract AntseedEmissions is Ownable, Pausable, ReentrancyGuard {
         for (uint256 i = 0; i < epochs.length; i++) {
             uint256 epoch = epochs[i];
             if (epoch >= _currentEpoch) revert EpochNotFinalized();
-            if (userEpochClaimed[msg.sender][epoch]) revert EpochAlreadyClaimed();
+            if (userEpochClaimed[msg.sender][epoch]) continue;
             if (userSellerPoints[msg.sender][epoch] == 0 && userBuyerPoints[msg.sender][epoch] == 0) continue;
 
             userEpochClaimed[msg.sender][epoch] = true;
+
+            // Accumulate reserve share on first claim for this epoch
+            if (!epochReserveAccounted[epoch]) {
+                epochReserveAccounted[epoch] = true;
+                reserveAccumulated += (getEpochEmission(epoch) * RESERVE_SHARE_PCT) / 100;
+            }
 
             (uint256 sellerReward, uint256 sellerExcess, uint256 buyerReward) =
                 _calcEpochReward(msg.sender, epoch, _maxSellerPct);

--- a/packages/contracts/test/AntseedEmissions.t.sol
+++ b/packages/contracts/test/AntseedEmissions.t.sol
@@ -192,17 +192,20 @@ contract AntseedEmissionsTest is Test {
         emissions.claimEmissions(_epochList(5));
     }
 
-    function test_claim_revert_doubleClaim() public {
+    function test_claim_duplicateEpochIsIdempotent() public {
         emissions.accrueSellerPoints(seller1, 100);
 
         vm.warp(block.timestamp + EPOCH_DURATION);
 
+        // First claim
         vm.prank(seller1);
         emissions.claimEmissions(_epochList(0));
+        uint256 balanceAfterFirst = token.balanceOf(seller1);
 
+        // Second claim of same epoch — should be a no-op (continue), not revert
         vm.prank(seller1);
-        vm.expectRevert(AntseedEmissions.EpochAlreadyClaimed.selector);
         emissions.claimEmissions(_epochList(0));
+        assertEq(token.balanceOf(seller1), balanceAfterFirst);
     }
 
     function test_claim_skipsZeroActivityEpochs() public {
@@ -396,9 +399,48 @@ contract AntseedEmissionsTest is Test {
     //               RESERVE
     // ═══════════════════════════════════════════════════════════════════
 
+    function test_reserveAccumulates_onClaim() public {
+        emissions.accrueSellerPoints(seller1, 100);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        assertEq(emissions.reserveAccumulated(), 0);
+
+        vm.prank(seller1);
+        emissions.claimEmissions(_epochList(0));
+
+        // Reserve should have 10% of epoch emission
+        uint256 expectedReserve = (INITIAL_EMISSION * 10) / 100;
+        // Plus any seller cap excess
+        uint256 reserveAmount = emissions.reserveAccumulated();
+        assertTrue(reserveAmount >= expectedReserve);
+    }
+
+    function test_reserveAccumulates_onlyOncePerEpoch() public {
+        // Use 10 sellers so each gets 10% (below 15% cap = no excess)
+        for (uint256 i = 1; i <= 10; i++) {
+            emissions.accrueSellerPoints(address(uint160(i)), 100);
+        }
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        vm.prank(address(uint160(1)));
+        emissions.claimEmissions(_epochList(0));
+        uint256 reserveAfterFirst = emissions.reserveAccumulated();
+
+        vm.prank(address(uint160(2)));
+        emissions.claimEmissions(_epochList(0));
+        uint256 reserveAfterSecond = emissions.reserveAccumulated();
+
+        // Reserve share (10%) added on first claim only
+        uint256 baseReserve = (INITIAL_EMISSION * 10) / 100;
+        assertEq(reserveAfterFirst, baseReserve);
+        // Second claim adds no additional reserve (no cap excess with 10% each)
+        assertEq(reserveAfterSecond, baseReserve);
+    }
+
     function test_reserveFlush() public {
-        // Trigger reserve accumulation via seller cap excess
-        emissions.accrueSellerPoints(seller1, 1_000_000);
+        emissions.accrueSellerPoints(seller1, 100);
         vm.warp(block.timestamp + EPOCH_DURATION);
 
         vm.prank(seller1);


### PR DESCRIPTION
## Summary
- Replace Synthetix-style continuous accumulator with weekly epoch-based emissions
- Points earned in epoch N only earn from epoch N's budget — no carry-over
- `claimEmissions(uint256[] epochs)` — caller specifies which epochs to claim, each claimable once, forever
- Empty epoch budgets roll forward to the next epoch with activity
- Per-seller cap (15% of seller pool per epoch), excess → reserve

## Motivation
The Synthetix model gave permanent earning rights — one transaction earned emissions forever. The new model requires continuous participation: stop working, stop earning.

## Test plan
- [x] 38 emissions tests passing (204 total contract tests)
- [ ] Verify node-side emissions client still compiles (interface unchanged)
- [ ] E2E payment flow CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)