### PR TITLE
fix(website): mobile card layout for pricing table, add anon tag

### DIFF
--- a/apps/network-stats/src/index.test.ts
+++ b/apps/network-stats/src/index.test.ts
@@ -17,6 +17,7 @@ import { NetworkPoller } from './poller.js';
 import { createServer } from './server.js';
 import type { PeerMetadata } from '@antseed/node';
 import { toPeerId } from '@antseed/node';
+import { METADATA_VERSION } from '@antseed/node/discovery';
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -27,7 +28,7 @@ function tmpCache(): string {
 function fakePeer(id: string, services: string[]): PeerMetadata {
   return {
     peerId: toPeerId(createHash('sha256').update(id).digest('hex').slice(0, 40)),
-    version: 4,
+    version: METADATA_VERSION,
     providers: [{ provider: 'test', services, defaultPricing: { inputUsdPerMillion: 10, outputUsdPerMillion: 10 }, maxConcurrency: 1, currentLoad: 0 }],
     region: 'eu-west-1',
     timestamp: Date.now(),

--- a/apps/website/src/pages/network.module.css
+++ b/apps/website/src/pages/network.module.css
@@ -335,6 +335,7 @@
 .tagOpenSource { background: #f0f9ff; color: #0284c7; }
 .tagRag       { background: #fdf4ff; color: #c026d3; }
 .tagEnterprise { background: #f8fafc; color: #475569; }
+.tagAnon      { background: #f0f9ff; color: #0e7490; }
 .tagDefault   { background: #f5f7fa; color: #64748b; }
 
 .tdContext {
@@ -465,41 +466,141 @@
 
 @media (max-width: 768px) {
   .page {
-    padding: 60px 16px 80px;
+    padding: 60px 12px 80px;
   }
 
   .statsBar {
     padding: 20px;
+    flex-direction: column;
+    gap: 16px;
   }
 
   .statDivider {
     display: none;
   }
 
-  .statsBar {
-    flex-direction: column;
-    gap: 16px;
-  }
-
   .statNum {
     font-size: 24px;
   }
 
-  .tableWrap {
-    border-radius: 12px;
-    overflow-x: auto;
+  .filterBar {
+    gap: 10px;
   }
 
-  .table {
-    min-width: 600px;
+  .searchInput {
+    font-size: 13px;
+    padding: 12px 36px 12px 40px;
+  }
+
+  .chip {
+    font-size: 11px;
+    padding: 5px 10px;
+  }
+
+  /* Card-based layout instead of table on mobile */
+  .tableWrap {
+    border: none;
+    box-shadow: none;
+    background: transparent;
+    border-radius: 0;
+  }
+
+  .table,
+  .table thead,
+  .table tbody,
+  .table tr,
+  .table th,
+  .table td {
+    display: block;
+  }
+
+  .table thead {
+    display: none;
+  }
+
+  .row {
+    background: white;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 16px;
+    margin-bottom: 12px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+    display: flex !important;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .tdModel {
+    width: 100%;
+    padding: 0 !important;
+    margin-bottom: 8px;
   }
 
   .modelLogo {
+    width: 28px;
+    height: 28px;
+  }
+
+  .modelName {
+    font-size: 15px;
+  }
+
+  .tdPrice {
+    padding: 0 !important;
+    text-align: left !important;
+    font-size: 13px;
+    flex: 1;
+  }
+
+  .tdPrice::before {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 9px;
+    color: #8b949e;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    display: block;
+    margin-bottom: 2px;
+    font-weight: 400;
+  }
+
+  .tdPrice:nth-of-type(2)::before {
+    content: 'Input /M';
+  }
+
+  .tdPrice:nth-of-type(3)::before {
+    content: 'Output /M';
+  }
+
+  .tdProviders {
+    padding: 0 !important;
+    text-align: left !important;
+  }
+
+  .tdProviders::before {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 9px;
+    color: #8b949e;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    display: block;
+    margin-bottom: 2px;
+    content: 'Peers';
+    font-weight: 400;
+  }
+
+  .peerCount {
     width: 24px;
     height: 24px;
+    font-size: 11px;
   }
 
   .tagBadge {
-    display: none;
+    font-size: 8px;
+    padding: 1px 5px;
+  }
+
+  .emptyRow {
+    padding: 40px 16px !important;
   }
 }

--- a/apps/website/src/pages/network.tsx
+++ b/apps/website/src/pages/network.tsx
@@ -159,7 +159,7 @@ function aggregateModels(peers: PeerMetadata[]): ModelRow[] {
       provider: meta?.provider ?? guessProvider(serviceId),
       logoUrl: guessLogo(serviceId),
       contextWindow: meta?.contextWindow ?? '—',
-      tags: meta?.tags ?? [...data.categories],
+      tags: ['anon', ...(meta?.tags ?? [...data.categories])],
       inputPrice: data.bestInput,
       outputPrice: data.bestOutput,
       peerCount: data.peerCount,
@@ -206,7 +206,7 @@ function guessLogo(serviceId: string): string {
 /* ── Helpers ──────────────────────────────────────────────────────── */
 
 const TAG_CLASS: Record<string, string> = {
-  coding: styles.tagCoding, code: styles.tagCode, privacy: styles.tagPrivacy,
+  anon: styles.tagAnon, coding: styles.tagCoding, code: styles.tagCode, privacy: styles.tagPrivacy,
   tee: styles.tagTee, chat: styles.tagChat, fast: styles.tagFast,
   cheap: styles.tagCheap, reasoning: styles.tagReasoning,
   'open-source': styles.tagOpenSource, rag: styles.tagRag,


### PR DESCRIPTION
## Summary
- Extracted from closed PR #269 (commit pushed after merge by @Amosme)
- On mobile (<768px), pricing table switches to card-based layout (no horizontal scroll)
- All services now display an `anon` tag since all models on the network are anonymous by default

## Test plan
- [ ] Verify pricing page on mobile viewport renders as cards
- [ ] Verify desktop layout unchanged
- [ ] Verify anon tag displays on all service rows