### PR TITLE
fix(node): cache env identity to survive repeated loadOrCreateIdentity calls

### DIFF
--- a/packages/node/src/p2p/identity.ts
+++ b/packages/node/src/p2p/identity.ts
@@ -64,6 +64,9 @@ export class FileIdentityStore implements IdentityStore {
 /** Environment variable for passing identity hex from a parent process (e.g. desktop → CLI). */
 const IDENTITY_HEX_ENV = 'ANTSEED_IDENTITY_HEX';
 
+/** Cache the identity resolved from the env var so repeated calls in the same process return the same key. */
+let _envIdentityCache: Identity | undefined;
+
 export function identityFromPrivateKeyHex(hex: string): Identity {
   const privateKey = hexToBytes(hex);
   const wallet = new Wallet('0x' + hex);
@@ -78,12 +81,18 @@ export function identityFromPrivateKeyHex(hex: string): Identity {
  * The peerId is derived as the EVM address (lowercase, no 0x prefix).
  */
 export async function loadOrCreateIdentity(configDirOrStore?: string | IdentityStore): Promise<Identity> {
+  // Return cached env identity if we already resolved it in a prior call.
+  if (_envIdentityCache) {
+    return _envIdentityCache;
+  }
+
   // Check for identity injected via environment (desktop → CLI child process).
   const rawEnvHex = process.env[IDENTITY_HEX_ENV]?.trim();
   const envHex = rawEnvHex?.startsWith('0x') ? rawEnvHex.slice(2) : rawEnvHex;
   if (envHex && envHex.length === 64) {
     delete process.env[IDENTITY_HEX_ENV];
-    return identityFromPrivateKeyHex(envHex);
+    _envIdentityCache = identityFromPrivateKeyHex(envHex);
+    return _envIdentityCache;
   }
 
   const store: IdentityStore =


### PR DESCRIPTION
## Summary
- `ANTSEED_IDENTITY_HEX` was consumed and deleted on the first `loadOrCreateIdentity()` call (pre-flight readiness check), so the second call in `AntseedNode.start()` fell through to the file store — loading a different key or generating a new one
- Providers passing their private key via the env var ended up with a mismatched identity after the prerequisite checks were added in f63fde5
- Fix: cache the env-resolved identity in a module-level variable so all calls in the same process return the same key

## Test plan
- [ ] `ANTSEED_IDENTITY_HEX=<key> antseed seller start` uses the provided key (verify wallet address in startup log)
- [ ] `antseed seller start` without env var still loads from `~/.antseed/identity.key` as before
- [ ] Desktop app (which injects identity via env var) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)