### PR TITLE
fix(cli): respect --data-dir for daemon and buyer state files

### DIFF
--- a/apps/cli/src/cli/commands/buyer/connection.ts
+++ b/apps/cli/src/cli/commands/buyer/connection.ts
@@ -1,11 +1,9 @@
 import type { Command } from 'commander'
 import { readFile, writeFile, rename } from 'node:fs/promises'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
 import { randomUUID } from 'node:crypto'
 import chalk from 'chalk'
-
-const BUYER_STATE_FILE = join(homedir(), '.antseed', 'buyer.state.json')
+import { getGlobalOptions } from '../types.js'
 
 interface BuyerStateFile {
   state: 'connected' | 'stopped'
@@ -16,21 +14,24 @@ interface BuyerStateFile {
   [key: string]: unknown
 }
 
-async function readStateFile(): Promise<BuyerStateFile | null> {
+function stateFilePath(dataDir: string): string {
+  return join(dataDir, 'buyer.state.json')
+}
+
+async function readStateFile(dataDir: string): Promise<BuyerStateFile | null> {
   try {
-    const raw = await readFile(BUYER_STATE_FILE, 'utf-8')
+    const raw = await readFile(stateFilePath(dataDir), 'utf-8')
     return JSON.parse(raw) as BuyerStateFile
   } catch {
     return null
   }
 }
 
-async function writeStateFile(data: BuyerStateFile): Promise<void> {
-  const dir = join(homedir(), '.antseed')
-  const tmp = join(dir, `.buyer.state.${randomUUID()}.json.tmp`)
+async function writeStateFile(dataDir: string, data: BuyerStateFile): Promise<void> {
+  const tmp = join(dataDir, `.buyer.state.${randomUUID()}.json.tmp`)
   try {
     await writeFile(tmp, JSON.stringify(data, null, 2))
-    await rename(tmp, BUYER_STATE_FILE)
+    await rename(tmp, stateFilePath(dataDir))
   } catch (err) {
     console.error(chalk.red(`Failed to write session state: ${err instanceof Error ? err.message : String(err)}`))
     process.exit(1)
@@ -46,8 +47,8 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-async function requireRunningBuyer(): Promise<BuyerStateFile> {
-  const state = await readStateFile()
+async function requireRunningBuyer(dataDir: string): Promise<BuyerStateFile> {
+  const state = await readStateFile(dataDir)
   if (!state) {
     console.error(chalk.red('No buyer connection found. Run `antseed buyer start` first.'))
     process.exit(1)
@@ -68,7 +69,8 @@ export function registerBuyerConnectionCommand(buyerCmd: Command): void {
     .command('get')
     .description('Show current session state (pinned service, pinned peer)')
     .action(async () => {
-      const state = await readStateFile()
+      const globalOpts = getGlobalOptions(buyerCmd)
+      const state = await readStateFile(globalOpts.dataDir)
       if (!state) {
         console.log(chalk.yellow('No buyer connection state found. Run `antseed buyer start` first.'))
         return
@@ -87,7 +89,8 @@ export function registerBuyerConnectionCommand(buyerCmd: Command): void {
     .option('--service <service>', 'override service ID for all routed requests')
     .option('--peer <peerId>', 'pin all requests to a specific peer ID (40-char hex EVM address)')
     .action(async (options) => {
-      const state = await requireRunningBuyer()
+      const globalOpts = getGlobalOptions(buyerCmd)
+      const state = await requireRunningBuyer(globalOpts.dataDir)
 
       if (options.service === undefined && options.peer === undefined) {
         console.error(chalk.red('Error: specify at least --service or --peer.'))
@@ -112,7 +115,7 @@ export function registerBuyerConnectionCommand(buyerCmd: Command): void {
         state.pinnedPeerId = peer.toLowerCase()
       }
 
-      await writeStateFile(state)
+      await writeStateFile(globalOpts.dataDir, state)
 
       if (options.service !== undefined) console.log(chalk.green(`Pinned service set to: ${state.pinnedService}`))
       if (options.peer !== undefined) console.log(chalk.green(`Pinned peer set to: ${state.pinnedPeerId}`))
@@ -124,7 +127,8 @@ export function registerBuyerConnectionCommand(buyerCmd: Command): void {
     .option('--service', 'clear only the service override')
     .option('--peer', 'clear only the peer pin')
     .action(async (options) => {
-      const state = await requireRunningBuyer()
+      const globalOpts = getGlobalOptions(buyerCmd)
+      const state = await requireRunningBuyer(globalOpts.dataDir)
 
       const clearAll = !options.service && !options.peer
       const clearService = clearAll || Boolean(options.service)
@@ -133,7 +137,7 @@ export function registerBuyerConnectionCommand(buyerCmd: Command): void {
       if (clearService) state.pinnedService = null
       if (clearPeer) state.pinnedPeerId = null
 
-      await writeStateFile(state)
+      await writeStateFile(globalOpts.dataDir, state)
 
       if (clearService && clearPeer) {
         console.log(chalk.green('All session overrides cleared.'))

--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -102,9 +102,9 @@ async function isRpcReachable(rpcUrl: string, timeoutMs = 1500): Promise<boolean
   }
 }
 
-async function getLocalSeederInfo(): Promise<LocalSeederInfo | null> {
+async function getLocalSeederInfo(dataDir: string): Promise<LocalSeederInfo | null> {
   try {
-    const stateFile = join(homedir(), '.antseed', 'daemon.state.json')
+    const stateFile = join(dataDir, 'daemon.state.json')
     const raw = await readFile(stateFile, 'utf-8')
     const state = JSON.parse(raw) as { state?: string; dhtPort?: number; signalingPort?: number; pid?: number }
     if (state.state === 'seeding' && state.dhtPort && state.pid) {
@@ -245,7 +245,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
         }
       }
 
-      const seederInfo = await getLocalSeederInfo()
+      const seederInfo = await getLocalSeederInfo(globalOpts.dataDir)
       const allBootstrapEntries = buildBuyerBootstrapEntries(config.network?.bootstrapNodes, seederInfo?.dhtPort)
       const bootstrapNodes = toBootstrapConfig(parseBootstrapList(allBootstrapEntries))
 
@@ -346,7 +346,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
 
       const proxyPort = effectiveBuyerConfig.proxyPort
       const proxySpinner = ora(`Starting local proxy on port ${proxyPort}...`).start()
-      const proxy = new BuyerProxy({ port: proxyPort, node, pinnedPeerId })
+      const proxy = new BuyerProxy({ port: proxyPort, node, pinnedPeerId, dataDir: globalOpts.dataDir })
       let ownsProxyListener = false
 
       try {

--- a/apps/cli/src/cli/commands/buyer/status.ts
+++ b/apps/cli/src/cli/commands/buyer/status.ts
@@ -3,13 +3,10 @@ import chalk from 'chalk';
 import Table from 'cli-table3';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { getGlobalOptions } from '../types.js';
 import { createDepositsClient, loadCryptoContext, formatUsdc } from '../../payment-utils.js';
 import { loadConfig } from '../../../config/loader.js';
 import { getNodeStatus } from '../../../status/node-status.js';
-
-const BUYER_STATE_FILE = join(homedir(), '.antseed', 'buyer.state.json');
 
 interface BuyerStateFile {
   state?: string;
@@ -19,9 +16,9 @@ interface BuyerStateFile {
   pinnedPeerId?: string | null;
 }
 
-async function readBuyerState(): Promise<BuyerStateFile | null> {
+async function readBuyerState(dataDir: string): Promise<BuyerStateFile | null> {
   try {
-    const raw = await readFile(BUYER_STATE_FILE, 'utf-8');
+    const raw = await readFile(join(dataDir, 'buyer.state.json'), 'utf-8');
     return JSON.parse(raw) as BuyerStateFile;
   } catch {
     return null;
@@ -37,8 +34,8 @@ export function registerBuyerStatusCommand(buyerCmd: Command): void {
       try {
         const globalOpts = getGlobalOptions(buyerCmd);
         const config = await loadConfig(globalOpts.config);
-        const nodeStatus = await getNodeStatus(config);
-        const buyerState = await readBuyerState();
+        const nodeStatus = await getNodeStatus(config, globalOpts.dataDir);
+        const buyerState = await readBuyerState(globalOpts.dataDir);
         const identity = await loadCryptoContext(globalOpts.dataDir);
 
         let depositsAvailable: string | null = null;

--- a/apps/cli/src/cli/commands/network/browse.ts
+++ b/apps/cli/src/cli/commands/network/browse.ts
@@ -4,38 +4,38 @@ import ora from 'ora';
 import Table from 'cli-table3';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
 import { getGlobalOptions } from '../types.js';
 import { loadConfig } from '../../../config/loader.js';
 import { AntseedNode, type PeerInfo } from '@antseed/node';
 import { parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery';
 import { parsePersistedPeers } from '../../../proxy/buyer-proxy.js';
 
-async function readPeersAt(path: string): Promise<PeerInfo[] | null> {
+function isProcessAlive(pid: number): boolean {
   try {
-    const raw = await readFile(path, 'utf-8');
-    const peers = parsePersistedPeers(JSON.parse(raw) as unknown);
-    return peers.length > 0 ? peers : null;
+    process.kill(pid, 0);
+    return true;
   } catch {
-    return null;
+    return false;
   }
 }
 
 /**
- * Try to load discovered peers from a running buyer daemon's state file.
- * Prefers the user-specified dataDir, falling back to the default ~/.antseed
- * location (which is where BuyerProxy currently persists regardless of dataDir).
+ * Try to load discovered peers from a live buyer daemon's state file.
+ * Returns null unless the file exists, the daemon reports `state === 'connected'`,
+ * its PID is still alive, and the peer list is non-empty. This avoids surfacing
+ * stale peer data from a daemon that exited without clearing the file.
  */
 async function loadPeersFromBuyerState(dataDir: string): Promise<PeerInfo[] | null> {
-  const dataDirPath = join(dataDir, 'buyer.state.json');
-  const fromDataDir = await readPeersAt(dataDirPath);
-  if (fromDataDir) return fromDataDir;
-
-  const defaultPath = join(homedir(), '.antseed', 'buyer.state.json');
-  if (defaultPath !== dataDirPath) {
-    return readPeersAt(defaultPath);
+  try {
+    const raw = await readFile(join(dataDir, 'buyer.state.json'), 'utf-8');
+    const parsed = JSON.parse(raw) as { state?: unknown; pid?: unknown };
+    if (parsed.state !== 'connected') return null;
+    if (typeof parsed.pid !== 'number' || !isProcessAlive(parsed.pid)) return null;
+    const peers = parsePersistedPeers(parsed);
+    return peers.length > 0 ? peers : null;
+  } catch {
+    return null;
   }
-  return null;
 }
 
 function getReputationColor(reputation: number): (message: string) => string {

--- a/apps/cli/src/cli/commands/network/browse.ts
+++ b/apps/cli/src/cli/commands/network/browse.ts
@@ -2,10 +2,41 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
 import Table from 'cli-table3';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 import { getGlobalOptions } from '../types.js';
 import { loadConfig } from '../../../config/loader.js';
-import { AntseedNode } from '@antseed/node';
+import { AntseedNode, type PeerInfo } from '@antseed/node';
 import { parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery';
+import { parsePersistedPeers } from '../../../proxy/buyer-proxy.js';
+
+async function readPeersAt(path: string): Promise<PeerInfo[] | null> {
+  try {
+    const raw = await readFile(path, 'utf-8');
+    const peers = parsePersistedPeers(JSON.parse(raw) as unknown);
+    return peers.length > 0 ? peers : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Try to load discovered peers from a running buyer daemon's state file.
+ * Prefers the user-specified dataDir, falling back to the default ~/.antseed
+ * location (which is where BuyerProxy currently persists regardless of dataDir).
+ */
+async function loadPeersFromBuyerState(dataDir: string): Promise<PeerInfo[] | null> {
+  const dataDirPath = join(dataDir, 'buyer.state.json');
+  const fromDataDir = await readPeersAt(dataDirPath);
+  if (fromDataDir) return fromDataDir;
+
+  const defaultPath = join(homedir(), '.antseed', 'buyer.state.json');
+  if (defaultPath !== dataDirPath) {
+    return readPeersAt(defaultPath);
+  }
+  return null;
+}
 
 function getReputationColor(reputation: number): (message: string) => string {
   if (reputation >= 80) {
@@ -15,6 +46,49 @@ function getReputationColor(reputation: number): (message: string) => string {
     return chalk.yellow;
   }
   return chalk.red;
+}
+
+function renderPeersTable(peers: PeerInfo[]): void {
+  const table = new Table({
+    head: [
+      chalk.bold('Name'),
+      chalk.bold('Peer ID'),
+      chalk.bold('Providers'),
+      chalk.bold('Input $/1M'),
+      chalk.bold('Output $/1M'),
+      chalk.bold('Reputation'),
+      chalk.bold('Load'),
+    ],
+    colWidths: [18, 16, 18, 14, 14, 12, 10],
+  });
+
+  for (const peer of peers) {
+    const reputation = peer.reputationScore ?? 0;
+    const repLabel = `${reputation}%`;
+    const repColor = getReputationColor(reputation);
+
+    const load = peer.currentLoad !== undefined && peer.maxConcurrency !== undefined
+      ? `${peer.currentLoad}/${peer.maxConcurrency}`
+      : chalk.dim('n/a');
+
+    table.push([
+      peer.displayName ?? chalk.dim('n/a'),
+      chalk.dim(peer.peerId.slice(0, 12) + '...'),
+      peer.providers.join(', '),
+      peer.defaultInputUsdPerMillion !== undefined
+        ? `$${peer.defaultInputUsdPerMillion.toFixed(2)}`
+        : chalk.dim('n/a'),
+      peer.defaultOutputUsdPerMillion !== undefined
+        ? `$${peer.defaultOutputUsdPerMillion.toFixed(2)}`
+        : chalk.dim('n/a'),
+      repColor(repLabel),
+      load,
+    ]);
+  }
+
+  console.log('');
+  console.log(table.toString());
+  console.log('');
 }
 
 /**
@@ -30,6 +104,26 @@ export function registerNetworkBrowseCommand(networkCmd: Command): void {
     .action(async (options) => {
       const globalOpts = getGlobalOptions(networkCmd);
       const config = await loadConfig(globalOpts.config);
+      const serviceFilter = options.service as string | undefined;
+
+      // Fast path: if a buyer daemon is running, it has already populated
+      // buyer.state.json with discovered peers. Read from there to skip a
+      // 30-second DHT round-trip.
+      const cachedPeers = await loadPeersFromBuyerState(globalOpts.dataDir);
+      if (cachedPeers) {
+        const filtered = serviceFilter
+          ? cachedPeers.filter((peer) => peer.providers.includes(serviceFilter))
+          : cachedPeers;
+        if (filtered.length > 0) {
+          if (options.json) {
+            console.log(JSON.stringify(filtered, null, 2));
+            return;
+          }
+          console.log(chalk.dim(`Loaded ${filtered.length} peer(s) from running buyer daemon`));
+          renderPeersTable(filtered);
+          return;
+        }
+      }
 
       const bootstrapNodes = config.network.bootstrapNodes.length > 0
         ? toBootstrapConfig(parseBootstrapList(config.network.bootstrapNodes))
@@ -51,7 +145,7 @@ export function registerNetworkBrowseCommand(networkCmd: Command): void {
       }
 
       try {
-        const peers = await node.discoverPeers(options.service as string | undefined);
+        const peers = await node.discoverPeers(serviceFilter);
         spinner.succeed(chalk.green(`Found ${peers.length} peer(s)`));
 
         if (peers.length === 0) {
@@ -66,47 +160,7 @@ export function registerNetworkBrowseCommand(networkCmd: Command): void {
           return;
         }
 
-        // Display peers in a table
-        const table = new Table({
-          head: [
-            chalk.bold('Name'),
-            chalk.bold('Peer ID'),
-            chalk.bold('Providers'),
-            chalk.bold('Input $/1M'),
-            chalk.bold('Output $/1M'),
-            chalk.bold('Reputation'),
-            chalk.bold('Load'),
-          ],
-          colWidths: [18, 16, 18, 14, 14, 12, 10],
-        });
-
-        for (const peer of peers) {
-          const reputation = peer.reputationScore ?? 0;
-          const repLabel = `${reputation}%`;
-          const repColor = getReputationColor(reputation);
-
-          const load = peer.currentLoad !== undefined && peer.maxConcurrency !== undefined
-            ? `${peer.currentLoad}/${peer.maxConcurrency}`
-            : chalk.dim('n/a');
-
-          table.push([
-            peer.displayName ?? chalk.dim('n/a'),
-            chalk.dim(peer.peerId.slice(0, 12) + '...'),
-            peer.providers.join(', '),
-            peer.defaultInputUsdPerMillion !== undefined
-              ? `$${peer.defaultInputUsdPerMillion.toFixed(2)}`
-              : chalk.dim('n/a'),
-            peer.defaultOutputUsdPerMillion !== undefined
-              ? `$${peer.defaultOutputUsdPerMillion.toFixed(2)}`
-              : chalk.dim('n/a'),
-            repColor(repLabel),
-            load,
-          ]);
-        }
-
-        console.log('');
-        console.log(table.toString());
-        console.log('');
+        renderPeersTable(peers);
       } catch (err) {
         spinner.fail(chalk.red(`Discovery failed: ${(err as Error).message}`));
       }

--- a/apps/cli/src/cli/commands/seller/status.ts
+++ b/apps/cli/src/cli/commands/seller/status.ts
@@ -5,6 +5,7 @@ import { getGlobalOptions } from '../types.js';
 import { loadConfig } from '../../../config/loader.js';
 import { resolveEffectiveSellerConfig } from '../../../config/effective.js';
 import { getNodeStatus } from '../../../status/node-status.js';
+import { loadCryptoContext } from '../../payment-utils.js';
 import { formatEarnings, formatTokens } from '../../formatters.js';
 
 type SellerNodeState = 'seeding' | 'connected' | 'idle';
@@ -19,7 +20,15 @@ export function registerSellerStatusCommand(sellerCmd: Command): void {
         const globalOpts = getGlobalOptions(sellerCmd);
         const config = await loadConfig(globalOpts.config);
         const effectiveSeller = resolveEffectiveSellerConfig({ config });
-        const status = await getNodeStatus(config);
+        const status = await getNodeStatus(config, globalOpts.dataDir);
+        let identityAddress: string | null = null;
+        try {
+          const cryptoContext = await loadCryptoContext(globalOpts.dataDir);
+          identityAddress = cryptoContext.address;
+        } catch {
+          // Identity unavailable — fall through and show "not configured"
+        }
+        const walletAddress = status.walletAddress ?? identityAddress;
 
         const providerSummary = Object.entries(effectiveSeller.providers).map(([name, cfg]) => {
           const defaults = cfg.defaults;
@@ -43,7 +52,7 @@ export function registerSellerStatusCommand(sellerCmd: Command): void {
             tokensToday: status.tokensToday,
             activeChannels: status.activeChannels,
             uptime: status.uptime,
-            walletAddress: status.walletAddress,
+            walletAddress,
             providers: providerSummary,
           }, null, 2));
           return;
@@ -69,7 +78,7 @@ export function registerSellerStatusCommand(sellerCmd: Command): void {
           ['Tokens today', formatTokens(status.tokensToday)],
           ['Active channels', String(status.activeChannels)],
           ['Uptime', status.uptime],
-          ['Wallet address', status.walletAddress ?? chalk.dim('not configured')],
+          ['Wallet address', walletAddress ?? chalk.dim('not configured')],
         );
 
         table.push([

--- a/apps/cli/src/cli/commands/seller/status.ts
+++ b/apps/cli/src/cli/commands/seller/status.ts
@@ -21,14 +21,13 @@ export function registerSellerStatusCommand(sellerCmd: Command): void {
         const config = await loadConfig(globalOpts.config);
         const effectiveSeller = resolveEffectiveSellerConfig({ config });
         const status = await getNodeStatus(config, globalOpts.dataDir);
-        let identityAddress: string | null = null;
-        try {
-          const cryptoContext = await loadCryptoContext(globalOpts.dataDir);
-          identityAddress = cryptoContext.address;
-        } catch {
-          // Identity unavailable — fall through and show "not configured"
-        }
-        const walletAddress = status.walletAddress ?? identityAddress;
+        const walletAddress = status.walletAddress ?? await (async () => {
+          try {
+            return (await loadCryptoContext(globalOpts.dataDir)).address;
+          } catch {
+            return null;
+          }
+        })();
 
         const providerSummary = Object.entries(effectiveSeller.providers).map(([name, cfg]) => {
           const defaults = cfg.defaults;

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -3,7 +3,6 @@ import { randomUUID } from 'node:crypto'
 import { watch, type FSWatcher } from 'node:fs'
 import { readFile, writeFile, rename, mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
-import { homedir } from 'node:os'
 import type {
   AntseedNode,
   PeerInfo,
@@ -61,6 +60,8 @@ export { rewriteServiceInBody } from './request-utils.js'
 export interface BuyerProxyConfig {
   port: number
   node: AntseedNode
+  /** Data directory used to persist buyer.state.json (discovered peers, session overrides). */
+  dataDir: string
   /** How often to refresh the peer list from DHT in the background (ms). Default: 300000 (5 min) */
   backgroundRefreshIntervalMs?: number
   /**
@@ -84,7 +85,6 @@ export interface BuyerProxyConfig {
   pinnedService?: string
 }
 
-const BUYER_STATE_FILE = join(homedir(), '.antseed', 'buyer.state.json')
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504])
 /** Max age for carrying forward peers not seen in the latest DHT scan. */
 const CARRY_FORWARD_TTL_MS = 30 * 60_000
@@ -267,6 +267,8 @@ export class BuyerProxy {
   private readonly _port: number
   private readonly _bgRefreshIntervalMs: number
   private readonly _peerCacheTtlMs: number
+  private readonly _stateDir: string
+  private readonly _stateFile: string
   private _pinnedPeer: string | null
   private _pinnedService: string | null
   private _stateFileWatcher: FSWatcher | null = null
@@ -288,6 +290,8 @@ export class BuyerProxy {
     this._port = config.port
     this._bgRefreshIntervalMs = config.backgroundRefreshIntervalMs ?? 5 * 60_000
     this._peerCacheTtlMs = Math.max(0, config.peerCacheTtlMs ?? 6 * 60_000)
+    this._stateDir = config.dataDir
+    this._stateFile = join(config.dataDir, 'buyer.state.json')
     this._pinnedPeer = config.pinnedPeerId?.toLowerCase() ?? null
     this._pinnedService = config.pinnedService?.trim() ?? null
     this._server = createServer((req, res) => {
@@ -324,7 +328,7 @@ export class BuyerProxy {
 
   private async _hydratePeersFromStateFile(): Promise<void> {
     try {
-      const raw = await readFile(BUYER_STATE_FILE, 'utf-8')
+      const raw = await readFile(this._stateFile, 'utf-8')
       const parsed = JSON.parse(raw) as unknown
       const peers = parsePersistedPeers(parsed)
       if (peers.length === 0) {
@@ -338,7 +342,7 @@ export class BuyerProxy {
         ? peersUpdatedAt
         : Date.now()
       this._cacheMutationEpoch += 1
-      log(`Hydrated ${peers.length} peer(s) from ${BUYER_STATE_FILE}`)
+      log(`Hydrated ${peers.length} peer(s) from ${this._stateFile}`)
     } catch {
       // File missing, unreadable, or malformed — non-fatal. The background
       // refresh will populate the cache shortly.
@@ -366,7 +370,7 @@ export class BuyerProxy {
 
   private _watchStateFile(): void {
     try {
-      this._stateFileWatcher = watch(BUYER_STATE_FILE, { persistent: false }, () => {
+      this._stateFileWatcher = watch(this._stateFile, { persistent: false }, () => {
         if (this._stateWatchDebounce) clearTimeout(this._stateWatchDebounce)
         this._stateWatchDebounce = setTimeout(() => {
           this._stateWatchDebounce = null
@@ -383,7 +387,7 @@ export class BuyerProxy {
 
   private async _reloadSessionOverrides(): Promise<void> {
     try {
-      const raw = await readFile(BUYER_STATE_FILE, 'utf-8')
+      const raw = await readFile(this._stateFile, 'utf-8')
       const parsed = JSON.parse(raw) as Record<string, unknown>
       const pinnedService = typeof parsed.pinnedService === 'string' && parsed.pinnedService.trim().length > 0
         ? parsed.pinnedService.trim()
@@ -403,19 +407,18 @@ export class BuyerProxy {
   private _mergeStateFile(patch: Record<string, unknown>): Promise<void> {
     this._stateWriteChain = this._stateWriteChain.then(async () => {
       try {
-        const dir = join(homedir(), '.antseed')
-        await mkdir(dir, { recursive: true })
+        await mkdir(this._stateDir, { recursive: true })
         let existing: Record<string, unknown> = {}
         try {
-          const raw = await readFile(BUYER_STATE_FILE, 'utf-8')
+          const raw = await readFile(this._stateFile, 'utf-8')
           existing = JSON.parse(raw) as Record<string, unknown>
         } catch {
           // file doesn't exist yet
         }
         const data = { ...existing, ...patch }
-        const tmp = join(homedir(), '.antseed', `.buyer.state.${randomUUID()}.json.tmp`)
+        const tmp = join(this._stateDir, `.buyer.state.${randomUUID()}.json.tmp`)
         await writeFile(tmp, JSON.stringify(data, null, 2))
-        await rename(tmp, BUYER_STATE_FILE)
+        await rename(tmp, this._stateFile)
       } catch {
         // non-fatal
       }

--- a/apps/cli/src/status/node-status.ts
+++ b/apps/cli/src/status/node-status.ts
@@ -3,6 +3,8 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { AntseedConfig } from '../config/types.js';
 
+const DEFAULT_DATA_DIR = join(homedir(), '.antseed');
+
 export interface NodeStatus {
   state: 'seeding' | 'connected' | 'idle';
   peerCount: number;
@@ -35,12 +37,12 @@ function isProcessAlive(pid: number): boolean {
 
 /**
  * Query the current node status.
- * Reads from the running daemon's state file at ~/.antseed/daemon.state.json.
+ * Reads from the running daemon's state file at <dataDir>/daemon.state.json.
  * Uses PID-based liveness check first, falls back to 30s stale threshold.
  * Returns idle state with zeroed metrics if no daemon is running or the state file is stale.
  */
-export async function getNodeStatus(config: AntseedConfig): Promise<NodeStatus> {
-  const stateFilePath = join(homedir(), '.antseed', 'daemon.state.json');
+export async function getNodeStatus(config: AntseedConfig, dataDir: string = DEFAULT_DATA_DIR): Promise<NodeStatus> {
+  const stateFilePath = join(dataDir, 'daemon.state.json');
 
   try {
     const raw = await readFile(stateFilePath, 'utf-8');

--- a/e2e/tests/openai-responses-sdk.test.ts
+++ b/e2e/tests/openai-responses-sdk.test.ts
@@ -113,6 +113,7 @@ describe('OpenAI SDK integration: Responses API over buyer proxy', () => {
     proxy = new BuyerProxy({
       node: buyerNode,
       port,
+      dataDir: buyerDataDir!,
       backgroundRefreshIntervalMs: 60_000,
       peerCacheTtlMs: 1_000,
     });


### PR DESCRIPTION
## Summary
- Several CLI commands hardcoded `~/.antseed` for `daemon.state.json` and `buyer.state.json`, so running with a custom `--data-dir` (e.g. in k8s deployments) made status commands show empty tables and broke buyer connection session overrides.
- `seller status` also never derived the wallet address from `ANTSEED_IDENTITY_HEX`, so the "become a provider" docs flow showed "not configured" even when the env var was set.
- `network browse` always did a fresh 30s DHT round-trip, even when a buyer daemon had already populated the peer cache.

## Changes
- `getNodeStatus` now takes `dataDir` and reads `<dataDir>/daemon.state.json`; `seller status` and `buyer status` pass `globalOpts.dataDir` through.
- `seller status` falls back to `loadCryptoContext(dataDir)` so the wallet address resolves from `ANTSEED_IDENTITY_HEX` or `identity.key` even before the daemon has started (matches `buyer status`).
- `getLocalSeederInfo` in `buyer start` takes `dataDir`.
- `BuyerProxy` takes `dataDir` in its config and stores the state-file path as an instance field; `buyer connection get/set/clear` and `buyer status` read/write `<dataDir>/buyer.state.json`.
- `network browse` reads discovered peers from `<dataDir>/buyer.state.json` (with fallback to `~/.antseed` for robustness) before starting an ephemeral node.

## Test plan
- [ ] \`pnpm --filter @antseed/cli run typecheck\` passes
- [ ] \`pnpm --filter @antseed/cli run test\` passes (4 pre-existing ChannelStore/metering failures are unrelated)
- [ ] \`antseed seller status\` with \`ANTSEED_IDENTITY_HEX\` set (no daemon running) shows the derived wallet address
- [ ] \`antseed seller status --data-dir <custom>\` against a seller daemon started with the same \`--data-dir\` shows populated metrics (peers, earnings, uptime)
- [ ] \`antseed network browse\` with a running buyer daemon returns instantly from the cached peer list