### PR TITLE
feat(contracts): update ANTS tokenomics — 5M/week, 1.04B cap, 2yr halving

### DIFF
--- a/packages/contracts/ANTSToken.sol
+++ b/packages/contracts/ANTSToken.sol
@@ -7,7 +7,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
 import {IAntseedRegistry} from "./interfaces/IAntseedRegistry.sol";
 
 contract ANTSToken is ERC20, Ownable {
-    uint256 public constant MAX_SUPPLY = 52_000_000e18; // 52M ANTS
+    uint256 public constant MAX_SUPPLY = 1_040_000_000e18; // 1.04B ANTS
 
     IAntseedRegistry public registry;
     bool public transfersEnabled;       // Phase 1: false. One-way toggle to true.

--- a/packages/contracts/AntseedEmissions.sol
+++ b/packages/contracts/AntseedEmissions.sol
@@ -100,7 +100,7 @@ contract AntseedEmissions is Ownable, Pausable, ReentrancyGuard {
         registry = IAntseedRegistry(_registry);
         INITIAL_EMISSION = _initialEmission;
         EPOCH_DURATION = _epochDuration;
-        HALVING_INTERVAL = 26;
+        HALVING_INTERVAL = 104;
         genesis = block.timestamp;
 
         SELLER_SHARE_PCT = 50;

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -173,7 +173,7 @@ All constants are configurable by the contract owner via dedicated setter functi
 | Constant | Default | Description |
 |---|---|---|
 | `EPOCH_DURATION` | 1 week | Duration of each emission epoch |
-| `HALVING_INTERVAL` | 26 epochs (~6 months) | Epochs between emission halvings |
+| `HALVING_INTERVAL` | 104 epochs (~2 years) | Epochs between emission halvings |
 | `INITIAL_EMISSION` | Set at deployment | Total ANTS emitted in epoch 0 |
 | `SELLER_SHARE_PCT` | 65% | Seller share of epoch emissions |
 | `BUYER_SHARE_PCT` | 25% | Buyer share of epoch emissions |

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -93,7 +93,7 @@ contract Deploy is Script {
         // 9. AntseedEmissions(registry, initialEmission, epochDuration)
         bytes memory emissionsBytecode = abi.encodePacked(
             vm.getCode("AntseedEmissions.sol:AntseedEmissions"),
-            abi.encode(address(antseedRegistry), uint256(1_000_000e18), uint256(7 days))
+            abi.encode(address(antseedRegistry), uint256(5_000_000e18), uint256(7 days))
         );
         address emissions;
         assembly { emissions := create(0, add(emissionsBytecode, 0x20), mload(emissionsBytecode)) }

--- a/packages/contracts/script/DeployBaseSepolia.s.sol
+++ b/packages/contracts/script/DeployBaseSepolia.s.sol
@@ -98,7 +98,7 @@ contract DeployBaseSepolia is Script {
         // 8. AntseedEmissions(registry, initialEmission, epochDuration)
         bytes memory emissionsBytecode = abi.encodePacked(
             vm.getCode("AntseedEmissions.sol:AntseedEmissions"),
-            abi.encode(address(antseedRegistry), uint256(1_000_000e18), uint256(7 days))
+            abi.encode(address(antseedRegistry), uint256(5_000_000e18), uint256(7 days))
         );
         address emissions;
         assembly { emissions := create(0, add(emissionsBytecode, 0x20), mload(emissionsBytecode)) }

--- a/packages/contracts/test/AntseedEmissions.t.sol
+++ b/packages/contracts/test/AntseedEmissions.t.sol
@@ -84,7 +84,7 @@ contract AntseedEmissionsTest is Test {
         assertEq(emissions.RESERVE_SHARE_PCT(), 15);
         assertEq(emissions.TEAM_SHARE_PCT(), 15);
         assertEq(emissions.MAX_SELLER_SHARE_PCT(), 49);
-        assertEq(emissions.HALVING_INTERVAL(), 26);
+        assertEq(emissions.HALVING_INTERVAL(), 104);
         assertEq(emissions.currentEmissionRate(), INITIAL_EMISSION / EPOCH_DURATION);
     }
 
@@ -104,14 +104,14 @@ contract AntseedEmissionsTest is Test {
 
     function test_halvingSchedule() public view {
         assertEq(emissions.getEpochEmission(0), INITIAL_EMISSION);
-        assertEq(emissions.getEpochEmission(25), INITIAL_EMISSION); // last epoch before halving
-        assertEq(emissions.getEpochEmission(26), INITIAL_EMISSION / 2);
-        assertEq(emissions.getEpochEmission(52), INITIAL_EMISSION / 4);
-        assertEq(emissions.getEpochEmission(104), INITIAL_EMISSION / 16);
+        assertEq(emissions.getEpochEmission(103), INITIAL_EMISSION); // last epoch before halving
+        assertEq(emissions.getEpochEmission(104), INITIAL_EMISSION / 2);
+        assertEq(emissions.getEpochEmission(208), INITIAL_EMISSION / 4);
+        assertEq(emissions.getEpochEmission(416), INITIAL_EMISSION / 16);
     }
 
     function test_currentEmissionRate_afterHalving() public {
-        vm.warp(block.timestamp + EPOCH_DURATION * 26);
+        vm.warp(block.timestamp + EPOCH_DURATION * 104);
         uint256 expectedRate = (INITIAL_EMISSION / 2) / EPOCH_DURATION;
         assertEq(emissions.currentEmissionRate(), expectedRate);
     }


### PR DESCRIPTION
## Summary
- **MAX_SUPPLY**: 52M → 1.04B ANTS
- **HALVING_INTERVAL**: 26 epochs (~6 months) → 104 epochs (~2 years)
- **INITIAL_EMISSION**: 1M → 5M ANTS/week in deploy scripts
- Updated tests and README to match

## Test plan
- [x] `forge test --match-contract AntseedEmissionsTest` — 51/51 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)