### PR TITLE
fix(website): mobile nav sidebar, card borders, default sort by price

### DIFF
--- a/apps/website/src/css/custom.css
+++ b/apps/website/src/css/custom.css
@@ -155,30 +155,31 @@ nav.navbar {
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' fill='%236b7280' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M11.944 0A12 12 0 000 12a12 12 0 0012 12 12 12 0 0012-12A12 12 0 0012 0a12 12 0 00-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 01.171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z'/%3E%3C/svg%3E");
 }
 
-/* Mobile sidebar styling */
+/* Mobile sidebar — full-width override */
+:root {
+  --ifm-navbar-sidebar-width: 100vw;
+}
+
 .navbar-sidebar {
   background: #f5f5f0 !important;
   --ifm-navbar-background-color: #f5f5f0;
-  height: 100vh !important;
-  width: 100vw !important;
-  max-width: 100vw !important;
-  display: flex !important;
-  flex-direction: column !important;
+  height: 100dvh !important;
 }
 
 .navbar-sidebar__item {
   background: #f5f5f0 !important;
+  overflow-y: auto !important;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 60px;
 }
 
 .navbar-sidebar__brand {
   background: #f5f5f0 !important;
   border-bottom: 1px solid rgba(10, 14, 20, 0.07);
-  flex: none !important;
 }
 
 .navbar-sidebar__items {
   background: #f5f5f0 !important;
-  flex: 1 !important;
 }
 
 .navbar-sidebar__items .menu__link {
@@ -201,21 +202,6 @@ nav.navbar {
 .navbar-sidebar .header-x-link,
 .navbar-sidebar .header-telegram-link {
   display: none;
-}
-
-/* Mobile sidebar — hide the secondary docs sub-panel and back button */
-.navbar-sidebar__items--show-secondary .navbar-sidebar__item:first-child {
-  display: none;
-}
-.navbar-sidebar__back {
-  display: none;
-}
-.navbar-sidebar__items {
-  transform: none !important;
-  transition: none !important;
-}
-.navbar-sidebar__item.menu {
-  display: block !important;
 }
 
 /* =============================================

--- a/apps/website/src/pages/network.module.css
+++ b/apps/website/src/pages/network.module.css
@@ -703,6 +703,10 @@
     gap: 8px;
   }
 
+  .row td {
+    border: none !important;
+  }
+
   .tdModel {
     width: 100%;
     padding: 0 !important;

--- a/apps/website/src/pages/network.tsx
+++ b/apps/website/src/pages/network.tsx
@@ -237,8 +237,8 @@ export default function PricingPage() {
   const [query, setQuery] = useState('');
   const [providerFilter, setProviderFilter] = useState<string | null>(null);
   const [tagFilter, setTagFilter] = useState<string | null>(null);
-  const [sortKey, setSortKey] = useState<SortKey>('totalTokens');
-  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  const [sortKey, setSortKey] = useState<SortKey>('inputPrice');
+  const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [showFilters, setShowFilters] = useState(false);
   const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
 


### PR DESCRIPTION
## Summary

- **Mobile nav sidebar**: panels are now full viewport width (`--ifm-navbar-sidebar-width: 100vw`). Removed the broken `transform: none !important` / `display: block !important` hacks from `f67f1e0` that left the infima secondary panel leaking into the primary view. Added `overflow-y: auto` + safe bottom padding, and switched `100vh` → `100dvh` so the iOS Safari toolbar doesn't clip the last item. (Port of the website portion of `11357f4` on \`backup/desktop-discover-mixed\`.)
- **Pricing page mobile cards**: infima sets `border: 1px solid` on every `table td` by default. On desktop `border-collapse: collapse` merges them, but the mobile card layout flips `.row` to flex, so each `td` kept its own border and rendered as an individual boxed element. Added `.row td { border: none !important }` inside the mobile `@media` block.
- **Default sort**: pricing page now sorts by input price ascending (cheapest first) instead of `totalTokens` descending.

## Test plan
- [ ] `pnpm --filter @antseed/website dev`, open http://localhost:3000 in a mobile viewport (Chrome DevTools → iPhone 14)
- [ ] Toggle the hamburger — sidebar fills the full viewport, Pricing / Docs / \$ANTS / Blog are visible without the secondary panel leaking on the right edge
- [ ] Navigate to /network — cards have a single outer border (no inner cell boxes) and services are ordered by ascending input price
- [ ] Desktop view of /network is unchanged (table layout, `border-collapse` still merges borders, column sort click still works)