### PR TITLE
feat(payments): serve /api/channels from buyer proxy instead of on-chain scan

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -647,6 +647,24 @@ export class BuyerProxy {
       return
     }
 
+    if (path === '/_antseed/channels' && method === 'GET') {
+      const channels = this._node.getActiveBuyerChannels().map((c) => ({
+        channelId: c.sessionId,
+        peerId: c.peerId,
+        seller: c.sellerEvmAddr,
+        buyer: c.buyerEvmAddr,
+        authMax: c.authMax,
+        deadline: c.deadline,
+        reservedAt: c.reservedAt,
+        status: c.status,
+        requestCount: c.requestCount,
+        tokensDelivered: c.tokensDelivered,
+      }))
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, channels }))
+      return
+    }
+
     const meteringMatch = path.match(/^\/_antseed\/metering\/(.+)$/)
     if (meteringMatch && method === 'GET') {
       const sellerPeerId = decodeURIComponent(meteringMatch[1]!)

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -648,18 +648,7 @@ export class BuyerProxy {
     }
 
     if (path === '/_antseed/channels' && method === 'GET') {
-      const channels = this._node.getActiveBuyerChannels().map((c) => ({
-        channelId: c.sessionId,
-        peerId: c.peerId,
-        seller: c.sellerEvmAddr,
-        buyer: c.buyerEvmAddr,
-        authMax: c.authMax,
-        deadline: c.deadline,
-        reservedAt: c.reservedAt,
-        status: c.status,
-        requestCount: c.requestCount,
-        tokensDelivered: c.tokensDelivered,
-      }))
+      const channels = this._node.getActiveBuyerChannels()
       res.writeHead(200, { 'content-type': 'application/json' })
       res.end(JSON.stringify({ ok: true, channels }))
       return

--- a/apps/payments/src/routes.ts
+++ b/apps/payments/src/routes.ts
@@ -113,7 +113,8 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
         channels: Array<{
           channelId: string;
           seller: string;
-          authMax: string;
+          reserveMax: string;
+          cumulativeSigned: string;
           deadline: number;
           status: string;
         }>;
@@ -121,8 +122,8 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
       const channels = (body.channels ?? []).map((c) => ({
         channelId: c.channelId,
         seller: c.seller,
-        deposit: formatUsdc6(BigInt(c.authMax)),
-        settled: formatUsdc6(0n),
+        deposit: formatUsdc6(BigInt(c.reserveMax)),
+        settled: formatUsdc6(BigInt(c.cumulativeSigned)),
         deadline: c.deadline,
         closeRequestedAt: 0,
         status: 1, // buyer proxy already filters to active

--- a/apps/payments/src/routes.ts
+++ b/apps/payments/src/routes.ts
@@ -1,11 +1,12 @@
 import type { FastifyInstance } from 'fastify';
 import type { CryptoContext, PaymentCryptoConfig } from './crypto-context.js';
-import { DepositsClient, ChannelsClient, formatUsdc, parseUsdc, signSetOperator, makeDepositsDomain, type ChainConfig } from '@antseed/node';
+import { DepositsClient, formatUsdc, parseUsdc, signSetOperator, makeDepositsDomain, type ChainConfig } from '@antseed/node';
 
 interface RouteContext {
   cryptoCtx: CryptoContext | null;
   cryptoConfig: PaymentCryptoConfig;
   chainConfig: ChainConfig;
+  proxyPort: number;
 }
 
 // Use shared utilities from @antseed/node
@@ -26,17 +27,6 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
   function getClient(): DepositsClient | null {
     if (!depositsClient) depositsClient = createClient(ctx.cryptoConfig);
     return depositsClient;
-  }
-
-  let channelsClient: ChannelsClient | null = null;
-  function getChannelsClient(): ChannelsClient | null {
-    if (!channelsClient && ctx.cryptoConfig.channelsContractAddress) {
-      channelsClient = new ChannelsClient({
-        rpcUrl: ctx.cryptoConfig.rpcUrl,
-        contractAddress: ctx.cryptoConfig.channelsContractAddress,
-      });
-    }
-    return channelsClient;
   }
 
   fastify.get('/api/balance', async (_request, reply) => {
@@ -102,64 +92,44 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
     }
   });
 
-  fastify.get('/api/channels', async (_request, reply) => {
+  fastify.get('/api/channels', async (_request, _reply) => {
     if (!ctx.cryptoCtx) {
       return { channels: [] };
     }
 
+    // Fetch active channels from the buyer proxy's local ChannelStore via
+    // its control-plane endpoint. The buyer runtime is the source of truth
+    // for channel state — avoids scanning on-chain event logs (which fails
+    // on public RPCs that cap eth_getLogs block range).
     try {
-      const client = getChannelsClient();
-      if (!client) return { channels: [] };
-
-      const buyerAddress = ctx.cryptoCtx.evmAddress;
-      // Pad buyer address to 32 bytes for topic filter (indexed address in events)
-      const buyerTopic = '0x' + buyerAddress.slice(2).toLowerCase().padStart(64, '0');
-
-      // Reserved event signature: Reserved(bytes32 indexed channelId, address indexed buyer, address indexed seller, uint128 maxAmount)
-      const { ethers } = await import('ethers');
-      const iface = new ethers.Interface([
-        'event Reserved(bytes32 indexed channelId, address indexed buyer, address indexed seller, uint128 maxAmount)',
-      ]);
-      const eventTopic = iface.getEvent('Reserved')!.topicHash;
-
-      const logs = await client.provider.getLogs({
-        address: ctx.cryptoConfig.channelsContractAddress,
-        topics: [eventTopic, null, buyerTopic],
-        fromBlock: ctx.chainConfig.channelsDeployBlock ?? 0,
-        toBlock: 'latest',
-      });
-
-      // Collect unique channelIds from events
-      const channelIds = new Set<string>();
-      for (const log of logs) {
-        // channelId is topic1
-        if (log.topics[1]) channelIds.add(log.topics[1]);
+      const url = `http://127.0.0.1:${ctx.proxyPort}/_antseed/channels`;
+      const resp = await fetch(url);
+      if (!resp.ok) {
+        fastify.log.warn(`[/api/channels] buyer proxy returned ${resp.status}`);
+        return { channels: [] };
       }
-
-      // Fetch channel details for each channelId
-      const channels = [];
-      for (const channelId of channelIds) {
-        try {
-          const session = await client.getSession(channelId);
-          // Only include Active channels (status === 1)
-          if (session.status === 1) {
-            channels.push({
-              channelId,
-              seller: session.seller,
-              deposit: formatUsdc6(session.deposit),
-              settled: formatUsdc6(session.settled),
-              deadline: Number(session.deadline),
-              closeRequestedAt: Number(session.closeRequestedAt),
-              status: session.status,
-            });
-          }
-        } catch {
-          // Skip channels that fail to fetch
-        }
-      }
-
+      const body = await resp.json() as {
+        ok: boolean;
+        channels: Array<{
+          channelId: string;
+          seller: string;
+          authMax: string;
+          deadline: number;
+          status: string;
+        }>;
+      };
+      const channels = (body.channels ?? []).map((c) => ({
+        channelId: c.channelId,
+        seller: c.seller,
+        deposit: formatUsdc6(BigInt(c.authMax)),
+        settled: formatUsdc6(0n),
+        deadline: c.deadline,
+        closeRequestedAt: 0,
+        status: 1, // buyer proxy already filters to active
+      }));
       return { channels };
     } catch (err) {
+      fastify.log.warn(`[/api/channels] buyer proxy unreachable: ${err instanceof Error ? err.message : String(err)}`);
       return { channels: [] };
     }
   });

--- a/apps/payments/src/server.ts
+++ b/apps/payments/src/server.ts
@@ -65,6 +65,7 @@ export async function createServer(options: PaymentsServerOptions) {
 
   // Resolve chain config: protocol defaults + user overrides from config.json
   let userOverrides: Record<string, unknown> = {};
+  let proxyPort = 8377;
   try {
     const cfgPath = options.dataDir
       ? path.join(options.dataDir, 'config.json')
@@ -73,6 +74,10 @@ export async function createServer(options: PaymentsServerOptions) {
     const config = JSON.parse(raw) as Record<string, unknown>;
     const payments = (config.payments ?? {}) as Record<string, unknown>;
     userOverrides = (payments.crypto ?? {}) as Record<string, unknown>;
+    const buyer = (config.buyer ?? {}) as Record<string, unknown>;
+    if (typeof buyer.proxyPort === 'number') {
+      proxyPort = buyer.proxyPort;
+    }
   } catch {
     // No config file — use protocol defaults
   }
@@ -92,7 +97,7 @@ export async function createServer(options: PaymentsServerOptions) {
     usdcContractAddress: chainConfig.usdcContractAddress,
   };
 
-  registerRoutes(fastify, { cryptoCtx, cryptoConfig, chainConfig });
+  registerRoutes(fastify, { cryptoCtx, cryptoConfig, chainConfig, proxyPort });
 
   // SPA fallback — only if static files are available
   if (staticRegistered) {

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -60,7 +60,6 @@ import {
   ChannelsClient,
   StakingClient,
   ChannelStore,
-  type StoredChannel,
 } from "./payments/index.js";
 import { debugLog, debugWarn } from "./utils/debug.js";
 import { parsePublicAddress } from "./discovery/public-address.js";
@@ -539,12 +538,51 @@ export class AntseedNode extends EventEmitter {
 
   /**
    * Return active buyer-side channels for the current identity's EVM address.
-   * Read from the local ChannelStore — no on-chain RPC calls.
+   * Combines the persistent ChannelStore (session metadata + cumulative signed
+   * amount) with the in-memory reserve ceiling tracked by BuyerPaymentManager.
+   *
+   * Note on field semantics (buyer side, base-6 USDC strings):
+   *   - reserveMax: current reserve ceiling — what the buyer authorized the
+   *     seller to lock via ReserveAuth. Lives only in memory on the payment
+   *     manager; falls back to stored authMax if unavailable.
+   *   - cumulativeSigned (stored as authMax): rolling total of SpendingAuth
+   *     amounts signed so far. Upper bound of what the seller can settle.
    */
-  getActiveBuyerChannels(): StoredChannel[] {
+  getActiveBuyerChannels(): Array<{
+    channelId: string;
+    peerId: string;
+    seller: string;
+    buyer: string;
+    reserveMax: string;
+    cumulativeSigned: string;
+    deadline: number;
+    reservedAt: number;
+    status: string;
+    requestCount: number;
+    tokensDelivered: string;
+  }> {
     const buyerAddress = this._identity?.wallet.address ?? null;
     if (!buyerAddress || !this._channelStore) return [];
-    return this._channelStore.getActiveChannelsByBuyer('buyer', buyerAddress);
+    const stored = this._channelStore.getActiveChannelsByBuyer('buyer', buyerAddress);
+    return stored.map((c) => {
+      const liveReserve = this._buyerPaymentManager?.getReserveCeiling(c.peerId);
+      const reserveMax = (liveReserve != null && liveReserve > 0n)
+        ? liveReserve.toString()
+        : c.authMax;
+      return {
+        channelId: c.sessionId,
+        peerId: c.peerId,
+        seller: c.sellerEvmAddr,
+        buyer: c.buyerEvmAddr,
+        reserveMax,
+        cumulativeSigned: c.authMax,
+        deadline: c.deadline,
+        reservedAt: c.reservedAt,
+        status: c.status,
+        requestCount: c.requestCount,
+        tokensDelivered: c.tokensDelivered,
+      };
+    });
   }
 
   async sendRequest(

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -60,6 +60,7 @@ import {
   ChannelsClient,
   StakingClient,
   ChannelStore,
+  type StoredChannel,
 } from "./payments/index.js";
 import { debugLog, debugWarn } from "./utils/debug.js";
 import { parsePublicAddress } from "./discovery/public-address.js";
@@ -534,6 +535,16 @@ export class AntseedNode extends EventEmitter {
       lifetimeAuthorizedUsdc: (lifetime?.totalAuthorizedUsdc ?? 0n).toString(),
       lifetimeFirstSessionAt: lifetime?.firstSessionAt ?? null,
     };
+  }
+
+  /**
+   * Return active buyer-side channels for the current identity's EVM address.
+   * Read from the local ChannelStore — no on-chain RPC calls.
+   */
+  getActiveBuyerChannels(): StoredChannel[] {
+    const buyerAddress = this._identity?.wallet.address ?? null;
+    if (!buyerAddress || !this._channelStore) return [];
+    return this._channelStore.getActiveChannelsByBuyer('buyer', buyerAddress);
   }
 
   async sendRequest(


### PR DESCRIPTION
## Summary
- The payments portal was silently showing "No active channels" because `/api/channels` scanned Reserved event logs from the Channels deploy block to `latest` on every request. Public Base RPC caps `eth_getLogs` block range, so the call threw and the outer catch swallowed it.
- Switch to the buyer proxy's control-plane endpoint — same convention as `/_antseed/peers`, `/_antseed/connect`, and `/_antseed/metering/<peerId>`. The buyer runtime is the source of truth for channel state (it writes `ChannelStore` on `reserve()`).

## Changes
- `packages/node` — new `Node.getActiveBuyerChannels()` that reads `ChannelStore.getActiveChannelsByBuyer('buyer', evmAddress)` for the current identity.
- `apps/cli/src/proxy/buyer-proxy.ts` — expose `GET /_antseed/channels` returning `{ ok, channels[] }`.
- `apps/payments/src/server.ts` — read `buyer.proxyPort` from `config.json` (default 8377) and pass into route context.
- `apps/payments/src/routes.ts` — `/api/channels` fetches `http://127.0.0.1:<proxyPort>/_antseed/channels` and maps to the UI's existing `ChannelData` shape. Drops the on-chain `eth_getLogs` scan, the `ChannelsClient` instance, and the stale event-decoding code.

## Follow-ups (not in this PR)
- `settled` is currently shown as `$0.000000` because `StoredChannel` doesn't track cumulative settled USDC locally — only `authMax` (the reserve ceiling). Live consumed USDC lives in `BuyerPaymentNegotiator`; wiring it through is a separate change.
- `closeRequestedAt` is always 0 since the local DB doesn't observe on-chain `requestClose` events. The UI will show the "Request Close" button even after a close has been requested on-chain.

## Test plan
- [ ] Start `antseed connect`, open one or more channels by making requests
- [ ] Open the payments portal — verify channels appear with the correct seller and Reserved amount
- [ ] Stop the buyer — verify `/api/channels` returns `{ channels: [] }` with a warning logged (no crash)