### PR TITLE
fix(payments): remove forced +1 cost floor, trust seller cost=0

### DIFF
--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -582,8 +582,8 @@ export class BuyerPaymentManager {
     } else {
       acceptedCost = buyerEstimatedRequestCost;
     }
-    // Minimum 1 base unit for monotonicity
-    if (acceptedCost === 0n) acceptedCost = 1n;
+    // If cost is 0, the cumulative amount stays the same — no spending auth needed
+    // but we still sign one to keep the seller's session alive.
 
     // Update cumulative metadata
     const prev = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
@@ -600,9 +600,6 @@ export class BuyerPaymentManager {
     const prevAmount = this._cumulativeAmount.get(sellerPeerId) ?? 0n;
     const maxSignable = this._maxSignable(sellerPeerId);
     let newAmount = prevAmount + acceptedCost;
-    if (newAmount > maxSignable) newAmount = maxSignable;
-    // Ensure monotonic increase (at least +1 per request)
-    if (newAmount <= prevAmount) newAmount = prevAmount + 1n;
     if (newAmount > maxSignable) newAmount = maxSignable;
     this._cumulativeAmount.set(sellerPeerId, newAmount);
 

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -368,9 +368,8 @@ describe('BuyerPaymentManager', () => {
       { inputBytes: SAMPLE_INPUT, outputBytes: SAMPLE_OUTPUT, sellerClaimedCost: 0n },
     );
 
-    // Seller claimed cost=0 is authoritative — no byte-based fallback
-    // +1 from minimum per-request cost floor
-    expect(BigInt(payload.cumulativeAmount)).toBe(10_001n);
+    // Seller claimed cost=0 is authoritative — no byte-based fallback, no forced +1
+    expect(BigInt(payload.cumulativeAmount)).toBe(10_000n);
   });
 
   it('signPerRequestAuth prefers reported tokens over byte estimation for metadata', async () => {


### PR DESCRIPTION
## Summary
- When seller reports `cost=0` (streaming responses), buyer now accepts 0 instead of falling back to byte-based estimation that inflated costs ~50-100x
- Removed forced `+1` minimum cost floor in `signPerRequestAuth` — if cost is 0, cumulative amount stays the same

**Context:** Streaming responses get `cost=0` from the seller because usage isn't parsed from SSE chunks. Previously the buyer would:
1. See `reportedTokens=0` → fall back to `_estimateResponseCost` (bytes/4) → inflated cost
2. Even if cost computed to 0, force it to 1 base unit "for monotonicity"

Now: seller says 0, buyer says 0.

## Test plan
- [x] All 516 unit tests pass
- [x] Updated test: `signPerRequestAuth trusts seller claimed cost of zero`

🤖 Generated with [Claude Code](https://claude.com/claude-code)