### PR TITLE
feat(network-stats): indexer sync status + on-chain seen-at timestamps

### DIFF
--- a/apps/network-stats/src/index.ts
+++ b/apps/network-stats/src/index.ts
@@ -12,12 +12,17 @@ const PORT = parseInt(process.env['PORT'] ?? '4000', 10);
 const CACHE_PATH = process.env['CACHE_PATH'];
 const CHAIN_ID = process.env['NETWORK_STATS_CHAIN_ID'] ?? 'base-mainnet';
 const DB_PATH = process.env['NETWORK_STATS_DB_PATH'] ?? 'data/network-stats.sqlite';
-const TICK_INTERVAL_MS = 60_000;
+const RPC_URL_OVERRIDE = process.env['NETWORK_STATS_RPC_URL'];
+const TICK_INTERVAL_MS = parseInt(process.env['NETWORK_STATS_TICK_INTERVAL_MS'] ?? '60000', 10);
+const MAX_BLOCKS_PER_TICK = parseInt(process.env['NETWORK_STATS_MAX_BLOCKS_PER_TICK'] ?? '2000', 10);
 const REORG_SAFETY_BLOCKS = 12;
 
 const poller = new NetworkPoller(CACHE_PATH);
 
-const chainConfig = resolveChainConfig({ chainId: CHAIN_ID });
+const chainConfig = resolveChainConfig({
+  chainId: CHAIN_ID,
+  ...(RPC_URL_OVERRIDE ? { rpcUrl: RPC_URL_OVERRIDE } : {}),
+});
 let store: SqliteStore | null = null;
 let indexer: MetadataIndexer | null = null;
 let stakingClient: StakingClient | null = null;
@@ -38,6 +43,8 @@ if (chainConfig.statsContractAddress && typeof chainConfig.statsDeployBlock === 
     deployBlock: chainConfig.statsDeployBlock,
     tickIntervalMs: TICK_INTERVAL_MS,
     reorgSafetyBlocks: REORG_SAFETY_BLOCKS,
+    maxBlocksPerTick: MAX_BLOCKS_PER_TICK,
+    rpcUrl: chainConfig.rpcUrl,
   });
   if (chainConfig.stakingContractAddress) {
     stakingClient = new StakingClient({
@@ -58,6 +65,10 @@ const server = createServer({
   poller,
   ...(store ? { store } : {}),
   ...(stakingClient ? { stakingClient } : {}),
+  ...(indexer ? { indexer } : {}),
+  ...(store && chainConfig.statsContractAddress
+    ? { chainId: CHAIN_ID, contractAddress: chainConfig.statsContractAddress }
+    : {}),
   port: PORT,
 });
 

--- a/apps/network-stats/src/indexer.ts
+++ b/apps/network-stats/src/indexer.ts
@@ -1,3 +1,4 @@
+import { ethers } from 'ethers';
 import type { StatsClient } from '@antseed/node';
 import type { SqliteStore } from './store.js';
 
@@ -10,6 +11,10 @@ export interface MetadataIndexerOptions {
   tickIntervalMs: number;       // e.g. 60_000
   reorgSafetyBlocks: number;    // e.g. 12
   maxBlocksPerTick?: number;    // optional cap to bound eth_getLogs range (default 2_000)
+  // When set, the indexer fetches block headers for event blocks and threads
+  // their timestamps into applyBatch, so first_seen_at reflects on-chain wall
+  // clock. Omitted in unit tests that mock the stats client.
+  rpcUrl?: string;
 }
 
 function logError(err: unknown): void {
@@ -25,8 +30,10 @@ export class MetadataIndexer {
   private readonly _tickIntervalMs: number;
   private readonly _reorgSafetyBlocks: number;
   private readonly _maxBlocksPerTick: number;
+  private readonly _provider: ethers.JsonRpcProvider | undefined;
   private _timer: ReturnType<typeof setInterval> | undefined;
   private _running = false;
+  private _latestBlock: number | null = null;
 
   constructor(options: MetadataIndexerOptions) {
     if (options.deployBlock < 0) {
@@ -46,6 +53,8 @@ export class MetadataIndexer {
 
     const provided = options.maxBlocksPerTick;
     this._maxBlocksPerTick = (provided !== undefined && provided > 0) ? provided : 2_000;
+
+    this._provider = options.rpcUrl ? new ethers.JsonRpcProvider(options.rpcUrl) : undefined;
   }
 
   start(): void {
@@ -57,6 +66,15 @@ export class MetadataIndexer {
 
   stop(): void {
     clearInterval(this._timer);
+  }
+
+  /**
+   * Returns the chain head observed on the most recent tick plus the
+   * indexer's reorg safety buffer. Null latestBlock means no tick has run
+   * yet (process just started and the first eth_blockNumber is still in flight).
+   */
+  getChainHead(): { latestBlock: number | null; reorgSafetyBlocks: number } {
+    return { latestBlock: this._latestBlock, reorgSafetyBlocks: this._reorgSafetyBlocks };
   }
 
   /**
@@ -72,6 +90,7 @@ export class MetadataIndexer {
     this._running = true;
     try {
       const latest = await this._statsClient.getBlockNumber();
+      this._latestBlock = latest;
       const safeTo = latest - this._reorgSafetyBlocks;
 
       if (safeTo < this._deployBlock) {
@@ -89,7 +108,42 @@ export class MetadataIndexer {
 
       const events = await this._statsClient.getMetadataRecordedEvents({ fromBlock, toBlock });
 
-      this._store.applyBatch(this._chainId, this._contractAddress, events, toBlock);
+      // Fetch block timestamps for each distinct block that carried an event,
+      // so applyBatch can stamp first_seen_at with on-chain wall clock. Only
+      // distinct blocks matter — a block with N events costs one getBlock call.
+      let blockTimestamps: Map<number, number> | undefined;
+      if (this._provider && events.length > 0) {
+        const uniqueBlocks = Array.from(new Set(events.map((e) => e.blockNumber)));
+        const blocks = await Promise.all(uniqueBlocks.map((b) => this._provider!.getBlock(b)));
+        blockTimestamps = new Map();
+        for (let i = 0; i < uniqueBlocks.length; i++) {
+          const block = blocks[i];
+          if (block) blockTimestamps.set(uniqueBlocks[i]!, block.timestamp);
+        }
+      }
+
+      // Always capture the checkpoint block's wall-clock so /stats can show
+      // how fresh the indexer is. Reuse the timestamp from the event-block
+      // fetch above if toBlock happened to carry an event, otherwise one
+      // extra getBlock call.
+      let newCheckpointTimestamp: number | null = null;
+      if (this._provider) {
+        if (blockTimestamps?.has(toBlock)) {
+          newCheckpointTimestamp = blockTimestamps.get(toBlock)!;
+        } else {
+          const block = await this._provider.getBlock(toBlock);
+          newCheckpointTimestamp = block?.timestamp ?? null;
+        }
+      }
+
+      this._store.applyBatch(
+        this._chainId,
+        this._contractAddress,
+        events,
+        toBlock,
+        blockTimestamps,
+        newCheckpointTimestamp,
+      );
 
       console.log(`[indexer] ${fromBlock}..${toBlock} events=${events.length}`);
     } catch (err) {

--- a/apps/network-stats/src/server.ts
+++ b/apps/network-stats/src/server.ts
@@ -9,11 +9,15 @@ import express from 'express';
 import type { NetworkPoller } from './poller.js';
 import type { StakingClient } from '@antseed/node';
 import type { SqliteStore } from './store.js';
+import type { MetadataIndexer } from './indexer.js';
 
 export interface CreateServerDeps {
   poller: NetworkPoller;
   store?: SqliteStore;            // undefined when indexer disabled for this chain
   stakingClient?: StakingClient;  // undefined when indexer disabled
+  indexer?: MetadataIndexer;      // source of chain head + reorg buffer for sync status
+  chainId?: string;               // used to look up the indexer checkpoint
+  contractAddress?: string;       // contract whose checkpoint to expose
   port?: number;
 }
 
@@ -57,7 +61,7 @@ export function __resetAgentIdCacheForTests(): void {
 }
 
 export function createServer(deps: CreateServerDeps): { start(): Promise<void>; stop(): void } {
-  const { poller, store, stakingClient, port = 4000 } = deps;
+  const { poller, store, stakingClient, indexer, chainId, contractAddress, port = 4000 } = deps;
   const app = express();
 
   app.use((_req, res, next) => {
@@ -100,6 +104,8 @@ export function createServer(deps: CreateServerDeps): { start(): Promise<void>; 
             uniqueChannels: totals.uniqueChannels,
             firstSettledBlock: totals.firstSettledBlock,
             lastSettledBlock: totals.lastSettledBlock,
+            firstSeenAt: totals.firstSeenAt,
+            lastSeenAt: totals.lastSeenAt,
             avgRequestsPerChannel: totals.avgRequestsPerChannel,
             avgRequestsPerBuyer: totals.avgRequestsPerBuyer,
             lastUpdatedAt: totals.lastUpdatedAt,
@@ -108,7 +114,32 @@ export function createServer(deps: CreateServerDeps): { start(): Promise<void>; 
       }),
     );
 
-    res.json({ ...snapshot, peers: enrichedPeers });
+    const indexerInfo =
+      chainId && contractAddress
+        ? store.getCheckpointInfo(chainId, contractAddress.toLowerCase())
+        : null;
+
+    // Chain head comes from the indexer's in-memory cache, refreshed on every
+    // tick. `synced` is true when the checkpoint has caught up to (latest − reorg
+    // buffer), i.e. there's nothing else the indexer could have processed.
+    const chainHead = indexer?.getChainHead();
+    const indexerPayload = indexerInfo
+      ? {
+          ...indexerInfo,
+          ...(chainHead?.latestBlock != null
+            ? {
+                latestBlock: chainHead.latestBlock,
+                synced: indexerInfo.lastBlock >= chainHead.latestBlock - chainHead.reorgSafetyBlocks,
+              }
+            : {}),
+        }
+      : null;
+
+    res.json({
+      ...snapshot,
+      peers: enrichedPeers,
+      ...(indexerPayload ? { indexer: indexerPayload } : {}),
+    });
   });
 
   app.get('/health', (_req, res) => {

--- a/apps/network-stats/src/store.ts
+++ b/apps/network-stats/src/store.ts
@@ -8,6 +8,8 @@ export interface SellerTotals {
   settlementCount: number;
   firstSettledBlock: number;
   lastSettledBlock: number;
+  firstSeenAt: number | null;
+  lastSeenAt: number | null;
   uniqueBuyers: number;
   uniqueChannels: number;
   avgRequestsPerChannel: number;
@@ -21,6 +23,8 @@ interface SellerRow {
   total_request_count: string;
   settlement_count: number;
   first_settled_block: number | null;
+  first_seen_at: number | null;
+  last_seen_at: number | null;
 }
 
 interface BuyerOrChannelRow {
@@ -38,6 +42,8 @@ interface SellerTotalsRow {
   settlement_count: number;
   first_settled_block: number | null;
   last_settled_block: number | null;
+  first_seen_at: number | null;
+  last_seen_at: number | null;
   last_updated_at: number;
 }
 
@@ -47,10 +53,10 @@ export class SqliteStore {
   // Prepared statements — compiled once in init(), reused on every applyBatch /
   // read call. Re-preparing on every invocation is measurable overhead when
   // catch-up indexing fires applyBatch many times in quick succession.
-  private _selectCheckpoint!: Database.Statement<[string, string], { last_block: number }>;
-  private _upsertCheckpoint!: Database.Statement<[string, string, number]>;
+  private _selectCheckpoint!: Database.Statement<[string, string], { last_block: number; last_block_timestamp: number | null }>;
+  private _upsertCheckpoint!: Database.Statement<[string, string, number, number | null]>;
   private _selectSeller!: Database.Statement<[number], SellerRow>;
-  private _upsertSeller!: Database.Statement<[number, string, string, string, number, number, number, number]>;
+  private _upsertSeller!: Database.Statement<[number, string, string, string, number, number, number, number | null, number | null, number]>;
   private _selectBuyer!: Database.Statement<[number, string], BuyerOrChannelRow>;
   private _upsertBuyer!: Database.Statement<[number, string, string, string, string, number, number, number]>;
   private _selectChannel!: Database.Statement<[number, string], BuyerOrChannelRow & { buyer: string }>;
@@ -74,6 +80,8 @@ export class SqliteStore {
         settlement_count INTEGER NOT NULL DEFAULT 0,
         first_settled_block INTEGER,
         last_settled_block INTEGER,
+        first_seen_at INTEGER,
+        last_seen_at INTEGER,
         last_updated_at INTEGER NOT NULL
       );
 
@@ -106,29 +114,33 @@ export class SqliteStore {
         chain_id TEXT NOT NULL,
         contract_address TEXT NOT NULL,
         last_block INTEGER NOT NULL,
+        last_block_timestamp INTEGER,
         PRIMARY KEY (chain_id, contract_address)
       );
     `);
 
     this._selectCheckpoint = this.db.prepare(
-      'SELECT last_block FROM indexer_checkpoint WHERE chain_id = ? AND contract_address = ?',
+      'SELECT last_block, last_block_timestamp FROM indexer_checkpoint WHERE chain_id = ? AND contract_address = ?',
     );
 
     this._upsertCheckpoint = this.db.prepare(
-      `INSERT INTO indexer_checkpoint (chain_id, contract_address, last_block)
-       VALUES (?, ?, ?)
-       ON CONFLICT(chain_id, contract_address) DO UPDATE SET last_block = excluded.last_block`,
+      `INSERT INTO indexer_checkpoint (chain_id, contract_address, last_block, last_block_timestamp)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(chain_id, contract_address) DO UPDATE SET
+         last_block = excluded.last_block,
+         last_block_timestamp = excluded.last_block_timestamp`,
     );
 
     this._selectSeller = this.db.prepare(
-      'SELECT total_input_tokens, total_output_tokens, total_request_count, settlement_count, first_settled_block FROM seller_metadata_totals WHERE agent_id = ?',
+      'SELECT total_input_tokens, total_output_tokens, total_request_count, settlement_count, first_settled_block, first_seen_at, last_seen_at FROM seller_metadata_totals WHERE agent_id = ?',
     );
 
     this._upsertSeller = this.db.prepare(
       `INSERT OR REPLACE INTO seller_metadata_totals
          (agent_id, total_input_tokens, total_output_tokens, total_request_count,
-          settlement_count, first_settled_block, last_settled_block, last_updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          settlement_count, first_settled_block, last_settled_block,
+          first_seen_at, last_seen_at, last_updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
 
     this._selectBuyer = this.db.prepare(
@@ -154,7 +166,7 @@ export class SqliteStore {
     );
 
     this._selectSellerTotals = this.db.prepare(
-      'SELECT total_request_count, total_input_tokens, total_output_tokens, settlement_count, first_settled_block, last_settled_block, last_updated_at FROM seller_metadata_totals WHERE agent_id = ?',
+      'SELECT total_request_count, total_input_tokens, total_output_tokens, settlement_count, first_settled_block, last_settled_block, first_seen_at, last_seen_at, last_updated_at FROM seller_metadata_totals WHERE agent_id = ?',
     );
 
     this._countBuyers = this.db.prepare(
@@ -189,6 +201,8 @@ export class SqliteStore {
     contractAddress: string,
     events: DecodedMetadataRecorded[],
     newCheckpoint: number,
+    blockTimestamps?: Map<number, number>,
+    newCheckpointTimestamp?: number | null,
   ): void {
     this.db.transaction(() => {
       for (const event of events) {
@@ -211,6 +225,13 @@ export class SqliteStore {
         const prevSellerCount = existingSeller ? BigInt(existingSeller.total_request_count) : 0n;
         const prevSellerSettlements = existingSeller?.settlement_count ?? 0;
         const prevSellerFirstBlock = existingSeller?.first_settled_block ?? null;
+        const prevSellerFirstSeen = existingSeller?.first_seen_at ?? null;
+        const prevSellerLastSeen = existingSeller?.last_seen_at ?? null;
+        const eventTimestamp = blockTimestamps?.get(event.blockNumber) ?? null;
+        const firstSeenAt = prevSellerFirstSeen ?? eventTimestamp;
+        // Events arrive sorted ascending by (blockNumber, logIndex), so the
+        // current event's block is always >= the stored last_seen_at.
+        const lastSeenAt = eventTimestamp ?? prevSellerLastSeen;
 
         this._upsertSeller.run(
           agentId,
@@ -220,6 +241,8 @@ export class SqliteStore {
           prevSellerSettlements + 1,
           prevSellerFirstBlock ?? event.blockNumber,
           event.blockNumber,
+          firstSeenAt,
+          lastSeenAt,
           now,
         );
 
@@ -263,8 +286,23 @@ export class SqliteStore {
         );
       }
 
-      this._upsertCheckpoint.run(chainId, contractAddress.toLowerCase(), newCheckpoint);
+      this._upsertCheckpoint.run(
+        chainId,
+        contractAddress.toLowerCase(),
+        newCheckpoint,
+        newCheckpointTimestamp ?? null,
+      );
     })();
+  }
+
+  /** Returns last indexed block + block timestamp, or null if no checkpoint. */
+  getCheckpointInfo(
+    chainId: string,
+    contractAddress: string,
+  ): { lastBlock: number; lastBlockTimestamp: number | null } | null {
+    const row = this._selectCheckpoint.get(chainId, contractAddress.toLowerCase());
+    if (row === undefined) return null;
+    return { lastBlock: row.last_block, lastBlockTimestamp: row.last_block_timestamp };
   }
 
   /** Returns cumulative totals for a single agentId, or null if never seen. */
@@ -288,6 +326,8 @@ export class SqliteStore {
       settlementCount: row.settlement_count,
       firstSettledBlock: row.first_settled_block ?? 0,
       lastSettledBlock: row.last_settled_block ?? 0,
+      firstSeenAt: row.first_seen_at,
+      lastSeenAt: row.last_seen_at,
       uniqueBuyers,
       uniqueChannels,
       avgRequestsPerChannel,


### PR DESCRIPTION
## Summary
- `/stats` now reports the indexer's sync position as a top-level `indexer` field: `{ lastBlock, lastBlockTimestamp, latestBlock, synced }`. `latestBlock` is the chain head observed on the most recent tick; `synced` is true when the checkpoint has caught up to `latestBlock - reorgSafetyBlocks`.
- Enriched peers' `onChainStats` now include `firstSeenAt` / `lastSeenAt`, stamped from the event block's on-chain timestamp (not indexer insertion time). The indexer fetches block timestamps for event blocks and the checkpoint block on each tick and threads them into `applyBatch`.
- New env overrides read by the GKE deployment: `NETWORK_STATS_DB_PATH`, `NETWORK_STATS_RPC_URL`, `NETWORK_STATS_TICK_INTERVAL_MS`, `NETWORK_STATS_MAX_BLOCKS_PER_TICK`. The RPC URL feeds through `resolveChainConfig` so the indexer and its timestamp-fetch provider share one endpoint.

## Schema change
`seller_metadata_totals` gains `first_seen_at` / `last_seen_at`; `indexer_checkpoint` gains `last_block_timestamp`. This app doesn't use the monorepo migration framework yet, so the PVC sqlite file must be wiped and re-indexed from `deployBlock` on deploy. Re-index from genesis takes ~2 minutes against `mainnet.base.org` at 2000 blocks/tick.

## Test plan
- [x] `pnpm --filter @antseed/network-stats run test` — 36/36 passing
- [x] `pnpm --filter @antseed/network-stats run build` — clean
- [x] Deployed as `gcr.io/sapient-spark-484208-n9/antseed-network-stats:0.2.61` to GKE (`antseed` namespace, `network-stats-pool` node pool). Verified `/stats` returns:
  ```json
  "indexer": {
    "lastBlock": 44658335,
    "lastBlockTimestamp": 1776106017,
    "latestBlock": 44658347,
    "synced": true
  }
  ```
  12-block gap equals `reorgSafetyBlocks`; `synced: true` as expected.
- [x] Verified `onChainStats` on the Seeder peer includes `firstSeenAt` / `lastSeenAt` (unix seconds from Base block timestamps).