### PR TITLE
fix(node): add model/provider context to error logs and cleanup

### DIFF
--- a/packages/node/src/p2p/connection-manager.ts
+++ b/packages/node/src/p2p/connection-manager.ts
@@ -801,7 +801,7 @@ export class ConnectionManager extends EventEmitter {
       return Array.isArray(server.urls) ? server.urls : [server.urls];
     });
 
-    return new ndc.PeerConnection(`idleai-${remotePeerId.slice(0, 12)}`, {
+    return new ndc.PeerConnection(`antseed-${remotePeerId.slice(0, 12)}`, {
       iceServers,
       iceTransportPolicy: this._iceConfig.iceTransportPolicy ?? "all",
     });
@@ -906,7 +906,7 @@ export class ConnectionManager extends EventEmitter {
         this._detectedTransportMode = "tcp";
         return this._detectedTransportMode;
       }
-      const probe = new ndc.PeerConnection("idleai-transport-probe", { iceServers: [] });
+      const probe = new ndc.PeerConnection("antseed-transport-probe", { iceServers: [] });
       try {
         const channel = probe.createDataChannel("probe", { ordered: true });
         channel.close();

--- a/packages/node/src/proxy/index.ts
+++ b/packages/node/src/proxy/index.ts
@@ -1,6 +1,6 @@
 export { ProxyMux } from './proxy-mux.js';
 export { encodeHttpRequest, decodeHttpRequest, encodeHttpResponse, decodeHttpResponse, encodeHttpResponseChunk, decodeHttpResponseChunk } from './request-codec.js';
-export { detectProviderFromHeaders, detectProviderFromPath, resolveProvider, IDLEAI_PROVIDER_HEADER } from './provider-detection.js';
+export { detectProviderFromHeaders, detectProviderFromPath, resolveProvider } from './provider-detection.js';
 export {
   detectRequestServiceApiProtocol,
   inferProviderDefaultServiceApiProtocols,

--- a/packages/node/src/proxy/provider-detection.ts
+++ b/packages/node/src/proxy/provider-detection.ts
@@ -1,8 +1,6 @@
 import type { ProviderType } from '../types/metering.js';
 
 export const ANTSEED_PROVIDER_HEADER = 'x-antseed-provider';
-/** @deprecated Use ANTSEED_PROVIDER_HEADER instead */
-export const IDLEAI_PROVIDER_HEADER = ANTSEED_PROVIDER_HEADER;
 
 const KNOWN_PROVIDERS = new Set<string>([
   'anthropic',

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -197,7 +197,8 @@ export class SellerRequestHandler {
 
       request.headers['x-antseed-buyer-peer-id'] = buyerPeerId;
 
-      debugLog(`[SellerHandler] Routing to provider "${provider.name}"`);
+      const requestedModel = this._extractRequestedService(request) ?? 'unknown';
+      debugLog(`[SellerHandler] Routing to provider "${provider.name}" model="${requestedModel}"`);
       const startTime = Date.now();
       let statusCode = 500;
       let responseBody: Uint8Array = new Uint8Array(0);
@@ -225,7 +226,12 @@ export class SellerRequestHandler {
           });
           statusCode = response.statusCode;
           responseBody = response.body ?? new Uint8Array(0);
-          debugLog(`[SellerHandler] Provider responded: status=${statusCode} (${Date.now() - startTime}ms, ${responseBody.length}b) bodyType=${typeof response.body} hasBody=${!!response.body}`);
+          if (statusCode >= 400) {
+            const errBody = new TextDecoder().decode(responseBody).slice(0, 200);
+            debugWarn(`[SellerHandler] Provider error response: status=${statusCode} provider="${provider.name}" model="${requestedModel}" buyer=${buyerPeerId.slice(0, 12)}... (${Date.now() - startTime}ms) body=${errBody}`);
+          } else {
+            debugLog(`[SellerHandler] Provider responded: status=${statusCode} (${Date.now() - startTime}ms, ${responseBody.length}b)`);
+          }
           responseUsage = parseResponseUsage(responseBody);
           debugLog(`[SellerHandler] Raw provider usage: in=${responseUsage.inputTokens} fresh=${responseUsage.freshInputTokens} cached=${responseUsage.cachedInputTokens} out=${responseUsage.outputTokens}`);
           if (!streamedResponseStarted) {
@@ -241,7 +247,7 @@ export class SellerRequestHandler {
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : "Internal error";
-          debugWarn(`[SellerHandler] Provider error after ${Date.now() - startTime}ms: ${message}`);
+          debugWarn(`[SellerHandler] Provider exception: provider="${provider.name}" model="${requestedModel}" buyer=${buyerPeerId.slice(0, 12)}... (${Date.now() - startTime}ms) ${message}`);
           responseBody = new TextEncoder().encode(message);
           if (streamedResponseStarted) {
             mux.sendProxyChunk({

--- a/packages/provider-core/src/http-relay.ts
+++ b/packages/provider-core/src/http-relay.ts
@@ -317,7 +317,9 @@ export class HttpRelay {
           const body = new TextDecoder().decode(
             debugChunks.reduce((a, b) => { const r = new Uint8Array(a.byteLength + b.byteLength); r.set(a); r.set(b, a.byteLength); return r; }, new Uint8Array(0))
           );
-          console.warn(`[http-relay] Short stream (${totalStreamBytes}b): ${JSON.stringify(body)}`);
+          let model = 'unknown';
+          try { model = JSON.parse(new TextDecoder().decode(request.body))?.model ?? 'unknown'; } catch {}
+          console.warn(`[http-relay] Short stream (${totalStreamBytes}b) model="${model}" url=${url}: ${JSON.stringify(body)}`);
         }
 
         this._callbacks.onResponseChunk?.({


### PR DESCRIPTION
## Summary
- Enhance seller request handler error logging: on 4xx/5xx provider responses, log provider name, model, buyer peer ID, and truncated response body instead of just status code and byte count
- Add model and upstream URL to the http-relay short-stream warning (e.g. DeepInfra "Chunk too big" errors)
- Clean up legacy "idleai" WebRTC connection labels → "antseed"
- Remove unexported deprecated `IDLEAI_PROVIDER_HEADER` alias

## Test plan
- [x] `packages/node` — 535/535 tests pass
- [x] `packages/provider-core` — 30/30 tests pass
- [x] Typecheck clean