### PR TITLE
fix(payments): enrich /api/channels with on-chain close state

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -647,8 +647,11 @@ export class BuyerProxy {
       return
     }
 
-    if (path === '/_antseed/channels' && method === 'GET') {
-      const channels = this._node.getActiveBuyerChannels()
+    if (path.startsWith('/_antseed/channels') && method === 'GET') {
+      const all = /[?&]all=1/.test(path)
+      const channels = all
+        ? this._node.getAllBuyerChannels()
+        : this._node.getActiveBuyerChannels()
       res.writeHead(200, { 'content-type': 'application/json' })
       res.end(JSON.stringify({ ok: true, channels }))
       return

--- a/apps/payments/src/routes.ts
+++ b/apps/payments/src/routes.ts
@@ -105,19 +105,21 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
 
   fastify.get('/api/channels', async (_request, _reply) => {
     if (!ctx.cryptoCtx) {
-      return { channels: [] };
+      return { channels: [], history: [] };
     }
 
-    // Fetch active channels from the buyer proxy's local ChannelStore via
-    // its control-plane endpoint. The buyer runtime is the source of truth
-    // for channel state — avoids scanning on-chain event logs (which fails
-    // on public RPCs that cap eth_getLogs block range).
+    // Fetch channels from the buyer proxy's local ChannelStore via its
+    // control-plane endpoint (source of truth for the list). Avoids
+    // eth_getLogs scans which are capped on public RPCs. Then enrich each
+    // channel with a point-read against channels(bytes32) to get the
+    // authoritative on-chain status + closeRequestedAt, and split into
+    // active vs history based on on-chain state.
     try {
-      const url = `http://127.0.0.1:${ctx.proxyPort}/_antseed/channels`;
+      const url = `http://127.0.0.1:${ctx.proxyPort}/_antseed/channels?all=1`;
       const resp = await fetch(url);
       if (!resp.ok) {
         fastify.log.warn(`[/api/channels] buyer proxy returned ${resp.status}`);
-        return { channels: [] };
+        return { channels: [], history: [] };
       }
       const body = await resp.json() as {
         ok: boolean;
@@ -130,19 +132,17 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
           status: string;
         }>;
       };
-      // Enrich with on-chain state (closeRequestedAt + status) via point-reads
-      // against channels(bytes32). Point-reads work on public RPCs where
-      // eth_getLogs is rate-limited, which is why the list itself comes from
-      // the buyer proxy's local store.
       const cc = getChannelsClient();
-      const channels = await Promise.all((body.channels ?? []).map(async (c) => {
+      const enriched = await Promise.all((body.channels ?? []).map(async (c) => {
         let closeRequestedAt = 0;
-        let status = 1;
+        let onchainStatus = 0; // 0=None, 1=Active, 2=Settled, 3=TimedOut
+        let onchainSettled: bigint | null = null;
         if (cc) {
           try {
             const onchain = await cc.getSession(c.channelId);
             closeRequestedAt = Number(onchain.closeRequestedAt);
-            status = onchain.status;
+            onchainStatus = onchain.status;
+            onchainSettled = onchain.settled;
           } catch (err) {
             fastify.log.warn(`[/api/channels] on-chain read failed for ${c.channelId.slice(0, 10)}: ${err instanceof Error ? err.message : String(err)}`);
           }
@@ -151,16 +151,21 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
           channelId: c.channelId,
           seller: c.seller,
           deposit: formatUsdc6(BigInt(c.reserveMax)),
-          settled: formatUsdc6(BigInt(c.cumulativeSigned)),
+          settled: formatUsdc6(onchainSettled ?? BigInt(c.cumulativeSigned)),
           deadline: c.deadline,
           closeRequestedAt,
-          status,
+          status: onchainStatus,
         };
       }));
-      return { channels };
+      // Active = on-chain status Active (1). Everything else is history
+      // (Settled=2, TimedOut=3, None=0 means the channel no longer exists
+      // on-chain — e.g., withdrawn and cleared).
+      const channels = enriched.filter((c) => c.status === 1);
+      const history = enriched.filter((c) => c.status !== 1);
+      return { channels, history };
     } catch (err) {
       fastify.log.warn(`[/api/channels] buyer proxy unreachable: ${err instanceof Error ? err.message : String(err)}`);
-      return { channels: [] };
+      return { channels: [], history: [] };
     }
   });
 

--- a/apps/payments/src/routes.ts
+++ b/apps/payments/src/routes.ts
@@ -132,31 +132,67 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
           status: string;
         }>;
       };
-      const cc = getChannelsClient();
-      const enriched = await Promise.all((body.channels ?? []).map(async (c) => {
-        let closeRequestedAt = 0;
-        let onchainStatus = 0; // 0=None, 1=Active, 2=Settled, 3=TimedOut
-        let onchainSettled: bigint | null = null;
-        if (cc) {
-          try {
-            const onchain = await cc.getSession(c.channelId);
-            closeRequestedAt = Number(onchain.closeRequestedAt);
-            onchainStatus = onchain.status;
-            onchainSettled = onchain.settled;
-          } catch (err) {
-            fastify.log.warn(`[/api/channels] on-chain read failed for ${c.channelId.slice(0, 10)}: ${err instanceof Error ? err.message : String(err)}`);
+      // Initialize the channels client outside the enrichment loop and catch
+      // init failures independently — a bad RPC URL must not discard the
+      // channel list we already have from the buyer proxy.
+      let cc: ChannelsClient | null = null;
+      try {
+        cc = getChannelsClient();
+      } catch (err) {
+        fastify.log.warn(`[/api/channels] channels client init failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+
+      const rawChannels = body.channels ?? [];
+      // Cap concurrent eth_call fan-out. Public RPCs rate-limit concurrent
+      // reads — the default wagmi primary (publicnode) was picked for 3/3
+      // reliability at 3 concurrent eth_calls; more than that and responses
+      // start coming back stale, which would resurrect the exact bug this
+      // PR fixes (status=1 / closeRequestedAt=0 placeholders).
+      const ON_CHAIN_READ_CONCURRENCY = 3;
+      const enriched: Array<{
+        channelId: string;
+        seller: string;
+        deposit: string;
+        settled: string;
+        deadline: number;
+        closeRequestedAt: number;
+        status: number;
+      }> = new Array(rawChannels.length);
+      let cursor = 0;
+      async function worker() {
+        while (true) {
+          const i = cursor++;
+          if (i >= rawChannels.length) return;
+          const c = rawChannels[i]!;
+          let closeRequestedAt = 0;
+          let onchainStatus = 0; // 0=None, 1=Active, 2=Settled, 3=TimedOut
+          let onchainSettled: bigint | null = null;
+          if (cc) {
+            try {
+              const onchain = await cc.getSession(c.channelId);
+              closeRequestedAt = Number(onchain.closeRequestedAt);
+              onchainStatus = onchain.status;
+              onchainSettled = onchain.settled;
+            } catch (err) {
+              fastify.log.warn(`[/api/channels] on-chain read failed for ${c.channelId.slice(0, 10)}: ${err instanceof Error ? err.message : String(err)}`);
+            }
           }
+          enriched[i] = {
+            channelId: c.channelId,
+            seller: c.seller,
+            deposit: formatUsdc6(BigInt(c.reserveMax)),
+            settled: formatUsdc6(onchainSettled ?? BigInt(c.cumulativeSigned)),
+            deadline: c.deadline,
+            closeRequestedAt,
+            status: onchainStatus,
+          };
         }
-        return {
-          channelId: c.channelId,
-          seller: c.seller,
-          deposit: formatUsdc6(BigInt(c.reserveMax)),
-          settled: formatUsdc6(onchainSettled ?? BigInt(c.cumulativeSigned)),
-          deadline: c.deadline,
-          closeRequestedAt,
-          status: onchainStatus,
-        };
-      }));
+      }
+      const workers = Array.from(
+        { length: Math.min(ON_CHAIN_READ_CONCURRENCY, rawChannels.length) },
+        () => worker(),
+      );
+      await Promise.all(workers);
       // Active = on-chain status Active (1). Everything else is history
       // (Settled=2, TimedOut=3, None=0 means the channel no longer exists
       // on-chain — e.g., withdrawn and cleared).

--- a/apps/payments/src/routes.ts
+++ b/apps/payments/src/routes.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import type { CryptoContext, PaymentCryptoConfig } from './crypto-context.js';
-import { DepositsClient, formatUsdc, parseUsdc, signSetOperator, makeDepositsDomain, type ChainConfig } from '@antseed/node';
+import { ChannelsClient, DepositsClient, formatUsdc, parseUsdc, signSetOperator, makeDepositsDomain, type ChainConfig } from '@antseed/node';
 
 interface RouteContext {
   cryptoCtx: CryptoContext | null;
@@ -27,6 +27,17 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
   function getClient(): DepositsClient | null {
     if (!depositsClient) depositsClient = createClient(ctx.cryptoConfig);
     return depositsClient;
+  }
+
+  let channelsClient: ChannelsClient | null = null;
+  function getChannelsClient(): ChannelsClient | null {
+    if (!channelsClient) {
+      channelsClient = new ChannelsClient({
+        rpcUrl: ctx.cryptoConfig.rpcUrl,
+        contractAddress: ctx.cryptoConfig.channelsContractAddress,
+      });
+    }
+    return channelsClient;
   }
 
   fastify.get('/api/balance', async (_request, reply) => {
@@ -119,14 +130,32 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
           status: string;
         }>;
       };
-      const channels = (body.channels ?? []).map((c) => ({
-        channelId: c.channelId,
-        seller: c.seller,
-        deposit: formatUsdc6(BigInt(c.reserveMax)),
-        settled: formatUsdc6(BigInt(c.cumulativeSigned)),
-        deadline: c.deadline,
-        closeRequestedAt: 0,
-        status: 1, // buyer proxy already filters to active
+      // Enrich with on-chain state (closeRequestedAt + status) via point-reads
+      // against channels(bytes32). Point-reads work on public RPCs where
+      // eth_getLogs is rate-limited, which is why the list itself comes from
+      // the buyer proxy's local store.
+      const cc = getChannelsClient();
+      const channels = await Promise.all((body.channels ?? []).map(async (c) => {
+        let closeRequestedAt = 0;
+        let status = 1;
+        if (cc) {
+          try {
+            const onchain = await cc.getSession(c.channelId);
+            closeRequestedAt = Number(onchain.closeRequestedAt);
+            status = onchain.status;
+          } catch (err) {
+            fastify.log.warn(`[/api/channels] on-chain read failed for ${c.channelId.slice(0, 10)}: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        }
+        return {
+          channelId: c.channelId,
+          seller: c.seller,
+          deposit: formatUsdc6(BigInt(c.reserveMax)),
+          settled: formatUsdc6(BigInt(c.cumulativeSigned)),
+          deadline: c.deadline,
+          closeRequestedAt,
+          status,
+        };
       }));
       return { channels };
     } catch (err) {

--- a/apps/payments/web/src/api.ts
+++ b/apps/payments/web/src/api.ts
@@ -58,7 +58,7 @@ export interface OperatorData {
   nonce: number;
 }
 
-export async function getChannels(): Promise<{ channels: ChannelData[] }> {
+export async function getChannels(): Promise<{ channels: ChannelData[]; history: ChannelData[] }> {
   return fetchJson('/api/channels');
 }
 

--- a/apps/payments/web/src/components/ChannelsView.tsx
+++ b/apps/payments/web/src/components/ChannelsView.tsx
@@ -145,8 +145,50 @@ function SessionCard({ session, config, onRefresh }: { session: ChannelData; con
   );
 }
 
+function HistoryCard({ session }: { session: ChannelData }) {
+  const label = session.status === 2 ? 'Settled' : session.status === 3 ? 'Timed out' : 'Closed';
+  return (
+    <div style={{
+      background: 'var(--card-bg)',
+      border: '1px solid var(--card-border)',
+      borderRadius: 12,
+      padding: 12,
+      marginBottom: 8,
+      opacity: 0.75,
+    }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+        <span style={{ fontSize: 12, color: 'var(--text-secondary)', fontWeight: 500 }}>
+          Seller: {truncateAddress(session.seller)}
+        </span>
+        <span style={{
+          display: 'inline-block',
+          padding: '2px 8px',
+          borderRadius: 12,
+          fontSize: 11,
+          fontWeight: 600,
+          background: 'rgba(148, 163, 184, 0.12)',
+          color: 'var(--text-muted)',
+        }}>
+          {label}
+        </span>
+      </div>
+      <div style={{ display: 'flex', gap: 24 }}>
+        <div>
+          <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Reserved</div>
+          <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>${session.deposit}</div>
+        </div>
+        <div>
+          <div style={{ fontSize: 10, fontWeight: 600, color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>Used</div>
+          <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--text-primary)' }}>${session.settled}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ChannelsView({ config }: ChannelsViewProps) {
   const [channels, setChannels] = useState<ChannelData[]>([]);
+  const [history, setHistory] = useState<ChannelData[]>([]);
   const [loading, setLoading] = useState(true);
   const [operatorSet, setOperatorSet] = useState<boolean | null>(null);
 
@@ -154,10 +196,11 @@ export function ChannelsView({ config }: ChannelsViewProps) {
     setLoading(true);
     try {
       const [channelsResult, operatorResult] = await Promise.all([
-        getChannels().catch(() => ({ channels: [] })),
+        getChannels().catch(() => ({ channels: [], history: [] })),
         getOperatorInfo().catch(() => null),
       ]);
       setChannels(channelsResult.channels);
+      setHistory(channelsResult.history ?? []);
       if (operatorResult) {
         setOperatorSet(operatorResult.operator !== '0x0000000000000000000000000000000000000000');
       }
@@ -199,6 +242,15 @@ export function ChannelsView({ config }: ChannelsViewProps) {
         config && channels.map((session) => (
           <SessionCard key={session.channelId} session={session} config={config} onRefresh={fetchData} />
         ))
+      )}
+
+      {history.length > 0 && (
+        <div style={{ marginTop: 24 }}>
+          <div className="card-section-title" style={{ marginBottom: 12 }}>History</div>
+          {history.map((session) => (
+            <HistoryCard key={session.channelId} session={session} />
+          ))}
+        </div>
       )}
     </div>
   );

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -585,6 +585,38 @@ export class AntseedNode extends EventEmitter {
     });
   }
 
+  /** All buyer channels (any local status), used for history views. */
+  getAllBuyerChannels(): Array<{
+    channelId: string;
+    peerId: string;
+    seller: string;
+    buyer: string;
+    reserveMax: string;
+    cumulativeSigned: string;
+    deadline: number;
+    reservedAt: number;
+    status: string;
+    requestCount: number;
+    tokensDelivered: string;
+  }> {
+    const buyerAddress = this._identity?.wallet.address ?? null;
+    if (!buyerAddress || !this._channelStore) return [];
+    const stored = this._channelStore.getAllChannelsByBuyer('buyer', buyerAddress);
+    return stored.map((c) => ({
+      channelId: c.sessionId,
+      peerId: c.peerId,
+      seller: c.sellerEvmAddr,
+      buyer: c.buyerEvmAddr,
+      reserveMax: c.authMax,
+      cumulativeSigned: c.authMax,
+      deadline: c.deadline,
+      reservedAt: c.reservedAt,
+      status: c.status,
+      requestCount: c.requestCount,
+      tokensDelivered: c.tokensDelivered,
+    }));
+  }
+
   async sendRequest(
     peer: PeerInfo,
     req: SerializedHttpRequest,

--- a/packages/node/src/payments/channel-store.ts
+++ b/packages/node/src/payments/channel-store.ts
@@ -283,6 +283,16 @@ export class ChannelStore {
     return rows.map(rowToChannel);
   }
 
+  /** All channels for a given buyer (any status), ordered by most recent first. */
+  getAllChannelsByBuyer(role: string, buyerEvmAddr: string): StoredChannel[] {
+    const rows = this._db
+      .prepare(
+        'SELECT * FROM payment_channels WHERE role = ? AND buyer_evm_addr = ? ORDER BY created_at DESC',
+      )
+      .all(role, buyerEvmAddr) as ChannelRow[];
+    return rows.map(rowToChannel);
+  }
+
   /** Aggregate totals across all channels for a given peer and role. */
   getTotalsByPeer(peerId: string, role: string): {
     totalSessions: number;


### PR DESCRIPTION
## Summary
- `/api/channels` was hardcoding `closeRequestedAt=0` and `status=1` because the buyer's local `payment_channels` table doesn't track either field. After clicking **Request Close** the UI never flipped to the closing badge / countdown timer.
- Enrich each channel with an on-chain point-read via `ChannelsClient.getSession` (`channels(bytes32)`). Point-reads work on public RPCs where `eth_getLogs` is rate-limited — which is why the list itself still comes from the buyer proxy's local store.

## Test plan
- [ ] Open the payments portal, reserve a channel against a seller
- [ ] Click **Request Close** → UI flips to the "Closing…" badge and shows a live countdown
- [ ] After 15 min grace, button switches to **Withdraw**
- [ ] Verify no regressions on the active channel listing