### PR TITLE
fix(seller): include current request cost in cumulative-cost header

### DIFF
--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -407,15 +407,13 @@ export class SellerRequestHandler {
     const pricing = this.resolveProviderPricing(provider, request);
     const costUsdc = computeCostUsdc(usage.inputTokens, usage.outputTokens, pricing);
     const session = spm.getChannelByPeer(buyerPeerId);
-    // Note: cumulative cost excludes the current request — recordSpend happens after this in the caller.
-    // This matches the non-streaming _injectCostHeaders path.
-    const cumulativeCost = session ? spm.getCumulativeSpend(session.sessionId) : 0n;
+    const prevCumulative = session ? spm.getCumulativeSpend(session.sessionId) : 0n;
 
     const trailer = JSON.stringify({
       'x-antseed-input-tokens': String(usage.inputTokens),
       'x-antseed-output-tokens': String(usage.outputTokens),
       'x-antseed-cost': costUsdc.toString(),
-      'x-antseed-cumulative-cost': cumulativeCost.toString(),
+      'x-antseed-cumulative-cost': (prevCumulative + costUsdc).toString(),
     });
 
     debugLog(
@@ -442,7 +440,8 @@ export class SellerRequestHandler {
     const pricing = this.resolveProviderPricing(provider, request);
     const costUsdc = computeCostUsdc(resolvedUsage.inputTokens, resolvedUsage.outputTokens, pricing);
     const session = spm.getChannelByPeer(buyerPeerId);
-    const cumulativeCost = session ? spm.getCumulativeSpend(session.sessionId) : 0n;
+    const prevCumulative = session ? spm.getCumulativeSpend(session.sessionId) : 0n;
+    const cumulativeCost = prevCumulative + costUsdc;
 
     debugLog(
       `[SellerHandler] Cost headers: in=${resolvedUsage.inputTokens} out=${resolvedUsage.outputTokens} ` +


### PR DESCRIPTION
## Summary
- `x-antseed-cumulative-cost` was always one request behind because `getCumulativeSpend()` was read before `recordSpend()` for the current request
- Now adds the current request's `costUsdc` to the previous cumulative in both streaming cost trailer and non-streaming headers

Closes #236

## Test plan
- [x] All 507 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)