### PR TITLE
feat(node): RPC fallback via ethers FallbackProvider for Base mainnet

### DIFF
--- a/apps/cli/src/cli/commands/buyer/balance.ts
+++ b/apps/cli/src/cli/commands/buyer/balance.ts
@@ -38,6 +38,7 @@ export function registerBuyerBalanceCommand(buyerCmd: Command): void {
 
       const depositsClient = new DepositsClient({
         rpcUrl: chainConfig.rpcUrl,
+        ...(chainConfig.fallbackRpcUrls ? { fallbackRpcUrls: chainConfig.fallbackRpcUrls } : {}),
         contractAddress: chainConfig.depositsContractAddress,
         usdcAddress: chainConfig.usdcContractAddress,
       });

--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -276,6 +276,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
         paymentsConfig = {
           enabled: true,
           rpcUrl: chainConfig.rpcUrl,
+          ...(chainConfig.fallbackRpcUrls ? { fallbackRpcUrls: chainConfig.fallbackRpcUrls } : {}),
           depositsAddress: chainConfig.depositsContractAddress,
           channelsAddress: chainConfig.channelsContractAddress,
           usdcAddress: chainConfig.usdcContractAddress,
@@ -332,6 +333,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
           const address = identity.wallet.address
           const depositsClient = new DepositsClient({
             rpcUrl: chainConfig.rpcUrl,
+            ...(chainConfig.fallbackRpcUrls ? { fallbackRpcUrls: chainConfig.fallbackRpcUrls } : {}),
             contractAddress: chainConfig.depositsContractAddress,
             usdcAddress: chainConfig.usdcContractAddress,
           })

--- a/apps/cli/src/cli/commands/buyer/withdraw.ts
+++ b/apps/cli/src/cli/commands/buyer/withdraw.ts
@@ -36,6 +36,7 @@ export function registerBuyerWithdrawCommand(buyerCmd: Command): void {
 
       const depositsClient = new DepositsClient({
         rpcUrl: payments.crypto.rpcUrl,
+        ...(payments.crypto.fallbackRpcUrls ? { fallbackRpcUrls: payments.crypto.fallbackRpcUrls } : {}),
         contractAddress: payments.crypto.depositsContractAddress,
         usdcAddress: payments.crypto.usdcContractAddress,
       });

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -374,6 +374,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
         const cryptoConfig: NonNullable<PaymentConfig['crypto']> = {
           chainId: cc.chainId,
           rpcUrl: cc.rpcUrl,
+          ...(cc.fallbackRpcUrls ? { fallbackRpcUrls: cc.fallbackRpcUrls } : {}),
           depositsContractAddress: cc.depositsContractAddress,
           channelsContractAddress: cc.channelsContractAddress,
           usdcAddress: cc.usdcContractAddress,
@@ -495,6 +496,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
           // Top-level fields required by the node for contract clients + EIP-712 domain
           ...(paymentConfig?.crypto ? {
             rpcUrl: paymentConfig.crypto.rpcUrl,
+            ...(paymentConfig.crypto.fallbackRpcUrls ? { fallbackRpcUrls: paymentConfig.crypto.fallbackRpcUrls } : {}),
             depositsAddress: paymentConfig.crypto.depositsContractAddress,
             channelsAddress: paymentConfig.crypto.channelsContractAddress,
             usdcAddress: paymentConfig.crypto.usdcAddress,

--- a/apps/cli/src/cli/payment-utils.ts
+++ b/apps/cli/src/cli/payment-utils.ts
@@ -70,6 +70,9 @@ export function requireCryptoConfig(config: AntseedConfig): NonNullable<AntseedC
   return {
     ...crypto,
     rpcUrl: crypto.rpcUrl || resolved.rpcUrl,
+    ...(resolved.fallbackRpcUrls && resolved.fallbackRpcUrls.length > 0
+      ? { fallbackRpcUrls: resolved.fallbackRpcUrls }
+      : {}),
     usdcContractAddress: crypto.usdcContractAddress || resolved.usdcContractAddress,
     depositsContractAddress: crypto.depositsContractAddress || resolved.depositsContractAddress,
     channelsContractAddress: crypto.channelsContractAddress || resolved.channelsContractAddress,
@@ -79,6 +82,12 @@ export function requireCryptoConfig(config: AntseedConfig): NonNullable<AntseedC
   };
 }
 
+function fallbackClientOpts(crypto: ReturnType<typeof requireCryptoConfig>) {
+  return crypto.fallbackRpcUrls && crypto.fallbackRpcUrls.length > 0
+    ? { fallbackRpcUrls: crypto.fallbackRpcUrls }
+    : {};
+}
+
 /**
  * Create a DepositsClient from the CLI config.
  */
@@ -86,6 +95,7 @@ export function createDepositsClient(config: AntseedConfig): DepositsClient {
   const crypto = requireCryptoConfig(config);
   return new DepositsClient({
     rpcUrl: crypto.rpcUrl,
+    ...fallbackClientOpts(crypto),
     contractAddress: crypto.depositsContractAddress,
     usdcAddress: crypto.usdcContractAddress,
   });
@@ -98,6 +108,7 @@ export function createChannelsClient(config: AntseedConfig): ChannelsClient {
   const crypto = requireCryptoConfig(config);
   return new ChannelsClient({
     rpcUrl: crypto.rpcUrl,
+    ...fallbackClientOpts(crypto),
     contractAddress: crypto.channelsContractAddress,
   });
 }
@@ -112,6 +123,7 @@ export function createIdentityClient(config: AntseedConfig): IdentityClient {
   }
   return new IdentityClient({
     rpcUrl: crypto.rpcUrl,
+    ...fallbackClientOpts(crypto),
     contractAddress: crypto.identityRegistryAddress,
   });
 }
@@ -126,6 +138,7 @@ export function createStakingClient(config: AntseedConfig): StakingClient {
   }
   return new StakingClient({
     rpcUrl: crypto.rpcUrl,
+    ...fallbackClientOpts(crypto),
     contractAddress: crypto.stakingContractAddress,
     usdcAddress: crypto.usdcContractAddress,
   });
@@ -141,6 +154,7 @@ export function createEmissionsClient(config: AntseedConfig): EmissionsClient {
   }
   return new EmissionsClient({
     rpcUrl: crypto.rpcUrl,
+    ...fallbackClientOpts(crypto),
     contractAddress: crypto.emissionsContractAddress,
   });
 }
@@ -155,6 +169,7 @@ export function createSubPoolClient(config: AntseedConfig): SubPoolClient {
   }
   return new SubPoolClient({
     rpcUrl: crypto.rpcUrl,
+    ...fallbackClientOpts(crypto),
     contractAddress: crypto.subPoolContractAddress,
     usdcAddress: crypto.usdcContractAddress,
   });

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -115,6 +115,8 @@ export interface PaymentsCLIConfig {
     chainId: 'base-local' | 'base-sepolia' | 'base-mainnet';
     /** Base JSON-RPC URL (e.g. http://127.0.0.1:8545 for local anvil) */
     rpcUrl: string;
+    /** Additional RPC endpoints tried in order via ethers FallbackProvider. */
+    fallbackRpcUrls?: string[];
     /** Deployed AntseedDeposits contract address */
     depositsContractAddress: string;
     /** Deployed AntseedChannels contract address */

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -4,9 +4,3 @@ import path from 'node:path';
 export const DEFAULT_CONFIG_PATH = path.join(homedir(), '.antseed', 'config.json');
 export const DEFAULT_BUYER_STATE_PATH = path.join(homedir(), '.antseed', 'buyer.state.json');
 export const DEFAULT_DASHBOARD_PORT = 3117;
-
-// mainnet.base.org rate-limits concurrent eth_call reads and intermittently
-// returns CALL_EXCEPTION / "missing revert data", which wedges the credits
-// pill at $0.00 on desktop. base-rpc.publicnode.com handles the concurrent
-// read pattern cleanly. Users can still override via payments.crypto.rpcUrl.
-export const DESKTOP_DEFAULT_BASE_MAINNET_RPC_URL = 'https://base-rpc.publicnode.com';

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -594,7 +594,7 @@ let cachedCreditsInfo: CreditsInfo | null = null;
 
 // Cached crypto config — invalidated on config update. Uses protocol defaults
 // from resolveChainConfig with optional user overrides from config.json.
-let cachedCryptoConfig: { rpcUrl: string; depositsAddress: string; channelsAddress: string; usdcAddress: string; chainId: number } | null = null;
+let cachedCryptoConfig: { rpcUrl: string; fallbackRpcUrls?: string[]; depositsAddress: string; channelsAddress: string; usdcAddress: string; chainId: number } | null = null;
 
 async function loadCachedCryptoConfig(): Promise<typeof cachedCryptoConfig> {
   if (cachedCryptoConfig) return cachedCryptoConfig;
@@ -612,7 +612,7 @@ async function loadCachedCryptoConfig(): Promise<typeof cachedCryptoConfig> {
   const userRpcUrl = asString(overrides.rpcUrl as string, '');
   const rpcUrl = userRpcUrl || (selectedChain === 'base-mainnet' ? DESKTOP_DEFAULT_BASE_MAINNET_RPC_URL : '');
   const cc = resolveChainConfig({ chainId: selectedChain, ...(rpcUrl ? { rpcUrl } : {}) });
-  cachedCryptoConfig = { rpcUrl: cc.rpcUrl, depositsAddress: cc.depositsContractAddress, channelsAddress: cc.channelsContractAddress, usdcAddress: cc.usdcContractAddress, chainId: cc.evmChainId };
+  cachedCryptoConfig = { rpcUrl: cc.rpcUrl, ...(cc.fallbackRpcUrls ? { fallbackRpcUrls: cc.fallbackRpcUrls } : {}), depositsAddress: cc.depositsContractAddress, channelsAddress: cc.channelsContractAddress, usdcAddress: cc.usdcContractAddress, chainId: cc.evmChainId };
   return cachedCryptoConfig;
 }
 
@@ -644,7 +644,7 @@ async function refreshCreditsInfo(): Promise<CreditsInfo> {
     creditsRpcFailCount = 0;
   }
 
-  const depositsClient = new DepositsClient({ rpcUrl: cc.rpcUrl, contractAddress: cc.depositsAddress, usdcAddress: cc.usdcAddress });
+  const depositsClient = new DepositsClient({ rpcUrl: cc.rpcUrl, ...(cc.fallbackRpcUrls ? { fallbackRpcUrls: cc.fallbackRpcUrls } : {}), contractAddress: cc.depositsAddress, usdcAddress: cc.usdcAddress });
 
   try {
     const [balance, creditLimit, operatorAddress] = await Promise.all([

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -107,7 +107,7 @@ const APP_ICON_PATH = resolveAppIconPath();
 // in some surfaces because the underlying bundle is Electron.app.
 app.setName(APP_NAME);
 
-import { DEFAULT_CONFIG_PATH, DESKTOP_DEFAULT_BASE_MAINNET_RPC_URL } from './constants.js';
+import { DEFAULT_CONFIG_PATH } from './constants.js';
 import { asRecord, asString } from './utils.js';
 
 function resolveActiveConfigPath(): string {
@@ -610,8 +610,7 @@ async function loadCachedCryptoConfig(): Promise<typeof cachedCryptoConfig> {
   // All contract addresses come from the preset in chain-config.ts.
   const selectedChain = asString(overrides.chainId as string, '') || 'base-mainnet';
   const userRpcUrl = asString(overrides.rpcUrl as string, '');
-  const rpcUrl = userRpcUrl || (selectedChain === 'base-mainnet' ? DESKTOP_DEFAULT_BASE_MAINNET_RPC_URL : '');
-  const cc = resolveChainConfig({ chainId: selectedChain, ...(rpcUrl ? { rpcUrl } : {}) });
+  const cc = resolveChainConfig({ chainId: selectedChain, ...(userRpcUrl ? { rpcUrl: userRpcUrl } : {}) });
   cachedCryptoConfig = { rpcUrl: cc.rpcUrl, ...(cc.fallbackRpcUrls ? { fallbackRpcUrls: cc.fallbackRpcUrls } : {}), depositsAddress: cc.depositsContractAddress, channelsAddress: cc.channelsContractAddress, usdcAddress: cc.usdcContractAddress, chainId: cc.evmChainId };
   return cachedCryptoConfig;
 }

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -616,11 +616,13 @@ async function loadOnChainClients(configPath: string): Promise<{ stakingClient: 
   if (!cc.stakingContractAddress) return null;
   cachedStakingClient = new StakingClient({
     rpcUrl: cc.rpcUrl,
+    ...(cc.fallbackRpcUrls ? { fallbackRpcUrls: cc.fallbackRpcUrls } : {}),
     contractAddress: cc.stakingContractAddress,
     usdcAddress: cc.usdcContractAddress,
   });
   cachedChannelsClient = new ChannelsClient({
     rpcUrl: cc.rpcUrl,
+    ...(cc.fallbackRpcUrls ? { fallbackRpcUrls: cc.fallbackRpcUrls } : {}),
     contractAddress: cc.channelsContractAddress,
   });
   return { stakingClient: cachedStakingClient, channelsClient: cachedChannelsClient };

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -16,7 +16,6 @@ import {
   loadChatWorkspaceDir,
   persistChatWorkspaceDir,
 } from './chat-workspace.js';
-import { DESKTOP_DEFAULT_BASE_MAINNET_RPC_URL } from './constants.js';
 import { asErrorMessage } from './utils.js';
 import { StakingClient, ChannelsClient, resolveChainConfig } from '@antseed/node';
 import {
@@ -608,10 +607,9 @@ async function loadOnChainClients(configPath: string): Promise<{ stakingClient: 
     ? overrides.chainId
     : 'base-mainnet';
   const userRpcUrl = typeof overrides.rpcUrl === 'string' && overrides.rpcUrl.trim().length > 0 ? overrides.rpcUrl : '';
-  const rpcUrl = userRpcUrl || (selectedChain === 'base-mainnet' ? DESKTOP_DEFAULT_BASE_MAINNET_RPC_URL : '');
   const cc = resolveChainConfig({
     chainId: selectedChain,
-    ...(rpcUrl ? { rpcUrl } : {}),
+    ...(userRpcUrl ? { rpcUrl: userRpcUrl } : {}),
   });
   if (!cc.stakingContractAddress) return null;
   cachedStakingClient = new StakingClient({

--- a/apps/network-stats/src/index.ts
+++ b/apps/network-stats/src/index.ts
@@ -33,6 +33,7 @@ if (chainConfig.statsContractAddress && typeof chainConfig.statsDeployBlock === 
   store.init();
   const statsClient = new StatsClient({
     rpcUrl: chainConfig.rpcUrl,
+    ...(chainConfig.fallbackRpcUrls ? { fallbackRpcUrls: chainConfig.fallbackRpcUrls } : {}),
     contractAddress: chainConfig.statsContractAddress,
   });
   indexer = new MetadataIndexer({
@@ -49,6 +50,7 @@ if (chainConfig.statsContractAddress && typeof chainConfig.statsDeployBlock === 
   if (chainConfig.stakingContractAddress) {
     stakingClient = new StakingClient({
       rpcUrl: chainConfig.rpcUrl,
+      ...(chainConfig.fallbackRpcUrls ? { fallbackRpcUrls: chainConfig.fallbackRpcUrls } : {}),
       contractAddress: chainConfig.stakingContractAddress,
       usdcAddress: chainConfig.usdcContractAddress,
     });

--- a/apps/payments/src/crypto-context.ts
+++ b/apps/payments/src/crypto-context.ts
@@ -10,6 +10,7 @@ export interface CryptoContext {
 
 export interface PaymentCryptoConfig {
   rpcUrl: string;
+  fallbackRpcUrls?: string[];
   depositsContractAddress: string;
   channelsContractAddress: string;
   usdcContractAddress: string;

--- a/apps/payments/src/routes.ts
+++ b/apps/payments/src/routes.ts
@@ -16,6 +16,7 @@ const parseUsdc6 = parseUsdc;
 function createClient(config: PaymentCryptoConfig): DepositsClient {
   return new DepositsClient({
     rpcUrl: config.rpcUrl,
+    ...(config.fallbackRpcUrls ? { fallbackRpcUrls: config.fallbackRpcUrls } : {}),
     contractAddress: config.depositsContractAddress,
     usdcAddress: config.usdcContractAddress,
   });
@@ -34,6 +35,7 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
     if (!channelsClient) {
       channelsClient = new ChannelsClient({
         rpcUrl: ctx.cryptoConfig.rpcUrl,
+        ...(ctx.cryptoConfig.fallbackRpcUrls ? { fallbackRpcUrls: ctx.cryptoConfig.fallbackRpcUrls } : {}),
         contractAddress: ctx.cryptoConfig.channelsContractAddress,
       });
     }

--- a/apps/payments/src/server.ts
+++ b/apps/payments/src/server.ts
@@ -85,6 +85,9 @@ export async function createServer(options: PaymentsServerOptions) {
   const chainConfig = resolveChainConfig({
     chainId: userOverrides.chainId as string | undefined,
     rpcUrl: userOverrides.rpcUrl as string | undefined,
+    ...(Array.isArray(userOverrides.fallbackRpcUrls)
+      ? { fallbackRpcUrls: userOverrides.fallbackRpcUrls as string[] }
+      : {}),
     depositsContractAddress: userOverrides.depositsContractAddress as string | undefined,
     channelsContractAddress: userOverrides.channelsContractAddress as string | undefined,
     usdcContractAddress: userOverrides.usdcContractAddress as string | undefined,
@@ -92,6 +95,7 @@ export async function createServer(options: PaymentsServerOptions) {
 
   const cryptoConfig: PaymentCryptoConfig = {
     rpcUrl: chainConfig.rpcUrl,
+    ...(chainConfig.fallbackRpcUrls ? { fallbackRpcUrls: chainConfig.fallbackRpcUrls } : {}),
     depositsContractAddress: chainConfig.depositsContractAddress,
     channelsContractAddress: chainConfig.channelsContractAddress,
     usdcContractAddress: chainConfig.usdcContractAddress,

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -100,6 +100,8 @@ export interface NodePaymentsConfig {
   paymentConfig?: PaymentConfig | null;
   /** Base JSON-RPC URL (e.g. http://127.0.0.1:8545 for anvil) */
   rpcUrl?: string;
+  /** Additional RPC endpoints for transparent failover via ethers FallbackProvider (quorum=1). */
+  fallbackRpcUrls?: string[];
   /** Deployed AntseedDeposits contract address */
   depositsAddress?: string;
   /** Deployed AntseedChannels contract address */
@@ -939,6 +941,7 @@ export class AntseedNode extends EventEmitter {
       if (this._channelStore) {
         const buyerPaymentConfig: BuyerPaymentConfig = {
           rpcUrl: payments.rpcUrl,
+          ...(payments.fallbackRpcUrls ? { fallbackRpcUrls: payments.fallbackRpcUrls } : {}),
           depositsContractAddress: payments.depositsAddress,
           channelsContractAddress: payments.channelsAddress,
           usdcAddress: payments.usdcAddress,
@@ -1024,10 +1027,13 @@ export class AntseedNode extends EventEmitter {
       return;
     }
 
+    const fallbackRpcUrls = payments.fallbackRpcUrls;
+
     // Initialize DepositsClient
     if (payments.rpcUrl && payments.depositsAddress && payments.usdcAddress) {
       this._depositsClient = new DepositsClient({
         rpcUrl: payments.rpcUrl,
+        ...(fallbackRpcUrls ? { fallbackRpcUrls } : {}),
         contractAddress: payments.depositsAddress,
         usdcAddress: payments.usdcAddress,
       });
@@ -1038,6 +1044,7 @@ export class AntseedNode extends EventEmitter {
     if (payments.rpcUrl && payments.channelsAddress) {
       this._channelsClient = new ChannelsClient({
         rpcUrl: payments.rpcUrl,
+        ...(fallbackRpcUrls ? { fallbackRpcUrls } : {}),
         contractAddress: payments.channelsAddress,
       });
       debugLog(`[Node] ChannelsClient initialized (contract=${payments.channelsAddress.slice(0, 10)}...)`);
@@ -1047,6 +1054,7 @@ export class AntseedNode extends EventEmitter {
     if (payments.rpcUrl && payments.stakingAddress && payments.usdcAddress) {
       this._stakingClient = new StakingClient({
         rpcUrl: payments.rpcUrl,
+        ...(fallbackRpcUrls ? { fallbackRpcUrls } : {}),
         contractAddress: payments.stakingAddress,
         usdcAddress: payments.usdcAddress,
       });
@@ -1057,6 +1065,7 @@ export class AntseedNode extends EventEmitter {
     if (payments.rpcUrl && payments.identityRegistryAddress) {
       this._identityClient = new IdentityClient({
         rpcUrl: payments.rpcUrl,
+        ...(fallbackRpcUrls ? { fallbackRpcUrls } : {}),
         contractAddress: payments.identityRegistryAddress,
       });
       debugLog(`[Node] IdentityClient initialized (contract=${payments.identityRegistryAddress.slice(0, 10)}...)`);
@@ -1078,6 +1087,7 @@ export class AntseedNode extends EventEmitter {
         payments.rpcUrl && payments.channelsAddress) {
       const sellerConfig: SellerPaymentConfig = {
         rpcUrl: payments.rpcUrl,
+        ...(fallbackRpcUrls ? { fallbackRpcUrls } : {}),
         channelsContractAddress: payments.channelsAddress,
         chainId: payments.chainId ?? 8453,
         dataDir: paymentsDir,

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -32,6 +32,7 @@ const DEFAULT_TOPUP_THRESHOLD = 0.85;
 
 export interface BuyerPaymentConfig {
   rpcUrl: string;
+  fallbackRpcUrls?: string[];
   depositsContractAddress: string;
   channelsContractAddress: string;
   usdcAddress: string;
@@ -107,6 +108,7 @@ export class BuyerPaymentManager {
     this._signer = identity.wallet;
     this._depositsClient = new DepositsClient({
       rpcUrl: config.rpcUrl,
+      ...(config.fallbackRpcUrls ? { fallbackRpcUrls: config.fallbackRpcUrls } : {}),
       contractAddress: config.depositsContractAddress,
       usdcAddress: config.usdcAddress,
     });

--- a/packages/node/src/payments/chain-config.ts
+++ b/packages/node/src/payments/chain-config.ts
@@ -4,6 +4,13 @@ export interface ChainConfig {
   chainId: ChainId;
   evmChainId: number;
   rpcUrl: string;
+  /**
+   * Additional RPC endpoints tried in order when the primary `rpcUrl` fails.
+   * Wired into ethers `FallbackProvider` with quorum=1 so the first successful
+   * response wins. Ordered by preference (first entry is highest priority
+   * after the primary).
+   */
+  fallbackRpcUrls?: string[];
   depositsContractAddress: string;
   channelsContractAddress: string;
   stakingContractAddress?: string;
@@ -30,9 +37,15 @@ const CHAIN_CONFIGS: Record<ChainId, ChainConfig> = {
   'base-mainnet': {
     chainId: 'base-mainnet',
     evmChainId: 8453,
-    // Official Base mainnet RPC. Users can override via payments.crypto.rpcUrl
-    // in config.json if they hit rate limits or want a different provider.
-    rpcUrl: 'https://mainnet.base.org',
+    // dRPC public endpoint — free tier, generous limits, flat 20 CU per call
+    // (no eth_getLogs penalty), built-in multi-provider routing. Users can
+    // override via payments.crypto.rpcUrl in config.json.
+    rpcUrl: 'https://base.drpc.org',
+    fallbackRpcUrls: [
+      'https://base.publicnode.com',
+      'https://base.llamarpc.com',
+      'https://mainnet.base.org',
+    ],
     usdcContractAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
     depositsContractAddress: '0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2',
     channelsContractAddress: '0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d',
@@ -89,6 +102,7 @@ export function getChainConfig(chainId?: ChainId | string): ChainConfig {
 export function resolveChainConfig(overrides?: {
   chainId?: ChainId | string;
   rpcUrl?: string;
+  fallbackRpcUrls?: string[];
   depositsContractAddress?: string;
   channelsContractAddress?: string;
   stakingContractAddress?: string;
@@ -98,9 +112,16 @@ export function resolveChainConfig(overrides?: {
   subPoolContractAddress?: string;
 }): ChainConfig {
   const base = getChainConfig(overrides?.chainId);
+  // If the caller overrode the primary rpcUrl without providing their own
+  // fallbacks, drop the defaults — they picked a specific endpoint, respect
+  // that choice and don't silently route around it.
+  const rpcOverridden = !!overrides?.rpcUrl;
+  const resolvedFallbacks = overrides?.fallbackRpcUrls
+    ?? (rpcOverridden ? [] : base.fallbackRpcUrls);
   return {
     ...base,
     ...(overrides?.rpcUrl ? { rpcUrl: overrides.rpcUrl } : {}),
+    ...(resolvedFallbacks !== undefined ? { fallbackRpcUrls: resolvedFallbacks } : {}),
     ...(overrides?.depositsContractAddress ? { depositsContractAddress: overrides.depositsContractAddress } : {}),
     ...(overrides?.channelsContractAddress ? { channelsContractAddress: overrides.channelsContractAddress } : {}),
     ...(overrides?.stakingContractAddress ? { stakingContractAddress: overrides.stakingContractAddress } : {}),

--- a/packages/node/src/payments/evm/ants-token-client.ts
+++ b/packages/node/src/payments/evm/ants-token-client.ts
@@ -3,6 +3,7 @@ import { BaseEvmClient } from './base-evm-client.js';
 
 export interface ANTSTokenClientConfig {
   rpcUrl: string;
+  fallbackRpcUrls?: string[];
   contractAddress: string;
 }
 
@@ -21,7 +22,7 @@ const ANTS_TOKEN_ABI = [
 
 export class ANTSTokenClient extends BaseEvmClient {
   constructor(config: ANTSTokenClientConfig) {
-    super(config.rpcUrl, config.contractAddress);
+    super(config.rpcUrl, config.contractAddress, config.fallbackRpcUrls);
   }
 
   async balanceOf(address: string): Promise<bigint> {

--- a/packages/node/src/payments/evm/base-evm-client.ts
+++ b/packages/node/src/payments/evm/base-evm-client.ts
@@ -1,4 +1,35 @@
-import { Contract, JsonRpcProvider, type AbstractSigner, type InterfaceAbi, type TransactionRequest, type TransactionResponse } from 'ethers';
+import {
+  Contract,
+  FallbackProvider,
+  JsonRpcProvider,
+  type AbstractProvider,
+  type AbstractSigner,
+  type InterfaceAbi,
+  type TransactionRequest,
+  type TransactionResponse,
+} from 'ethers';
+
+/**
+ * Build an ethers Provider for a list of RPC URLs. When `fallbackRpcUrls` is
+ * non-empty, returns a `FallbackProvider` with quorum=1 and priorities in the
+ * order [primary, ...fallbacks], so the first successful response wins and a
+ * failing endpoint transparently rolls over to the next. For a single URL,
+ * returns a plain `JsonRpcProvider` to avoid the FallbackProvider startup
+ * network-detection handshake.
+ */
+function buildProvider(rpcUrl: string, fallbackRpcUrls?: string[]): AbstractProvider {
+  if (!fallbackRpcUrls || fallbackRpcUrls.length === 0) {
+    return new JsonRpcProvider(rpcUrl);
+  }
+  const urls = [rpcUrl, ...fallbackRpcUrls];
+  const configs = urls.map((url, i) => ({
+    provider: new JsonRpcProvider(url),
+    priority: i + 1,
+    stallTimeout: 2000,
+    weight: 1,
+  }));
+  return new FallbackProvider(configs, undefined, { quorum: 1 });
+}
 
 export const ERC20_ABI = [
   'function approve(address spender, uint256 amount) external returns (bool)',
@@ -14,17 +45,17 @@ const GAS_BUFFER_NUMERATOR = 130n;
 const GAS_BUFFER_DENOMINATOR = 100n;
 
 export abstract class BaseEvmClient {
-  protected readonly _provider: JsonRpcProvider;
+  protected readonly _provider: AbstractProvider;
   protected readonly _contractAddress: string;
   protected readonly _nonceCursor = new Map<string, number>();
   private readonly _nonceLocks = new Map<string, Promise<void>>();
 
-  constructor(rpcUrl: string, contractAddress: string) {
-    this._provider = new JsonRpcProvider(rpcUrl);
+  constructor(rpcUrl: string, contractAddress: string, fallbackRpcUrls?: string[]) {
+    this._provider = buildProvider(rpcUrl, fallbackRpcUrls);
     this._contractAddress = contractAddress;
   }
 
-  get provider(): JsonRpcProvider { return this._provider; }
+  get provider(): AbstractProvider { return this._provider; }
   get contractAddress(): string { return this._contractAddress; }
 
   protected _ensureConnected(signer: AbstractSigner): AbstractSigner {

--- a/packages/node/src/payments/evm/channels-client.ts
+++ b/packages/node/src/payments/evm/channels-client.ts
@@ -3,6 +3,7 @@ import { BaseEvmClient } from './base-evm-client.js';
 
 export interface ChannelsClientConfig {
   rpcUrl: string;
+  fallbackRpcUrls?: string[];
   contractAddress: string;
 }
 
@@ -47,7 +48,7 @@ export interface CloseRequestedEvent {
 
 export class ChannelsClient extends BaseEvmClient {
   constructor(config: ChannelsClientConfig) {
-    super(config.rpcUrl, config.contractAddress);
+    super(config.rpcUrl, config.contractAddress, config.fallbackRpcUrls);
   }
 
   async reserve(

--- a/packages/node/src/payments/evm/deposits-client.ts
+++ b/packages/node/src/payments/evm/deposits-client.ts
@@ -4,6 +4,7 @@ import { BaseEvmClient, ERC20_ABI } from './base-evm-client.js';
 
 export interface DepositsClientConfig {
   rpcUrl: string;
+  fallbackRpcUrls?: string[];
   contractAddress: string;
   usdcAddress: string;
 }
@@ -31,7 +32,7 @@ export class DepositsClient extends BaseEvmClient {
   private readonly _usdcAddress: string;
 
   constructor(config: DepositsClientConfig) {
-    super(config.rpcUrl, config.contractAddress);
+    super(config.rpcUrl, config.contractAddress, config.fallbackRpcUrls);
     this._usdcAddress = config.usdcAddress;
   }
 

--- a/packages/node/src/payments/evm/emissions-client.ts
+++ b/packages/node/src/payments/evm/emissions-client.ts
@@ -3,6 +3,7 @@ import { BaseEvmClient } from './base-evm-client.js';
 
 export interface EmissionsClientConfig {
   rpcUrl: string;
+  fallbackRpcUrls?: string[];
   contractAddress: string;
 }
 
@@ -31,7 +32,7 @@ const EMISSIONS_ABI = [
 
 export class EmissionsClient extends BaseEvmClient {
   constructor(config: EmissionsClientConfig) {
-    super(config.rpcUrl, config.contractAddress);
+    super(config.rpcUrl, config.contractAddress, config.fallbackRpcUrls);
   }
 
   async claimSellerEmissions(signer: AbstractSigner, epochs: number[]): Promise<string> {

--- a/packages/node/src/payments/evm/identity-client.ts
+++ b/packages/node/src/payments/evm/identity-client.ts
@@ -3,6 +3,7 @@ import { BaseEvmClient } from './base-evm-client.js';
 
 export interface IdentityClientConfig {
   rpcUrl: string;
+  fallbackRpcUrls?: string[];
   contractAddress: string;
 }
 
@@ -24,7 +25,7 @@ const IDENTITY_REGISTRY_ABI = [
 
 export class IdentityClient extends BaseEvmClient {
   constructor(config: IdentityClientConfig) {
-    super(config.rpcUrl, config.contractAddress);
+    super(config.rpcUrl, config.contractAddress, config.fallbackRpcUrls);
   }
 
   // ── Write methods ──────────────────────────────────────────────────

--- a/packages/node/src/payments/evm/staking-client.ts
+++ b/packages/node/src/payments/evm/staking-client.ts
@@ -4,6 +4,7 @@ import { BaseEvmClient } from './base-evm-client.js';
 
 export interface StakingClientConfig {
   rpcUrl: string;
+  fallbackRpcUrls?: string[];
   contractAddress: string;
   usdcAddress: string;
 }
@@ -22,7 +23,7 @@ export class StakingClient extends BaseEvmClient {
   private readonly _usdcAddress: string;
 
   constructor(config: StakingClientConfig) {
-    super(config.rpcUrl, config.contractAddress);
+    super(config.rpcUrl, config.contractAddress, config.fallbackRpcUrls);
     this._usdcAddress = config.usdcAddress;
   }
 

--- a/packages/node/src/payments/evm/stats-client.ts
+++ b/packages/node/src/payments/evm/stats-client.ts
@@ -3,6 +3,7 @@ import { BaseEvmClient } from './base-evm-client.js';
 
 export interface StatsClientConfig {
   rpcUrl: string;
+  fallbackRpcUrls?: string[];
   contractAddress: string;
 }
 
@@ -25,7 +26,7 @@ const STATS_ABI = [
 
 export class StatsClient extends BaseEvmClient {
   constructor(config: StatsClientConfig) {
-    super(config.rpcUrl, config.contractAddress);
+    super(config.rpcUrl, config.contractAddress, config.fallbackRpcUrls);
   }
 
   /**

--- a/packages/node/src/payments/evm/subpool-client.ts
+++ b/packages/node/src/payments/evm/subpool-client.ts
@@ -3,6 +3,7 @@ import { BaseEvmClient } from './base-evm-client.js';
 
 export interface SubPoolClientConfig {
   rpcUrl: string;
+  fallbackRpcUrls?: string[];
   contractAddress: string;
   usdcAddress: string;
 }
@@ -36,7 +37,7 @@ export class SubPoolClient extends BaseEvmClient {
   private readonly _usdcAddress: string;
 
   constructor(config: SubPoolClientConfig) {
-    super(config.rpcUrl, config.contractAddress);
+    super(config.rpcUrl, config.contractAddress, config.fallbackRpcUrls);
     this._usdcAddress = config.usdcAddress;
   }
 

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -20,6 +20,7 @@ import { classifyOnChainChannel, matchesChannelParties } from './channel-session
 
 export interface SellerPaymentConfig {
   rpcUrl: string;
+  fallbackRpcUrls?: string[];
   channelsContractAddress: string;
   chainId: number;
   dataDir: string;
@@ -99,6 +100,7 @@ export class SellerPaymentManager {
     this._signer = identity.wallet;
     this._channelsClient = new ChannelsClient({
       rpcUrl: config.rpcUrl,
+      ...(config.fallbackRpcUrls ? { fallbackRpcUrls: config.fallbackRpcUrls } : {}),
       contractAddress: config.channelsContractAddress,
     });
     this._channelStore = channelStore;

--- a/packages/node/src/payments/types.ts
+++ b/packages/node/src/payments/types.ts
@@ -43,6 +43,8 @@ export interface CryptoPaymentConfig {
   chainId: ChainId;
   /** Base JSON-RPC URL (e.g. http://127.0.0.1:8545 for anvil) */
   rpcUrl: string;
+  /** Additional RPC endpoints for failover via ethers FallbackProvider. */
+  fallbackRpcUrls?: string[];
   /** Deployed AntseedDeposits contract address */
   depositsContractAddress: string;
   /** Deployed AntseedChannels contract address */


### PR DESCRIPTION
## Summary
- Switch `base-mainnet` primary RPC from `mainnet.base.org` to **dRPC** (`https://base.drpc.org`) and add a prioritized fallback list: `publicnode`, `llamarpc`, `mainnet.base.org`.
- Wire an optional `fallbackRpcUrls?: string[]` through `BaseEvmClient` and every subclass (Deposits, Channels, Staking, Identity, Stats, SubPool, Emissions, ANTSToken). When provided, the client builds an ethers `FallbackProvider` with `quorum=1` over `[primary, ...fallbacks]` so a failing endpoint transparently rolls over to the next. Single-URL path still uses a plain `JsonRpcProvider` to avoid the `FallbackProvider` startup network-detection handshake.
- `resolveChainConfig` now carries `fallbackRpcUrls` and **drops defaults when the caller overrides `rpcUrl` without providing their own fallback list** — if someone picks a specific endpoint, respect that choice.
- Threaded through `NodePaymentsConfig`, `SellerPaymentConfig`, `BuyerPaymentConfig`, `CryptoPaymentConfig` (CLI config), CLI `payment-utils` helpers, `apps/network-stats`, `apps/payments`, desktop `main.ts`, and desktop `pi-chat-engine.ts`.

## Why
`mainnet.base.org` has tight rate limits; users on the default config hit 429s under sustained load. dRPC's free tier is far more generous (flat 20 CU per call, no `eth_getLogs` penalty, built-in multi-provider routing), and the fallback chain means a single provider outage no longer bricks payments.

## Test plan
- [x] `pnpm run typecheck` — clean across all packages
- [x] `pnpm run test` — all suites pass (`packages/node` 535/535, `e2e` 65/65, etc.)
- [x] Existing base-local (anvil) flow unaffected: `base-local` preset has no `fallbackRpcUrls`, single-URL branch takes the plain `JsonRpcProvider` path
- [ ] Manual smoke on base-mainnet: start buyer against default config, open channel, settle — verify dRPC is the primary and fallback triggers when primary is throttled