### PR TITLE
feat(buyer-proxy): Hydrate peer cache from state file on startup

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import type { PeerInfo } from '@antseed/node'
-import { selectCandidatePeersForRouting, rewriteServiceInBody } from './buyer-proxy.js'
+import { parsePersistedPeers, selectCandidatePeersForRouting, rewriteServiceInBody } from './buyer-proxy.js'
 
 function makePeer(seed: string, providers: string[]): PeerInfo {
   const repeated = (seed.repeat(40) + 'a'.repeat(40)).slice(0, 40)
@@ -89,6 +89,133 @@ test('selectCandidatePeersForRouting can still include peers without service pro
 
   assert.equal(result.candidatePeers.length, 1)
   assert.equal(result.candidatePeers[0]?.peerId, peerWithoutMetadata.peerId)
+})
+
+// parsePersistedPeers — hydrates _cachedPeers from buyer.state.json at startup
+// so the first request after launch can route from the warm cache without
+// blocking on DHT discovery.
+
+const validPeerId = 'a'.repeat(40)
+const MAX_AGE_MS = 30 * 60_000
+const NOW = 1_700_000_000_000
+
+test('parsePersistedPeers returns [] for null/undefined/junk input', () => {
+  assert.deepEqual(parsePersistedPeers(null, NOW), [])
+  assert.deepEqual(parsePersistedPeers(undefined, NOW), [])
+  assert.deepEqual(parsePersistedPeers(42, NOW), [])
+  assert.deepEqual(parsePersistedPeers('nope', NOW), [])
+})
+
+test('parsePersistedPeers returns [] when discoveredPeers is missing or not an array', () => {
+  assert.deepEqual(parsePersistedPeers({}, NOW), [])
+  assert.deepEqual(parsePersistedPeers({ discoveredPeers: 'oops' }, NOW), [])
+  assert.deepEqual(parsePersistedPeers({ discoveredPeers: null }, NOW), [])
+})
+
+test('parsePersistedPeers drops entries with invalid peerIds and normalizes case', () => {
+  const result = parsePersistedPeers(
+    {
+      discoveredPeers: [
+        { peerId: 'too-short', providers: [], lastSeen: NOW },
+        { peerId: 123, providers: [], lastSeen: NOW },
+        { peerId: validPeerId.toUpperCase(), providers: ['openai'], lastSeen: NOW },
+      ],
+    },
+    NOW,
+  )
+  assert.equal(result.length, 1)
+  assert.equal(result[0]?.peerId, validPeerId)
+})
+
+test('parsePersistedPeers drops entries with non-array providers', () => {
+  const result = parsePersistedPeers(
+    {
+      discoveredPeers: [
+        { peerId: validPeerId, providers: 'openai', lastSeen: NOW },
+      ],
+    },
+    NOW,
+  )
+  assert.equal(result.length, 0)
+})
+
+test('parsePersistedPeers drops entries with stale or missing lastSeen', () => {
+  const result = parsePersistedPeers(
+    {
+      discoveredPeers: [
+        { peerId: validPeerId, providers: ['openai'], lastSeen: NOW - MAX_AGE_MS },
+        { peerId: 'b'.repeat(40), providers: ['openai'] },
+        { peerId: 'c'.repeat(40), providers: ['openai'], lastSeen: 'nope' },
+      ],
+    },
+    NOW,
+  )
+  assert.equal(result.length, 0)
+})
+
+test('parsePersistedPeers preserves provider metadata so routing filters still work', () => {
+  const persisted = {
+    discoveredPeers: [
+      {
+        peerId: validPeerId,
+        displayName: 'Alice',
+        publicAddress: '1.2.3.4:1234',
+        providers: ['claude-oauth'],
+        services: ['claude-opus-4-6'],
+        providerPricing: null,
+        providerServiceCategories: null,
+        providerServiceApiProtocols: {
+          'claude-oauth': {
+            services: {
+              'claude-opus-4-6': ['anthropic-messages'],
+            },
+          },
+        },
+        defaultInputUsdPerMillion: 3,
+        defaultOutputUsdPerMillion: 15,
+        maxConcurrency: 4,
+        lastSeen: NOW - 5_000,
+      },
+    ],
+  }
+  const [peer] = parsePersistedPeers(persisted, NOW)
+  assert.ok(peer, 'expected a peer')
+  assert.equal(peer!.peerId, validPeerId)
+  assert.equal(peer!.displayName, 'Alice')
+  assert.equal(peer!.publicAddress, '1.2.3.4:1234')
+  assert.deepEqual(peer!.providers, ['claude-oauth'])
+  assert.equal(peer!.defaultInputUsdPerMillion, 3)
+  assert.equal(peer!.defaultOutputUsdPerMillion, 15)
+  assert.equal(peer!.maxConcurrency, 4)
+  assert.equal(peer!.lastSeen, NOW - 5_000)
+
+  // The hydrated peer should still satisfy the routing filter for its service.
+  const result = selectCandidatePeersForRouting(
+    [peer!],
+    'anthropic-messages',
+    'claude-opus-4-6',
+    null,
+  )
+  assert.equal(result.candidatePeers.length, 1)
+  assert.equal(result.candidatePeers[0]?.peerId, validPeerId)
+  assert.equal(result.routePlanByPeerId.get(validPeerId)?.provider, 'claude-oauth')
+})
+
+test('parsePersistedPeers filters non-string entries out of providers', () => {
+  const result = parsePersistedPeers(
+    {
+      discoveredPeers: [
+        {
+          peerId: validPeerId,
+          providers: ['openai', 42, null, 'claude-oauth'],
+          lastSeen: NOW,
+        },
+      ],
+    },
+    NOW,
+  )
+  assert.equal(result.length, 1)
+  assert.deepEqual(result[0]?.providers, ['openai', 'claude-oauth'])
 })
 
 // rewriteServiceInBody tests

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -66,7 +66,8 @@ export interface BuyerProxyConfig {
   /**
    * Max age for the in-memory peer cache before it is treated as stale (ms).
    * Stale caches can still be used for routing while background refresh repopulates.
-   * Default: 30000 (30s).
+   * Default: 360000 (6 min) — chosen to exceed `backgroundRefreshIntervalMs`
+   * (5 min) so a healthy proxy never naturally reaches the "stale" threshold.
    */
   peerCacheTtlMs?: number
   /**
@@ -197,6 +198,63 @@ const PROTOCOL_TRANSFORMS: Record<string, ProtocolTransformStrategy> = {
 }
 
 /**
+ * Parses a buyer.state.json blob into PeerInfo[], dropping entries with
+ * missing/invalid peerIds, non-array providers, or lastSeen timestamps older
+ * than the carry-forward window. Exported for unit testing.
+ */
+export function parsePersistedPeers(
+  parsed: unknown,
+  nowMs: number = Date.now(),
+  maxAgeMs: number = CARRY_FORWARD_TTL_MS,
+): PeerInfo[] {
+  if (!parsed || typeof parsed !== 'object') return []
+  const discovered = (parsed as { discoveredPeers?: unknown }).discoveredPeers
+  if (!Array.isArray(discovered)) return []
+
+  const peers: PeerInfo[] = []
+  for (const raw of discovered) {
+    if (!raw || typeof raw !== 'object') continue
+    const entry = raw as Record<string, unknown>
+    const peerId = typeof entry.peerId === 'string' ? entry.peerId.toLowerCase() : ''
+    if (!/^[0-9a-f]{40}$/.test(peerId)) continue
+    if (!Array.isArray(entry.providers)) continue
+    const providers = entry.providers.filter((p): p is string => typeof p === 'string')
+    const lastSeen = typeof entry.lastSeen === 'number' && Number.isFinite(entry.lastSeen)
+      ? entry.lastSeen
+      : 0
+    if (lastSeen <= 0 || nowMs - lastSeen >= maxAgeMs) continue
+
+    const peer: PeerInfo = {
+      peerId: peerId as PeerInfo['peerId'],
+      lastSeen,
+      providers,
+    }
+    if (typeof entry.displayName === 'string') peer.displayName = entry.displayName
+    if (typeof entry.publicAddress === 'string') peer.publicAddress = entry.publicAddress
+    if (entry.providerPricing && typeof entry.providerPricing === 'object') {
+      peer.providerPricing = entry.providerPricing as PeerInfo['providerPricing']
+    }
+    if (entry.providerServiceCategories && typeof entry.providerServiceCategories === 'object') {
+      peer.providerServiceCategories = entry.providerServiceCategories as PeerInfo['providerServiceCategories']
+    }
+    if (entry.providerServiceApiProtocols && typeof entry.providerServiceApiProtocols === 'object') {
+      peer.providerServiceApiProtocols = entry.providerServiceApiProtocols as PeerInfo['providerServiceApiProtocols']
+    }
+    if (typeof entry.defaultInputUsdPerMillion === 'number') {
+      peer.defaultInputUsdPerMillion = entry.defaultInputUsdPerMillion
+    }
+    if (typeof entry.defaultOutputUsdPerMillion === 'number') {
+      peer.defaultOutputUsdPerMillion = entry.defaultOutputUsdPerMillion
+    }
+    if (typeof entry.maxConcurrency === 'number') {
+      peer.maxConcurrency = entry.maxConcurrency
+    }
+    peers.push(peer)
+  }
+  return peers
+}
+
+/**
  * Local HTTP proxy that forwards requests to P2P sellers.
  *
  * Tools like Claude CLI set ANTHROPIC_BASE_URL=http://localhost:8377
@@ -229,7 +287,7 @@ export class BuyerProxy {
     this._node = config.node
     this._port = config.port
     this._bgRefreshIntervalMs = config.backgroundRefreshIntervalMs ?? 5 * 60_000
-    this._peerCacheTtlMs = Math.max(0, config.peerCacheTtlMs ?? 30_000)
+    this._peerCacheTtlMs = Math.max(0, config.peerCacheTtlMs ?? 6 * 60_000)
     this._pinnedPeer = config.pinnedPeerId?.toLowerCase() ?? null
     this._pinnedService = config.pinnedService?.trim() ?? null
     this._server = createServer((req, res) => {
@@ -244,6 +302,11 @@ export class BuyerProxy {
   }
 
   async start(): Promise<void> {
+    // Hydrate the in-memory peer cache from the persisted state file BEFORE
+    // the server starts accepting requests. This lets the first request after
+    // startup route from the warm cache without blocking on DHT discovery.
+    // The background refresh still runs to pick up fresh peers and IP changes.
+    await this._hydratePeersFromStateFile()
     await new Promise<void>((resolve, reject) => {
       this._server.once('error', reject)
       this._server.listen(this._port, '127.0.0.1', () => {
@@ -257,6 +320,29 @@ export class BuyerProxy {
     void this._refreshPeersNow().catch(() => {})
     await this._writeStateFile('connected')
     this._watchStateFile()
+  }
+
+  private async _hydratePeersFromStateFile(): Promise<void> {
+    try {
+      const raw = await readFile(BUYER_STATE_FILE, 'utf-8')
+      const parsed = JSON.parse(raw) as unknown
+      const peers = parsePersistedPeers(parsed)
+      if (peers.length === 0) {
+        return
+      }
+      this._cachedPeers = peers
+      // Preserve the original discovery timestamp so cacheAgeMs reflects how
+      // long ago the persisted data was actually written, not startup time.
+      const peersUpdatedAt = (parsed as { peersUpdatedAt?: unknown }).peersUpdatedAt
+      this._cacheLastUpdatedAtMs = typeof peersUpdatedAt === 'number' && Number.isFinite(peersUpdatedAt)
+        ? peersUpdatedAt
+        : Date.now()
+      this._cacheMutationEpoch += 1
+      log(`Hydrated ${peers.length} peer(s) from ${BUYER_STATE_FILE}`)
+    } catch {
+      // File missing, unreadable, or malformed — non-fatal. The background
+      // refresh will populate the cache shortly.
+    }
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
## Summary

Hydrates the buyer proxy's in-memory peer cache from `~/.antseed/buyer.state.json` at startup so the first request after a restart routes from the warm cache instead of blocking on a cold DHT lookup. Also bumps `peerCacheTtlMs` default from 30s → 6 min so it exceeds the 5 min background refresh interval.

## Why

`BuyerProxy.start()` previously left `_cachedPeers` empty until the first background DHT refresh returned, so any request landing in that window blocked inside `_getPeers()` → `discoverPeers()` (typically 1–3 s before the first token). Peers are already persisted to disk via `_persistPeersToState()`, so reading them back on startup eliminates that cold-start wait for both pinned and non-pinned routing.

The TTL bump prevents a healthy proxy from naturally reaching the "stale" threshold that triggers an extra forced DHT refresh on the pinned-peer fallback path. With a 5 min background refresh, the cache age now never exceeds TTL under normal operation.

## Changes

- `parsePersistedPeers(parsed, nowMs?, maxAgeMs?)` — pure, exported, defensively validates the persisted shape, normalizes peerId case, drops entries whose `lastSeen` is outside the 30 min carry-forward window, and preserves `providerServiceApiProtocols` so routing filters still match on hydrated peers.
- `_hydratePeersFromStateFile()` — called from `start()` before `server.listen`. Populates `_cachedPeers` and sets `_cacheLastUpdatedAtMs` from the file's `peersUpdatedAt` so TTL reflects real age, not startup time. Silent on missing/malformed files.
- `peerCacheTtlMs` default: 30s → 6 min.
- 7 new unit tests for `parsePersistedPeers`.

## Test plan

- [x] `pnpm --filter @antseed/cli typecheck`
- [x] `pnpm --filter @antseed/cli test` — 7 new tests pass; 4 pre-existing ChannelStore failures on `main` unchanged
- [ ] Manual: `antseed buyer stop && antseed buyer start`, then issue a pinned and a non-pinned request within the first second; confirm both route from cache without the cold-start DHT wait