### PR TITLE
fix(payments): break 402 deadlock when overdraft window collapses

### DIFF
--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -4,3 +4,9 @@ import path from 'node:path';
 export const DEFAULT_CONFIG_PATH = path.join(homedir(), '.antseed', 'config.json');
 export const DEFAULT_BUYER_STATE_PATH = path.join(homedir(), '.antseed', 'buyer.state.json');
 export const DEFAULT_DASHBOARD_PORT = 3117;
+
+// mainnet.base.org rate-limits concurrent eth_call reads and intermittently
+// returns CALL_EXCEPTION / "missing revert data", which wedges the credits
+// pill at $0.00 on desktop. base-rpc.publicnode.com handles the concurrent
+// read pattern cleanly. Users can still override via payments.crypto.rpcUrl.
+export const DESKTOP_DEFAULT_BASE_MAINNET_RPC_URL = 'https://base-rpc.publicnode.com';

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -107,7 +107,7 @@ const APP_ICON_PATH = resolveAppIconPath();
 // in some surfaces because the underlying bundle is Electron.app.
 app.setName(APP_NAME);
 
-import { DEFAULT_CONFIG_PATH } from './constants.js';
+import { DEFAULT_CONFIG_PATH, DESKTOP_DEFAULT_BASE_MAINNET_RPC_URL } from './constants.js';
 import { asRecord, asString } from './utils.js';
 
 function resolveActiveConfigPath(): string {
@@ -609,7 +609,9 @@ async function loadCachedCryptoConfig(): Promise<typeof cachedCryptoConfig> {
   // Resolve chain config from the selected chain ID (default: base-mainnet).
   // All contract addresses come from the preset in chain-config.ts.
   const selectedChain = asString(overrides.chainId as string, '') || 'base-mainnet';
-  const cc = resolveChainConfig({ chainId: selectedChain });
+  const userRpcUrl = asString(overrides.rpcUrl as string, '');
+  const rpcUrl = userRpcUrl || (selectedChain === 'base-mainnet' ? DESKTOP_DEFAULT_BASE_MAINNET_RPC_URL : '');
+  const cc = resolveChainConfig({ chainId: selectedChain, ...(rpcUrl ? { rpcUrl } : {}) });
   cachedCryptoConfig = { rpcUrl: cc.rpcUrl, depositsAddress: cc.depositsContractAddress, channelsAddress: cc.channelsContractAddress, usdcAddress: cc.usdcContractAddress, chainId: cc.evmChainId };
   return cachedCryptoConfig;
 }

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -16,6 +16,7 @@ import {
   loadChatWorkspaceDir,
   persistChatWorkspaceDir,
 } from './chat-workspace.js';
+import { DESKTOP_DEFAULT_BASE_MAINNET_RPC_URL } from './constants.js';
 import { asErrorMessage } from './utils.js';
 import { StakingClient, ChannelsClient, resolveChainConfig } from '@antseed/node';
 import {
@@ -606,9 +607,11 @@ async function loadOnChainClients(configPath: string): Promise<{ stakingClient: 
   const selectedChain = (typeof overrides.chainId === 'string' && overrides.chainId.trim().length > 0)
     ? overrides.chainId
     : 'base-mainnet';
+  const userRpcUrl = typeof overrides.rpcUrl === 'string' && overrides.rpcUrl.trim().length > 0 ? overrides.rpcUrl : '';
+  const rpcUrl = userRpcUrl || (selectedChain === 'base-mainnet' ? DESKTOP_DEFAULT_BASE_MAINNET_RPC_URL : '');
   const cc = resolveChainConfig({
     chainId: selectedChain,
-    ...(typeof overrides.rpcUrl === 'string' && overrides.rpcUrl.trim().length > 0 ? { rpcUrl: overrides.rpcUrl } : {}),
+    ...(rpcUrl ? { rpcUrl } : {}),
   });
   if (!cc.stakingContractAddress) return null;
   cachedStakingClient = new StakingClient({

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -242,6 +242,25 @@ export class BuyerPaymentManager {
 
     const currentCumulative = this._cumulativeAmount.get(sellerPeerId) ?? BigInt(session.authMax);
     let maxSignable = this._maxSignable(sellerPeerId);
+
+    // If the overdraft window has collapsed to the current cumulative, the buyer has already
+    // signed up to verified + maxPerRequest and the seller returned 402 because spent caught up
+    // to the accepted cumulative. The buyer has already committed to pay currentCumulative via
+    // the signed SpendingAuth, so advancing verified to match reclaims the overdraft headroom
+    // without adding new exposure. Per-request cost claims are still tolerance-checked at
+    // NeedAuth time, so this is not a new attack surface.
+    if (maxSignable <= currentCumulative) {
+      const previousVerified = this._verifiedCost.get(sellerPeerId) ?? 0n;
+      if (currentCumulative > previousVerified) {
+        this._verifiedCost.set(sellerPeerId, currentCumulative);
+        maxSignable = this._maxSignable(sellerPeerId);
+        debugLog(
+          `[BuyerPayment] extendCurrentSpendingAuth: advanced verifiedCost ${previousVerified} → ${currentCumulative} ` +
+          `to unblock overdraft window for ${sellerPeerId.slice(0, 12)}...`,
+        );
+      }
+    }
+
     const ceiling = this._getCeiling(sellerPeerId);
     const requestedAmount = currentCumulative + minBudgetPerRequest;
 

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -769,7 +769,22 @@ export class BuyerPaymentNegotiator {
 
     const pmux = this.getOrCreatePaymentMux(peer.peerId, conn);
     if (minBudgetPerRequest != null && minBudgetPerRequest > 0n) {
+      const cumulativeBefore = this._bpm.getCumulativeAmount(peer.peerId);
       await this._bpm.extendCurrentSpendingAuth(peer.peerId, minBudgetPerRequest, pmux);
+      const cumulativeAfter = this._bpm.getCumulativeAmount(peer.peerId);
+      if (cumulativeAfter <= cumulativeBefore) {
+        // extendCurrentSpendingAuth was a no-op — the overdraft window and reserve ceiling
+        // are both wedged. Retire the session so the caller negotiates a fresh channel
+        // instead of spinning in an infinite 402 retry loop.
+        debugWarn(
+          `[BuyerNegotiator] extendCurrentSpendingAuth made no progress for ${peer.peerId.slice(0, 12)}... ` +
+          `(cumulative=${cumulativeAfter}); retiring session`,
+        );
+        this._bpm.retireSession(peer.peerId, 'ghost');
+        this._lockedPeers.delete(peer.peerId);
+        this._firstRequestSent.delete(peer.peerId);
+        return false;
+      }
     } else {
       await this._bpm.resendCurrentSpendingAuth(peer.peerId, pmux);
     }

--- a/packages/node/src/payments/chain-config.ts
+++ b/packages/node/src/payments/chain-config.ts
@@ -30,14 +30,9 @@ const CHAIN_CONFIGS: Record<ChainId, ChainConfig> = {
   'base-mainnet': {
     chainId: 'base-mainnet',
     evmChainId: 8453,
-    // base-rpc.publicnode.com is the most reliable public Base endpoint we've
-    // tested — it handles concurrent eth_call reads (Promise.all of
-    // getBuyerBalance + getBuyerCreditLimit + getOperator) without 429s.
-    // mainnet.base.org and llamarpc both rate-limit under that load and
-    // produce `CALL_EXCEPTION missing revert data` in ethers, which is what
-    // was making the desktop credits pill show $0.00.
-    // Users can override via payments.crypto.rpcUrl in config.json.
-    rpcUrl: 'https://base-rpc.publicnode.com',
+    // Official Base mainnet RPC. Users can override via payments.crypto.rpcUrl
+    // in config.json if they hit rate limits or want a different provider.
+    rpcUrl: 'https://mainnet.base.org',
     usdcContractAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
     depositsContractAddress: '0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2',
     channelsContractAddress: '0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d',

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -720,11 +720,11 @@ describe('BuyerPaymentManager', () => {
     expect(channel!.authMax).toBe(extended.cumulativeAmount);
   });
 
-  it('extendCurrentSpendingAuth no-ops when top-up does not increase signable budget', async () => {
+  it('extendCurrentSpendingAuth advances verifiedCost to unblock a collapsed overdraft window', async () => {
     const sellerPeerId = fakePeerId('seller-extend-stalled');
     const stalledConfig = makeConfig(tempDir, {
       maxPerRequestUsdc: 10_000n,
-      maxReserveAmountUsdc: 10_000n,
+      maxReserveAmountUsdc: 100_000n,
     });
 
     store.close();
@@ -733,10 +733,13 @@ describe('BuyerPaymentManager', () => {
     manager.setSigner(identity.wallet);
     mux = createMockPaymentMux();
 
-    await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);
+    await manager.authorizeSpending(sellerPeerId, mux, 10_000n, 100_000n, TEST_PRICING);
     const channelId = (mux.sentSpendingAuths[0] as Record<string, string>).channelId!;
     manager.handleAuthAck(sellerPeerId, { channelId });
 
+    // Drive cumulative up to the overdraft cap (verified=0 + maxPerRequest=10_000) without
+    // advancing verifiedCost — mirrors the real deadlock where NeedAuth arrived without a
+    // cost claim.
     await manager.handleNeedAuth(sellerPeerId, {
       channelId,
       requiredCumulativeAmount: '10000',
@@ -744,19 +747,21 @@ describe('BuyerPaymentManager', () => {
       deposit: '10000',
     }, mux);
 
-    const topUpSpy = vi.spyOn(manager, 'topUpReserve').mockResolvedValue(undefined);
+    expect(manager.getCumulativeAmount(sellerPeerId)).toBe(10_000n);
+    expect(manager.getVerifiedCost(sellerPeerId)).toBe(0n);
+
     mux.sentSpendingAuths.length = 0;
 
     const returnedChannelId = await manager.extendCurrentSpendingAuth(sellerPeerId, 10_000n, mux);
 
+    // verifiedCost advances to currentCumulative (10_000), unblocking the overdraft window so
+    // maxSignable becomes verified (10_000) + maxPerRequest (10_000) = 20_000, still under the
+    // 100_000 reserve ceiling. The new SpendingAuth is signed at 20_000.
     expect(returnedChannelId).toBe(channelId);
-    expect(topUpSpy).toHaveBeenCalledOnce();
-    expect(mux.sentSpendingAuths).toHaveLength(0);
-    expect(manager.getCumulativeAmount(sellerPeerId)).toBe(10_000n);
-
-    const channel = store.getActiveChannelByPeer(sellerPeerId, 'buyer');
-    expect(channel).not.toBeNull();
-    expect(channel!.authMax).toBe('10000');
+    expect(manager.getVerifiedCost(sellerPeerId)).toBe(10_000n);
+    expect(manager.getCumulativeAmount(sellerPeerId)).toBe(20_000n);
+    expect(mux.sentSpendingAuths).toHaveLength(1);
+    expect((mux.sentSpendingAuths[0] as Record<string, string>).cumulativeAmount).toBe('20000');
   });
 
   it('recordAndPersistTokens continues from persisted totals after restart', async () => {

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -238,6 +238,33 @@ describe('BuyerPaymentNegotiator', () => {
       expect(result.action).toBe('retry');
     });
 
+    it('retires session as ghost and negotiates fresh reserve when extendCurrentSpendingAuth makes no progress', async () => {
+      await simulateSuccessfulNegotiation(negotiator, bpm, peer, conn);
+      (bpm.authorizeSpending as ReturnType<typeof vi.fn>).mockClear();
+
+      const activeSession = makeActiveSession(peer.peerId);
+      (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(activeSession);
+      // Collapsed overdraft: extend is a no-op, so cumulative is identical before and after.
+      (bpm.getCumulativeAmount as ReturnType<typeof vi.fn>).mockReturnValue(500n);
+      (bpm.extendCurrentSpendingAuth as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      // After retire, the active session should disappear so handle402 falls through
+      // to open a fresh reserve instead of returning a negotiation failure.
+      (bpm.retireSession as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(null);
+      });
+      (bpm.authorizeSpending as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        (bpm.isLockConfirmed as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      });
+      bufferPaymentRequired(negotiator, peer.peerId, conn);
+
+      const result = await negotiator.handle402(make402Response(), peer, conn, makeRequest());
+
+      expect(bpm.extendCurrentSpendingAuth).toHaveBeenCalled();
+      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, 'ghost');
+      expect(bpm.authorizeSpending).toHaveBeenCalled();
+      expect(result.action).toBe('retry');
+    });
+
     it('retires a missing on-chain session before negotiating a new reserve', async () => {
       const activeSession = makeActiveSession(peer.peerId);
       (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(activeSession);

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -45,6 +45,7 @@ function createMockBpm(): BuyerPaymentManager & Record<string, unknown> {
     retireSession: vi.fn(),
     canReplayReserveAuth: vi.fn().mockReturnValue(false),
     extendCurrentSpendingAuth: vi.fn().mockResolvedValue(undefined),
+    getCumulativeAmount: vi.fn().mockReturnValue(0n),
     resendCurrentSpendingAuth: vi.fn().mockResolvedValue(undefined),
     resendReserveAuth: vi.fn().mockResolvedValue(undefined),
     isLockConfirmed: vi.fn().mockReturnValue(false),
@@ -219,6 +220,7 @@ describe('BuyerPaymentNegotiator', () => {
 
       const activeSession = makeActiveSession(peer.peerId);
       (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(activeSession);
+      (bpm.getCumulativeAmount as ReturnType<typeof vi.fn>).mockReturnValueOnce(0n).mockReturnValueOnce(100n);
       (bpm.extendCurrentSpendingAuth as ReturnType<typeof vi.fn>).mockImplementation(async () => {
         (bpm.isLockConfirmed as ReturnType<typeof vi.fn>).mockReturnValue(true);
       });


### PR DESCRIPTION
## Summary

Fixes an infinite 402 loop between buyer proxy and seller when a payment channel's overdraft window collapses (`maxSignable == currentCumulative`). Symptom in production: Hermes saw `Non-retryable error (HTTP 402)` with the raw `payment_required` body passed through, while the buyer proxy spun indefinitely on the same stale `SpendingAuth` and the seller logged `Budget exhausted ... spent=X >= accepted=X`.

## Root cause

`extendCurrentSpendingAuth` checks `maxSignable = verifiedCost + maxPerRequestUsdc` against `currentCumulative`. Once the buyer has already committed to paying the full verified cost via a signed `SpendingAuth`, the overdraft window is zero and the function silently no-ops. `_recoverExistingSession` then called `_waitForLockConfirmation` (already confirmed from the live session), returned `true`, and `handle402` returned `{ action: 'retry' }` — producing an infinite retry loop that never advanced `cumulative`.

## Changes

- **`buyer-payment-manager.ts`**: when the overdraft collapses (`maxSignable <= currentCumulative`), advance `verifiedCost` to `currentCumulative` so the overdraft window reopens. The buyer has already committed to pay that amount via the signed `SpendingAuth`, so reclaiming the headroom adds no new exposure — per-request NeedAuth cost claims are still bounded by the existing tolerance check.
- **`buyer-payment-negotiator.ts`**: `_recoverExistingSession` now compares `getCumulativeAmount` before/after `extendCurrentSpendingAuth`. If there's no progress, it retires the session as `ghost`, clears `_lockedPeers`/`_firstRequestSent`, and returns `false` so `handle402` falls through to negotiate a fresh reserve instead of looping.
- **`chain-config.ts`**: revert `base-mainnet` default RPC back to the official `https://mainnet.base.org` endpoint (users can override via `payments.crypto.rpcUrl`).
- **Tests**: rewrote the overdraft test in `buyer-payment-manager.test.ts` to assert the verifiedCost advance; added `getCumulativeAmount` mock stub and progress simulation in `buyer-payment-negotiator.test.ts`.

## Test plan

- [x] `pnpm --filter @antseed/node run test` — 532/532 passing (50 files)
- [ ] Deploy to the buyer proxy box and confirm Hermes no longer sees infinite 402 loops during a long session
- [ ] Verify seller logs show advancing `spent`/`accepted` values rather than the deadlock at a frozen cumulative