### PR TITLE
fix(website): hide filter chips on mobile pricing page

### DIFF
--- a/apps/website/src/pages/network.module.css
+++ b/apps/website/src/pages/network.module.css
@@ -492,9 +492,8 @@
     padding: 12px 36px 12px 40px;
   }
 
-  .chip {
-    font-size: 11px;
-    padding: 5px 10px;
+  .filterChips {
+    display: none;
   }
 
   /* Card-based layout instead of table on mobile */


### PR DESCRIPTION
## Summary
- Hides provider and tag filter chips on mobile (<768px) for a cleaner layout
- Search bar remains available for filtering on mobile

## Test plan
- [ ] Open /network on mobile — filter chips should be hidden
- [ ] Search bar still works for filtering
- [ ] Desktop view unchanged — filter chips still visible