### PR TITLE
fix(node): use negotiated reserve amount

### DIFF
--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -271,9 +271,16 @@ export class BuyerPaymentManager {
     sellerPeerId: string,
     paymentMux: PaymentMux,
     minBudgetPerRequest: bigint,
-    pricing?: ServicePricing,
+    reserveAmountOrPricing?: bigint | ServicePricing,
+    pricingArg?: ServicePricing,
   ): Promise<string> {
     const sellerEvmAddr = peerIdToAddress(sellerPeerId);
+    const reserveAmount = typeof reserveAmountOrPricing === 'bigint'
+      ? reserveAmountOrPricing
+      : this._config.maxReserveAmountUsdc;
+    const pricing = typeof reserveAmountOrPricing === 'bigint'
+      ? pricingArg
+      : reserveAmountOrPricing;
 
     // Budget validation: reject if seller demands more than buyer's overdraft limit
     if (minBudgetPerRequest > this._config.maxPerRequestUsdc) {
@@ -301,7 +308,7 @@ export class BuyerPaymentManager {
 
     // Sign ReserveAuth — binds channelId, maxAmount, deadline on-chain
     const channelsDomain = this._channelsDomain;
-    const maxAmount = this._config.maxReserveAmountUsdc;
+    const maxAmount = reserveAmount;
     const reserveMsg: ReserveAuthMessage = {
       channelId,
       maxAmount,

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -558,7 +558,7 @@ export class BuyerPaymentNegotiator {
         : undefined;
 
     try {
-      await this._bpm.authorizeSpending(peer.peerId, pmux, minBudgetPerRequest, pricing);
+      await this._bpm.authorizeSpending(peer.peerId, pmux, minBudgetPerRequest, amount, pricing);
       debugLog(`[BuyerNegotiator] SpendingAuth sent to seller ${peer.peerId.slice(0, 12)}..., waiting for AuthAck...`);
 
       await this._waitForLockConfirmation(peer.peerId);

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -337,6 +337,13 @@ describe('BuyerPaymentNegotiator', () => {
 
       expect(result.action).toBe('retry');
       expect(bpm.authorizeSpending).toHaveBeenCalled();
+      expect(bpm.authorizeSpending).toHaveBeenCalledWith(
+        peer.peerId,
+        expect.anything(),
+        10000n,
+        100000n,
+        { inputUsdPerMillion: 3, outputUsdPerMillion: 15 },
+      );
     });
 
     it('enriches 402 body with PaymentRequired data', async () => {


### PR DESCRIPTION
## Summary
- pass the capped negotiated reserve amount through buyer payment negotiation instead of always signing the config default reserve ceiling
- keep `BuyerPaymentManager.authorizeSpending()` backward-compatible with existing direct call sites
- add a negotiator regression assertion that the negotiated reserve amount is forwarded correctly

## Why
The buyer was still signing a `$5.00` initial reserve from config even when the negotiated `suggestedAmount` was lower. On the deployed channels contract this can exceed `FIRST_SIGN_CAP` and revert reserve with `FirstSignCapExceeded()`.

## Verification
- `pnpm --filter @antseed/node exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @antseed/node exec vitest run tests/buyer-payment-negotiator.test.ts`