### PR TITLE
fix(node): seller idle settle reliability — gas buffer, stale skip, min delta

### DIFF
--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -7,7 +7,7 @@ import { getGlobalOptions } from '../types.js'
 import { loadConfig } from '../../../config/loader.js'
 import { AntseedNode, type Provider, resolveChainConfig, loadOrCreateIdentity } from '@antseed/node'
 import type { PaymentConfig } from '@antseed/node/payments'
-import { checkSellerReadiness } from '@antseed/node/payments'
+import { checkSellerReadiness, DEFAULT_MIN_SETTLE_DELTA_STR } from '@antseed/node/payments'
 import {
   createIdentityClient,
   createStakingClient,
@@ -288,6 +288,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
     .option('--output-usd-per-million <number>', 'runtime-only output pricing override in USD per 1M tokens', parseFloat)
     .option('--dht-port <number>', 'UDP port for DHT (default: 6881)', parseInt)
     .option('--signaling-port <number>', 'TCP port for P2P signaling (default: 6882)', parseInt)
+    .option('--min-settle-delta <usdc>', 'minimum unsettled delta (USDC decimal, e.g. 0.002) before idle settle submits a tx')
     .option('--skip-prereq-check', 'skip pre-flight checks (services configured, on-chain registration + stake). Use only for local testing.')
     .action(async (options) => {
       const globalOpts = getGlobalOptions(sellerCmd)
@@ -458,6 +459,12 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
       }
       const minBudgetPerRequest = config.payments.minBudgetPerRequest ?? '10000'
       console.log(chalk.dim(`  min budget per request: ${minBudgetPerRequest} base units`))
+      // CLI flag (decimal USDC) overrides config JSON (base-unit string).
+      const minSettleDeltaFlag = options.minSettleDelta as string | undefined
+      const minSettleDelta = minSettleDeltaFlag !== undefined
+        ? toUSDCBaseUnits(minSettleDeltaFlag, DEFAULT_MIN_SETTLE_DELTA_STR)
+        : (config.payments.minSettleDelta ?? DEFAULT_MIN_SETTLE_DELTA_STR)
+      console.log(chalk.dim(`  min settle delta: ${minSettleDelta} base units`))
       console.log(chalk.dim(`  reserve floor: ${effectiveSellerConfig.reserveFloor}`))
       console.log(chalk.dim(`  max concurrent buyers: ${effectiveSellerConfig.maxConcurrentBuyers}`))
       console.log('')
@@ -484,6 +491,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
           sellerWalletAddress,
           paymentConfig,
           minBudgetPerRequest: config.payments.minBudgetPerRequest ?? '10000',
+          minSettleDelta,
           // Top-level fields required by the node for contract clients + EIP-712 domain
           ...(paymentConfig?.crypto ? {
             rpcUrl: paymentConfig.crypto.rpcUrl,

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -98,6 +98,13 @@ export interface PaymentsCLIConfig {
   platformFeeRate: number;
   /** Minimum USDC per request in base units (seller). Default: "10000" ($0.01). */
   minBudgetPerRequest?: string;
+  /**
+   * Minimum unsettled delta (base units) required before the seller's idle
+   * settle loop submits a tx. Skips dust settles whose gas cost exceeds the
+   * amount. Only applied in idle settle — close() still settles the full
+   * amount. Default: "2000" (~$0.002).
+   */
+  minSettleDelta?: string;
   /** Maximum USDC the buyer authorizes per single request in base units. Default: "100000" ($0.10). */
   maxPerRequestUsdc?: string;
   /** Maximum total USDC the buyer will reserve in a single SpendingAuth in base units. Default: "1000000" ($1.00). */

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -118,6 +118,8 @@ export interface NodePaymentsConfig {
   defaultAuthDurationSecs?: number;
   /** Minimum USDC per request (base units) for seller. Default: "10000" ($0.01). */
   minBudgetPerRequest?: string;
+  /** Minimum unsettled delta (base units) required before idle settle submits a tx. Default: "2000" (~$0.002). */
+  minSettleDelta?: string;
   /** Maximum USDC the buyer authorizes per single request (base units). Default: "500000" ($0.50). */
   maxPerRequestUsdc?: string;
   /** Maximum total USDC the buyer will reserve in a single SpendingAuth (base units). Default: "10000000" ($10.00). */
@@ -1078,6 +1080,7 @@ export class AntseedNode extends EventEmitter {
         chainId: payments.chainId ?? 8453,
         dataDir: paymentsDir,
         ...(payments.minBudgetPerRequest ? { minBudgetPerRequest: payments.minBudgetPerRequest } : {}),
+        ...(payments.minSettleDelta ? { minSettleDelta: payments.minSettleDelta } : {}),
       };
       this._sellerPaymentManager = new SellerPaymentManager(this._identity, sellerConfig, this._channelStore);
       debugLog(`[Node] SellerPaymentManager initialized`);

--- a/packages/node/src/payments/evm/base-evm-client.ts
+++ b/packages/node/src/payments/evm/base-evm-client.ts
@@ -1,4 +1,4 @@
-import { Contract, JsonRpcProvider, type AbstractSigner, type InterfaceAbi } from 'ethers';
+import { Contract, JsonRpcProvider, type AbstractSigner, type InterfaceAbi, type TransactionRequest, type TransactionResponse } from 'ethers';
 
 export const ERC20_ABI = [
   'function approve(address spender, uint256 amount) external returns (bool)',
@@ -40,22 +40,9 @@ export abstract class BaseEvmClient {
   ): Promise<string> {
     const connected = this._ensureConnected(signer);
     const signerAddress = await connected.getAddress();
-    const nonce = await this._reserveNonce(signerAddress);
     const contract = new Contract(this._contractAddress, abi, connected);
-    let tx;
-    try {
-      const fn = contract.getFunction(method);
-      const populated = await fn.populateTransaction(...args);
-      populated.nonce = nonce;
-      const estimated = await connected.estimateGas(populated);
-      populated.gasLimit = (estimated * GAS_BUFFER_NUMERATOR) / GAS_BUFFER_DENOMINATOR;
-      tx = await connected.sendTransaction(populated);
-    } catch (err) {
-      // Tx was never sent (e.g. estimateGas reverted) — roll back the nonce cursor
-      // so subsequent txs don't skip a nonce and hang forever.
-      this._nonceCursor.delete(signerAddress);
-      throw err;
-    }
+    const populated = await contract.getFunction(method).populateTransaction(...args);
+    const tx = await this._sendBuffered(connected, signerAddress, populated);
     const receipt = await tx.wait();
     if (!receipt) throw new Error('Transaction was dropped or replaced');
     return receipt.hash;
@@ -75,11 +62,35 @@ export abstract class BaseEvmClient {
     const connected = this._ensureConnected(signer);
     const signerAddress = await connected.getAddress();
     const usdc = new Contract(usdcAddress, ERC20_ABI, connected);
-    const approveNonce = await this._reserveNonce(signerAddress);
-    const approveTx = await usdc.getFunction('approve')(this._contractAddress, amount, { nonce: approveNonce });
+    const approvePopulated = await usdc.getFunction('approve').populateTransaction(this._contractAddress, amount);
+    const approveTx = await this._sendBuffered(connected, signerAddress, approvePopulated);
     const approveReceipt = await approveTx.wait();
     if (!approveReceipt) throw new Error('Approve transaction was dropped or replaced');
     return this._execWrite(signer, abi, method, ...args);
+  }
+
+  /**
+   * Reserve a nonce, apply the gas buffer, and broadcast. On any failure —
+   * estimateGas revert, RPC timeout, submission error — roll back the nonce
+   * cursor. `_reserveNonce` reads `getTransactionCount(..., 'pending')` on
+   * the next call, so an in-flight tx (if sendTransaction failed after the
+   * node accepted it) is still accounted for and we won't reuse its nonce.
+   */
+  private async _sendBuffered(
+    connected: AbstractSigner,
+    signerAddress: string,
+    populated: TransactionRequest,
+  ): Promise<TransactionResponse> {
+    const nonce = await this._reserveNonce(signerAddress);
+    populated.nonce = nonce;
+    try {
+      const estimated = await connected.estimateGas(populated);
+      populated.gasLimit = (estimated * GAS_BUFFER_NUMERATOR) / GAS_BUFFER_DENOMINATOR;
+      return await connected.sendTransaction(populated);
+    } catch (err) {
+      this._nonceCursor.delete(signerAddress);
+      throw err;
+    }
   }
 
   protected async _reserveNonce(address: string): Promise<number> {

--- a/packages/node/src/payments/evm/base-evm-client.ts
+++ b/packages/node/src/payments/evm/base-evm-client.ts
@@ -6,6 +6,13 @@ export const ERC20_ABI = [
   'function allowance(address owner, address spender) external view returns (uint256)',
 ] as const;
 
+/** Gas limit buffer multiplier over `eth_estimateGas` (30%). Protects against
+ *  non-deterministic gas in contract branches (cold vs. warm SSTOREs, try/catch
+ *  fallback paths, variable-length metadata hashing) — without a buffer, a tx
+ *  whose actual gas is even a hair above the estimate reverts with OOG. */
+const GAS_BUFFER_NUMERATOR = 130n;
+const GAS_BUFFER_DENOMINATOR = 100n;
+
 export abstract class BaseEvmClient {
   protected readonly _provider: JsonRpcProvider;
   protected readonly _contractAddress: string;
@@ -25,9 +32,6 @@ export abstract class BaseEvmClient {
     return signer.connect(this._provider);
   }
 
-  /**
-   * Execute a write transaction: connect signer, reserve nonce, send, wait for receipt.
-   */
   protected async _execWrite(
     signer: AbstractSigner,
     abi: InterfaceAbi,
@@ -40,7 +44,12 @@ export abstract class BaseEvmClient {
     const contract = new Contract(this._contractAddress, abi, connected);
     let tx;
     try {
-      tx = await contract.getFunction(method)(...args, { nonce });
+      const fn = contract.getFunction(method);
+      const populated = await fn.populateTransaction(...args);
+      populated.nonce = nonce;
+      const estimated = await connected.estimateGas(populated);
+      populated.gasLimit = (estimated * GAS_BUFFER_NUMERATOR) / GAS_BUFFER_DENOMINATOR;
+      tx = await connected.sendTransaction(populated);
     } catch (err) {
       // Tx was never sent (e.g. estimateGas reverted) — roll back the nonce cursor
       // so subsequent txs don't skip a nonce and hang forever.

--- a/packages/node/src/payments/index.ts
+++ b/packages/node/src/payments/index.ts
@@ -75,7 +75,7 @@ export { BuyerPaymentNegotiator } from './buyer-payment-negotiator.js';
 export type { BuyerNegotiatorConfig, Handle402Result, NegotiationEmitter } from './buyer-payment-negotiator.js';
 
 // Seller payment manager
-export { SellerPaymentManager } from './seller-payment-manager.js';
+export { SellerPaymentManager, DEFAULT_MIN_SETTLE_DELTA_STR } from './seller-payment-manager.js';
 export type { SellerPaymentConfig } from './seller-payment-manager.js';
 
 // Pricing utilities

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -722,6 +722,9 @@ export class SellerPaymentManager {
         return;
       }
       if (delta < this._minSettleDelta) {
+        // Mark this cumulative as a no-op so the next tick short-circuits
+        // without re-querying getSession until amount actually advances.
+        this._lastSettledCumulative.set(channelId, amount);
         debugLog(`[SellerPayment] Skip settle ${channelId.slice(0, 18)}... — delta=${delta} below minSettleDelta=${this._minSettleDelta}`);
         return;
       }

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -27,10 +27,21 @@ export interface SellerPaymentConfig {
   minBudgetPerRequest?: string;
   /** Whether to immediately settle when buyer disconnects. Default: true. */
   settleOnDisconnect?: boolean;
+  /**
+   * Minimum unsettled delta (base units) required before idle settle will
+   * submit a tx. Skips tiny settles whose gas cost exceeds the amount being
+   * claimed. Only applied in `settleOnly` mode — final close() always settles
+   * the full amount so no dust is left behind. Default: "2000" (~$0.002).
+   */
+  minSettleDelta?: string;
 }
 
 /** Default minimum budget per request: $0.50 USDC (base units). */
 const DEFAULT_MIN_BUDGET_PER_REQUEST = '500000';
+
+/** ~200× typical Base settle gas cost at 0.006 gwei. */
+export const DEFAULT_MIN_SETTLE_DELTA_STR = '2000';
+const DEFAULT_MIN_SETTLE_DELTA = BigInt(DEFAULT_MIN_SETTLE_DELTA_STR);
 
 /** Stored auth entry for buyer's SpendingAuth signature. */
 interface LatestAuth {
@@ -72,6 +83,13 @@ export class SellerPaymentManager {
   /** channelId -> number of failed close() attempts. In-memory only; resets on node restart. */
   private readonly _closeRetryCount = new Map<string, number>();
 
+  /** channelId -> cumulative amount last successfully settled on-chain by this
+   *  process. Lets the idle-settle loop skip the `getSession` RPC when the
+   *  local accepted cumulative hasn't moved since our last settle. */
+  private readonly _lastSettledCumulative = new Map<string, bigint>();
+
+  private readonly _minSettleDelta: bigint;
+
   /** Max close() retries before giving up (buyer must requestClose on-chain) */
   private static readonly MAX_CLOSE_RETRIES = 3;
 
@@ -84,6 +102,9 @@ export class SellerPaymentManager {
       contractAddress: config.channelsContractAddress,
     });
     this._channelStore = channelStore;
+    this._minSettleDelta = config.minSettleDelta !== undefined
+      ? BigInt(config.minSettleDelta)
+      : DEFAULT_MIN_SETTLE_DELTA;
 
     // Hydrate from persisted channels
     const activeChannels = this._channelStore.getActiveChannels('seller');
@@ -172,6 +193,7 @@ export class SellerPaymentManager {
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
     this._reserveMax.delete(channelId);
+    this._lastSettledCumulative.delete(channelId);
     this._activeBuyers.delete(peerId);
     debugLog(`[SellerPayment] Evicted stale channel ${channelId.slice(0, 18)}... — ${reason}`);
   }
@@ -671,10 +693,43 @@ export class SellerPaymentManager {
       if (settleOnly) return;
       debugLog(`[SellerPayment] Zero-cumulative channel ${channelId.slice(0, 18)}... — deferring to timeout checker`);
     } else if (settleOnly) {
-      if (amount === 0n) return; // No SpendingAuth to settle
-      debugLog(`[SellerPayment] Settling channel ${channelId.slice(0, 18)}... cumulative=${amount} (keeping open)`);
+      if (amount === 0n) return;
+
+      // Skip the getSession RPC entirely when our local cumulative hasn't
+      // moved since we last settled this channel — the contract would revert
+      // with InvalidAmount (strict `>` check) and we'd waste an RPC round-trip.
+      const lastSettled = this._lastSettledCumulative.get(channelId);
+      if (lastSettled !== undefined && amount <= lastSettled) {
+        debugLog(`[SellerPayment] Skip settle ${channelId.slice(0, 18)}... — cumulative unchanged since last settle (${amount})`);
+        return;
+      }
+
+      // Cache miss (e.g. after restart) or local cumulative has advanced —
+      // confirm against on-chain state in case another process settled.
+      let onChainSettled: bigint;
+      try {
+        const onChain = await this._channelsClient.getSession(channelId);
+        onChainSettled = onChain.settled;
+      } catch (err) {
+        debugWarn(`[SellerPayment] getSession failed for ${channelId.slice(0, 18)}...: ${err instanceof Error ? err.message : err} — attempting settle anyway`);
+        onChainSettled = 0n;
+      }
+      const delta = amount - onChainSettled;
+      if (delta <= 0n) {
+        // Resync the cache so we stop hitting the RPC on every idle tick.
+        this._lastSettledCumulative.set(channelId, onChainSettled);
+        debugLog(`[SellerPayment] Skip settle ${channelId.slice(0, 18)}... — already settled on-chain (local=${amount}, onChain=${onChainSettled})`);
+        return;
+      }
+      if (delta < this._minSettleDelta) {
+        debugLog(`[SellerPayment] Skip settle ${channelId.slice(0, 18)}... — delta=${delta} below minSettleDelta=${this._minSettleDelta}`);
+        return;
+      }
+
+      debugLog(`[SellerPayment] Settling channel ${channelId.slice(0, 18)}... cumulative=${amount} delta=${delta} (keeping open)`);
       try {
         await this._channelsClient.settle(this._signer, channelId, amount, metadata, sig);
+        this._lastSettledCumulative.set(channelId, amount);
         debugLog(`[SellerPayment] Settled channel ${channelId.slice(0, 18)}... — channel remains open`);
       } catch (err) {
         debugWarn(`[SellerPayment] Failed to settle channel: ${err instanceof Error ? err.message : err}`);
@@ -703,6 +758,7 @@ export class SellerPaymentManager {
     this._spent.delete(channelId);
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
+    this._lastSettledCumulative.delete(channelId);
     this._activeBuyers.delete(buyerPeerId);
   }
 
@@ -867,6 +923,7 @@ export class SellerPaymentManager {
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
     this._reserveMax.delete(channelId);
+    this._lastSettledCumulative.delete(channelId);
 
     // Find and remove buyer from active set
     const channel = this._channelStore.getChannel(channelId);

--- a/packages/node/tests/base-evm-client.test.ts
+++ b/packages/node/tests/base-evm-client.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { AbstractSigner, InterfaceAbi, TransactionRequest, TransactionResponse } from 'ethers';
+import { BaseEvmClient } from '../src/payments/evm/base-evm-client.js';
+
+class TestEvmClient extends BaseEvmClient {
+  constructor() {
+    super('http://127.0.0.1:1', '0x' + 'aa'.repeat(20));
+  }
+  async exec(signer: AbstractSigner, abi: InterfaceAbi, method: string, ...args: unknown[]): Promise<string> {
+    return this._execWrite(signer, abi, method, ...args);
+  }
+  get nonceCursor(): Map<string, number> {
+    return this._nonceCursor;
+  }
+}
+
+const ABI = [
+  'function transfer(address to, uint256 amount) external returns (bool)',
+] as const;
+
+describe('BaseEvmClient._execWrite', () => {
+  it('applies a 30% buffer over estimateGas before sending the tx', async () => {
+    const client = new TestEvmClient();
+
+    // Stub the nonce read so we never touch the network.
+    vi.spyOn(client.provider, 'getTransactionCount').mockResolvedValue(42);
+
+    const captured: TransactionRequest[] = [];
+    const fakeSigner = {
+      provider: client.provider,
+      getAddress: async () => '0x' + 'bb'.repeat(20),
+      connect() { return fakeSigner; },
+      estimateGas: async (_tx: TransactionRequest) => 100_000n,
+      sendTransaction: async (tx: TransactionRequest): Promise<TransactionResponse> => {
+        captured.push(tx);
+        return {
+          hash: '0xdeadbeef',
+          wait: async () => ({ hash: '0xdeadbeef' }),
+        } as unknown as TransactionResponse;
+      },
+    } as unknown as AbstractSigner;
+
+    const hash = await client.exec(
+      fakeSigner,
+      ABI as unknown as InterfaceAbi,
+      'transfer',
+      '0x' + '01'.repeat(20),
+      100n,
+    );
+
+    expect(hash).toBe('0xdeadbeef');
+    expect(captured.length).toBe(1);
+    const sent = captured[0]!;
+    // 100,000 * 130 / 100 = 130,000
+    expect(sent.gasLimit).toBe(130_000n);
+    expect(sent.nonce).toBe(42);
+    expect(typeof sent.data).toBe('string');
+    expect(sent.to?.toString().toLowerCase()).toBe('0x' + 'aa'.repeat(20));
+  });
+
+  it('rolls back the nonce cursor when estimateGas reverts', async () => {
+    const client = new TestEvmClient();
+    vi.spyOn(client.provider, 'getTransactionCount').mockResolvedValue(7);
+
+    const fakeSigner = {
+      provider: client.provider,
+      getAddress: async () => '0x' + 'cc'.repeat(20),
+      connect() { return fakeSigner; },
+      estimateGas: async () => { throw new Error('execution reverted: not allowed'); },
+      sendTransaction: async () => { throw new Error('should not be reached'); },
+    } as unknown as AbstractSigner;
+
+    await expect(
+      client.exec(fakeSigner, ABI as unknown as InterfaceAbi, 'transfer', '0x' + '02'.repeat(20), 1n),
+    ).rejects.toThrow(/execution reverted/);
+
+    // Cursor was wiped so the next attempt re-reads pending nonce.
+    expect(client.nonceCursor.has('0x' + 'cc'.repeat(20))).toBe(false);
+  });
+});

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -673,15 +673,20 @@ describe('SellerPaymentManager', () => {
       vi.spyOn(mgr.channelsClient, 'reserve').mockResolvedValue('0xreserve-hash');
 
       await seedAcceptedAuth(mgr, channelId, 104_000n);
-      vi.spyOn(mgr.channelsClient, 'getSession').mockResolvedValue(
+      const getSessionSpy = vi.spyOn(mgr.channelsClient, 'getSession').mockResolvedValue(
         // delta = 104000 - 100000 = 4000 < 5000 → skip
         makeOnChainChannel(buyerIdentity, sellerIdentity, { settled: 100_000n }),
       );
       const settleSpy = vi.spyOn(mgr.channelsClient, 'settle').mockResolvedValue('0xsettle-hash');
 
       await mgr.settleSession(buyerIdentity.peerId, { settleOnly: true });
+      // Second tick with no new requests: cache must short-circuit so we
+      // don't burn an RPC every idle interval until the delta crosses the
+      // threshold. Regression guard for the dust-skip caching gap.
+      await mgr.settleSession(buyerIdentity.peerId, { settleOnly: true });
 
       expect(settleSpy).not.toHaveBeenCalled();
+      expect(getSessionSpy).toHaveBeenCalledOnce();
       expect(mgr.hasSession(buyerIdentity.peerId)).toBe(true);
     });
 

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -107,6 +107,21 @@ function makeChannelId(n: number): string {
   return '0x' + n.toString(16).padStart(2, '0').repeat(32);
 }
 
+function makeOnChainChannel(buyer: Identity, seller: Identity, overrides: Record<string, unknown> = {}) {
+  return {
+    buyer: buyer.wallet.address,
+    seller: seller.wallet.address,
+    deposit: 2_000_000n,
+    settled: 500_000n,
+    metadataHash: ZERO_METADATA_HASH,
+    deadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
+    settledAt: 0n,
+    closeRequestedAt: 0n,
+    status: 1,
+    ...overrides,
+  };
+}
+
 describe('SellerPaymentManager', () => {
   let tempDir: string;
   let store: ChannelStore;
@@ -435,21 +450,6 @@ describe('SellerPaymentManager', () => {
       return channel;
     }
 
-    function makeOnChainChannel(buyer: Identity, seller: Identity, overrides: Record<string, unknown> = {}) {
-      return {
-        buyer: buyer.wallet.address,
-        seller: seller.wallet.address,
-        deposit: 2_000_000n,
-        settled: 500_000n,
-        metadataHash: ZERO_METADATA_HASH,
-        deadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
-        settledAt: 0n,
-        closeRequestedAt: 0n,
-        status: 1,
-        ...overrides,
-      };
-    }
-
     const ZERO_CHANNEL = {
       buyer: '0x0000000000000000000000000000000000000000',
       seller: '0x0000000000000000000000000000000000000000',
@@ -628,6 +628,112 @@ describe('SellerPaymentManager', () => {
       await mgr.validateHydratedChannels();
 
       expect(mgr.hasSession(buyerIdentity.peerId)).toBe(true);
+    });
+  });
+
+  describe('settleSession idle-settle skip logic', () => {
+    async function seedAcceptedAuth(
+      mgr: SellerPaymentManager,
+      channelId: string,
+      cumulativeAmount: bigint,
+    ): Promise<void> {
+      const reserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { isReserve: true });
+      await mgr.handleSpendingAuth(buyerIdentity.peerId, reserve, mux);
+      const spend = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { cumulativeAmount });
+      await mgr.handleSpendingAuth(buyerIdentity.peerId, spend, mux);
+    }
+
+    it('skips idle settle when localAmount equals on-chain settled (stale re-settle)', async () => {
+      const channelId = makeChannelId(50);
+      await seedAcceptedAuth(manager, channelId, 100_000n);
+
+      vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(
+        makeOnChainChannel(buyerIdentity, sellerIdentity, { settled: 100_000n }),
+      );
+      const settleSpy = vi.spyOn(manager.channelsClient, 'settle').mockResolvedValue('0xsettle-hash');
+
+      await manager.settleSession(buyerIdentity.peerId, { settleOnly: true });
+
+      expect(manager.channelsClient.getSession).toHaveBeenCalledWith(channelId);
+      expect(settleSpy).not.toHaveBeenCalled();
+      // Channel stays alive so the buyer can resume
+      expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
+    });
+
+    it('skips idle settle when delta is below minSettleDelta', async () => {
+      const channelId = makeChannelId(51);
+      const customConfig: SellerPaymentConfig = {
+        rpcUrl: 'http://127.0.0.1:8545',
+        channelsContractAddress: CONTRACT_ADDR,
+        chainId: CHAIN_ID,
+        dataDir: tempDir,
+        minSettleDelta: '5000',
+      };
+      const mgr = new SellerPaymentManager(sellerIdentity, customConfig, store);
+      vi.spyOn(mgr.channelsClient, 'reserve').mockResolvedValue('0xreserve-hash');
+
+      await seedAcceptedAuth(mgr, channelId, 104_000n);
+      vi.spyOn(mgr.channelsClient, 'getSession').mockResolvedValue(
+        // delta = 104000 - 100000 = 4000 < 5000 → skip
+        makeOnChainChannel(buyerIdentity, sellerIdentity, { settled: 100_000n }),
+      );
+      const settleSpy = vi.spyOn(mgr.channelsClient, 'settle').mockResolvedValue('0xsettle-hash');
+
+      await mgr.settleSession(buyerIdentity.peerId, { settleOnly: true });
+
+      expect(settleSpy).not.toHaveBeenCalled();
+      expect(mgr.hasSession(buyerIdentity.peerId)).toBe(true);
+    });
+
+    it('proceeds with idle settle when delta is at or above minSettleDelta', async () => {
+      const channelId = makeChannelId(52);
+      const customConfig: SellerPaymentConfig = {
+        rpcUrl: 'http://127.0.0.1:8545',
+        channelsContractAddress: CONTRACT_ADDR,
+        chainId: CHAIN_ID,
+        dataDir: tempDir,
+        minSettleDelta: '5000',
+      };
+      const mgr = new SellerPaymentManager(sellerIdentity, customConfig, store);
+      vi.spyOn(mgr.channelsClient, 'reserve').mockResolvedValue('0xreserve-hash');
+
+      await seedAcceptedAuth(mgr, channelId, 105_000n);
+      vi.spyOn(mgr.channelsClient, 'getSession').mockResolvedValue(
+        // delta = 105000 - 100000 = 5000 == min → settle proceeds
+        makeOnChainChannel(buyerIdentity, sellerIdentity, { settled: 100_000n }),
+      );
+      const settleSpy = vi.spyOn(mgr.channelsClient, 'settle').mockResolvedValue('0xsettle-hash');
+
+      await mgr.settleSession(buyerIdentity.peerId, { settleOnly: true });
+
+      expect(settleSpy).toHaveBeenCalledOnce();
+      const [, calledChannelId, calledAmount] = settleSpy.mock.calls[0]!;
+      expect(calledChannelId).toBe(channelId);
+      expect(calledAmount).toBe(105_000n);
+    });
+
+    it('close path ignores minSettleDelta and still settles tiny deltas', async () => {
+      const channelId = makeChannelId(53);
+      const customConfig: SellerPaymentConfig = {
+        rpcUrl: 'http://127.0.0.1:8545',
+        channelsContractAddress: CONTRACT_ADDR,
+        chainId: CHAIN_ID,
+        dataDir: tempDir,
+        minSettleDelta: '1000000', // absurdly high
+      };
+      const mgr = new SellerPaymentManager(sellerIdentity, customConfig, store);
+      vi.spyOn(mgr.channelsClient, 'reserve').mockResolvedValue('0xreserve-hash');
+      const closeSpy = vi.spyOn(mgr.channelsClient, 'close').mockResolvedValue('0xclose-hash');
+      const getSessionSpy = vi.spyOn(mgr.channelsClient, 'getSession');
+
+      await seedAcceptedAuth(mgr, channelId, 101_000n);
+
+      // Not settleOnly — close path
+      await mgr.settleSession(buyerIdentity.peerId, {});
+
+      expect(closeSpy).toHaveBeenCalledOnce();
+      // close path never consults on-chain state for the dust check
+      expect(getSessionSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Closes #290.

## Summary
- **Gas buffer**: `BaseEvmClient._execWrite` now explicitly populates the tx, estimates gas, and applies a 30% buffer so non-deterministic execution (cold/warm SSTOREs, try/catch fallbacks, variable-length metadata hashing) can't push the tx past `eth_estimateGas` and revert with OOG.
- **Stale re-settle**: idle `settleOnly` now consults on-chain state and skips when the local cumulative is already settled. A `_lastSettledCumulative` cache lets the steady-state idle loop short-circuit without hitting the RPC at all.
- **Dust settles**: new `SellerPaymentConfig.minSettleDelta` (default `2000` base units, ~\$0.002) gates idle settle only — `close()` still settles the full amount so no dust is left behind. Wired through `--min-settle-delta <usdc>` CLI flag and `payments.minSettleDelta` in `config.json`.

## Test plan
- [x] `pnpm --filter @antseed/node typecheck`
- [x] `pnpm --filter @antseed/cli typecheck`
- [x] `pnpm --filter @antseed/node test -- --run tests/seller-payment-manager.test.ts tests/base-evm-client.test.ts` (29/29 pass, including 4 new idle-settle skip-logic tests + 2 new gas-buffer/nonce-rollback tests)
- [ ] Manual: run a local seller against anvil and confirm idle settle no longer reverts on the second tick after a successful settle.