### PR TITLE
fix(config): Restore payment renegotiation

### DIFF
--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -586,6 +586,9 @@ export class AntseedNode extends EventEmitter {
   async connectToPeer(peer: PeerInfo): Promise<void> {
     const conn = await this._getOrCreateConnection(peer);
     this._getOrCreateMux(peer.peerId, conn);
+    if (this._buyerPaymentManager) {
+      this._getOrCreateBuyerPaymentMux(peer.peerId, conn);
+    }
   }
 
   async sendRequest(
@@ -624,6 +627,9 @@ export class AntseedNode extends EventEmitter {
     const conn = await this._getOrCreateConnection(peer);
     debugLog(`[Node] Connection to ${peer.peerId.slice(0, 12)}... state=${conn.state}`);
     const mux = this._getOrCreateMux(peer.peerId, conn);
+    if (this._buyerPaymentManager) {
+      this._getOrCreateBuyerPaymentMux(peer.peerId, conn);
+    }
 
     // Extract and strip x-antseed-spending-auth header if present (manual approval flow)
     const externalSpendingAuth = req.headers[ANTSEED_SPENDING_AUTH_HEADER] ?? null;
@@ -632,12 +638,10 @@ export class AntseedNode extends EventEmitter {
       req = { ...req, headers: cleanHeaders };
     }
 
-    // If we already have a payment session with this peer, skip negotiation.
-    const needsPaymentNegotiation = this._buyerPaymentManager
-      && !this._buyerLockedPeers.has(peer.peerId);
+    const hasBuyerPaymentManager = Boolean(this._buyerPaymentManager);
 
     // If an external spending auth was provided, apply it before sending the request.
-    if (externalSpendingAuth && needsPaymentNegotiation) {
+    if (externalSpendingAuth && hasBuyerPaymentManager) {
       debugLog(`[Node] Applying external spending auth for ${peer.peerId.slice(0, 12)}...`);
       await this._applyExternalSpendingAuth(peer, conn, externalSpendingAuth);
     }
@@ -842,7 +846,8 @@ export class AntseedNode extends EventEmitter {
     // wait for the seller's PaymentRequired message, negotiate, and retry.
     const response = await executeRequest();
 
-    if (response.statusCode === 402 && needsPaymentNegotiation && !externalSpendingAuth) {
+    if (response.statusCode === 402 && hasBuyerPaymentManager && !externalSpendingAuth) {
+      const hadLockedSession = this._buyerLockedPeers.has(peer.peerId);
       const manualApproval = await this._isManualApprovalEnabled();
       const directPaymentBody = parsePaymentRequiredBody(response.body);
       const responseAlreadyHasRequirements = Boolean(directPaymentBody?.minBudgetPerRequest);
@@ -877,6 +882,15 @@ export class AntseedNode extends EventEmitter {
       // If manual approval is on, always return the 402 to the caller
       if (manualApproval) {
         return returnPaymentRequired(responseAlreadyHasRequirements ? 'manual approval (direct body)' : 'manual approval');
+      }
+
+      // A 402 on an existing paid session means the current authorization is no
+      // longer usable. Clear buyer-side session state so auto-negotiation can
+      // establish a fresh authorization instead of short-circuiting.
+      if (hadLockedSession) {
+        this._buyerLockedPeers.delete(peer.peerId);
+        this._buyerFirstRequestSent.delete(peer.peerId);
+        this._buyerPaymentManager?.cleanupSession(peer.peerId);
       }
 
       // Auto mode: check if we can actually pay before attempting negotiation
@@ -1324,6 +1338,11 @@ export class AntseedNode extends EventEmitter {
           if (accepted > 0n && spent >= accepted) {
             // Budget exhausted — no remaining authorized balance
             const reserveMax = this._sellerPaymentManager.getReserveMax(session.sessionId);
+            const firstProvider = this._providers[0];
+            const providerPricing = firstProvider?.pricing?.defaults;
+            const requirements = this._sellerPaymentManager.getPaymentRequirements(
+              request.requestId, buyerPeerId, providerPricing,
+            );
             if (reserveMax > 0n && accepted >= reserveMax) {
               // Truly exhausted (at reserve cap) — settle so buyer can start a new session
               debugLog(`[Node] Session fully exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} >= accepted=${accepted} >= reserveMax=${reserveMax}) — settling and returning 402`);
@@ -1333,12 +1352,26 @@ export class AntseedNode extends EventEmitter {
             } else {
               debugLog(`[Node] Budget exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} >= accepted=${accepted}) — returning 402, awaiting NeedAuth response`);
             }
-            mux.sendProxyResponse({
-              requestId: request.requestId,
-              statusCode: 402,
-              headers: { "content-type": "application/json" },
-              body: new TextEncoder().encode(JSON.stringify({ error: 'payment_required' })),
-            });
+            if (requirements) {
+              mux.sendProxyResponse({
+                requestId: request.requestId,
+                statusCode: 402,
+                headers: { "content-type": "application/json" },
+                body: new TextEncoder().encode(JSON.stringify({
+                  error: 'payment_required',
+                  minBudgetPerRequest: requirements.minBudgetPerRequest,
+                  suggestedAmount: requirements.suggestedAmount,
+                })),
+              });
+              paymentMux.sendPaymentRequired(requirements);
+            } else {
+              mux.sendProxyResponse({
+                requestId: request.requestId,
+                statusCode: 402,
+                headers: { "content-type": "application/json" },
+                body: new TextEncoder().encode(JSON.stringify({ error: 'payment_required' })),
+              });
+            }
             return;
           }
         }

--- a/packages/node/tests/node-payment-mux-wiring.test.ts
+++ b/packages/node/tests/node-payment-mux-wiring.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AntseedNode, type NodeConfig } from '../src/node.js';
+import type { SerializedHttpRequest } from '../src/types/http.js';
+import type { SerializedHttpResponse } from '../src/types/http.js';
+import type { PeerInfo } from '../src/types/peer.js';
+
+function createNode(config: Partial<NodeConfig> = {}): AntseedNode {
+  const node = new AntseedNode({
+    role: 'buyer',
+    ...config,
+  });
+
+  (node as any)._identity = {
+    peerId: 'a'.repeat(40),
+    privateKey: new Uint8Array(32),
+    publicKey: new Uint8Array(32),
+  };
+  (node as any)._connectionManager = {};
+  return node;
+}
+
+describe('AntseedNode buyer payment mux wiring', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates buyer payment mux before sending outbound requests when payments are enabled', async () => {
+    const node = createNode();
+    const peer = { peerId: 'b'.repeat(40) } as PeerInfo;
+    const request: SerializedHttpRequest = {
+      requestId: 'req-payment-mux',
+      method: 'POST',
+      path: '/v1/chat/completions',
+      headers: { 'content-type': 'application/json' },
+      body: new Uint8Array(0),
+    };
+
+    const conn = { state: 'open' };
+    const sendProxyRequest = vi.fn((
+      _: SerializedHttpRequest,
+      onResponse: (response: unknown, metadata: { streamingStart: boolean }) => void,
+    ) => {
+      onResponse({
+        requestId: request.requestId,
+        statusCode: 200,
+        headers: {},
+        body: new Uint8Array(0),
+      }, { streamingStart: false });
+    });
+
+    (node as any)._buyerPaymentManager = {};
+    (node as any)._getOrCreateConnection = vi.fn(async () => conn);
+    (node as any)._getOrCreateMux = vi.fn(() => ({
+      sendProxyRequest,
+      cancelProxyRequest: vi.fn(),
+    }));
+    const getOrCreateBuyerPaymentMux = vi
+      .spyOn(node as any, '_getOrCreateBuyerPaymentMux')
+      .mockReturnValue({} as never);
+
+    await (node as any)._sendRequestInternal(peer, request, undefined);
+
+    expect(getOrCreateBuyerPaymentMux).toHaveBeenCalledWith(peer.peerId, conn);
+    expect(sendProxyRequest).toHaveBeenCalledOnce();
+    expect(
+      getOrCreateBuyerPaymentMux.mock.invocationCallOrder[0],
+    ).toBeLessThan(sendProxyRequest.mock.invocationCallOrder[0]);
+  });
+
+  it('re-negotiates on 402 even when the peer was already locked', async () => {
+    const node = createNode();
+    const peer = { peerId: 'b'.repeat(40) } as PeerInfo;
+    const request: SerializedHttpRequest = {
+      requestId: 'req-relock',
+      method: 'POST',
+      path: '/v1/chat/completions',
+      headers: { 'content-type': 'application/json' },
+      body: new Uint8Array(0),
+    };
+
+    const conn = { state: 'open' };
+    const responses: SerializedHttpResponse[] = [
+      {
+        requestId: request.requestId,
+        statusCode: 402,
+        headers: { 'content-type': 'application/json' },
+        body: new TextEncoder().encode(JSON.stringify({
+          error: 'payment_required',
+          minBudgetPerRequest: '10000',
+          suggestedAmount: '100000',
+        })),
+      },
+      {
+        requestId: request.requestId,
+        statusCode: 200,
+        headers: {},
+        body: new Uint8Array(0),
+      },
+    ];
+    const sendProxyRequest = vi.fn((
+      _: SerializedHttpRequest,
+      onResponse: (response: SerializedHttpResponse, metadata: { streamingStart: boolean }) => void,
+    ) => {
+      const next = responses.shift();
+      if (!next) throw new Error('no more responses');
+      onResponse(next, { streamingStart: false });
+    });
+
+    (node as any)._buyerPaymentManager = { cleanupSession: vi.fn() };
+    (node as any)._depositsClient = { getBuyerBalance: vi.fn(async () => ({ available: 1n })) };
+    (node as any)._identity.wallet = { address: '0x' + '11'.repeat(20) };
+    (node as any)._buyerLockedPeers.add(peer.peerId);
+    (node as any)._getOrCreateConnection = vi.fn(async () => conn);
+    (node as any)._getOrCreateMux = vi.fn(() => ({
+      sendProxyRequest,
+      cancelProxyRequest: vi.fn(),
+    }));
+    vi.spyOn(node as any, '_getOrCreateBuyerPaymentMux').mockReturnValue({} as never);
+    vi.spyOn(node as any, '_isManualApprovalEnabled').mockResolvedValue(false);
+    const negotiatePayment = vi.spyOn(node as any, '_negotiatePayment').mockImplementation(async () => {
+      expect((node as any)._buyerLockedPeers.has(peer.peerId)).toBe(false);
+      expect((node as any)._buyerFirstRequestSent.has(peer.peerId)).toBe(false);
+    });
+
+    const response = await (node as any)._sendRequestInternal(peer, request, undefined);
+
+    expect(response.statusCode).toBe(200);
+    expect(negotiatePayment).toHaveBeenCalledWith(peer, conn);
+    expect((node as any)._buyerPaymentManager.cleanupSession).toHaveBeenCalledWith(peer.peerId);
+  });
+});


### PR DESCRIPTION
## Description

Fixes two regressions in the buyer/seller payment negotiation flow.
Buyer connections now wire payment mux handlers before sending requests, and exhausted sessions can renegotiate cleanly after a 402 instead of getting stuck in a retry loop.

## Release Notes

- Fixed payment session renegotiation after budget exhaustion
- Fixed buyer payment mux wiring so NeedAuth and PaymentRequired messages are handled on active sessions

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [ ] Lint and unit tests pass locally with my changes
