### PR TITLE
feat(desktop): add peer filter + volume slider to Discover

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.module.scss
@@ -5,9 +5,6 @@
   flex-direction: column;
   gap: 12px;
   flex-shrink: 0;
-  min-height: 0;
-  max-height: 100%;
-  overflow: hidden;
   padding: 8px;
 }
 
@@ -123,6 +120,90 @@
   &::placeholder { color: var(--text-muted); }
   &:hover { border-color: var(--border-strong); }
   &:focus { border-color: var(--text-primary); }
+}
+
+/* ── Peers list ─────────────────────────────────────────────────────── */
+
+.field-peers {
+  max-height: 220px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.peer-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 190px;
+  overflow-y: auto;
+  padding-right: 4px;
+
+  &::-webkit-scrollbar { width: 4px; }
+  &::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thumb);
+    border-radius: 2px;
+  }
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--scrollbar-thumb-hover);
+  }
+}
+
+.peer-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 5px 6px;
+  margin: 0 -2px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  font-family: inherit;
+  font-size: 12px;
+  text-align: left;
+  color: var(--text-secondary);
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.1s ease, color 0.1s ease;
+
+  &:hover {
+    background: var(--bg-card);
+    color: var(--text-primary);
+  }
+}
+
+.peer-row-active {
+  background: var(--bg-card);
+  color: var(--text-primary);
+}
+
+.peer-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  font-size: 11px;
+  font-weight: 700;
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+
+.peer-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.peer-check {
+  flex-shrink: 0;
+  color: var(--text-primary);
 }
 
 /* ── Vertical list (checkboxes / radios) ────────────────────────────── */

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.tsx
@@ -3,9 +3,7 @@ import type { DiscoverFilterState } from '../../hooks/useDiscoverFilters';
 import {
   MAX_INPUT_PRICE_SLIDER_USD, INPUT_PRICE_SLIDER_STEP,
   MAX_OUTPUT_PRICE_SLIDER_USD, OUTPUT_PRICE_SLIDER_STEP,
-  MAX_CHANNELS_SLIDER, CHANNELS_SLIDER_STEP,
-  MAX_REQUESTS_SLIDER, REQUESTS_SLIDER_STEP,
-  MAX_TOKENS_SLIDER, TOKENS_SLIDER_STEP,
+  MAX_VOLUME_SLIDER_USDC, VOLUME_SLIDER_STEP,
   type TimeWindow,
 } from './discover-filter-util';
 import styles from './DiscoverFilters.module.scss';
@@ -20,24 +18,14 @@ function formatPriceLabel(value: number, max: number): string {
   return `Up to $${value.toFixed(2)}/M`;
 }
 
-function formatChannelsLabel(value: number): string {
+function formatVolumeLabel(value: number): string {
   if (value <= 0) return 'Any';
-  if (value >= MAX_CHANNELS_SLIDER) return `${MAX_CHANNELS_SLIDER}+`;
-  return `${value}+`;
-}
-
-function formatRequestsLabel(value: number): string {
-  if (value <= 0) return 'Any';
-  if (value >= MAX_REQUESTS_SLIDER) return `${MAX_REQUESTS_SLIDER}+`;
-  return `${value}+`;
-}
-
-function formatTokensLabel(value: number): string {
-  if (value <= 0) return 'Any';
-  const suffix = value >= MAX_TOKENS_SLIDER ? '+' : '+';
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(value % 1_000_000 === 0 ? 0 : 1)}M${suffix}`;
-  if (value >= 1_000) return `${Math.round(value / 1_000)}K${suffix}`;
-  return `${value}${suffix}`;
+  if (value >= 1_000) {
+    const k = value / 1_000;
+    const str = k % 1 === 0 ? k.toFixed(0) : k.toFixed(1);
+    return `$${str}K+`;
+  }
+  return `$${value}+`;
 }
 
 const TIME_WINDOW_OPTIONS: ReadonlyArray<{ value: TimeWindow; label: string }> = [
@@ -50,28 +38,50 @@ const TIME_WINDOW_OPTIONS: ReadonlyArray<{ value: TimeWindow; label: string }> =
 export const DiscoverFilters = memo(function DiscoverFilters({ filters }: Props) {
   return (
     <aside className={styles.filters}>
-      {/* Search */}
-      <div className={styles.field}>
-        <div className={styles.label}>Search</div>
-        <div className={styles.searchBox}>
-          <svg
-            className={styles.searchIcon}
-            width="14" height="14" viewBox="0 0 16 16" fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-            aria-hidden="true"
-          >
-            <circle cx="7" cy="7" r="5.25" stroke="currentColor" strokeWidth="1.5"/>
-            <path d="M11 11L14 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
-          </svg>
-          <input
-            type="text"
-            className={styles.searchInput}
-            value={filters.search}
-            onChange={(e) => filters.setSearch(e.target.value)}
-            placeholder="Service, peer, category…"
-          />
+      {/* Peers */}
+      {filters.availablePeers.length > 0 && (
+        <div className={`${styles.field} ${styles.fieldPeers}`}>
+          <div className={styles.label}>Peers</div>
+          <div className={styles.peerList}>
+            {filters.availablePeers.map((p) => {
+              const active = filters.peerSet.has(p.peerId);
+              return (
+                <button
+                  key={p.peerId}
+                  type="button"
+                  className={`${styles.peerRow} ${active ? styles.peerRowActive : ''}`}
+                  onClick={() => filters.togglePeer(p.peerId)}
+                  aria-pressed={active}
+                  title={p.peerId}
+                >
+                  <span className={styles.peerAvatar} style={{ background: p.gradient }}>
+                    {p.letter}
+                  </span>
+                  <span className={styles.peerLabel}>{p.label}</span>
+                  {active && (
+                    <svg
+                      className={styles.peerCheck}
+                      width="14"
+                      height="14"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      aria-hidden="true"
+                    >
+                      <path
+                        d="M3.5 8.5L6.5 11.5L12.5 5"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  )}
+                </button>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Categories */}
       {filters.availableCategories.length > 0 && (
@@ -147,62 +157,21 @@ export const DiscoverFilters = memo(function DiscoverFilters({ filters }: Props)
         <span>Supports prompt caching</span>
       </label>
 
-      {/* ── Peer subsection ─────────────────────────────────────────── */}
-      <div className={styles.sectionHeader} />
-
-      {/* Min channels served slider */}
+      {/* Min volume served slider */}
       <div className={styles.field}>
         <div className={styles.sliderHeader}>
-          <span className={styles.label}>Channels served</span>
-          <span className={styles.sliderValue}>{formatChannelsLabel(filters.minChannels)}</span>
+          <span className={styles.label}>Volume served</span>
+          <span className={styles.sliderValue}>{formatVolumeLabel(filters.minVolumeUsdc)}</span>
         </div>
         <div className={styles.sliderWrapper}>
           <input
             type="range"
             className={styles.slider}
             min={0}
-            max={MAX_CHANNELS_SLIDER}
-            step={CHANNELS_SLIDER_STEP}
-            value={filters.minChannels}
-            onChange={(e) => filters.setMinChannels(Number(e.target.value))}
-          />
-        </div>
-      </div>
-
-      {/* Min requests served slider */}
-      <div className={styles.field}>
-        <div className={styles.sliderHeader}>
-          <span className={styles.label}>Requests served</span>
-          <span className={styles.sliderValue}>{formatRequestsLabel(filters.minRequests)}</span>
-        </div>
-        <div className={styles.sliderWrapper}>
-          <input
-            type="range"
-            className={styles.slider}
-            min={0}
-            max={MAX_REQUESTS_SLIDER}
-            step={REQUESTS_SLIDER_STEP}
-            value={filters.minRequests}
-            onChange={(e) => filters.setMinRequests(Number(e.target.value))}
-          />
-        </div>
-      </div>
-
-      {/* Min tokens served slider */}
-      <div className={styles.field}>
-        <div className={styles.sliderHeader}>
-          <span className={styles.label}>Tokens served</span>
-          <span className={styles.sliderValue}>{formatTokensLabel(filters.minTokens)}</span>
-        </div>
-        <div className={styles.sliderWrapper}>
-          <input
-            type="range"
-            className={styles.slider}
-            min={0}
-            max={MAX_TOKENS_SLIDER}
-            step={TOKENS_SLIDER_STEP}
-            value={filters.minTokens}
-            onChange={(e) => filters.setMinTokens(Number(e.target.value))}
+            max={MAX_VOLUME_SLIDER_USDC}
+            step={VOLUME_SLIDER_STEP}
+            value={filters.minVolumeUsdc}
+            onChange={(e) => filters.setMinVolumeUsdc(Number(e.target.value))}
           />
         </div>
       </div>

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
@@ -65,9 +65,39 @@
 .controls-row {
   display: flex;
   align-items: center;
-  justify-content: flex-end;
   gap: 8px;
   width: 100%;
+}
+
+.search-box {
+  position: relative;
+  flex: 1;
+  max-width: 420px;
+}
+
+.search-icon {
+  position: absolute;
+  left: 11px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.search-input {
+  width: 100%;
+  height: 32px;
+  padding: 0 12px 0 32px;
+  font-size: 13px;
+  font-family: inherit;
+  color: var(--text-primary);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
+  border-radius: 8px;
+  outline: none;
+  transition: border-color 0.12s ease, background-color 0.12s ease;
+
+  &::placeholder { color: var(--text-muted); }
 }
 
 .sort-select {
@@ -107,6 +137,7 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
+  margin-left: auto;
   width: 32px;
   height: 32px;
   padding: 0;

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -244,6 +244,7 @@ export function DiscoverWelcome({ serviceOptions, onStartChatting }: DiscoverWel
   const hasActiveFilters =
     filterState.search.trim() !== '' ||
     filterState.categorySet.size > 0 ||
+    filterState.peerSet.size > 0 ||
     filterState.maxInputPrice < MAX_INPUT_PRICE_SLIDER_USD ||
     filterState.maxOutputPrice < MAX_OUTPUT_PRICE_SLIDER_USD ||
     filterState.cachedOnly ||
@@ -251,9 +252,7 @@ export function DiscoverWelcome({ serviceOptions, onStartChatting }: DiscoverWel
     filterState.minStakeUsdc > 0 ||
     filterState.lastSeenWindow !== 'any' ||
     filterState.lastSettledWindow !== 'any' ||
-    filterState.minChannels > 0 ||
-    filterState.minRequests > 0 ||
-    filterState.minTokens > 0;
+    filterState.minVolumeUsdc > 0;
 
   const hasNetworkData = serviceOptions.length > 0 || rows.length > 0;
   const cards = useMemo(() => {
@@ -271,6 +270,7 @@ export function DiscoverWelcome({ serviceOptions, onStartChatting }: DiscoverWel
   useEffect(() => { setPage(1); }, [
     filterState.search,
     filterState.categorySet,
+    filterState.peerSet,
     filterState.maxInputPrice,
     filterState.maxOutputPrice,
     filterState.cachedOnly,
@@ -278,9 +278,7 @@ export function DiscoverWelcome({ serviceOptions, onStartChatting }: DiscoverWel
     filterState.minStakeUsdc,
     filterState.lastSeenWindow,
     filterState.lastSettledWindow,
-    filterState.minChannels,
-    filterState.minRequests,
-    filterState.minTokens,
+    filterState.minVolumeUsdc,
     filterState.sortKey,
   ]);
 
@@ -315,6 +313,25 @@ export function DiscoverWelcome({ serviceOptions, onStartChatting }: DiscoverWel
           </div>
 
           <div className={styles.controlsRow}>
+            <div className={styles.searchBox}>
+              <svg
+                className={styles.searchIcon}
+                width="14" height="14" viewBox="0 0 16 16" fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+              >
+                <circle cx="7" cy="7" r="5.25" stroke="currentColor" strokeWidth="1.5"/>
+                <path d="M11 11L14 14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/>
+              </svg>
+              <input
+                type="text"
+                className={styles.searchInput}
+                value={filterState.search}
+                onChange={(e) => filterState.setSearch(e.target.value)}
+                placeholder="Search services, peers, categories…"
+                aria-label="Search services"
+              />
+            </div>
             <button
               type="button"
               className={`${styles.filterTrigger}${drawerOpen && !drawerClosing ? ` ${styles.filterTriggerActive}` : ''}`}

--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.test.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.test.ts
@@ -4,7 +4,7 @@ import {
   matchesSearch, matchesMaxInputPrice, matchesMaxOutputPrice,
   matchesCachedOnly, matchesMinStake,
   matchesLastSeen, matchesLastSettled,
-  matchesMinChannels, matchesMinRequests, matchesMinTokens,
+  matchesMinVolume,
   applyFilters, applySort, paginate, totalPagesFor,
   MAX_INPUT_PRICE_SLIDER_USD, MAX_OUTPUT_PRICE_SLIDER_USD,
 } from './discover-filter-util';
@@ -91,25 +91,11 @@ test('matchesLastSettled uses onChainLastSettledAt in seconds', () => {
   assert.ok(!matchesLastSettled(mkRow({ onChainLastSettledAt: monthAgoSec }), 'month', nowMs));
 });
 
-test('matchesMinChannels compares onChainActiveChannelCount to slider value', () => {
-  assert.ok(matchesMinChannels(mkRow({ onChainActiveChannelCount: 5 }), 5));
-  assert.ok(!matchesMinChannels(mkRow({ onChainActiveChannelCount: 3 }), 5));
-  assert.ok(!matchesMinChannels(mkRow({ onChainActiveChannelCount: 0 }), 1));
-  assert.ok(matchesMinChannels(mkRow({ onChainActiveChannelCount: 0 }), 0));
-});
-
-test('matchesMinRequests parses networkRequests bigint', () => {
-  assert.ok(matchesMinRequests(mkRow({ networkRequests: '100' }), 100));
-  assert.ok(!matchesMinRequests(mkRow({ networkRequests: '50' }), 100));
-  assert.ok(!matchesMinRequests(mkRow({ networkRequests: null }), 100));
-  assert.ok(matchesMinRequests(mkRow({ networkRequests: null }), 0));
-});
-
-test('matchesMinTokens sums input+output token strings', () => {
-  assert.ok(matchesMinTokens(mkRow({ networkInputTokens: '600', networkOutputTokens: '500' }), 1000));
-  assert.ok(!matchesMinTokens(mkRow({ networkInputTokens: '300', networkOutputTokens: '200' }), 1000));
-  assert.ok(matchesMinTokens(mkRow({ networkInputTokens: null, networkOutputTokens: null }), 0));
-  assert.ok(!matchesMinTokens(mkRow({ networkInputTokens: null, networkOutputTokens: null }), 1));
+test('matchesMinVolume compares base-6 USDC bigint to slider value', () => {
+  assert.ok(matchesMinVolume(mkRow({ onChainTotalVolumeUsdc: '10000000' }), 10));
+  assert.ok(!matchesMinVolume(mkRow({ onChainTotalVolumeUsdc: '9999999' }), 10));
+  assert.ok(matchesMinVolume(mkRow({ onChainTotalVolumeUsdc: '0' }), 0));
+  assert.ok(!matchesMinVolume(mkRow({ onChainTotalVolumeUsdc: '0' }), 1));
 });
 
 test('applyFilters composes all predicates', () => {
@@ -118,13 +104,13 @@ test('applyFilters composes all predicates', () => {
     mkRow({ serviceLabel: 'B', inputUsdPerMillion: 10, categories: ['coding'] }),
   ];
   const filtered = applyFilters(rows, {
-    search: '', categorySet: new Set(['coding']),
+    search: '', categorySet: new Set(['coding']), peerSet: new Set(),
     maxInputPrice: MAX_INPUT_PRICE_SLIDER_USD,
     maxOutputPrice: MAX_OUTPUT_PRICE_SLIDER_USD,
     cachedOnly: false, chattedOnly: false,
     minStakeUsdc: 0,
     lastSeenWindow: 'any', lastSettledWindow: 'any',
-    minChannels: 0, minRequests: 0, minTokens: 0,
+    minVolumeUsdc: 0,
   });
   assert.equal(filtered.length, 1);
   assert.equal(filtered[0]!.serviceLabel, 'B');

--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
@@ -15,12 +15,8 @@ export const MAX_INPUT_PRICE_SLIDER_USD = 3;
 export const INPUT_PRICE_SLIDER_STEP = 0.1;
 export const MAX_OUTPUT_PRICE_SLIDER_USD = 3;
 export const OUTPUT_PRICE_SLIDER_STEP = 0.1;
-export const MAX_CHANNELS_SLIDER = 100;
-export const CHANNELS_SLIDER_STEP = 10;
-export const MAX_REQUESTS_SLIDER = 5000;
-export const REQUESTS_SLIDER_STEP = 100;
-export const MAX_TOKENS_SLIDER = 100_000_000;
-export const TOKENS_SLIDER_STEP = 500_000;
+export const MAX_VOLUME_SLIDER_USDC = 100;
+export const VOLUME_SLIDER_STEP = 5;
 export const MAX_STAKE_SLIDER_USDC = 1000;
 
 export type TimeWindow = 'any' | 'today' | 'week' | 'month';
@@ -28,6 +24,7 @@ export type TimeWindow = 'any' | 'today' | 'week' | 'month';
 export type DiscoverFilterInputs = {
   search: string;
   categorySet: Set<string>;
+  peerSet: Set<string>;
   maxInputPrice: number;
   maxOutputPrice: number;
   cachedOnly: boolean;
@@ -35,9 +32,7 @@ export type DiscoverFilterInputs = {
   lastSeenWindow: TimeWindow;
   lastSettledWindow: TimeWindow;
   minStakeUsdc: number;
-  minChannels: number;
-  minRequests: number;
-  minTokens: number;
+  minVolumeUsdc: number;
 };
 
 function parseBigintSafe(value: string | null | undefined): bigint {
@@ -85,6 +80,11 @@ export function matchesCategoryFilter(row: DiscoverRow, set: Set<string>): boole
   return row.categories.some((c) => set.has(c.toLowerCase()));
 }
 
+export function matchesPeerFilter(row: DiscoverRow, set: Set<string>): boolean {
+  if (set.size === 0) return true;
+  return set.has(row.peerId);
+}
+
 export function matchesCachedOnly(row: DiscoverRow, enabled: boolean): boolean {
   if (!enabled) return true;
   const cached = row.cachedInputUsdPerMillion;
@@ -124,31 +124,11 @@ export function matchesLastSettled(row: DiscoverRow, window: TimeWindow, nowMs?:
   return matchesTimeWindow(row.onChainLastSettledAt, window, 'sec', nowMs);
 }
 
-export function matchesMinChannels(row: DiscoverRow, minChannels: number): boolean {
-  if (minChannels <= 0) return true;
-  return row.onChainActiveChannelCount >= minChannels;
-}
-
-export function pickRequests(row: DiscoverRow): bigint {
-  if (row.networkRequests !== null) return parseBigintSafe(row.networkRequests);
-  return BigInt(row.lifetimeRequests);
-}
-
-export function pickTokens(row: DiscoverRow): bigint {
-  if (row.networkInputTokens !== null || row.networkOutputTokens !== null) {
-    return parseBigintSafe(row.networkInputTokens) + parseBigintSafe(row.networkOutputTokens);
-  }
-  return BigInt(row.lifetimeInputTokens + row.lifetimeOutputTokens);
-}
-
-export function matchesMinRequests(row: DiscoverRow, minRequests: number): boolean {
-  if (minRequests <= 0) return true;
-  return pickRequests(row) >= BigInt(minRequests);
-}
-
-export function matchesMinTokens(row: DiscoverRow, minTokens: number): boolean {
-  if (minTokens <= 0) return true;
-  return pickTokens(row) >= BigInt(minTokens);
+export function matchesMinVolume(row: DiscoverRow, minVolumeUsdc: number): boolean {
+  if (minVolumeUsdc <= 0) return true;
+  const volume = parseBigintSafe(row.onChainTotalVolumeUsdc);
+  const threshold = BigInt(Math.floor(minVolumeUsdc * 1_000_000));
+  return volume >= threshold;
 }
 
 export function applyFilters(rows: DiscoverRow[], inputs: DiscoverFilterInputs): DiscoverRow[] {
@@ -156,6 +136,7 @@ export function applyFilters(rows: DiscoverRow[], inputs: DiscoverFilterInputs):
   return rows.filter((row) =>
     matchesSearch(row, inputs.search)
     && matchesCategoryFilter(row, inputs.categorySet)
+    && matchesPeerFilter(row, inputs.peerSet)
     && matchesMaxInputPrice(row, inputs.maxInputPrice)
     && matchesMaxOutputPrice(row, inputs.maxOutputPrice)
     && matchesCachedOnly(row, inputs.cachedOnly)
@@ -163,9 +144,7 @@ export function applyFilters(rows: DiscoverRow[], inputs: DiscoverFilterInputs):
     && matchesMinStake(row, inputs.minStakeUsdc)
     && matchesLastSeen(row, inputs.lastSeenWindow, nowMs)
     && matchesLastSettled(row, inputs.lastSettledWindow, nowMs)
-    && matchesMinChannels(row, inputs.minChannels)
-    && matchesMinRequests(row, inputs.minRequests)
-    && matchesMinTokens(row, inputs.minTokens)
+    && matchesMinVolume(row, inputs.minVolumeUsdc)
   );
 }
 

--- a/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.test.ts
+++ b/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.test.ts
@@ -26,13 +26,13 @@ function mkRow(i: number, chat: boolean): DiscoverRow {
 test('pipeline: filter → sort → paginate on 25 rows', () => {
   const rows = Array.from({ length: 25 }, (_, i) => mkRow(i + 1, i % 3 === 0));
   const filtered = applyFilters(rows, {
-    search: '', categorySet: new Set(),
+    search: '', categorySet: new Set(), peerSet: new Set(),
     maxInputPrice: MAX_INPUT_PRICE_SLIDER_USD,
     maxOutputPrice: MAX_OUTPUT_PRICE_SLIDER_USD,
     cachedOnly: false, chattedOnly: true,
     minStakeUsdc: 0,
     lastSeenWindow: 'any', lastSettledWindow: 'any',
-    minChannels: 0, minRequests: 0, minTokens: 0,
+    minVolumeUsdc: 0,
   });
   assert.equal(filtered.length, 9);
   const sorted = applySort(filtered, 'recentlyUsed', 'desc');
@@ -45,13 +45,13 @@ test('pipeline: filter → sort → paginate on 25 rows', () => {
 test('pipeline: chattedOnly + stake filter', () => {
   const rows = [mkRow(1, true), mkRow(50, true), mkRow(100, false)];
   const filtered = applyFilters(rows, {
-    search: '', categorySet: new Set(),
+    search: '', categorySet: new Set(), peerSet: new Set(),
     maxInputPrice: MAX_INPUT_PRICE_SLIDER_USD,
     maxOutputPrice: MAX_OUTPUT_PRICE_SLIDER_USD,
     cachedOnly: false, chattedOnly: true,
     minStakeUsdc: 50,
     lastSeenWindow: 'any', lastSettledWindow: 'any',
-    minChannels: 0, minRequests: 0, minTokens: 0,
+    minVolumeUsdc: 0,
   });
   assert.equal(filtered.length, 1);
   assert.equal(filtered[0]!.serviceLabel, 'Svc50');

--- a/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.ts
+++ b/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.ts
@@ -1,14 +1,23 @@
 import { useMemo, useState, useCallback } from 'react';
 import type { DiscoverRow } from '../../core/state';
+import { getPeerGradient } from '../../core/peer-utils';
 import {
   applyFilters, applySort,
   MAX_INPUT_PRICE_SLIDER_USD, MAX_OUTPUT_PRICE_SLIDER_USD,
   type DiscoverSortKey, type TimeWindow,
 } from '../components/chat/discover-filter-util';
 
+export type DiscoverPeerOption = {
+  peerId: string;
+  label: string;
+  letter: string;
+  gradient: string;
+};
+
 export type DiscoverFilterState = {
   search: string;
   categorySet: Set<string>;
+  peerSet: Set<string>;
   maxInputPrice: number;
   maxOutputPrice: number;
   cachedOnly: boolean;
@@ -16,16 +25,16 @@ export type DiscoverFilterState = {
   minStakeUsdc: number;
   lastSeenWindow: TimeWindow;
   lastSettledWindow: TimeWindow;
-  minChannels: number;
-  minRequests: number;
-  minTokens: number;
+  minVolumeUsdc: number;
   sortKey: DiscoverSortKey;
 
   sortedRows: DiscoverRow[];
   availableCategories: string[];
+  availablePeers: DiscoverPeerOption[];
 
   setSearch: (v: string) => void;
   toggleCategory: (cat: string) => void;
+  togglePeer: (peerId: string) => void;
   setMaxInputPrice: (v: number) => void;
   setMaxOutputPrice: (v: number) => void;
   setCachedOnly: (v: boolean) => void;
@@ -33,9 +42,7 @@ export type DiscoverFilterState = {
   setMinStakeUsdc: (v: number) => void;
   setLastSeenWindow: (v: TimeWindow) => void;
   setLastSettledWindow: (v: TimeWindow) => void;
-  setMinChannels: (v: number) => void;
-  setMinRequests: (v: number) => void;
-  setMinTokens: (v: number) => void;
+  setMinVolumeUsdc: (v: number) => void;
   setSortKey: (k: DiscoverSortKey) => void;
   resetAll: () => void;
 };
@@ -43,6 +50,7 @@ export type DiscoverFilterState = {
 export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
   const [search, setSearch] = useState('');
   const [categorySet, setCategorySet] = useState<Set<string>>(() => new Set());
+  const [peerSet, setPeerSet] = useState<Set<string>>(() => new Set());
   const [maxInputPrice, setMaxInputPrice] = useState<number>(MAX_INPUT_PRICE_SLIDER_USD);
   const [maxOutputPrice, setMaxOutputPrice] = useState<number>(MAX_OUTPUT_PRICE_SLIDER_USD);
   const [cachedOnly, setCachedOnly] = useState(false);
@@ -50,9 +58,7 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
   const [minStakeUsdc, setMinStakeUsdc] = useState<number>(0);
   const [lastSeenWindow, setLastSeenWindow] = useState<TimeWindow>('any');
   const [lastSettledWindow, setLastSettledWindow] = useState<TimeWindow>('any');
-  const [minChannels, setMinChannels] = useState<number>(0);
-  const [minRequests, setMinRequests] = useState<number>(0);
-  const [minTokens, setMinTokens] = useState<number>(0);
+  const [minVolumeUsdc, setMinVolumeUsdc] = useState<number>(0);
   const [sortKey, setSortKey] = useState<DiscoverSortKey>('recentlyUsed');
 
   const toggleCategory = useCallback((cat: string) => {
@@ -65,9 +71,19 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
     });
   }, []);
 
+  const togglePeer = useCallback((peerId: string) => {
+    setPeerSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(peerId)) next.delete(peerId);
+      else next.add(peerId);
+      return next;
+    });
+  }, []);
+
   const resetAll = useCallback(() => {
     setSearch('');
     setCategorySet(new Set());
+    setPeerSet(new Set());
     setMaxInputPrice(MAX_INPUT_PRICE_SLIDER_USD);
     setMaxOutputPrice(MAX_OUTPUT_PRICE_SLIDER_USD);
     setCachedOnly(false);
@@ -75,9 +91,7 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
     setMinStakeUsdc(0);
     setLastSeenWindow('any');
     setLastSettledWindow('any');
-    setMinChannels(0);
-    setMinRequests(0);
-    setMinTokens(0);
+    setMinVolumeUsdc(0);
     setSortKey('recentlyUsed');
   }, []);
 
@@ -87,13 +101,25 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
     return Array.from(set).sort((a, b) => a.localeCompare(b));
   }, [rows]);
 
+  const availablePeers = useMemo<DiscoverPeerOption[]>(() => {
+    const seen = new Map<string, DiscoverPeerOption>();
+    for (const r of rows) {
+      if (!r.peerId || seen.has(r.peerId)) continue;
+      const label = r.peerDisplayName?.trim() || r.peerLabel?.trim() || r.peerId;
+      const gradient = getPeerGradient(r.peerId || r.peerLabel || r.provider || r.serviceId);
+      const letter = (label || '?').charAt(0).toUpperCase();
+      seen.set(r.peerId, { peerId: r.peerId, label, letter, gradient });
+    }
+    return Array.from(seen.values()).sort((a, b) => a.label.localeCompare(b.label));
+  }, [rows]);
+
   const filteredRows = useMemo(
     () => applyFilters(rows, {
-      search, categorySet, maxInputPrice, maxOutputPrice, cachedOnly, chattedOnly, minStakeUsdc,
-      lastSeenWindow, lastSettledWindow, minChannels, minRequests, minTokens,
+      search, categorySet, peerSet, maxInputPrice, maxOutputPrice, cachedOnly, chattedOnly, minStakeUsdc,
+      lastSeenWindow, lastSettledWindow, minVolumeUsdc,
     }),
-    [rows, search, categorySet, maxInputPrice, maxOutputPrice, cachedOnly, chattedOnly, minStakeUsdc,
-      lastSeenWindow, lastSettledWindow, minChannels, minRequests, minTokens],
+    [rows, search, categorySet, peerSet, maxInputPrice, maxOutputPrice, cachedOnly, chattedOnly, minStakeUsdc,
+      lastSeenWindow, lastSettledWindow, minVolumeUsdc],
   );
 
   const sortedRows = useMemo(
@@ -104,6 +130,7 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
   return {
     search,
     categorySet,
+    peerSet,
     maxInputPrice,
     maxOutputPrice,
     cachedOnly,
@@ -111,16 +138,16 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
     minStakeUsdc,
     lastSeenWindow,
     lastSettledWindow,
-    minChannels,
-    minRequests,
-    minTokens,
+    minVolumeUsdc,
     sortKey,
 
     sortedRows,
     availableCategories,
+    availablePeers,
 
     setSearch,
     toggleCategory,
+    togglePeer,
     setMaxInputPrice,
     setMaxOutputPrice,
     setCachedOnly,
@@ -128,9 +155,7 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
     setMinStakeUsdc,
     setLastSeenWindow,
     setLastSettledWindow,
-    setMinChannels,
-    setMinRequests,
-    setMinTokens,
+    setMinVolumeUsdc,
     setSortKey,
     resetAll,
   };


### PR DESCRIPTION
## Description

Overhauls the Discover welcome filter panel: multi-select Peers filter (colored avatar list with inline checkmark), single on-chain "Volume served" slider replacing the channels/requests/tokens sliders, search input moved from the drawer into the main toolbar, active-filter dot on the filter icon, and the drawer now scrolls internally when its content overflows.

## Release Notes

- Discover: filter services by peer (multi-select with peer avatars)
- Discover: replaced Channels / Requests / Tokens sliders with a single "Volume served" slider backed by on-chain USDC volume
- Discover: moved the search input from the filter drawer into the main toolbar
- Discover: filter button now shows a dot indicator when any filter is active
- Discover: filter drawer scrolls internally when the filter content exceeds its height

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes