### PR TITLE
fix(payments): gate deposit on allowance via useSimulateContract

### DIFF
--- a/apps/payments/web/src/App.tsx
+++ b/apps/payments/web/src/App.tsx
@@ -53,7 +53,7 @@ export function App() {
     localStorage.setItem('antseed-payments-theme', isDark ? 'dark' : 'light');
   }, [isDark]);
 
-  const refreshBalance = useCallback(async () => {
+  const fetchBalance = useCallback(async () => {
     try {
       const data = await getBalance();
       setBalance(data);
@@ -62,10 +62,16 @@ export function App() {
     }
   }, []);
 
+  const refreshBalance = useCallback(async () => {
+    await fetchBalance();
+    // Retry after delay to catch backend indexing lag after on-chain tx
+    setTimeout(fetchBalance, 3000);
+  }, [fetchBalance]);
+
   useEffect(() => {
-    void refreshBalance();
+    void fetchBalance();
     void getConfig().then(setConfig).catch(() => {});
-  }, [refreshBalance]);
+  }, [fetchBalance]);
 
   const available = balance ? parseFloat(balance.available) : 0;
   const reserved = balance ? parseFloat(balance.reserved) : 0;

--- a/apps/payments/web/src/components/DepositView.tsx
+++ b/apps/payments/web/src/components/DepositView.tsx
@@ -133,6 +133,7 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
 
   const { isSuccess: approveConfirmed } = useWaitForTransactionReceipt({
     hash: approveTxHash,
+    query: { enabled: step === 'approving' && !!approveTxHash },
   });
 
   // Simulate deposit — only when allowance is sufficient
@@ -141,7 +142,7 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
     abi: DEPOSITS_ABI,
     functionName: 'deposit',
     args: [depositTarget as `0x${string}`, usdcAmount],
-    query: { enabled: hasAllowance && !!config && !!depositTarget },
+    query: { enabled: hasAllowance && !!config && !!depositTarget, retry: 3, retryDelay: 2000 },
   });
 
   // Deposit (uses pre-simulated request)
@@ -153,16 +154,16 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
 
   const { isSuccess: depositConfirmed } = useWaitForTransactionReceipt({
     hash: depositTxHash,
+    query: { enabled: step === 'depositing' && !!depositTxHash },
   });
 
-  // After approval confirms → refetch allowance so simulation picks up the new state
+  // After approval confirms → refetch allowance (triggers simulation via hasAllowance)
   useEffect(() => {
-    if (step === 'approving' && approveConfirmed) {
-      refetchAllowance();
-    }
+    if (step !== 'approving' || !approveConfirmed) return;
+    refetchAllowance();
   }, [step, approveConfirmed, refetchAllowance]);
 
-  // Once simulation is ready after approval → send deposit
+  // Once simulation succeeds after approval → send deposit
   useEffect(() => {
     if (step !== 'approving' || !depositSim?.request) return;
     setStep('depositing');
@@ -192,7 +193,8 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
     // Allowance already sufficient — simulation is ready, send deposit directly
     if (depositSim?.request) {
       setStep('depositing');
-      writeDeposit(depositSim.request, {
+      const { gas: _gas, ...depositRequest } = depositSim.request;
+      writeDeposit(depositRequest, {
         onError: (err) => {
           setStep('idle');
           setError(err.message.split('\n')[0] ?? err.message);


### PR DESCRIPTION
## Summary
- Use `useSimulateContract` with `enabled: hasAllowance` so deposit gas estimation only runs when on-chain allowance is sufficient
- Gate `useWaitForTransactionReceipt` with `enabled` tied to current step to prevent stale `isSuccess` from firing effects
- After approval confirms, refetch allowance → simulation auto-triggers → deposit fires with correct gas
- Simulation retries 3x with 2s delay to handle RPC state lag after approval
- Balance bar does a delayed retry 3s after deposit to catch backend indexing lag

## Test plan
- [ ] Deposit with no prior allowance: approve → wait → deposit (two wallet prompts, not instant)
- [ ] Deposit with existing allowance: single wallet prompt, no approve step
- [ ] Balance bar updates after deposit confirms
- [ ] Verify MetaMask shows valid gas estimate (not "Unavailable")

🤖 Generated with [Claude Code](https://claude.com/claude-code)