### PR TITLE
fix(desktop): remove 120s dispatch fallback that could kill a later turn

### DIFF
--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1537,17 +1537,6 @@ export function initChatModule({
               reportChatError(result.error, 'Request failed');
               setChatSending(false);
             }
-          } else if (uiState.chatSending) {
-            // Fallback timeout in case stream completion event is missed
-            setTimeout(() => {
-              if (!uiState.chatSending) return;
-              setChatSending(false);
-              clearChatError();
-              void refreshChatConversations();
-              if (uiState.chatActiveConversation) {
-                void openConversation(uiState.chatActiveConversation);
-              }
-            }, 120_000);
           }
         } catch (err) {
           reportChatError(err, 'Chat send failed');


### PR DESCRIPTION
## Summary

- `dispatchChatRequest` scheduled a bare `setTimeout` after every successful stream send to force-clear `chatSending` after 120s "in case the stream completion event is missed"
- The handle was never stored, so a stale timer from an earlier fast turn could fire mid-next-turn and silently make the thinking ant disappear
- The fallback also imposed a hard 2-minute cap on any turn, which is too short for long agent tool loops

Removed entirely — rely on real `chat:ai-stream-done` / `chat:ai-stream-error` / abort events instead.

## Test plan

- [ ] Send a short chat message, verify ant appears and disappears cleanly on completion
- [ ] Send a second message within 2 minutes of the first, verify the ant stays visible for the full second turn
- [ ] Send a long agent turn (> 2 minutes of tool calls), verify the ant persists the whole time