### PR TITLE
chore: trim web-only deps from @antseed/payments runtime

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.80",
+  "version": "0.1.81",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [

--- a/apps/payments/package.json
+++ b/apps/payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/payments",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Buyer payments portal for AntSeed",
   "files": [
     "dist"
@@ -24,24 +24,24 @@
     "@antseed/node": "workspace:*",
     "@fastify/cors": "^10.0.0",
     "@fastify/static": "^9.0.0",
+    "fastify": "^5.7.4"
+  },
+  "devDependencies": {
     "@metamask/sdk": "^0.34.0",
     "@rainbow-me/rainbowkit": "^2.2.10",
     "@tanstack/react-query": "^5.94.5",
-    "ethers": "^6.13.0",
-    "fastify": "^5.7.4",
-    "viem": "^2.47.6",
-    "wagmi": "^2.14.0"
-  },
-  "devDependencies": {
     "@types/node": "^20.11.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.0",
     "concurrently": "^9.0.1",
+    "ethers": "^6.13.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sass": "^1.97.3",
     "typescript": "^5.6.0",
-    "vite": "^6.0.0"
+    "viem": "^2.47.6",
+    "vite": "^6.0.0",
+    "wagmi": "^2.14.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -254,6 +254,10 @@ importers:
       '@fastify/static':
         specifier: ^9.0.0
         version: 9.0.0
+      fastify:
+        specifier: ^5.7.4
+        version: 5.7.4
+    devDependencies:
       '@metamask/sdk':
         specifier: ^0.34.0
         version: 0.34.0(bufferutil@4.1.0)(encoding@0.1.13)(utf-8-validate@5.0.10)
@@ -263,19 +267,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.94.5
         version: 5.97.0(react@18.3.1)
-      ethers:
-        specifier: ^6.13.0
-        version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      fastify:
-        specifier: ^5.7.4
-        version: 5.7.4
-      viem:
-        specifier: ^2.47.6
-        version: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi:
-        specifier: ^2.14.0
-        version: 2.19.5(@tanstack/query-core@5.97.0)(@tanstack/react-query@5.97.0(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(encoding@0.1.13)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
-    devDependencies:
       '@types/node':
         specifier: ^20.11.0
         version: 20.19.33
@@ -291,6 +282,9 @@ importers:
       concurrently:
         specifier: ^9.0.1
         version: 9.2.1
+      ethers:
+        specifier: ^6.13.0
+        version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -303,9 +297,15 @@ importers:
       typescript:
         specifier: ^5.6.0
         version: 5.9.3
+      viem:
+        specifier: ^2.47.6
+        version: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@20.19.33)(jiti@1.21.7)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      wagmi:
+        specifier: ^2.14.0
+        version: 2.19.5(@tanstack/query-core@5.97.0)(@tanstack/react-query@5.97.0(react@18.3.1))(@types/react@18.3.28)(bufferutil@4.1.0)(encoding@0.1.13)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76)
 
   apps/website:
     dependencies:


### PR DESCRIPTION
## Summary
- \`@antseed/payments\` listed wagmi, @rainbow-me/rainbowkit, @metamask/sdk, viem, @tanstack/react-query, react, react-dom, ethers as **runtime** \`dependencies\`, but they are only consumed by the vite-built web bundle (\`dist/web/\`). The fastify server in \`dist/*.js\` only needs fastify + @antseed/node.
- Moved them to \`devDependencies\`. A global \`npm i -g @antseed/cli\` no longer drags the entire wallet-connect / wagmi / metamask tree through the payments transitive dep (~200 packages removed from the workspace tree after \`pnpm install\`).
- Verified other workspace packages: \`apps/dashboard\` already uses an isolated nested \`web/package.json\`; \`apps/website\` is private. Payments was the only offender.
- Bumps: \`@antseed/payments\` 0.1.3 → 0.1.4, \`@antseed/cli\` 0.1.80 → 0.1.81.

## Test plan
- [x] \`pnpm install\` — lockfile updates cleanly, 200 packages removed
- [x] \`pnpm -F @antseed/payments run build\` — tsc + vite build both pass
- [x] \`pnpm run typecheck\` — all 19 workspace packages pass
- [ ] After publish: \`npm i -g @antseed/cli@0.1.81\` and confirm install size drops significantly