### PR TITLE
Rename Operator/Wallet labels in desktop + portal

### DIFF
--- a/apps/desktop/src/renderer/ui/components/TitleBar.tsx
+++ b/apps/desktop/src/renderer/ui/components/TitleBar.tsx
@@ -126,7 +126,7 @@ export function TitleBar() {
               </div>
               <div className={styles.creditsDropdownSection}>
                 <div className={styles.creditsDropdownRow}>
-                  <span className={styles.creditsDropdownLabel}>Operator</span>
+                  <span className={styles.creditsDropdownLabel}>Your Wallet</span>
                   {creditsOperatorAddress ? (
                     <span className={styles.creditsDropdownValueGreen}>
                       {creditsOperatorAddress.slice(0, 6)}...{creditsOperatorAddress.slice(-4)}
@@ -137,7 +137,7 @@ export function TitleBar() {
                 </div>
                 {creditsEvmAddress && (
                   <div className={styles.creditsDropdownRow}>
-                    <span className={styles.creditsDropdownLabel}>Wallet</span>
+                    <span className={styles.creditsDropdownLabel}>Your Signer</span>
                     <span className={styles.creditsDropdownValueMuted}>
                       {creditsEvmAddress.slice(0, 6)}...{creditsEvmAddress.slice(-4)}
                     </span>

--- a/apps/payments/web/src/components/ChannelsView.tsx
+++ b/apps/payments/web/src/components/ChannelsView.tsx
@@ -235,7 +235,7 @@ function SetOperatorBanner({ config, onSet }: { config: PaymentConfig | null; on
       const signResult = await signOperatorAuth(address);
       if (!signResult.ok) {
         setSetting(false);
-        setError('Failed to sign operator authorization');
+        setError('Failed to sign wallet authorization');
         return;
       }
 
@@ -252,14 +252,14 @@ function SetOperatorBanner({ config, onSet }: { config: PaymentConfig | null; on
       });
     } catch (err) {
       setSetting(false);
-      setError(err instanceof Error ? err.message : 'Failed to set operator');
+      setError(err instanceof Error ? err.message : 'Failed to set wallet');
     }
   }, [address, config, writeContract, reset]);
 
   return (
     <div className="status-msg" style={{ marginTop: 0, marginBottom: 16, fontSize: 12 }}>
       <div style={{ color: 'var(--text-secondary)', marginBottom: 8 }}>
-        No operator set. Set your connected wallet as the operator to manage channels.
+        No wallet set. This is the wallet used to claim ANTS rewards and manage channels. Set your connected wallet to continue.
       </div>
       <button
         className="btn-outline"
@@ -267,7 +267,7 @@ function SetOperatorBanner({ config, onSet }: { config: PaymentConfig | null; on
         onClick={handleSetOperator}
         disabled={setting || !address}
       >
-        {setting ? 'Setting operator...' : 'Set Operator'}
+        {setting ? 'Setting wallet...' : 'Set Your Wallet'}
       </button>
       {error && <div style={{ color: 'var(--error)', marginTop: 6 }}>{error}</div>}
     </div>


### PR DESCRIPTION
## Summary
- Desktop credits dropdown: "Operator" → "Your Wallet", "Wallet" → "Your Signer"
- Portal channels view: "Set Operator" → "Set Your Wallet", updated banner and error messages with helper text explaining wallet purpose

Closes #224

## Test plan
- [ ] Open desktop app, click credits badge — verify labels say "Your Wallet" and "Your Signer"
- [ ] Open portal channels view without operator set — verify banner says "No wallet set..." and button says "Set Your Wallet"

🤖 Generated with [Claude Code](https://claude.com/claude-code)