### PR TITLE
fix(payments): Stop serving after auth rejection

### DIFF
--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -107,7 +107,7 @@ export class SellerRequestHandler {
         if (session) {
           const accepted = spm.getAcceptedCumulative(session.sessionId);
           const spent = spm.getCumulativeSpend(session.sessionId);
-          if (accepted > 0n && spent >= accepted) {
+          if (spent > 0n && spent >= accepted) {
             const reserveMax = spm.getReserveMax(session.sessionId);
             const matchedProvider = this.matchProvider(request);
             const providerPricing = matchedProvider

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import { SellerRequestHandler } from '../src/seller-request-handler.js';
 import type { SerializedHttpRequest } from '../src/types/http.js';
 import type { Provider } from '../src/interfaces/seller-provider.js';
-import { encodeHttpRequest } from '../src/proxy/request-codec.js';
+import { decodeHttpResponse, encodeHttpRequest } from '../src/proxy/request-codec.js';
+import { decodeFrame } from '../src/p2p/message-protocol.js';
 import { MessageType } from '../src/types/protocol.js';
 
 function makeProvider(inputUsdPerMillion: number, outputUsdPerMillion: number, opts: {
@@ -154,5 +155,72 @@ describe('SellerRequestHandler payment pricing selection', () => {
       currentAcceptedCumulative: '0',
       requiredCumulativeAmount: '0',
     }));
+  });
+
+  it('stops serving once delivered spend has caught up to the last accepted auth', async () => {
+    const provider = makeProvider(1, 1, {
+      name: 'paid-tier',
+      services: ['local-test'],
+    });
+    provider.handleRequest = vi.fn(async (req) => ({
+      requestId: req.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ ok: true })),
+    }));
+
+    const sendPaymentRequired = vi.fn();
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: {
+        hasSession: () => true,
+        getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '1000000' }),
+        recordSpend: vi.fn(),
+        getCumulativeSpend: () => 2_184n,
+        getAcceptedCumulative: () => 0n,
+        getReserveMax: () => 1_000_000n,
+        getPaymentRequirements: () => ({ minBudgetPerRequest: '50000', suggestedAmount: '1000000' }),
+      } as any,
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = {
+      send(frame: Uint8Array) {
+        sentFrames.push(frame);
+      },
+    } as any;
+    const paymentMux = {
+      sendNeedAuth: vi.fn(),
+      sendPaymentRequired,
+    } as any;
+
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    const request: SerializedHttpRequest = {
+      requestId: 'req-exhausted-budget',
+      method: 'POST',
+      path: '/v1/chat/completions',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })),
+    };
+
+    await mux.handleFrame({
+      type: MessageType.HttpRequest,
+      messageId: 1,
+      payload: encodeHttpRequest(request),
+    });
+
+    expect(provider.handleRequest).not.toHaveBeenCalled();
+    expect(sendPaymentRequired).toHaveBeenCalledOnce();
+    expect(sentFrames).toHaveLength(1);
+
+    const decoded = decodeFrame(sentFrames[0]!);
+    expect(decoded?.message.type).toBe(MessageType.HttpResponse);
+    const response = decodeHttpResponse(decoded!.message.payload);
+    expect(response.statusCode).toBe(402);
   });
 });


### PR DESCRIPTION
## Description

Stops the seller from routing new requests once delivered spend has caught up to the last accepted cumulative auth. This closes the gap where a buyer rejects a `NeedAuth`, but the seller still serves another request because the previous gate only blocked when the accepted amount was already positive.

## Release Notes

- Fixed seller-side request gating so delivery stops immediately after a buyer refuses a higher cumulative auth
- Added a regression test covering the exhausted-auth path that must return `402` instead of calling the provider

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [ ] Lint and unit tests pass locally with my changes

Note: `pnpm --filter @antseed/node test -- node-payment-pricing.test.ts` passes locally. The broader seller payment manager suite is currently blocked in this environment by a `better-sqlite3` native module ABI mismatch with the active Node version.