### PR TITLE
fix(payments): clear stale auth after on-chain reconciliation

### DIFF
--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -143,11 +143,16 @@ export class SellerPaymentManager {
         const localSpent = this._spent.get(channel.sessionId) ?? 0n;
         if (onChainSettled > localSpent) {
           this._spent.set(channel.sessionId, onChainSettled);
-          // Clear stale auth — the old SpendingAuth has cumulativeAmount ≤ on-chain settled,
-          // so settle() would revert with InvalidAmount. The seller will request a fresh
-          // SpendingAuth from the buyer via NeedAuth on the next request.
-          this._latestAuth.delete(channel.sessionId);
-          debugLog(`[SellerPayment] Reconciled spent for ${channel.sessionId.slice(0, 18)}...: local=${localSpent} → on-chain=${onChainSettled} (cleared stale auth)`);
+          // Clear auth only if its cumulative would revert settle() with InvalidAmount
+          // (cumulativeAmount must be > on-chain settled). If auth is still valid
+          // (cumulative > settled), keep it so the seller can close if buyer disconnects.
+          const existingAuth = this._latestAuth.get(channel.sessionId);
+          if (existingAuth && existingAuth.cumulativeAmount <= onChainSettled) {
+            this._latestAuth.delete(channel.sessionId);
+            debugLog(`[SellerPayment] Reconciled spent for ${channel.sessionId.slice(0, 18)}...: local=${localSpent} → on-chain=${onChainSettled} (cleared stale auth, authCumulative=${existingAuth.cumulativeAmount})`);
+          } else {
+            debugLog(`[SellerPayment] Reconciled spent for ${channel.sessionId.slice(0, 18)}...: local=${localSpent} → on-chain=${onChainSettled}`);
+          }
         }
       } catch (err) {
         debugWarn(`[SellerPayment] Failed to validate channel ${channel.sessionId.slice(0, 18)}...: ${err instanceof Error ? err.message : err}`);

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -477,9 +477,11 @@ describe('SellerPaymentManager', () => {
       expect(mgr.getCumulativeSpend(channelId)).toBe(800_000n);
     });
 
-    it('clears stale auth after reconciling spent upward', async () => {
+    it('clears stale auth when authMax <= on-chain settled', async () => {
       const channelId = makeChannelId(36);
+      // authMax=600000 < on-chain settled=800000 → auth is stale
       seedChannel(store, channelId, buyerIdentity, sellerIdentity, {
+        authMax: '600000',
         tokensDelivered: '100000',
         latestSpendingAuthSig: '0xoldauth',
       });
@@ -496,13 +498,35 @@ describe('SellerPaymentManager', () => {
 
       await mgr.validateHydratedChannels();
 
-      // After reconciliation, auth should be cleared — old sig can't settle
+      // Auth should be cleared — settle(600000) would revert since 600000 <= 800000
       const settleParamsAfter = (mgr as unknown as { _getSettleParams: (id: string) => { amount: bigint } })._getSettleParams(channelId);
       expect(settleParamsAfter.amount).toBe(0n);
     });
 
-    it('does NOT clear auth when no reconciliation needed', async () => {
+    it('preserves valid auth when authMax > on-chain settled', async () => {
       const channelId = makeChannelId(37);
+      // authMax=1000000 > on-chain settled=800000 → auth is still valid
+      seedChannel(store, channelId, buyerIdentity, sellerIdentity, {
+        authMax: '1000000',
+        tokensDelivered: '100000',
+        latestSpendingAuthSig: '0xvalidauth',
+      });
+
+      const mgr = makeFreshManager();
+
+      vi.spyOn(mgr.channelsClient, 'getSession').mockResolvedValue(
+        makeOnChainChannel(buyerIdentity, sellerIdentity, { settled: 800_000n }),
+      );
+
+      await mgr.validateHydratedChannels();
+
+      // Auth should remain — settle(1000000) would succeed since 1000000 > 800000
+      const settleParams = (mgr as unknown as { _getSettleParams: (id: string) => { amount: bigint } })._getSettleParams(channelId);
+      expect(settleParams.amount).toBeGreaterThan(0n);
+    });
+
+    it('does NOT clear auth when no reconciliation needed', async () => {
+      const channelId = makeChannelId(38);
       seedChannel(store, channelId, buyerIdentity, sellerIdentity, {
         tokensDelivered: '800000',
         latestSpendingAuthSig: '0xvalidauth',


### PR DESCRIPTION
## Summary
- After seller restart, if on-chain `settled` > local `spent`, the old SpendingAuth has a cumulative ≤ on-chain settled — making it unusable for `settle()` (reverts `InvalidAmount`)
- Now clears `_latestAuth` during reconciliation, so the seller will request a fresh SpendingAuth from the buyer via `NeedAuth` on the next request
- Includes all `validateHydratedChannels` tests (were missing from main after #247 merge)

## Problem
After a seller pod restart, the channel is correctly identified as active on-chain and kept. But:
1. `_latestAuth` holds a stale SpendingAuth (cumulative ≤ on-chain settled)
2. Seller serves requests (hasSession=true) but can never settle on-chain
3. Idle-settle reverts with `InvalidAmount` every time
4. No new charges appear on-chain despite buyer usage

## Test plan
- [x] 524 tests pass (8 new tests for validateHydratedChannels including stale auth clearing)
- [ ] Deploy to testnet, verify reconciliation clears auth and new SpendingAuth is requested
- [ ] Confirm settle succeeds on-chain after fresh auth exchange