### PR TITLE
fix(payments): hydrate buyer verifiedCost on restart

### DIFF
--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -128,8 +128,10 @@ export class BuyerPaymentManager {
         cumulativeOutputTokens: BigInt(channel.previousConsumption),
         cumulativeRequestCount: BigInt(channel.requestCount),
       });
-      // verifiedCost and pricing are not persisted — start from 0 on hydration.
-      // This is conservative: the buyer treats all previously-signed amounts as unverified.
+      // Hydrate verifiedCost to authMax so _maxSignable can grow beyond maxPerRequestUsdc.
+      // Without this, maxSignable = 0 + maxPerRequestUsdc after restart, permanently capping
+      // the cumulative and causing non-monotonic SpendingAuth rejections on the seller.
+      this._verifiedCost.set(peerId, BigInt(channel.authMax));
     }
   }
 


### PR DESCRIPTION
## Summary
- Hydrate `_verifiedCost` from stored `authMax` during buyer startup
- Without this, `_maxSignable = 0 + maxPerRequestUsdc` after restart, permanently capping the cumulative at 100000

## Problem
After buyer restart, `_verifiedCost` started at 0. The overdraft model computes `maxSignable = verifiedCost + maxPerRequestUsdc`. With `verifiedCost=0`, the cumulative was capped at `maxPerRequestUsdc` (100000 = $0.10). The buyer kept sending `cumulativeAmount=100000` on every SpendingAuth, which the seller rejected as non-monotonic since its `_acceptedCumulative` was higher from the previous session.

This is the root cause of no on-chain settlements — the buyer couldn't send valid SpendingAuth after restart, so the seller had no usable signatures for settle().

## Test plan
- [x] 525 tests pass
- [ ] Deploy buyer, verify cumulative grows past 100000
- [ ] Confirm seller accepts SpendingAuth and idle-settle succeeds on-chain