### PR TITLE
fix(payments): Restrict wagmi to Base mainnet only

### DIFF
--- a/apps/payments/web/src/wagmi-config.ts
+++ b/apps/payments/web/src/wagmi-config.ts
@@ -1,8 +1,8 @@
 import { getDefaultConfig } from '@rainbow-me/rainbowkit';
-import { base, baseSepolia, hardhat } from 'wagmi/chains';
+import { base } from 'wagmi/chains';
 
 export const wagmiConfig = getDefaultConfig({
   appName: 'AntSeed Payments',
   projectId: '9a1851410cb5589bc351a6dabf17140e',
-  chains: [base, baseSepolia, hardhat],
+  chains: [base],
 });


### PR DESCRIPTION
## Description

Follow-up to #267. Remove `baseSepolia` and `hardhat` chains from the payments portal wagmi config — production users should only see Base mainnet.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)