### PR TITLE
chore: bump node@0.2.59 cli@0.1.84 and all plugins/packages

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/dashboard",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Antseed Network web dashboard — monitoring and configuration UI",
   "type": "module",
   "files": [

--- a/packages/ant-agent/package.json
+++ b/packages/ant-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/ant-agent",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Ant agent runtime for AntSeed — monetize knowledge with read-only, knowledge-augmented AI agents",
   "type": "module",
   "files": [

--- a/packages/api-adapter/package.json
+++ b/packages/api-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/api-adapter",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "HTTP-level format translation between LLM API protocols (Anthropic Messages, OpenAI Chat Completions, OpenAI Responses)",
   "type": "module",
   "files": [

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/node",
-  "version": "0.2.58",
+  "version": "0.2.59",
   "description": "Antseed Network protocol SDK — P2P inference marketplace",
   "type": "module",
   "files": [

--- a/packages/provider-core/package.json
+++ b/packages/provider-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-core",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "description": "Shared provider infrastructure for Antseed plugins",
   "type": "module",
   "files": [

--- a/packages/router-core/package.json
+++ b/packages/router-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/router-core",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Shared router infrastructure for Antseed plugins",
   "type": "module",
   "files": [

--- a/plugins/provider-anthropic/package.json
+++ b/plugins/provider-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-anthropic",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Anthropic API key provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/provider-claude-code/package.json
+++ b/plugins/provider-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-claude-code",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Claude Code keychain provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/provider-claude-oauth/package.json
+++ b/plugins/provider-claude-oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-claude-oauth",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "Third-party Anthropic Claude provider with OAuth authentication",
   "type": "module",
   "files": [

--- a/plugins/provider-local-llm/package.json
+++ b/plugins/provider-local-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-local-llm",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Local LLM provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/provider-openai-responses/package.json
+++ b/plugins/provider-openai-responses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-openai-responses",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "OpenAI Responses provider plugin for Antseed via Codex backend auth",
   "type": "module",
   "files": [

--- a/plugins/provider-openai/package.json
+++ b/plugins/provider-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-openai",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "description": "OpenAI-compatible provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/router-local/package.json
+++ b/plugins/router-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/router-local",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "description": "Antseed local router plugin — Claude Code, Aider, Continue.dev",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary
- Patch-bump all 14 publishable `@antseed/*` packages to sync source with npm after publishing `node@0.2.59` / `cli@0.1.84`.
- Already published to npm — this commit is the source-of-truth record so `origin/main` matches registry state.

## Why
Previous publish drift (`eb8d5d5`) was pushed just before this. Keeping every publish accompanied by a committed bump on `main` prevents a repeat.

## Test plan
- [x] \`pnpm -r publish\` succeeded for all 14 packages
- [x] Fresh \`npm install @antseed/cli@0.1.84\` in a tmpdir, \`antseed --version\` → \`0.1.84\`