### PR TITLE
feat: add $ANTS token page

### DIFF
--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -158,7 +158,6 @@ const config: Config = {
         src: 'logo.svg',
       },
       items: [
-        {to: '/ants-token', label: '$ANTS', position: 'right'},
         {to: '/network', label: 'Pricing', position: 'right'},
         {
           type: 'docSidebar',
@@ -167,6 +166,7 @@ const config: Config = {
           position: 'right',
           className: 'header-docs-link',
         },
+        {to: '/ants-token', label: '$ANTS', position: 'right'},
         {to: '/blog', label: 'Blog', position: 'right'},
         {
           href: 'https://github.com/antseed',

--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -158,6 +158,7 @@ const config: Config = {
         src: 'logo.svg',
       },
       items: [
+        {to: '/ants-token', label: '$ANTS', position: 'right'},
         {to: '/network', label: 'Pricing', position: 'right'},
         {
           type: 'docSidebar',

--- a/apps/website/src/pages/ants-token.module.css
+++ b/apps/website/src/pages/ants-token.module.css
@@ -1,0 +1,585 @@
+/* ANTS Token page — matches site design system */
+
+/* ── HERO ── */
+.hero {
+  text-align: center;
+  padding: 80px 20px 60px;
+  max-width: 820px;
+  margin: 0 auto;
+}
+.heroKicker {
+  display: inline-block;
+  font-size: 20px;
+  font-weight: 700;
+  color: #1FD87A !important;
+  font-family: 'JetBrains Mono', monospace;
+  letter-spacing: 2px;
+  margin-bottom: 20px;
+  text-decoration: none !important;
+  transition: opacity 0.15s;
+}
+.heroKicker:hover {
+  opacity: 0.7;
+}
+.heroTitle {
+  font-size: clamp(36px, 5.5vw, 68px);
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: -2.5px;
+  margin-bottom: 24px;
+  color: #1a1a1a;
+}
+.heroTitle em {
+  font-style: italic;
+  color: #1FD87A;
+}
+/* Status indicator */
+.heroStatus {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px 6px 10px;
+  border-radius: 20px;
+  background: rgba(220, 60, 60, 0.06);
+  border: 1px solid rgba(220, 60, 60, 0.15);
+  margin-bottom: 24px;
+}
+.statusDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #dc3c3c;
+  box-shadow: 0 0 0 3px rgba(220, 60, 60, 0.15);
+  animation: pulseRed 2s ease-in-out infinite;
+}
+@keyframes pulseRed {
+  0%, 100% { box-shadow: 0 0 0 3px rgba(220, 60, 60, 0.15); }
+  50% { box-shadow: 0 0 0 6px rgba(220, 60, 60, 0.08); }
+}
+.statusText {
+  font-size: 12px;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+  color: #dc3c3c;
+  letter-spacing: 0.5px;
+}
+
+.heroSub {
+  font-size: 16px;
+  color: #888;
+  line-height: 1.7;
+  max-width: 600px;
+  margin: 0 auto 36px;
+}
+.heroCtas {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+/* ── BUTTONS ── */
+.ctaPrimary {
+  display: inline-flex;
+  align-items: center;
+  padding: 14px 28px;
+  border-radius: 12px;
+  background: #1a1a1a;
+  color: #fff !important;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none !important;
+  transition: background 0.15s, transform 0.15s;
+}
+.ctaPrimary:hover { background: #333; transform: translateY(-1px); }
+.ctaSecondary {
+  display: inline-flex;
+  align-items: center;
+  padding: 14px 28px;
+  border-radius: 12px;
+  background: transparent;
+  border: 1px solid #e8e8e3;
+  color: #1a1a1a !important;
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none !important;
+  transition: border-color 0.15s, transform 0.15s;
+}
+.ctaSecondary:hover { border-color: #aaa; transform: translateY(-1px); }
+
+/* ── TOKEN OVERVIEW ── */
+.overview {
+  padding: 0 60px 80px;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+.overviewHeader {
+  text-align: center;
+  margin-bottom: 36px;
+}
+.overviewHeader h2 {
+  font-size: clamp(28px, 3.5vw, 40px);
+  font-weight: 700;
+  letter-spacing: -1.5px;
+  margin-bottom: 14px;
+}
+.overviewHeader p {
+  font-size: 15px;
+  color: #888;
+  line-height: 1.6;
+}
+
+/* Supply bar */
+.supplyBar {
+  margin-bottom: 32px;
+}
+.supplyBarTrack {
+  height: 12px;
+  background: #f0f0eb;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.supplyBarFill {
+  height: 100%;
+  background: linear-gradient(90deg, #1FD87A, #17b866);
+  border-radius: 6px;
+  min-width: 4px;
+  transition: width 0.6s ease;
+}
+.supplyBarLabels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 8px;
+  font-size: 12px;
+  font-family: 'JetBrains Mono', monospace;
+  color: #888;
+}
+
+/* Stats grid */
+.statsGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+.statCard {
+  background: #fff;
+  border: 1px solid #e8e8e3;
+  border-radius: 14px;
+  padding: 24px;
+  text-align: center;
+}
+.statValue {
+  font-size: 24px;
+  font-weight: 700;
+  color: #1a1a1a;
+  letter-spacing: -0.5px;
+  margin-bottom: 6px;
+}
+.statLabel {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+  color: #888;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+/* ── EMISSIONS ── */
+.emissions {
+  padding: 60px 60px 80px;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+.emissionsHeader {
+  text-align: center;
+  margin-bottom: 48px;
+}
+.emissionsHeader h2 {
+  font-size: clamp(26px, 3vw, 36px);
+  font-weight: 700;
+  letter-spacing: -1.2px;
+  margin-bottom: 12px;
+}
+.emissionsHeader p {
+  font-size: 15px;
+  color: #888;
+  line-height: 1.6;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+/* Halving chart */
+.halvingChart {
+  background: #fff;
+  border: 1px solid #e8e8e3;
+  border-radius: 16px;
+  padding: 32px;
+  margin-bottom: 24px;
+}
+.halvingSvg {
+  width: 100%;
+  height: 100px;
+}
+.halvingLabels {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 12px;
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+  color: #888;
+}
+.halvingLabels span:nth-child(2) {
+  color: #1FD87A;
+  font-weight: 600;
+}
+
+/* Current epoch card */
+.emissionsCurrentCard {
+  background: #1a1a1a;
+  border-radius: 14px;
+  padding: 28px 32px;
+  text-align: center;
+  margin-bottom: 32px;
+}
+.emissionsCurrentTitle {
+  font-size: 11px;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+  color: #888;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+.emissionsCurrentValue {
+  font-size: clamp(28px, 3vw, 40px);
+  font-weight: 700;
+  color: #1FD87A;
+  letter-spacing: -1px;
+  margin-bottom: 8px;
+}
+.emissionsCurrentSub {
+  font-size: 13px;
+  font-family: 'JetBrains Mono', monospace;
+  color: #666;
+}
+
+/* Split grid */
+.splitGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+.splitCard {
+  background: #fff;
+  border: 1px solid #e8e8e3;
+  border-radius: 14px;
+  padding: 28px;
+}
+.splitCardAccent {
+  border-color: #1FD87A;
+}
+.splitPct {
+  font-size: 32px;
+  font-weight: 700;
+  color: #1a1a1a;
+  letter-spacing: -1px;
+  margin-bottom: 4px;
+}
+.splitCardAccent .splitPct {
+  color: #1FD87A;
+}
+.splitLabel {
+  font-size: 13px;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
+  color: #1a1a1a;
+  margin-bottom: 10px;
+}
+.splitDesc {
+  font-size: 13px;
+  color: #888;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ── NETWORK ACTIVITY ── */
+.activity {
+  padding: 60px 60px 80px;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+.activityHeader {
+  text-align: center;
+  margin-bottom: 36px;
+}
+.activityHeader h2 {
+  font-size: clamp(26px, 3vw, 36px);
+  font-weight: 700;
+  letter-spacing: -1.2px;
+  margin-bottom: 12px;
+}
+.activityHeader p {
+  font-size: 15px;
+  color: #888;
+  line-height: 1.6;
+}
+
+/* Dune banner */
+.duneBanner {
+  display: block;
+  background: #1a1a1a;
+  border-radius: 16px;
+  padding: 36px 40px;
+  text-decoration: none !important;
+  transition: background 0.15s, transform 0.15s;
+}
+.duneBanner:hover {
+  background: #252525;
+  transform: translateY(-2px);
+}
+.duneBannerContent {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+.duneBannerIcon {
+  width: 56px;
+  height: 56px;
+  border-radius: 14px;
+  background: rgba(31, 216, 122, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #1FD87A;
+}
+.duneBannerText {
+  flex: 1;
+}
+.duneBannerTitle {
+  font-size: 18px;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: -0.3px;
+  margin-bottom: 6px;
+}
+.duneBannerSub {
+  font-size: 14px;
+  color: #888;
+  line-height: 1.6;
+}
+
+/* ── HOW TO EARN ── */
+.earn {
+  padding: 60px 60px 80px;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+.earnHeader {
+  text-align: center;
+  margin-bottom: 48px;
+}
+.earnHeader h2 {
+  font-size: clamp(26px, 3vw, 36px);
+  font-weight: 700;
+  letter-spacing: -1.2px;
+  margin-bottom: 12px;
+}
+.earnHeader p {
+  font-size: 15px;
+  color: #888;
+  line-height: 1.6;
+}
+.earnGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+.earnCard {
+  background: #fff;
+  border: 1px solid #e8e8e3;
+  border-radius: 16px;
+  padding: 36px;
+}
+.earnStep {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  font-weight: 700;
+  color: #1FD87A;
+  margin-bottom: 16px;
+}
+.earnCard h3 {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  margin-bottom: 12px;
+}
+.earnCard p {
+  font-size: 14px;
+  color: #888;
+  line-height: 1.65;
+  margin: 0;
+}
+
+/* ── CONTRACT DETAILS ── */
+.contracts {
+  padding: 60px 60px 80px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+.contractsHeader {
+  text-align: center;
+  margin-bottom: 36px;
+}
+.contractsHeader h2 {
+  font-size: clamp(24px, 2.5vw, 32px);
+  font-weight: 700;
+  letter-spacing: -1px;
+}
+.contractsTable {
+  background: #fff;
+  border: 1px solid #e8e8e3;
+  border-radius: 16px;
+  overflow: hidden;
+}
+.contractsRow {
+  display: flex;
+  align-items: baseline;
+  gap: 20px;
+  padding: 16px 28px;
+  border-bottom: 1px solid #f5f5f0;
+}
+.contractsRow:last-child { border-bottom: none; }
+.contractsLabel {
+  font-size: 12px;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+  color: #888;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+  min-width: 160px;
+  flex-shrink: 0;
+}
+.contractsValue {
+  font-size: 14px;
+  color: #1a1a1a;
+  line-height: 1.5;
+}
+.contractsLink {
+  color: #1FD87A !important;
+  text-decoration: none !important;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  font-weight: 600;
+  border-bottom: 1px solid rgba(31, 216, 122, 0.3);
+  padding-bottom: 1px;
+  transition: border-color 0.15s;
+}
+.contractsLink:hover {
+  border-color: #1FD87A;
+}
+
+/* ── BOTTOM CTA ── */
+.bottomCta {
+  text-align: center;
+  padding: 80px 20px 100px;
+  max-width: 600px;
+  margin: 0 auto;
+}
+.bottomCta h2 {
+  font-size: clamp(28px, 3.5vw, 42px);
+  font-weight: 700;
+  letter-spacing: -1.5px;
+  margin-bottom: 14px;
+}
+.bottomCta > p {
+  font-size: 16px;
+  color: #888;
+  line-height: 1.6;
+  margin-bottom: 32px;
+}
+.bottomCtaBtns {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 28px;
+}
+.bottomLinks {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+.bottomLinks a {
+  color: #888 !important;
+  text-decoration: none !important;
+}
+.bottomLinks a:hover { color: #1a1a1a !important; }
+.bottomLinks span { color: #ddd; }
+
+/* ── RESPONSIVE ── */
+@media (max-width: 900px) {
+  .overview,
+  .emissions,
+  .activity,
+  .earn,
+  .contracts {
+    padding: 40px 20px 60px;
+  }
+  .statsGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .splitGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .earnGrid {
+    grid-template-columns: 1fr;
+  }
+  .contractsRow { flex-direction: column; gap: 4px; }
+  .contractsLabel { min-width: unset; }
+  .duneBanner { padding: 28px 24px; }
+  .duneBannerContent { gap: 16px; }
+}
+
+@media (max-width: 600px) {
+  .heroTitle {
+    font-size: clamp(32px, 9vw, 48px);
+    letter-spacing: -1.5px;
+  }
+  .heroSub { font-size: 15px; }
+  .heroCtas {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .ctaPrimary,
+  .ctaSecondary {
+    justify-content: center;
+  }
+  .statsGrid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .splitGrid {
+    grid-template-columns: 1fr;
+  }
+  .bottomCtaBtns {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .bottomCtaBtns .ctaPrimary,
+  .bottomCtaBtns .ctaSecondary {
+    justify-content: center;
+  }
+  .bottomLinks {
+    flex-direction: column;
+    gap: 8px;
+  }
+  .bottomLinks span { display: none; }
+  .contractsRow { padding: 14px 20px; }
+  .duneBannerContent { flex-direction: column; text-align: center; }
+  .duneBannerIcon { margin: 0 auto; }
+}

--- a/apps/website/src/pages/ants-token.tsx
+++ b/apps/website/src/pages/ants-token.tsx
@@ -1,0 +1,354 @@
+import {useState, useEffect, useMemo} from 'react';
+import Link from '@docusaurus/Link';
+import Layout from '@theme/Layout';
+import styles from './ants-token.module.css';
+
+const RELEASES_URL = 'https://github.com/AntSeed/antseed/releases/latest';
+const GH_API_LATEST = 'https://api.github.com/repos/AntSeed/antseed/releases/latest';
+const DUNE_URL = 'https://dune.com/antseed_com/antseed';
+const ANTS_TOKEN_ADDRESS = '0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263';
+const ANTS_BASESCAN_URL = `https://basescan.org/token/${ANTS_TOKEN_ADDRESS}`;
+
+/* ── Download helpers (same as homepage) ───────────────────────── */
+function buildDmgUrl(tag: string, arch: 'arm64' | 'x64'): string {
+  const version = tag.replace(/^v/, '');
+  const suffix = arch === 'arm64' ? '-arm64' : '';
+  return `https://github.com/AntSeed/antseed/releases/download/${tag}/AntSeed-Desktop-${version}${suffix}.dmg`;
+}
+
+function isMac(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /Macintosh|Mac OS X/.test(navigator.userAgent);
+}
+
+function useLatestRelease() {
+  const [tag, setTag] = useState<string | null>(null);
+  const [arch, setArch] = useState<'arm64' | 'x64'>('arm64');
+  const mac = useMemo(isMac, []);
+
+  useEffect(() => {
+    if (!mac) return;
+    const nav = navigator as Navigator & { userAgentData?: { getHighEntropyValues(hints: string[]): Promise<{ architecture?: string }> } };
+    if (nav.userAgentData?.getHighEntropyValues) {
+      nav.userAgentData.getHighEntropyValues(['architecture'])
+        .then(data => { if (data.architecture === 'x86') setArch('x64'); })
+        .catch(() => {});
+    }
+    fetch(GH_API_LATEST)
+      .then(r => r.json())
+      .then(data => { if (data?.tag_name) setTag(data.tag_name as string); })
+      .catch(() => {});
+  }, [mac]);
+
+  const dmgUrl = mac && tag ? buildDmgUrl(tag, arch) : null;
+  return { dmgUrl };
+}
+
+/* ── Epoch countdown ───────────────────────────────────────────── */
+const EPOCH_DURATION = 604_800; // 1 week in seconds
+
+// Genesis timestamp from AntseedEmissions contract on Base mainnet (block 44469557)
+// Read via: eth_call genesis() on 0x36877fBa8Fa333aa46a1c57b66D132E4995C86b5
+const GENESIS: number = 1775728461; // 2026-04-09T09:54:21Z
+
+function useEpochCountdown() {
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Math.floor(Date.now() / 1000)), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  if (GENESIS === 0) {
+    return { epoch: 0, timeLeft: 'Not started', started: false };
+  }
+
+  const elapsed = now - GENESIS;
+  const epoch = Math.floor(elapsed / EPOCH_DURATION);
+  const epochEnd = GENESIS + (epoch + 1) * EPOCH_DURATION;
+  const remaining = Math.max(0, epochEnd - now);
+
+  const d = Math.floor(remaining / 86400);
+  const h = Math.floor((remaining % 86400) / 3600);
+  const m = Math.floor((remaining % 3600) / 60);
+  const s = remaining % 60;
+
+  const timeLeft = d > 0
+    ? `${d}d ${h}h ${m}m`
+    : h > 0
+      ? `${h}h ${m}m ${s}s`
+      : `${m}m ${s}s`;
+
+  return { epoch, timeLeft, started: true };
+}
+
+/* ── Token constants ───────────────────────────────────────────── */
+const MAX_SUPPLY = 1_040_000_000;
+const INITIAL_EMISSION = 5_000_000;
+const HALVING_INTERVAL = 104;
+
+/* ── SUPPLY BAR ────────────────────────────────────────────────── */
+function SupplyBar({totalSupply}: {totalSupply: number}) {
+  const ratio = (totalSupply / MAX_SUPPLY) * 100;
+  return (
+    <div className={styles.supplyBar}>
+      <div className={styles.supplyBarTrack}>
+        <div className={styles.supplyBarFill} style={{width: `${Math.max(ratio, 0.3)}%`}} />
+      </div>
+      <div className={styles.supplyBarLabels}>
+        <span>{totalSupply === 0 ? '0' : `${(totalSupply / 1e6).toFixed(1)}M`} minted</span>
+        <span>{(MAX_SUPPLY / 1e6).toFixed(0)}M max</span>
+      </div>
+    </div>
+  );
+}
+
+/* ── HALVING CHART ─────────────────────────────────────────────── */
+function HalvingCurve({currentEpoch}: {currentEpoch: number}) {
+  const points: {epoch: number; emission: number}[] = [];
+  let em = INITIAL_EMISSION;
+  for (let e = 0; e <= 624; e++) {
+    if (e > 0 && e % HALVING_INTERVAL === 0) em = em / 2;
+    if (e % 8 === 0) points.push({epoch: e, emission: em});
+  }
+  const w = 100;
+  const h = 40;
+  const pathD = points.map((p, i) => {
+    const x = (p.epoch / 624) * w;
+    const y = h - (p.emission / INITIAL_EMISSION) * h;
+    return `${i === 0 ? 'M' : 'L'}${x},${y}`;
+  }).join(' ');
+
+  return (
+    <div className={styles.halvingChart}>
+      <svg viewBox={`0 0 ${w} ${h + 4}`} preserveAspectRatio="none" className={styles.halvingSvg}>
+        <path d={pathD} fill="none" stroke="#1FD87A" strokeWidth="1.5" />
+        <circle cx={Math.max((currentEpoch / 624) * w, 1)} cy={0} r="2.5" fill="#1FD87A" />
+      </svg>
+      <div className={styles.halvingLabels}>
+        <span>Epoch 0</span>
+        <span>You are here — Epoch {currentEpoch}</span>
+        <span>Epoch 624</span>
+      </div>
+    </div>
+  );
+}
+
+/* ── MAIN PAGE ─────────────────────────────────────────────────── */
+export default function AntsToken(): JSX.Element {
+  const {dmgUrl} = useLatestRelease();
+  const {epoch, timeLeft, started} = useEpochCountdown();
+
+  const epochBudget = started
+    ? INITIAL_EMISSION / Math.pow(2, Math.floor(epoch / HALVING_INTERVAL))
+    : INITIAL_EMISSION;
+
+  const emissionRate = started ? epochBudget / EPOCH_DURATION : 0;
+  const nextHalvingIn = HALVING_INTERVAL - (epoch % HALVING_INTERVAL);
+
+  return (
+    <Layout
+      title="ANTS Token | AntSeed"
+      description="ANTS is earned by the people who build and use the network. Hard-capped at 1.04B with automatic halvings."
+    >
+
+      {/* ── HERO ── */}
+      <section className={styles.hero}>
+        <a href={ANTS_BASESCAN_URL} target="_blank" rel="noopener noreferrer" className={styles.heroKicker}>$ANTS</a>
+        <h1 className={styles.heroTitle}>
+          A network owned by<br />
+          <em>the people who use it.</em>
+        </h1>
+        <div className={styles.heroStatus}>
+          <span className={styles.statusDot} />
+          <span className={styles.statusText}>Tokens Restricted</span>
+        </div>
+        <p className={styles.heroSub}>
+          ANTS is earned — not bought. Sellers and buyers who create real economic activity on the
+          network receive ANTS proportional to their contribution. Hard-capped at 1.04B with
+          automatic halvings.
+        </p>
+        <div className={styles.heroCtas}>
+          <a href={dmgUrl ?? RELEASES_URL} target="_blank" rel="noopener noreferrer" className={styles.ctaPrimary}>
+            Download AntStation →
+          </a>
+          <Link to="/docs/lightpaper" className={styles.ctaSecondary}>Lightpaper</Link>
+        </div>
+      </section>
+
+      {/* ── TOKEN OVERVIEW ── */}
+      <section className={styles.overview}>
+        <div className={styles.overviewHeader}>
+          <h2>Token supply</h2>
+          <p>1.04 billion hard cap. No minting beyond emissions. No admin mint function.</p>
+        </div>
+
+        <SupplyBar totalSupply={0} />
+
+        <div className={styles.statsGrid}>
+          <div className={styles.statCard}>
+            <div className={styles.statValue}>0</div>
+            <div className={styles.statLabel}>Total Supply</div>
+          </div>
+          <div className={styles.statCard}>
+            <div className={styles.statValue}>0%</div>
+            <div className={styles.statLabel}>Minted</div>
+          </div>
+          <div className={styles.statCard}>
+            <div className={styles.statValue}>Epoch {epoch}</div>
+            <div className={styles.statLabel}>Current Epoch</div>
+          </div>
+          <div className={styles.statCard}>
+            <div className={styles.statValue}>{timeLeft}</div>
+            <div className={styles.statLabel}>Until Next Epoch</div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── EMISSIONS ── */}
+      <section className={styles.emissions}>
+        <div className={styles.emissionsHeader}>
+          <h2>Emission schedule</h2>
+          <p>
+            Each epoch (1 week) distributes a fixed ANTS budget. Every 104 epochs (~2 years),
+            the budget halves. Six halvings reduce emissions to near-zero.
+          </p>
+        </div>
+
+        <HalvingCurve currentEpoch={epoch} />
+
+        <div className={styles.emissionsCurrentCard}>
+          <div className={styles.emissionsCurrentTitle}>
+            {started ? 'Current epoch budget' : 'First epoch budget'}
+          </div>
+          <div className={styles.emissionsCurrentValue}>
+            {(epochBudget / 1e6).toFixed(0)}M ANTS
+          </div>
+          <div className={styles.emissionsCurrentSub}>
+            {started
+              ? `${emissionRate.toFixed(3)} ANTS/sec · next halving in ${nextHalvingIn} epochs`
+              : 'Emissions begin when the contract is deployed on Base'
+            }
+          </div>
+        </div>
+
+        <div className={styles.splitGrid}>
+          {[
+            {pct: '50%', label: 'Sellers', desc: 'Pro-rata by USDC volume settled. Capped at 50% of seller pool per seller per epoch.', accent: true},
+            {pct: '20%', label: 'Buyers', desc: 'Pro-rata by USDC spent. Rewards active usage and seller diversity.', accent: false},
+            {pct: '15%', label: 'Protocol Reserve', desc: 'Unclaimed allocations and seller cap overages flow here. Funds ecosystem growth.', accent: false},
+            {pct: '15%', label: 'Team', desc: 'Vested to core contributors. Aligned with long-term network health.', accent: false},
+          ].map(s => (
+            <div key={s.label} className={`${styles.splitCard} ${s.accent ? styles.splitCardAccent : ''}`}>
+              <div className={styles.splitPct}>{s.pct}</div>
+              <div className={styles.splitLabel}>{s.label}</div>
+              <p className={styles.splitDesc}>{s.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── NETWORK ACTIVITY (Dune) ── */}
+      <section className={styles.activity}>
+        <div className={styles.activityHeader}>
+          <h2>Network activity</h2>
+          <p>Real economic activity backing the token. All settlement happens on Base.</p>
+        </div>
+
+        <a href={DUNE_URL} target="_blank" rel="noopener noreferrer" className={styles.duneBanner}>
+          <div className={styles.duneBannerContent}>
+            <div className={styles.duneBannerIcon}>
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 3v18h18"/>
+                <path d="M7 16l4-8 4 4 5-9"/>
+              </svg>
+            </div>
+            <div className={styles.duneBannerText}>
+              <div className={styles.duneBannerTitle}>Live on Dune Analytics</div>
+              <div className={styles.duneBannerSub}>
+                Volume, channels, fees, staking, and deposits — all from on-chain data.
+                Open dashboard →
+              </div>
+            </div>
+          </div>
+        </a>
+      </section>
+
+      {/* ── HOW TO EARN ── */}
+      <section className={styles.earn}>
+        <div className={styles.earnHeader}>
+          <h2>How to earn ANTS</h2>
+          <p>No mining. No staking ANTS. Just use the network.</p>
+        </div>
+
+        <div className={styles.earnGrid}>
+          <div className={styles.earnCard}>
+            <div className={styles.earnStep}>01</div>
+            <h3>As a seller</h3>
+            <p>Stake USDC, serve requests, settle on-chain. Your share of the 50% seller pool is proportional to your USDC volume that epoch. Capped at 50% of seller pool per seller.</p>
+          </div>
+          <div className={styles.earnCard}>
+            <div className={styles.earnStep}>02</div>
+            <h3>As a buyer</h3>
+            <p>Deposit USDC, use the network, pay for AI services. Your share of the 20% buyer pool is proportional to your USDC spend that epoch. Diversity bonus for using multiple sellers.</p>
+          </div>
+          <div className={styles.earnCard}>
+            <div className={styles.earnStep}>03</div>
+            <h3>Claim each epoch</h3>
+            <p>At epoch end, call claim with the epoch numbers you participated in. ANTS are minted directly to your wallet. Unclaimed emissions flow to the protocol reserve.</p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── CONTRACT DETAILS ── */}
+      <section className={styles.contracts}>
+        <div className={styles.contractsHeader}>
+          <h2>On-chain details</h2>
+        </div>
+        <div className={styles.contractsTable}>
+          <div className={styles.contractsRow}>
+            <span className={styles.contractsLabel}>Token contract</span>
+            <span className={styles.contractsValue}>
+              <a href={ANTS_BASESCAN_URL} target="_blank" rel="noopener noreferrer" className={styles.contractsLink}>
+                {ANTS_TOKEN_ADDRESS.slice(0, 6)}...{ANTS_TOKEN_ADDRESS.slice(-4)} on Base
+              </a>
+            </span>
+          </div>
+          {[
+            {label: 'Token standard', value: 'ERC-20'},
+            {label: 'Max supply', value: '1,040,000,000 ANTS'},
+            {label: 'Epoch duration', value: '1 week (604,800 seconds)'},
+            {label: 'Halving interval', value: 'Every 104 epochs (~2 years)'},
+            {label: 'Network fee', value: '2% of settlement (200 bps) — distributed back to stakers'},
+            {label: 'Transfers', value: 'Currently restricted'},
+          ].map(r => (
+            <div key={r.label} className={styles.contractsRow}>
+              <span className={styles.contractsLabel}>{r.label}</span>
+              <span className={styles.contractsValue}>{r.value}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* ── BOTTOM CTA ── */}
+      <section className={styles.bottomCta}>
+        <h2>Start earning ANTS</h2>
+        <p>Download AntStation, join the network as a provider or buyer, and start accumulating.</p>
+        <div className={styles.bottomCtaBtns}>
+          <a href={dmgUrl ?? RELEASES_URL} target="_blank" rel="noopener noreferrer" className={styles.ctaPrimary}>
+            Download AntStation →
+          </a>
+          <Link to="/providers" className={styles.ctaSecondary}>Become a provider</Link>
+        </div>
+        <div className={styles.bottomLinks}>
+          <Link to="/docs/lightpaper">Lightpaper</Link>
+          <span>·</span>
+          <Link to="/docs/payments">Payment protocol</Link>
+          <span>·</span>
+          <a href={DUNE_URL} target="_blank" rel="noopener noreferrer">Network dashboard</a>
+        </div>
+      </section>
+
+    </Layout>
+  );
+}

--- a/apps/website/src/pages/ants-token.tsx
+++ b/apps/website/src/pages/ants-token.tsx
@@ -127,7 +127,7 @@ function HalvingCurve({currentEpoch}: {currentEpoch: number}) {
       </svg>
       <div className={styles.halvingLabels}>
         <span>Epoch 0</span>
-        <span>You are here — Epoch {currentEpoch}</span>
+        <span>You are here - Epoch {currentEpoch}</span>
         <span>Epoch 624</span>
       </div>
     </div>
@@ -164,7 +164,7 @@ export default function AntsToken(): JSX.Element {
           <span className={styles.statusText}>Tokens Restricted</span>
         </div>
         <p className={styles.heroSub}>
-          ANTS is earned — not bought. Sellers and buyers who create real economic activity on the
+          ANTS is earned, not bought. Sellers and buyers who create real economic activity on the
           network receive ANTS proportional to their contribution. Hard-capped at 1.04B with
           automatic halvings.
         </p>
@@ -266,7 +266,7 @@ export default function AntsToken(): JSX.Element {
             <div className={styles.duneBannerText}>
               <div className={styles.duneBannerTitle}>Live on Dune Analytics</div>
               <div className={styles.duneBannerSub}>
-                Volume, channels, fees, staking, and deposits — all from on-chain data.
+                Volume, channels, fees, staking, and deposits, all from on-chain data.
                 Open dashboard →
               </div>
             </div>
@@ -319,7 +319,7 @@ export default function AntsToken(): JSX.Element {
             {label: 'Max supply', value: '1,040,000,000 ANTS'},
             {label: 'Epoch duration', value: '1 week (604,800 seconds)'},
             {label: 'Halving interval', value: 'Every 104 epochs (~2 years)'},
-            {label: 'Network fee', value: '2% of settlement (200 bps) — distributed back to stakers'},
+            {label: 'Network fee', value: '2% of settlement (200 bps), distributed back to stakers'},
             {label: 'Transfers', value: 'Currently restricted'},
           ].map(r => (
             <div key={r.label} className={styles.contractsRow}>

--- a/apps/website/src/pages/network.module.css
+++ b/apps/website/src/pages/network.module.css
@@ -335,6 +335,7 @@
 .tagOpenSource { background: #f0f9ff; color: #0284c7; }
 .tagRag       { background: #fdf4ff; color: #c026d3; }
 .tagEnterprise { background: #f8fafc; color: #475569; }
+.tagAnon      { background: #f0f9ff; color: #0e7490; }
 .tagDefault   { background: #f5f7fa; color: #64748b; }
 
 .tdContext {
@@ -465,41 +466,141 @@
 
 @media (max-width: 768px) {
   .page {
-    padding: 60px 16px 80px;
+    padding: 60px 12px 80px;
   }
 
   .statsBar {
     padding: 20px;
+    flex-direction: column;
+    gap: 16px;
   }
 
   .statDivider {
     display: none;
   }
 
-  .statsBar {
-    flex-direction: column;
-    gap: 16px;
-  }
-
   .statNum {
     font-size: 24px;
   }
 
-  .tableWrap {
-    border-radius: 12px;
-    overflow-x: auto;
+  .filterBar {
+    gap: 10px;
   }
 
-  .table {
-    min-width: 600px;
+  .searchInput {
+    font-size: 13px;
+    padding: 12px 36px 12px 40px;
+  }
+
+  .chip {
+    font-size: 11px;
+    padding: 5px 10px;
+  }
+
+  /* Card-based layout instead of table on mobile */
+  .tableWrap {
+    border: none;
+    box-shadow: none;
+    background: transparent;
+    border-radius: 0;
+  }
+
+  .table,
+  .table thead,
+  .table tbody,
+  .table tr,
+  .table th,
+  .table td {
+    display: block;
+  }
+
+  .table thead {
+    display: none;
+  }
+
+  .row {
+    background: white;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 16px;
+    margin-bottom: 12px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+    display: flex !important;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .tdModel {
+    width: 100%;
+    padding: 0 !important;
+    margin-bottom: 8px;
   }
 
   .modelLogo {
+    width: 28px;
+    height: 28px;
+  }
+
+  .modelName {
+    font-size: 15px;
+  }
+
+  .tdPrice {
+    padding: 0 !important;
+    text-align: left !important;
+    font-size: 13px;
+    flex: 1;
+  }
+
+  .tdPrice::before {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 9px;
+    color: #8b949e;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    display: block;
+    margin-bottom: 2px;
+    font-weight: 400;
+  }
+
+  .tdPrice:nth-of-type(2)::before {
+    content: 'Input /M';
+  }
+
+  .tdPrice:nth-of-type(3)::before {
+    content: 'Output /M';
+  }
+
+  .tdProviders {
+    padding: 0 !important;
+    text-align: left !important;
+  }
+
+  .tdProviders::before {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 9px;
+    color: #8b949e;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    display: block;
+    margin-bottom: 2px;
+    content: 'Peers';
+    font-weight: 400;
+  }
+
+  .peerCount {
     width: 24px;
     height: 24px;
+    font-size: 11px;
   }
 
   .tagBadge {
-    display: none;
+    font-size: 8px;
+    padding: 1px 5px;
+  }
+
+  .emptyRow {
+    padding: 40px 16px !important;
   }
 }

--- a/apps/website/src/pages/network.tsx
+++ b/apps/website/src/pages/network.tsx
@@ -159,7 +159,7 @@ function aggregateModels(peers: PeerMetadata[]): ModelRow[] {
       provider: meta?.provider ?? guessProvider(serviceId),
       logoUrl: guessLogo(serviceId),
       contextWindow: meta?.contextWindow ?? '—',
-      tags: meta?.tags ?? [...data.categories],
+      tags: ['anon', ...(meta?.tags ?? [...data.categories])],
       inputPrice: data.bestInput,
       outputPrice: data.bestOutput,
       peerCount: data.peerCount,
@@ -206,7 +206,7 @@ function guessLogo(serviceId: string): string {
 /* ── Helpers ──────────────────────────────────────────────────────── */
 
 const TAG_CLASS: Record<string, string> = {
-  coding: styles.tagCoding, code: styles.tagCode, privacy: styles.tagPrivacy,
+  anon: styles.tagAnon, coding: styles.tagCoding, code: styles.tagCode, privacy: styles.tagPrivacy,
   tee: styles.tagTee, chat: styles.tagChat, fast: styles.tagFast,
   cheap: styles.tagCheap, reasoning: styles.tagReasoning,
   'open-source': styles.tagOpenSource, rag: styles.tagRag,


### PR DESCRIPTION
## Summary
- New `/ants-token` page with live epoch countdown, emission schedule, Dune dashboard link, and on-chain contract details
- `$ANTS` navbar item added before Pricing
- All data sourced from deployed Base mainnet contracts (genesis `1775728461`, initial emission 5M ANTS/week)
- Token contract linked to Basescan (`0xa87E...5263`)
- Fully responsive (mobile + desktop)

## Test plan
- [ ] Verify epoch countdown ticks correctly (currently ~5d remaining in epoch 0)
- [ ] Verify `$ANTS` kicker and contract table link go to Basescan
- [ ] Verify Dune banner links to dune.com/antseed_com/antseed
- [ ] Verify Download AntStation links to latest GitHub release
- [ ] Verify `$ANTS` appears in navbar (desktop) and hamburger menu (mobile)
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)