### PR TITLE
docs(desktop): add provider/API guide URLs to system prompt

### DIFF
--- a/apps/desktop/src/main/chat-system-prompt.ts
+++ b/apps/desktop/src/main/chat-system-prompt.ts
@@ -44,14 +44,18 @@ Guidelines:
 
 AntSeed documentation (use web_fetch on these URLs only when the user asks about AntSeed, AntStation, or the network):
 - Light paper: https://antseed.com/docs/lightpaper
-- Getting started: https://antseed.com/docs/intro
+- Getting started: https://antseed.com/docs/
 - Install: https://antseed.com/docs/install
 - Configuration: https://antseed.com/docs/config
+- How to become a provider (sell AI services for USDC): https://antseed.com/docs/guides/become-a-provider
+- How to use the API (point any AI tool at the local buyer proxy): https://antseed.com/docs/guides/using-the-api
 - Protocol overview: https://antseed.com/docs/overview
 - When asked about: discovery (https://antseed.com/docs/discovery), transport (https://antseed.com/docs/transport), metering (https://antseed.com/docs/metering), payments (https://antseed.com/docs/payments), reputation (https://antseed.com/docs/reputation), security (https://antseed.com/docs/security)
 - Plugins: provider API (https://antseed.com/docs/provider-api), router API (https://antseed.com/docs/router-api), creating plugins (https://antseed.com/docs/create-plugin)
 - CLI reference: commands (https://antseed.com/docs/commands), flags (https://antseed.com/docs/flags)
-- When working on AntSeed topics, fetch and read the relevant docs before answering`;
+- When the user asks "how do I become a provider / seller / earn", fetch https://antseed.com/docs/guides/become-a-provider before answering.
+- When the user asks "how do I use the API / connect a tool / point Claude Code or Cursor at AntSeed", fetch https://antseed.com/docs/guides/using-the-api before answering.
+- When working on any other AntSeed topic, fetch and read the relevant doc above before answering.`;
 
 export function buildAntstationSystemPrompt(
   basePrompt: string | undefined,


### PR DESCRIPTION
Adds two website guide URLs to the AntStation system prompt and fixes the broken `/docs/intro` URL (correct slug is `/docs/`).

- `https://antseed.com/docs/guides/become-a-provider`
- `https://antseed.com/docs/guides/using-the-api`

Adds explicit trigger rules so the model fetches each guide when the user asks "how do I become a provider" or "how do I use the API".

All existing protocol/plugins/CLI URLs were verified against the docusaurus slugs and are correct.