### PR TITLE
Fix mobile: hide sort controls, default sort by service

### DIFF
--- a/apps/website/src/pages/network.module.css
+++ b/apps/website/src/pages/network.module.css
@@ -514,7 +514,7 @@
   }
 
   .table thead {
-    display: none;
+    display: none !important;
   }
 
   .row {

--- a/apps/website/src/pages/network.tsx
+++ b/apps/website/src/pages/network.tsx
@@ -233,7 +233,8 @@ export default function PricingPage() {
   const [query, setQuery] = useState('');
   const [providerFilter, setProviderFilter] = useState<string | null>(null);
   const [tagFilter, setTagFilter] = useState<string | null>(null);
-  const [sortKey, setSortKey] = useState<SortKey>('inputPrice');
+  const isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
+  const [sortKey, setSortKey] = useState<SortKey>(isMobile ? 'name' : 'inputPrice');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
 
   // Fetch live network data


### PR DESCRIPTION
## Summary
- **Hide sort controls on mobile**: The table `<thead>` sort buttons (SERVICE, INPUT /M, OUTPUT /M, PEERS) were rendering as stacked block elements on mobile despite a `display: none` rule. Added `!important` to ensure they stay hidden.
- **Default sort by service name on mobile**: On mobile viewports (≤768px), the default sort is now by service name (ascending) instead of input price, so services are alphabetically ordered out of the box.

## Test plan
- [ ] Open antseed.com/network on a mobile device or narrow viewport (≤768px)
- [ ] Verify sort header buttons (SERVICE ↕, INPUT /M, etc.) are no longer visible
- [ ] Verify services are sorted alphabetically by name by default
- [ ] Verify desktop layout is unchanged (sort buttons still visible, default sort by input price)

https://claude.ai/code/session_01MfaV1oVHL5yXTq8bRXPcEY