### PR TITLE
fix(desktop): pin peer + preselect service when clicking + in sidebar

### DIFF
--- a/apps/desktop/src/renderer/ui/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/ui/components/Sidebar.tsx
@@ -367,7 +367,7 @@ function PeerGroupSection({
 const EMPTY_CONVERSATIONS: unknown[] = [];
 
 function ChatSidebar({ onSelectView }: { onSelectView: (view: ViewName) => void }) {
-  const { chatConversations, chatActiveConversation, chatActiveChannels } = useUiSnapshot();
+  const { chatConversations, chatActiveConversation, chatActiveChannels, chatServiceOptions } = useUiSnapshot();
   const actions = useActions();
   const conversations = Array.isArray(chatConversations) ? chatConversations : EMPTY_CONVERSATIONS;
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
@@ -401,10 +401,29 @@ function ChatSidebar({ onSelectView }: { onSelectView: (view: ViewName) => void 
     onSelectView('chat');
   }, [actions, onSelectView]);
 
-  const handleNewChat = useCallback((_peerId: string) => {
+  const handleNewChat = useCallback((peerId: string) => {
+    if (peerId) {
+      // Pin the new chat to this peer and pre-select a service it offers.
+      // Prefer a service matching the most recent conversation with the peer
+      // (conv.service matches option.id), otherwise fall back to any option
+      // for that peer.
+      const group = peerGroups.find((g) => g.peerId === peerId);
+      const recentService = group && group.conversations.length > 0
+        ? String((group.conversations[0] as ConvRecord).service || '').trim()
+        : '';
+      const options = Array.isArray(chatServiceOptions) ? chatServiceOptions : [];
+      const match =
+        (recentService
+          ? options.find((o) => o.peerId === peerId && o.id === recentService)
+          : undefined) ||
+        options.find((o) => o.peerId === peerId);
+      if (match) {
+        actions.handleServiceChange(match.value, peerId);
+      }
+    }
     actions.startNewChat();
     onSelectView('chat');
-  }, [actions, onSelectView]);
+  }, [actions, onSelectView, peerGroups, chatServiceOptions]);
 
   const handleCloseChannel = useCallback(() => {
     actions.requestChannelClose();


### PR DESCRIPTION
## Summary
- The peer group "+" button in the chat sidebar (`Sidebar.tsx`) called `handleNewChat(peerId)` but the callback ignored the argument (`_peerId`) and only invoked `actions.startNewChat()`. New chats inherited whatever service/peer was previously selected, so clicking "+" on a peer did not actually pin that peer nor filter the service dropdown to its services.
- Look up a matching entry in `chatServiceOptions` (preferring one whose `id` matches the most recent conversation's `service` for that peer, falling back to any option with that `peerId`) and call `actions.handleServiceChange(value, peerId)` before `startNewChat()`. This mirrors the `DiscoverView` flow, so `ChatView`'s `peerServiceOptions` filter resolves to the intended peer and a valid service is preselected.

## Test plan
- [ ] Open desktop, have conversations with at least two different peers.
- [ ] Click the "+" button on a peer group in the sidebar — verify the header shows that peer and the Select Service dropdown is filtered to that peer's services with one preselected.
- [ ] Click "+" on a different peer — verify the header + dropdown update to the new peer, not the previous one.
- [ ] Verify the preselected service matches the most recent conversation's service with that peer when it's still offered.