### PR TITLE
fix(seller): handle /v1/models locally, stop resetting idle timer

### DIFF
--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -148,6 +148,14 @@ export class SellerRequestHandler {
         }
       }
 
+      // Handle /v1/models locally — return seller's configured services without
+      // upstream call or resetting idle timers (these are metadata queries, not inference).
+      if (request.method === 'GET' && (request.path === '/v1/models' || request.path.startsWith('/v1/models/'))) {
+        const modelsResponse = this._handleModelsRequest(request);
+        mux.sendProxyResponse(modelsResponse);
+        return;
+      }
+
       const provider = this.matchProvider(request);
 
       if (!provider) {
@@ -287,6 +295,48 @@ export class SellerRequestHandler {
     });
 
     return { mux };
+  }
+
+  // -- Local /v1/models handler --
+
+  private _handleModelsRequest(request: SerializedHttpRequest): SerializedHttpResponse {
+    const allServices = this._deps.providers.flatMap((p) => p.services);
+    const now = Math.floor(Date.now() / 1000);
+
+    // GET /v1/models/:id — single model lookup
+    const singleModelMatch = request.path.match(/^\/v1\/models\/(.+)$/);
+    if (singleModelMatch) {
+      const modelId = decodeURIComponent(singleModelMatch[1]!);
+      if (allServices.includes(modelId)) {
+        return {
+          requestId: request.requestId,
+          statusCode: 200,
+          headers: { 'content-type': 'application/json' },
+          body: new TextEncoder().encode(JSON.stringify({
+            id: modelId, object: 'model', created: now, owned_by: 'antseed',
+          })),
+        };
+      }
+      return {
+        requestId: request.requestId,
+        statusCode: 404,
+        headers: { 'content-type': 'application/json' },
+        body: new TextEncoder().encode(JSON.stringify({
+          error: { message: `Model '${modelId}' not found`, type: 'invalid_request_error', code: 'model_not_found' },
+        })),
+      };
+    }
+
+    // GET /v1/models — list all
+    const models = allServices.map((id) => ({
+      id, object: 'model' as const, created: now, owned_by: 'antseed',
+    }));
+    return {
+      requestId: request.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ object: 'list', data: models })),
+    };
   }
 
   // -- Provider matching (public for announcer pricing in _startSeller) --


### PR DESCRIPTION
## Summary
- `GET /v1/models` and `GET /v1/models/:id` now return the seller's configured services directly
- No upstream proxy call, no session tracker interaction, no idle timer reset
- Returns OpenAI-compatible format: `{ object: "list", data: [{ id, object: "model", ... }] }`

## Problem
Hermes polls `GET /v1/models` periodically to check model availability. These requests were proxied to Together AI (returning their full 290KB model list) and reset the idle-settle timer each time. Since polls happen every few minutes, the 10-minute idle-settle timer never fires — preventing any on-chain settlement.

## Test plan
- [x] 525 tests pass
- [ ] Deploy, verify `/v1/models` returns seller services (not Together's full list)
- [ ] Verify idle-settle fires after 10 min of no chat requests
- [ ] Confirm new settle transaction appears on BaseScan