### PR TITLE
chore(node): add debug log for raw provider cached token counts

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.66",
+  "version": "0.1.67",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/node",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "description": "Antseed Network protocol SDK — P2P inference marketplace",
   "type": "module",
   "files": [

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -196,6 +196,7 @@ export class SellerRequestHandler {
           responseBody = response.body ?? new Uint8Array(0);
           debugLog(`[SellerHandler] Provider responded: status=${statusCode} (${Date.now() - startTime}ms, ${responseBody.length}b) bodyType=${typeof response.body} hasBody=${!!response.body}`);
           responseUsage = parseResponseUsage(responseBody);
+          debugLog(`[SellerHandler] Raw provider usage: in=${responseUsage.inputTokens} fresh=${responseUsage.freshInputTokens} cached=${responseUsage.cachedInputTokens} out=${responseUsage.outputTokens}`);
           if (!streamedResponseStarted) {
             const responseToSend = this._injectCostHeaders(response, provider, request, buyerPeerId, responseUsage);
             mux.sendProxyResponse(responseToSend);


### PR DESCRIPTION
## Summary
- Adds `[SellerHandler] Raw provider usage: in=... fresh=... cached=... out=...` debug log after `parseResponseUsage()` to trace whether upstream providers (e.g. Together AI) actually return `prompt_tokens_details.cached_tokens`
- Bumps node@0.2.40, cli@0.1.67 (already published to npm and deployed to GKE seller + EC2 buyer)

## Context
Buyer logs showed `cached=12800` from the Together AI seller, but Together supposedly doesn't return cached token data. This log will confirm the source next time it appears.

## Test plan
- [x] Deployed to testnet-together (GKE), confirmed log appears with `cached=0` for qwen3.5-9b
- [x] Buyer (Hermes Jeff, EC2) updated and verified matching `cached=0` in buyer logs