### PR TITLE
fix(contracts): Enforce staked agent binding

### DIFF
--- a/packages/contracts/AntseedStaking.sol
+++ b/packages/contracts/AntseedStaking.sol
@@ -34,6 +34,7 @@ contract AntseedStaking is Ownable, ReentrancyGuard {
     // ─── Storage ────────────────────────────────────────────────────────
     mapping(address => SellerAccount) public sellers;
     mapping(address => uint256) public sellerAgentId;
+    mapping(uint256 => address) public agentSeller;
 
     // ─── Configurable Constants ─────────────────────────────────────────
     uint256 public MIN_SELLER_STAKE = 10_000_000;
@@ -49,6 +50,7 @@ contract AntseedStaking is Ownable, ReentrancyGuard {
     error ActiveChannels();
     error NotAgentOwner();
     error AgentIdMismatch();
+    error AgentAlreadyBound();
 
     // ─── Constructor ────────────────────────────────────────────────────
     constructor(address _usdc, address _registry) Ownable(msg.sender) {
@@ -75,6 +77,8 @@ contract AntseedStaking is Ownable, ReentrancyGuard {
         if (IERC8004Registry(registry.identityRegistry()).ownerOf(agentId) != seller) revert NotAgentOwner();
         uint256 existingAgentId = sellerAgentId[seller];
         if (existingAgentId != 0 && existingAgentId != agentId) revert AgentIdMismatch();
+        address existingSeller = agentSeller[agentId];
+        if (existingSeller != address(0) && existingSeller != seller) revert AgentAlreadyBound();
 
         usdc.safeTransferFrom(msg.sender, address(this), amount);
 
@@ -84,6 +88,7 @@ contract AntseedStaking is Ownable, ReentrancyGuard {
         }
         sa.stake += amount;
         sellerAgentId[seller] = agentId;
+        agentSeller[agentId] = seller;
 
         emit Staked(seller, agentId, amount);
     }
@@ -100,8 +105,10 @@ contract AntseedStaking is Ownable, ReentrancyGuard {
         uint256 payout = sa.stake - slashAmount;
 
         uint256 stakeAmount = sa.stake;
+        uint256 agentId = sellerAgentId[msg.sender];
         sa.stake = 0;
         sellerAgentId[msg.sender] = 0;
+        agentSeller[agentId] = address(0);
 
         if (payout > 0) {
             usdc.safeTransfer(msg.sender, payout);

--- a/packages/contracts/MockERC8004Registry.sol
+++ b/packages/contracts/MockERC8004Registry.sol
@@ -17,6 +17,7 @@ contract MockERC8004Registry is IERC8004Registry {
 
     event Registered(uint256 indexed agentId, address indexed owner);
     event MetadataSet(uint256 indexed agentId, string key, bytes value);
+    event Transferred(uint256 indexed agentId, address indexed from, address indexed to);
 
     function register() external returns (uint256 agentId) {
         agentId = _nextId++;
@@ -50,5 +51,15 @@ contract MockERC8004Registry is IERC8004Registry {
 
     function getMetadata(uint256 agentId, string calldata key) external view returns (bytes memory) {
         return _metadata[agentId][key];
+    }
+
+    function transferAgent(uint256 agentId, address to) external {
+        require(to != address(0), "Invalid recipient");
+        address from = _owners[agentId];
+        require(from == msg.sender, "Not owner");
+        _owners[agentId] = to;
+        _balances[from]--;
+        _balances[to]++;
+        emit Transferred(agentId, from, to);
     }
 }

--- a/packages/contracts/test/AntseedStaking.t.sol
+++ b/packages/contracts/test/AntseedStaking.t.sol
@@ -184,6 +184,20 @@ contract AntseedStakingTest is Test {
         vm.stopPrank();
     }
 
+    function test_stake_revert_agentAlreadyBoundToAnotherSeller() public {
+        _stakeAs(seller, MIN_STAKE);
+
+        vm.prank(seller);
+        identityRegistry.transferAgent(sellerAgentId, seller2);
+
+        usdc.mint(seller2, MIN_STAKE);
+        vm.startPrank(seller2);
+        usdc.approve(address(staking), MIN_STAKE);
+        vm.expectRevert(AntseedStaking.AgentAlreadyBound.selector);
+        staking.stake(sellerAgentId, MIN_STAKE);
+        vm.stopPrank();
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     //                        stakeFor()
     // ═══════════════════════════════════════════════════════════════════
@@ -271,6 +285,40 @@ contract AntseedStakingTest is Test {
         staking.unstake();
 
         assertEq(staking.getStake(seller), 0);
+    }
+
+    function test_unstake_afterIdentityTransfer_succeedsAndClearsBinding() public {
+        _stakeAs(seller, MIN_STAKE);
+
+        vm.prank(seller);
+        identityRegistry.transferAgent(sellerAgentId, seller2);
+
+        vm.prank(seller);
+        staking.unstake();
+
+        assertEq(staking.getStake(seller), 0);
+        assertEq(staking.getAgentId(seller), 0);
+        assertEq(staking.agentSeller(sellerAgentId), address(0));
+    }
+
+    function test_newOwnerCanStakeTransferredAgentAfterPreviousSellerUnstakes() public {
+        _stakeAs(seller, MIN_STAKE);
+
+        vm.prank(seller);
+        identityRegistry.transferAgent(sellerAgentId, seller2);
+
+        vm.prank(seller);
+        staking.unstake();
+
+        usdc.mint(seller2, MIN_STAKE);
+        vm.startPrank(seller2);
+        usdc.approve(address(staking), MIN_STAKE);
+        staking.stake(sellerAgentId, MIN_STAKE);
+        vm.stopPrank();
+
+        assertEq(staking.getAgentId(seller2), sellerAgentId);
+        assertEq(staking.agentSeller(sellerAgentId), seller2);
+        assertEq(staking.getStake(seller2), MIN_STAKE);
     }
 
     // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Description

Enforces a unique seller binding for each staked ERC-8004 agent ID in `AntseedStaking`. This prevents a transferred identity from being rebound by a second seller while the original seller is still staked, while still allowing the original staker to unstake and the new owner to stake afterward.

## Release Notes

- Fixed staking so a transferred ERC-8004 agent ID cannot be staked by a second seller while the original seller is still bound
- Added tests covering transfer, unstake, and rebinding flow for staked agent IDs

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
