### PR TITLE
fix(node): skip 402/reserve handshake for free-priced services

### DIFF
--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -73,39 +73,48 @@ export class SellerRequestHandler {
         const providerPricing = matchedProvider
           ? this.resolveProviderPricing(matchedProvider, request)
           : undefined;
-        const requirements = spm?.getPaymentRequirements(
-          request.requestId, buyerPeerId, providerPricing,
-        );
-        if (requirements) {
-          debugLog(`[SellerHandler] No payment session for ${buyerPeerId.slice(0, 12)}... — sending 402 + PaymentRequired`);
-          const paymentBody = JSON.stringify({
-            error: 'payment_required',
-            minBudgetPerRequest: requirements.minBudgetPerRequest,
-            suggestedAmount: requirements.suggestedAmount,
-            ...(requirements.inputUsdPerMillion != null ? { inputUsdPerMillion: requirements.inputUsdPerMillion } : {}),
-            ...(requirements.outputUsdPerMillion != null ? { outputUsdPerMillion: requirements.outputUsdPerMillion } : {}),
-            ...(requirements.cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion: requirements.cachedInputUsdPerMillion } : {}),
-          });
-          mux.sendProxyResponse({
-            requestId: request.requestId,
-            statusCode: 402,
-            headers: { "content-type": "application/json" },
-            body: new TextEncoder().encode(paymentBody),
-          });
-          paymentMux.sendPaymentRequired(requirements);
+        // Free services (both input and output priced at 0) skip the payment
+        // channel handshake entirely — no 402, no ReserveAuth, no on-chain reserve.
+        const isFree = providerPricing
+          ? providerPricing.inputUsdPerMillion === 0 && providerPricing.outputUsdPerMillion === 0
+          : false;
+        if (isFree) {
+          debugLog(`[SellerHandler] Free service for ${buyerPeerId.slice(0, 12)}... — skipping 402 / payment channel`);
         } else {
-          debugWarn(`[SellerHandler] No payment session — returning 402`);
-          mux.sendProxyResponse({
-            requestId: request.requestId,
-            statusCode: 402,
-            headers: { "content-type": "application/json" },
-            body: new TextEncoder().encode(JSON.stringify({
+          const requirements = spm?.getPaymentRequirements(
+            request.requestId, buyerPeerId, providerPricing,
+          );
+          if (requirements) {
+            debugLog(`[SellerHandler] No payment session for ${buyerPeerId.slice(0, 12)}... — sending 402 + PaymentRequired`);
+            const paymentBody = JSON.stringify({
               error: 'payment_required',
-              message: 'Seller not ready, try again later',
-            })),
-          });
+              minBudgetPerRequest: requirements.minBudgetPerRequest,
+              suggestedAmount: requirements.suggestedAmount,
+              ...(requirements.inputUsdPerMillion != null ? { inputUsdPerMillion: requirements.inputUsdPerMillion } : {}),
+              ...(requirements.outputUsdPerMillion != null ? { outputUsdPerMillion: requirements.outputUsdPerMillion } : {}),
+              ...(requirements.cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion: requirements.cachedInputUsdPerMillion } : {}),
+            });
+            mux.sendProxyResponse({
+              requestId: request.requestId,
+              statusCode: 402,
+              headers: { "content-type": "application/json" },
+              body: new TextEncoder().encode(paymentBody),
+            });
+            paymentMux.sendPaymentRequired(requirements);
+          } else {
+            debugWarn(`[SellerHandler] No payment session — returning 402`);
+            mux.sendProxyResponse({
+              requestId: request.requestId,
+              statusCode: 402,
+              headers: { "content-type": "application/json" },
+              body: new TextEncoder().encode(JSON.stringify({
+                error: 'payment_required',
+                message: 'Seller not ready, try again later',
+              })),
+            });
+          }
+          return;
         }
-        return;
       }
 
       // Check budget before routing — reject if buyer hasn't authorized enough

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -157,6 +157,77 @@ describe('SellerRequestHandler payment pricing selection', () => {
     }));
   });
 
+  it('skips the 402 / ReserveAuth handshake when the service is free', async () => {
+    const provider = makeProvider(0, 0, {
+      name: 'free-tier',
+      services: ['local-test'],
+    });
+    provider.handleRequest = vi.fn(async (req) => ({
+      requestId: req.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ ok: true })),
+    }));
+
+    const sendPaymentRequired = vi.fn();
+    const sendNeedAuth = vi.fn();
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      // No active session — this is the "first request" condition that
+      // previously triggered 402 → ReserveAuth → on-chain reserve().
+      sellerPaymentManager: {
+        hasSession: () => false,
+        getChannelByPeer: () => undefined,
+        getPaymentRequirements: () => ({ minBudgetPerRequest: '0', suggestedAmount: '0' }),
+      } as any,
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = {
+      send(frame: Uint8Array) {
+        sentFrames.push(frame);
+      },
+    } as any;
+    const paymentMux = {
+      sendNeedAuth,
+      sendPaymentRequired,
+    } as any;
+
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    const request: SerializedHttpRequest = {
+      requestId: 'req-free-service',
+      method: 'POST',
+      path: '/v1/chat/completions',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })),
+    };
+
+    await mux.handleFrame({
+      type: MessageType.HttpRequest,
+      messageId: 1,
+      payload: encodeHttpRequest(request),
+    });
+
+    // Provider handled the request — not blocked by payment handshake.
+    expect(provider.handleRequest).toHaveBeenCalledOnce();
+    // No 402, no PaymentRequired, no NeedAuth — free services bypass the
+    // channel handshake entirely so the seller never calls reserve().
+    expect(sendPaymentRequired).not.toHaveBeenCalled();
+    expect(sendNeedAuth).not.toHaveBeenCalled();
+
+    const responseFrames = sentFrames
+      .map((f) => decodeFrame(f))
+      .filter((d) => d?.message.type === MessageType.HttpResponse);
+    expect(responseFrames).toHaveLength(1);
+    const response = decodeHttpResponse(responseFrames[0]!.message.payload);
+    expect(response.statusCode).toBe(200);
+  });
+
   it('stops serving once delivered spend has caught up to the last accepted auth', async () => {
     const provider = makeProvider(1, 1, {
       name: 'paid-tier',


### PR DESCRIPTION
## Summary
- Free services (both `inputUsdPerMillion` and `outputUsdPerMillion` equal to 0) now bypass the seller's 402 → `PaymentRequired` → `ReserveAuth` → on-chain `reserve()` handshake entirely.
- Sellers serve free requests directly, so buyers no longer need wallet prompts or gas for services that cost nothing.
- `recordSpend` / `sendNeedAuth` are already gated on `spm.hasSession(buyerPeerId)`, which is false when no session was ever opened, so the post-response path naturally short-circuits for free traffic.

## Test plan
- [x] New test in `packages/node/tests/node-payment-pricing.test.ts`: `skips the 402 / ReserveAuth handshake when the service is free` — asserts the provider handled the request, `sendPaymentRequired` / `sendNeedAuth` were not called, and the HTTP 200 response was sent on the wire.
- [x] Existing payment-pricing tests still pass (4/4).
- [ ] Manual: run a free provider end-to-end and confirm no `reserve()` tx is emitted on the seller side.