### PR TITLE
fix(payments): use fallback RPC to avoid Base public throttling

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/payments/web/src/wagmi-config.ts
+++ b/apps/payments/web/src/wagmi-config.ts
@@ -1,8 +1,19 @@
 import { getDefaultConfig } from '@rainbow-me/rainbowkit';
 import { base } from 'wagmi/chains';
+import { http, fallback } from 'viem';
 
+// Use a fallback chain of RPCs so we don't get rate-limited by the public
+// Base endpoint (mainnet.base.org returns 429 under any concurrent load).
+// viem's fallback transport rotates on failure and re-ranks healthy nodes.
 export const wagmiConfig = getDefaultConfig({
   appName: 'AntSeed Payments',
   projectId: '9a1851410cb5589bc351a6dabf17140e',
   chains: [base],
+  transports: {
+    [base.id]: fallback([
+      http('https://base.llamarpc.com'),
+      http('https://base-rpc.publicnode.com'),
+      http('https://mainnet.base.org'),
+    ]),
+  },
 });

--- a/packages/node/src/payments/chain-config.ts
+++ b/packages/node/src/payments/chain-config.ts
@@ -24,7 +24,10 @@ const CHAIN_CONFIGS: Record<ChainId, ChainConfig> = {
   'base-mainnet': {
     chainId: 'base-mainnet',
     evmChainId: 8453,
-    rpcUrl: 'https://mainnet.base.org',
+    // mainnet.base.org is heavily rate-limited (429 under any concurrent load).
+    // llamarpc is a free, no-key public endpoint with much higher limits.
+    // Users can override via payments.crypto.rpcUrl in config.json.
+    rpcUrl: 'https://base.llamarpc.com',
     usdcContractAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
     depositsContractAddress: '0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2',
     channelsContractAddress: '0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d',


### PR DESCRIPTION
## Summary

The public Base mainnet RPC (`https://mainnet.base.org`) is heavily rate-limited and returns 429 / "resource unavailable" under any concurrent load. This breaks the deposit flow for end users (`requested resource not available` on tx submission) and spams the desktop credits poller with transient `CALL_EXCEPTION` warnings.

## Changes

**`apps/payments/web/src/wagmi-config.ts`** — wrap the Base transport in viem `fallback` with three endpoints:

```ts
transports: {
  [base.id]: fallback([
    http('https://base.llamarpc.com'),
    http('https://base-rpc.publicnode.com'),
    http('https://mainnet.base.org'),
  ]),
}
```

viem auto-rotates on failure and re-ranks healthy nodes, so users won't see 429s on the deposit flow anymore. The official Base RPC stays as a last-resort fallback.

**`packages/node/src/payments/chain-config.ts`** — switch the default `base-mainnet` `rpcUrl` from `mainnet.base.org` → `base.llamarpc.com`. This affects every server-side ethers consumer (desktop credits poller, CLI buyer, seller, dashboard). Single string, no consumer changes. Users can still override via `payments.crypto.rpcUrl` in `config.json` if they want their own Alchemy/Infura endpoint.

## Also included

`chore(desktop): commit 0.1.32 version bump` — the version bump from the v0.1.32 release earlier today was never committed.

## Verification

Both alt RPCs return the correct chain ID (`0x2105` = 8453) via direct curl. Typecheck clean for `@antseed/node` and `@antseed/payments`.

## Rollout to fix end users

After merge:
1. Bump and republish `@antseed/node` patch
2. Bump and republish `@antseed/cli` patch (picks up new node)
3. Bump and release desktop v0.1.33 (ships the new payments web bundle)