### PR TITLE
fix(cli): return JSON 404 for unknown buyer proxy paths

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -672,6 +672,19 @@ export class BuyerProxy {
       return this._handleControlPlane(req, res, method, path)
     }
 
+    // Only proxy known API paths — reject everything else with 404
+    const normalizedPath = path.split('?')[0]?.trim().toLowerCase() ?? '/'
+    const isKnownApiPath =
+      normalizedPath.startsWith('/v1/messages') ||
+      normalizedPath.startsWith('/v1/chat/completions') ||
+      normalizedPath.startsWith('/v1/responses') ||
+      normalizedPath.startsWith('/v1/models')
+    if (!isKnownApiPath) {
+      res.writeHead(404, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ error: { message: 'Not found', type: 'invalid_request_error' } }))
+      return
+    }
+
     // Collect request body
     const chunks: Buffer[] = []
     for await (const chunk of req) {


### PR DESCRIPTION
## Summary
- Buyer proxy was forwarding all HTTP requests (including browser visits to `/`) to the connected peer, showing the peer's homepage
- Now only known API paths (`/v1/messages`, `/v1/chat/completions`, `/v1/responses`, `/v1/models`) are proxied
- Unknown paths return a JSON 404 matching the OpenAI error shape

## Test plan
- [ ] Visit `http://localhost:<port>/` in a browser — should see JSON 404
- [ ] Send a request to `/v1/chat/completions` — should proxy normally
- [ ] Send a request to `/v1/models` — should proxy normally
- [ ] `/_antseed/*` control-plane endpoints still work