### PR TITLE
Fix payments deposit flow to use configured chain

### DIFF
--- a/apps/payments/web/src/components/ChannelsView.tsx
+++ b/apps/payments/web/src/components/ChannelsView.tsx
@@ -4,6 +4,7 @@ import { parseAbi } from 'viem';
 import type { PaymentConfig } from '../types';
 import { getChannels, getOperatorInfo, signOperatorAuth, type ChannelData } from '../api';
 import { CHANNELS_ABI } from '../channels-abi';
+import { getErrorMessage, usePaymentNetwork } from '../payment-network';
 
 interface ChannelsViewProps {
   config: PaymentConfig | null;
@@ -59,6 +60,8 @@ const parsedAbi = parseAbi(CHANNELS_ABI);
 
 function SessionCard({ session, config, onRefresh }: { session: ChannelData; config: PaymentConfig; onRefresh: () => void }) {
   const status = getSessionStatus(session);
+  const { expectedChainId, ensureCorrectNetwork } = usePaymentNetwork(config);
+  const [error, setError] = useState<string | null>(null);
 
   const {
     writeContract: writeRequestClose,
@@ -67,6 +70,7 @@ function SessionCard({ session, config, onRefresh }: { session: ChannelData; con
 
   const { isSuccess: closeConfirmed } = useWaitForTransactionReceipt({
     hash: closeTxHash,
+    chainId: expectedChainId,
   });
 
   const {
@@ -76,25 +80,40 @@ function SessionCard({ session, config, onRefresh }: { session: ChannelData; con
 
   const { isSuccess: withdrawConfirmed } = useWaitForTransactionReceipt({
     hash: withdrawTxHash,
+    chainId: expectedChainId,
   });
 
-  const handleRequestClose = useCallback(() => {
-    writeRequestClose({
-      address: config.channelsContractAddress as `0x${string}`,
-      abi: parsedAbi,
-      functionName: 'requestClose',
-      args: [session.channelId as `0x${string}`],
-    });
-  }, [config.channelsContractAddress, session.channelId, writeRequestClose]);
+  const handleRequestClose = useCallback(async () => {
+    setError(null);
+    try {
+      await ensureCorrectNetwork();
+      writeRequestClose({
+        address: config.channelsContractAddress as `0x${string}`,
+        abi: parsedAbi,
+        functionName: 'requestClose',
+        chainId: expectedChainId,
+        args: [session.channelId as `0x${string}`],
+      });
+    } catch (err) {
+      setError(getErrorMessage(err));
+    }
+  }, [config.channelsContractAddress, ensureCorrectNetwork, expectedChainId, session.channelId, writeRequestClose]);
 
-  const handleWithdraw = useCallback(() => {
-    writeWithdraw({
-      address: config.channelsContractAddress as `0x${string}`,
-      abi: parsedAbi,
-      functionName: 'withdraw',
-      args: [session.channelId as `0x${string}`],
-    });
-  }, [config.channelsContractAddress, session.channelId, writeWithdraw]);
+  const handleWithdraw = useCallback(async () => {
+    setError(null);
+    try {
+      await ensureCorrectNetwork();
+      writeWithdraw({
+        address: config.channelsContractAddress as `0x${string}`,
+        abi: parsedAbi,
+        functionName: 'withdraw',
+        chainId: expectedChainId,
+        args: [session.channelId as `0x${string}`],
+      });
+    } catch (err) {
+      setError(getErrorMessage(err));
+    }
+  }, [config.channelsContractAddress, ensureCorrectNetwork, expectedChainId, session.channelId, writeWithdraw]);
 
   return (
     <div style={{
@@ -140,6 +159,9 @@ function SessionCard({ session, config, onRefresh }: { session: ChannelData; con
       )}
       {withdrawConfirmed && (
         <div className="status-msg status-success" style={{ fontSize: 11 }}>Withdrawn. Tx: {withdrawTxHash?.slice(0, 18)}... <button className="btn-link" onClick={onRefresh} style={{ fontSize: 11 }}>Refresh</button></div>
+      )}
+      {error && (
+        <div className="status-msg status-error" style={{ fontSize: 11 }}>{error}</div>
       )}
     </div>
   );
@@ -266,9 +288,10 @@ function SetOperatorBanner({ config, onSet }: { config: PaymentConfig | null; on
   const { address } = useAccount();
   const [setting, setSetting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { expectedChainId, ensureCorrectNetwork } = usePaymentNetwork(config);
 
   const { writeContract, data: txHash, reset } = useWriteContract();
-  const { isSuccess } = useWaitForTransactionReceipt({ hash: txHash });
+  const { isSuccess } = useWaitForTransactionReceipt({ hash: txHash, chainId: expectedChainId });
 
   useEffect(() => {
     if (isSuccess && setting) {
@@ -284,6 +307,7 @@ function SetOperatorBanner({ config, onSet }: { config: PaymentConfig | null; on
     reset();
 
     try {
+      await ensureCorrectNetwork();
       const signResult = await signOperatorAuth(address);
       if (!signResult.ok) {
         setSetting(false);
@@ -295,18 +319,19 @@ function SetOperatorBanner({ config, onSet }: { config: PaymentConfig | null; on
         address: config.depositsContractAddress as `0x${string}`,
         abi: DEPOSITS_OPERATOR_ABI,
         functionName: 'setOperator',
+        chainId: expectedChainId,
         args: [signResult.buyer as `0x${string}`, address as `0x${string}`, BigInt(signResult.nonce), signResult.signature as `0x${string}`],
       }, {
         onError: (err) => {
           setSetting(false);
-          setError(err.message.split('\n')[0] ?? err.message);
+          setError(getErrorMessage(err));
         },
       });
     } catch (err) {
       setSetting(false);
-      setError(err instanceof Error ? err.message : 'Failed to set wallet');
+      setError(getErrorMessage(err, 'Failed to set wallet'));
     }
-  }, [address, config, writeContract, reset]);
+  }, [address, config, ensureCorrectNetwork, expectedChainId, writeContract, reset]);
 
   return (
     <div className="status-msg" style={{ marginTop: 0, marginBottom: 16, fontSize: 12 }}>

--- a/apps/payments/web/src/components/DepositView.tsx
+++ b/apps/payments/web/src/components/DepositView.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
 import {
   useAccount,
+  useChainId,
   useWriteContract,
   useSimulateContract,
   useWaitForTransactionReceipt,
@@ -9,6 +10,7 @@ import {
 } from 'wagmi';
 import { parseUnits } from 'viem';
 import type { PaymentConfig } from '../types';
+import { getErrorMessage, usePaymentNetwork } from '../payment-network';
 import './DepositView.scss';
 
 interface DepositViewProps {
@@ -103,13 +105,20 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
   buyerAddress: string | null;
   onDeposited: () => void;
 }) {
-  const { address, isConnected, chain } = useAccount();
+  const { address, isConnected } = useAccount();
+  const connectedChainId = useChainId();
   const [amount, setAmount] = useState('10');
   const [step, setStep] = useState<'idle' | 'approving' | 'depositing' | 'done'>('idle');
   const [error, setError] = useState<string | null>(null);
 
-  const expectedChainId = config?.evmChainId;
-  const wrongChain = isConnected && chain && expectedChainId && chain.id !== expectedChainId;
+  const {
+    expectedChainId,
+    targetChainName,
+    walletChainId,
+    wrongChain,
+    isSwitchingChain,
+    ensureCorrectNetwork,
+  } = usePaymentNetwork(config);
   const depositTarget = buyerAddress ?? address;
 
   // Read on-chain allowance (always, when connected)
@@ -174,7 +183,7 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
     writeDeposit({ ...depositSim.request, chainId: expectedChainId }, {
       onError: (err) => {
         setStep('idle');
-        setError(err.message.split('\n')[0] ?? err.message);
+        setError(getErrorMessage(err));
       },
     });
   }, [step, depositSim, expectedChainId, writeDeposit]);
@@ -187,14 +196,18 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
     }
   }, [depositConfirmed, step, onDeposited]);
 
-  function handleDeposit() {
+  async function handleDeposit() {
     if (!address || !amount || parseFloat(amount) <= 0 || !config || !depositTarget) return;
-    if (!expectedChainId || wrongChain) {
-      setError('Please switch to the configured payments network before depositing.');
+
+    setError(null);
+
+    try {
+      await ensureCorrectNetwork();
+    } catch (err) {
+      setError(getErrorMessage(err, `Please switch your wallet to ${targetChainName}.`));
       return;
     }
 
-    setError(null);
     resetApprove();
     resetDeposit();
 
@@ -205,7 +218,7 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
       writeDeposit({ ...depositRequest, chainId: expectedChainId }, {
         onError: (err) => {
           setStep('idle');
-          setError(err.message.split('\n')[0] ?? err.message);
+          setError(getErrorMessage(err));
         },
       });
       return;
@@ -222,7 +235,7 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
     }, {
       onError: (err) => {
         setStep('idle');
-        setError(err.message.split('\n')[0] ?? err.message);
+        setError(getErrorMessage(err));
       },
     });
   }
@@ -239,13 +252,6 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
     <div className="deposit-form">
       {!isConnected ? (
         <div className="deposit-connect-wrapper">
-          <ConnectButton />
-        </div>
-      ) : wrongChain ? (
-        <div className="deposit-wrong-chain">
-          <div className="deposit-wrong-chain-text">
-            Please switch to the correct network in your wallet.
-          </div>
           <ConnectButton />
         </div>
       ) : step === 'done' ? (
@@ -280,6 +286,12 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
             <span className="deposit-connected-label">Connected</span>
           </div>
 
+          {wrongChain && (
+            <div className="status-msg" style={{ marginTop: 0, marginBottom: 16 }}>
+              Wallet is on chain {walletChainId ?? connectedChainId}. Switch to {targetChainName} before depositing.
+            </div>
+          )}
+
           <div className="input-group">
             <label className="input-label">Amount (USDC)</label>
             <input
@@ -298,9 +310,11 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
           <button
             className="btn-primary"
             onClick={handleDeposit}
-            disabled={step !== 'idle' || !amount || parseFloat(amount) <= 0 || !config}
+            disabled={step !== 'idle' || !amount || parseFloat(amount) <= 0 || !config || isSwitchingChain}
           >
-            {step === 'approving' ? 'Approving USDC...' :
+            {isSwitchingChain ? `Switching to ${targetChainName}...` :
+             wrongChain ? `Switch to ${targetChainName}` :
+             step === 'approving' ? 'Approving USDC...' :
              step === 'depositing' ? 'Depositing...' :
              'Deposit USDC'}
           </button>

--- a/apps/payments/web/src/components/DepositView.tsx
+++ b/apps/payments/web/src/components/DepositView.tsx
@@ -117,6 +117,7 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
     address: config?.usdcContractAddress as `0x${string}`,
     abi: ERC20_ABI,
     functionName: 'allowance',
+    chainId: expectedChainId,
     args: [address as `0x${string}`, config?.depositsContractAddress as `0x${string}`],
     query: { enabled: isConnected && !!config && !!address },
   });
@@ -133,6 +134,7 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
 
   const { isSuccess: approveConfirmed } = useWaitForTransactionReceipt({
     hash: approveTxHash,
+    chainId: expectedChainId,
     query: { enabled: step === 'approving' && !!approveTxHash },
   });
 
@@ -141,6 +143,7 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
     address: config?.depositsContractAddress as `0x${string}`,
     abi: DEPOSITS_ABI,
     functionName: 'deposit',
+    chainId: expectedChainId,
     args: [depositTarget as `0x${string}`, usdcAmount],
     query: { enabled: hasAllowance && !!config && !!depositTarget, retry: 3, retryDelay: 2000 },
   });
@@ -154,6 +157,7 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
 
   const { isSuccess: depositConfirmed } = useWaitForTransactionReceipt({
     hash: depositTxHash,
+    chainId: expectedChainId,
     query: { enabled: step === 'depositing' && !!depositTxHash },
   });
 
@@ -167,13 +171,13 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
   useEffect(() => {
     if (step !== 'approving' || !depositSim?.request) return;
     setStep('depositing');
-    writeDeposit(depositSim.request, {
+    writeDeposit({ ...depositSim.request, chainId: expectedChainId }, {
       onError: (err) => {
         setStep('idle');
         setError(err.message.split('\n')[0] ?? err.message);
       },
     });
-  }, [step, depositSim, writeDeposit]);
+  }, [step, depositSim, expectedChainId, writeDeposit]);
 
   // After deposit confirms → done
   useEffect(() => {
@@ -185,6 +189,10 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
 
   function handleDeposit() {
     if (!address || !amount || parseFloat(amount) <= 0 || !config || !depositTarget) return;
+    if (!expectedChainId || wrongChain) {
+      setError('Please switch to the configured payments network before depositing.');
+      return;
+    }
 
     setError(null);
     resetApprove();
@@ -194,7 +202,7 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
     if (depositSim?.request) {
       setStep('depositing');
       const { gas: _gas, ...depositRequest } = depositSim.request;
-      writeDeposit(depositRequest, {
+      writeDeposit({ ...depositRequest, chainId: expectedChainId }, {
         onError: (err) => {
           setStep('idle');
           setError(err.message.split('\n')[0] ?? err.message);
@@ -209,6 +217,7 @@ function CryptoDeposit({ config, buyerAddress, onDeposited }: {
       address: config.usdcContractAddress as `0x${string}`,
       abi: ERC20_ABI,
       functionName: 'approve',
+      chainId: expectedChainId,
       args: [config.depositsContractAddress as `0x${string}`, usdcAmount],
     }, {
       onError: (err) => {

--- a/apps/payments/web/src/payment-network.ts
+++ b/apps/payments/web/src/payment-network.ts
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { useAccount, useSwitchChain } from 'wagmi';
+import { base } from 'wagmi/chains';
+import { useChainModal } from '@rainbow-me/rainbowkit';
+import type { PaymentConfig } from './types';
+
+const PAYMENT_CHAINS = {
+  [base.id]: base,
+} as const;
+
+export function getPaymentChainName(config: PaymentConfig | null): string {
+  if (!config?.evmChainId) return 'configured payments network';
+  return PAYMENT_CHAINS[config.evmChainId as keyof typeof PAYMENT_CHAINS]?.name ?? config.chainId;
+}
+
+export function getErrorMessage(error: unknown, fallback = 'Something went wrong.'): string {
+  if (error instanceof Error) {
+    return error.message.split('\n')[0] ?? error.message;
+  }
+  return fallback;
+}
+
+export function usePaymentNetwork(config: PaymentConfig | null) {
+  const { isConnected, connector } = useAccount();
+  const { switchChainAsync, isPending: isSwitchingChain } = useSwitchChain();
+  const { openChainModal } = useChainModal();
+  const [walletChainId, setWalletChainId] = useState<number | undefined>(undefined);
+
+  const expectedChainId = config?.evmChainId;
+  const targetChainName = getPaymentChainName(config);
+  const wrongChain = Boolean(
+    isConnected &&
+    expectedChainId &&
+    walletChainId &&
+    walletChainId !== expectedChainId
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function refreshWalletChainId() {
+      if (!isConnected || !connector?.getChainId) {
+        if (!cancelled) setWalletChainId(undefined);
+        return;
+      }
+
+      try {
+        const chainId = await connector.getChainId();
+        if (!cancelled) setWalletChainId(chainId);
+      } catch {
+        if (!cancelled) setWalletChainId(undefined);
+      }
+    }
+
+    void refreshWalletChainId();
+
+    if (!connector?.emitter?.on) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const handleChange = (data?: { chainId?: string | number }) => {
+      if (typeof data?.chainId === 'number') {
+        setWalletChainId(data.chainId);
+        return;
+      }
+      if (typeof data?.chainId === 'string') {
+        setWalletChainId(Number(data.chainId));
+        return;
+      }
+      void refreshWalletChainId();
+    };
+
+    connector.emitter.on('change', handleChange);
+
+    return () => {
+      cancelled = true;
+      connector.emitter.off?.('change', handleChange);
+    };
+  }, [connector, isConnected]);
+
+  async function getCurrentWalletChainId() {
+    if (!isConnected || !connector?.getChainId) {
+      return undefined;
+    }
+
+    const chainId = await connector.getChainId();
+    setWalletChainId(chainId);
+    return chainId;
+  }
+
+  async function waitForWalletChain(targetChainId: number, timeoutMs = 10_000) {
+    const startedAt = Date.now();
+
+    while (Date.now() - startedAt < timeoutMs) {
+      const currentChainId = await getCurrentWalletChainId();
+      if (currentChainId === targetChainId) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+
+    throw new Error(`Wallet is still on chain ${walletChainId ?? 'unknown'}. Please switch to ${targetChainName} and try again.`);
+  }
+
+  async function ensureCorrectNetwork() {
+    if (!isConnected) {
+      throw new Error('Connect your wallet before continuing.');
+    }
+    if (!expectedChainId) {
+      throw new Error('Payments network is not configured.');
+    }
+    const currentChainId = await getCurrentWalletChainId();
+    if (currentChainId === expectedChainId) {
+      return;
+    }
+
+    if (typeof switchChainAsync === 'function') {
+      await switchChainAsync({ chainId: expectedChainId });
+      await waitForWalletChain(expectedChainId);
+      return;
+    }
+
+    if (typeof openChainModal === 'function') {
+      openChainModal();
+    }
+
+    throw new Error(`Please switch your wallet to ${targetChainName} and try again.`);
+  }
+
+  return {
+    expectedChainId,
+    targetChainName,
+    walletChainId,
+    wrongChain,
+    isSwitchingChain,
+    ensureCorrectNetwork,
+  };
+}


### PR DESCRIPTION
## Summary
- pin payments allowance reads, simulations, writes, and receipt polling to the configured `evmChainId`
- block deposits when the connected wallet is on the wrong network instead of falling through to the wallet's active chain
- keep the existing desktop-configured chain selection as the single source of truth

## Verification
- `npm run build` in `apps/payments`