### PR TITLE
feat(network-stats): add leaderboard with settlement indexing

### DIFF
--- a/apps/network-stats/src/index.ts
+++ b/apps/network-stats/src/index.ts
@@ -1,12 +1,13 @@
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 
-import { StakingClient, StatsClient, resolveChainConfig } from '@antseed/node';
+import { ChannelsClient, StakingClient, StatsClient, resolveChainConfig } from '@antseed/node';
 
 import { NetworkPoller } from './poller.js';
 import { createServer } from './server.js';
 import { SqliteStore } from './store.js';
 import { MetadataIndexer } from './indexer.js';
+import { SettlementIndexer } from './settlement-indexer.js';
 
 const PORT = parseInt(process.env['PORT'] ?? '4000', 10);
 const CACHE_PATH = process.env['CACHE_PATH'];
@@ -25,6 +26,7 @@ const chainConfig = resolveChainConfig({
 });
 let store: SqliteStore | null = null;
 let indexer: MetadataIndexer | null = null;
+let settlementIndexer: SettlementIndexer | null = null;
 let stakingClient: StakingClient | null = null;
 
 if (chainConfig.statsContractAddress && typeof chainConfig.statsDeployBlock === 'number') {
@@ -55,6 +57,30 @@ if (chainConfig.statsContractAddress && typeof chainConfig.statsDeployBlock === 
       usdcAddress: chainConfig.usdcContractAddress,
       evmChainId: chainConfig.evmChainId,
     });
+    // Settlement indexer — indexes ChannelSettled events for leaderboard
+    if (typeof chainConfig.channelsDeployBlock === 'number') {
+      const channelsClient = new ChannelsClient({
+        rpcUrl: chainConfig.rpcUrl,
+        ...(chainConfig.fallbackRpcUrls ? { fallbackRpcUrls: chainConfig.fallbackRpcUrls } : {}),
+        contractAddress: chainConfig.channelsContractAddress,
+        evmChainId: chainConfig.evmChainId,
+      });
+      settlementIndexer = new SettlementIndexer({
+        store,
+        channelsClient,
+        statsClient,
+        stakingClient,
+        chainId: CHAIN_ID,
+        contractAddress: chainConfig.channelsContractAddress.toLowerCase(),
+        deployBlock: chainConfig.channelsDeployBlock,
+        tickIntervalMs: TICK_INTERVAL_MS,
+        reorgSafetyBlocks: REORG_SAFETY_BLOCKS,
+        maxBlocksPerTick: MAX_BLOCKS_PER_TICK,
+        rpcUrl: chainConfig.rpcUrl,
+      });
+    } else {
+      console.log(`[network-stats] settlement indexer disabled for chain ${CHAIN_ID} (no channelsDeployBlock configured)`);
+    }
   } else {
     console.warn(`[network-stats] stats contract is configured for ${CHAIN_ID} but staking contract is not — /stats enrichment will fall back to the legacy non-enriched payload`);
   }
@@ -69,15 +95,18 @@ const server = createServer({
   ...(store ? { store } : {}),
   ...(stakingClient ? { stakingClient } : {}),
   ...(indexer ? { indexer } : {}),
+  ...(settlementIndexer ? { settlementIndexer } : {}),
   ...(store && chainConfig.statsContractAddress
     ? { chainId: CHAIN_ID, contractAddress: chainConfig.statsContractAddress }
     : {}),
+  ...(settlementIndexer ? { channelsContractAddress: chainConfig.channelsContractAddress } : {}),
   port: PORT,
 });
 
 await server.start();
 await poller.start();
 indexer?.start();
+settlementIndexer?.start();
 
 process.on('SIGINT', shutdown);
 process.on('SIGTERM', shutdown);
@@ -85,6 +114,7 @@ process.on('SIGTERM', shutdown);
 function shutdown(): void {
   console.log('[network-stats] shutting down...');
   indexer?.stop();
+  settlementIndexer?.stop();
   store?.close();
   poller.stop();
   server.stop();

--- a/apps/network-stats/src/server.ts
+++ b/apps/network-stats/src/server.ts
@@ -8,16 +8,19 @@
 import express from 'express';
 import type { NetworkPoller } from './poller.js';
 import type { StakingClient } from '@antseed/node';
-import type { SqliteStore } from './store.js';
+import type { SqliteStore, LeaderboardRole, LeaderboardPeriod } from './store.js';
 import type { MetadataIndexer } from './indexer.js';
+import type { SettlementIndexer } from './settlement-indexer.js';
 
 export interface CreateServerDeps {
   poller: NetworkPoller;
   store?: SqliteStore;            // undefined when indexer disabled for this chain
   stakingClient?: StakingClient;  // undefined when indexer disabled
   indexer?: MetadataIndexer;      // source of chain head + reorg buffer for sync status
+  settlementIndexer?: SettlementIndexer;
   chainId?: string;               // used to look up the indexer checkpoint
   contractAddress?: string;       // contract whose checkpoint to expose
+  channelsContractAddress?: string;
   port?: number;
 }
 
@@ -61,7 +64,7 @@ export function __resetAgentIdCacheForTests(): void {
 }
 
 export function createServer(deps: CreateServerDeps): { start(): Promise<void>; stop(): void } {
-  const { poller, store, stakingClient, indexer, chainId, contractAddress, port = 4000 } = deps;
+  const { poller, store, stakingClient, indexer, settlementIndexer, chainId, contractAddress, channelsContractAddress, port = 4000 } = deps;
   const app = express();
 
   app.use((_req, res, next) => {
@@ -139,6 +142,71 @@ export function createServer(deps: CreateServerDeps): { start(): Promise<void>; 
       ...snapshot,
       peers: enrichedPeers,
       ...(indexerPayload ? { indexer: indexerPayload } : {}),
+    });
+  });
+
+  /**
+   * GET /leaderboard?role=seller|buyer&period=day|month|all&date=YYYY-MM-DD&limit=50
+   *
+   * Returns a ranked list of sellers or buyers by USDC volume for the given period.
+   */
+  app.get('/leaderboard', (req, res) => {
+    if (!store) {
+      res.status(503).json({ error: 'Settlement indexer not configured' });
+      return;
+    }
+
+    const role = req.query['role'] as string | undefined;
+    if (role !== 'seller' && role !== 'buyer') {
+      res.status(400).json({ error: 'role must be "seller" or "buyer"' });
+      return;
+    }
+
+    const period = (req.query['period'] as string | undefined) ?? 'all';
+    if (period !== 'day' && period !== 'month' && period !== 'all') {
+      res.status(400).json({ error: 'period must be "day", "month", or "all"' });
+      return;
+    }
+
+    const limitStr = req.query['limit'] as string | undefined;
+    const limit = limitStr ? Math.min(Math.max(parseInt(limitStr, 10) || 50, 1), 200) : 50;
+
+    let date: Date | undefined;
+    const dateStr = req.query['date'] as string | undefined;
+    if (dateStr) {
+      const parsed = new Date(dateStr + 'T00:00:00Z');
+      if (isNaN(parsed.getTime())) {
+        res.status(400).json({ error: 'date must be YYYY-MM-DD' });
+        return;
+      }
+      date = parsed;
+    }
+
+    const entries = store.getLeaderboard(role as LeaderboardRole, period as LeaderboardPeriod, date, limit);
+
+    // Include settlement indexer sync status if available
+    const settlementCheckpoint = channelsContractAddress && chainId
+      ? store.getCheckpointInfo(chainId, channelsContractAddress.toLowerCase())
+      : null;
+    const settlementHead = settlementIndexer?.getChainHead();
+    const indexerStatus = settlementCheckpoint
+      ? {
+          ...settlementCheckpoint,
+          ...(settlementHead?.latestBlock != null
+            ? {
+                latestBlock: settlementHead.latestBlock,
+                synced: settlementCheckpoint.lastBlock >= settlementHead.latestBlock - settlementHead.reorgSafetyBlocks,
+              }
+            : {}),
+        }
+      : null;
+
+    res.json({
+      role,
+      period,
+      ...(dateStr ? { date: dateStr } : {}),
+      entries,
+      ...(indexerStatus ? { indexer: indexerStatus } : {}),
     });
   });
 

--- a/apps/network-stats/src/settlement-indexer.ts
+++ b/apps/network-stats/src/settlement-indexer.ts
@@ -1,0 +1,197 @@
+import { ethers } from 'ethers';
+import type { ChannelsClient, StatsClient, StakingClient, DecodedMetadataRecorded } from '@antseed/node';
+import type { SqliteStore } from './store.js';
+
+export interface SettlementIndexerOptions {
+  store: SqliteStore;
+  channelsClient: Pick<ChannelsClient, 'getChannelSettledEvents' | 'getBlockNumber'>;
+  statsClient: Pick<StatsClient, 'getMetadataRecordedEvents'>;
+  stakingClient: Pick<StakingClient, 'getAgentId'>;
+  chainId: string;
+  contractAddress: string;     // channels contract, lowercased
+  deployBlock: number;
+  tickIntervalMs: number;
+  reorgSafetyBlocks: number;
+  maxBlocksPerTick?: number;
+  rpcUrl: string;              // required — block timestamps are mandatory for leaderboard
+}
+
+function logError(err: unknown): void {
+  console.error('[settlement-indexer] error:', err);
+}
+
+export class SettlementIndexer {
+  private readonly _store: SqliteStore;
+  private readonly _channelsClient: Pick<ChannelsClient, 'getChannelSettledEvents' | 'getBlockNumber'>;
+  private readonly _statsClient: Pick<StatsClient, 'getMetadataRecordedEvents'>;
+  private readonly _stakingClient: Pick<StakingClient, 'getAgentId'>;
+  private readonly _chainId: string;
+  private readonly _contractAddress: string;
+  private readonly _deployBlock: number;
+  private readonly _tickIntervalMs: number;
+  private readonly _reorgSafetyBlocks: number;
+  private readonly _maxBlocksPerTick: number;
+  private readonly _provider: ethers.JsonRpcProvider;
+  private _timer: ReturnType<typeof setInterval> | undefined;
+  private _running = false;
+  private _latestBlock: number | null = null;
+
+  // Cache seller address → agentId. Staked sellers don't change agentId,
+  // so cache indefinitely. Unstaked (agentId=0) cached for 5 min.
+  private readonly _agentIdCache = new Map<string, { agentId: number; expiresAt: number }>();
+  private static readonly UNSTAKED_TTL_MS = 5 * 60 * 1000;
+
+  constructor(options: SettlementIndexerOptions) {
+    if (options.deployBlock < 0) {
+      throw new Error('deployBlock must be >= 0');
+    }
+    if (options.tickIntervalMs <= 0) {
+      throw new Error('tickIntervalMs must be > 0');
+    }
+
+    this._store = options.store;
+    this._channelsClient = options.channelsClient;
+    this._statsClient = options.statsClient;
+    this._stakingClient = options.stakingClient;
+    this._chainId = options.chainId;
+    this._contractAddress = options.contractAddress;
+    this._deployBlock = options.deployBlock;
+    this._tickIntervalMs = options.tickIntervalMs;
+    this._reorgSafetyBlocks = options.reorgSafetyBlocks;
+
+    const provided = options.maxBlocksPerTick;
+    this._maxBlocksPerTick = (provided !== undefined && provided > 0) ? provided : 2_000;
+    this._provider = new ethers.JsonRpcProvider(options.rpcUrl);
+  }
+
+  start(): void {
+    void this.tick().catch(logError);
+    this._timer = setInterval(() => void this.tick().catch(logError), this._tickIntervalMs);
+  }
+
+  stop(): void {
+    clearInterval(this._timer);
+  }
+
+  getChainHead(): { latestBlock: number | null; reorgSafetyBlocks: number } {
+    return { latestBlock: this._latestBlock, reorgSafetyBlocks: this._reorgSafetyBlocks };
+  }
+
+  async tick(): Promise<void> {
+    if (this._running) return;
+    this._running = true;
+    try {
+      const latest = await this._channelsClient.getBlockNumber();
+      this._latestBlock = latest;
+      const safeTo = latest - this._reorgSafetyBlocks;
+
+      if (safeTo < this._deployBlock) return;
+
+      const checkpoint = this._store.getCheckpoint(this._chainId, this._contractAddress);
+      const fromBlock = checkpoint === null ? this._deployBlock : checkpoint + 1;
+
+      if (fromBlock > safeTo) return;
+
+      const toBlock = Math.min(safeTo, fromBlock + this._maxBlocksPerTick - 1);
+
+      // 1. Fetch ChannelSettled events
+      const events = await this._channelsClient.getChannelSettledEvents({ fromBlock, toBlock });
+
+      if (events.length === 0) {
+        // No events — just advance the checkpoint
+        let checkpointTs: number | null = null;
+        const block = await this._provider.getBlock(toBlock);
+        checkpointTs = block?.timestamp ?? null;
+        this._store.applySettlementBatch(
+          this._chainId,
+          this._contractAddress,
+          [],
+          new Map(),
+          new Map(),
+          toBlock,
+          new Map(),
+          checkpointTs,
+        );
+        console.log(`[settlement-indexer] ${fromBlock}..${toBlock} events=0`);
+        return;
+      }
+
+      // 2. Fetch block timestamps for all event blocks
+      const uniqueBlocks = Array.from(new Set(events.map((e) => e.blockNumber)));
+      const blocks = await Promise.all(uniqueBlocks.map((b) => this._provider.getBlock(b)));
+      const blockTimestamps = new Map<number, number>();
+      for (let i = 0; i < uniqueBlocks.length; i++) {
+        const block = blocks[i];
+        if (block) blockTimestamps.set(uniqueBlocks[i]!, block.timestamp);
+      }
+
+      // Checkpoint timestamp
+      let checkpointTs: number | null = null;
+      if (blockTimestamps.has(toBlock)) {
+        checkpointTs = blockTimestamps.get(toBlock)!;
+      } else {
+        const block = await this._provider.getBlock(toBlock);
+        checkpointTs = block?.timestamp ?? null;
+      }
+
+      // 3. Fetch MetadataRecorded events from the same block range (for token counts)
+      const metadataEvents = await this._statsClient.getMetadataRecordedEvents({ fromBlock, toBlock });
+      const metadataByTx = new Map<string, DecodedMetadataRecorded[]>();
+      for (const m of metadataEvents) {
+        const existing = metadataByTx.get(m.txHash);
+        if (existing) {
+          existing.push(m);
+        } else {
+          metadataByTx.set(m.txHash, [m]);
+        }
+      }
+
+      // 4. Resolve seller addresses → agentIds
+      const uniqueSellers = Array.from(new Set(events.map((e) => e.seller)));
+      const agentIdBySeller = new Map<string, number>();
+      await Promise.all(
+        uniqueSellers.map(async (seller) => {
+          const agentId = await this._resolveAgentId(seller);
+          agentIdBySeller.set(seller, agentId);
+        }),
+      );
+
+      // 5. Store
+      this._store.applySettlementBatch(
+        this._chainId,
+        this._contractAddress,
+        events,
+        metadataByTx,
+        agentIdBySeller,
+        toBlock,
+        blockTimestamps,
+        checkpointTs,
+      );
+
+      console.log(`[settlement-indexer] ${fromBlock}..${toBlock} events=${events.length}`);
+    } catch (err) {
+      console.error('[settlement-indexer] tick error:', err);
+    } finally {
+      this._running = false;
+    }
+  }
+
+  private async _resolveAgentId(seller: string): Promise<number> {
+    const key = seller.toLowerCase();
+    const cached = this._agentIdCache.get(key);
+    if (cached !== undefined && cached.expiresAt > Date.now()) {
+      return cached.agentId;
+    }
+    try {
+      const agentId = await this._stakingClient.getAgentId(key);
+      this._agentIdCache.set(key, {
+        agentId,
+        expiresAt: agentId === 0 ? Date.now() + SettlementIndexer.UNSTAKED_TTL_MS : Infinity,
+      });
+      return agentId;
+    } catch (err) {
+      console.warn(`[settlement-indexer] getAgentId failed for ${key}:`, err);
+      return 0;
+    }
+  }
+}

--- a/apps/network-stats/src/store.test.ts
+++ b/apps/network-stats/src/store.test.ts
@@ -8,7 +8,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { SqliteStore } from './store.js';
-import type { DecodedMetadataRecorded } from '@antseed/node';
+import type { DecodedMetadataRecorded, DecodedChannelSettled } from '@antseed/node';
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -51,6 +51,8 @@ describe('SqliteStore', () => {
       'seller_buyer_totals',
       'seller_channel_totals',
       'seller_metadata_totals',
+      'settlement_events',
+      'sqlite_sequence',
     ]);
     store.close();
   });
@@ -261,6 +263,237 @@ describe('SqliteStore', () => {
     assert.equal(after2.firstSettledBlock, 500);
     assert.equal(after2.lastSettledBlock, 750);
     assert.equal(after2.settlementCount, 2);
+    store.close();
+  });
+
+  // ── settlement_events / leaderboard tests ──────────────────────────────────
+
+  it('applySettlementBatch inserts events and advances checkpoint', () => {
+    const store = new SqliteStore(':memory:');
+    store.init();
+
+    const event: DecodedChannelSettled = {
+      blockNumber: 100,
+      txHash: '0x' + 'a'.repeat(64),
+      logIndex: 0,
+      channelId: '0x' + '1'.repeat(64),
+      buyer: '0x' + 'b'.repeat(40),
+      seller: '0x' + 's'.repeat(40),
+      cumulativeAmount: 5000n,
+      delta: 5000n,
+      totalSettled: 5000n,
+      platformFee: 50n,
+      metadata: '0x',
+    };
+
+    const metadataByTx = new Map([
+      [event.txHash, [makeEvent({
+        txHash: event.txHash,
+        channelId: event.channelId,
+        inputTokens: 100n,
+        outputTokens: 200n,
+        requestCount: 3n,
+      })]],
+    ]);
+
+    const agentIdBySeller = new Map([[event.seller, 42]]);
+    const blockTimestamps = new Map([[100, 1700000000]]);
+
+    store.applySettlementBatch(
+      'base', '0xchannels', [event], metadataByTx, agentIdBySeller,
+      100, blockTimestamps, 1700000000,
+    );
+
+    assert.equal(store.getCheckpoint('base', '0xchannels'), 100);
+
+    // Leaderboard should show this seller
+    const sellers = store.getLeaderboard('seller', 'all');
+    assert.equal(sellers.length, 1);
+    assert.equal(sellers[0]!.id, '42');
+    assert.equal(sellers[0]!.totalRevenue, '5000');
+    assert.equal(sellers[0]!.totalFees, '50');
+    assert.equal(sellers[0]!.totalInputTokens, '100');
+    assert.equal(sellers[0]!.totalOutputTokens, '200');
+    assert.equal(sellers[0]!.totalRequests, '3');
+    assert.equal(sellers[0]!.settlementCount, 1);
+
+    // Buyer leaderboard
+    const buyers = store.getLeaderboard('buyer', 'all');
+    assert.equal(buyers.length, 1);
+    assert.equal(buyers[0]!.id, event.buyer);
+    assert.equal(buyers[0]!.totalRevenue, '5000');
+
+    store.close();
+  });
+
+  it('getLeaderboard filters by day', () => {
+    const store = new SqliteStore(':memory:');
+    store.init();
+
+    // Two events on different days
+    const day1Ts = Math.floor(Date.UTC(2025, 0, 15) / 1000); // Jan 15 2025
+    const day2Ts = Math.floor(Date.UTC(2025, 0, 16) / 1000); // Jan 16 2025
+
+    const event1: DecodedChannelSettled = {
+      blockNumber: 100, txHash: '0x' + 'a'.repeat(64), logIndex: 0,
+      channelId: '0x' + '1'.repeat(64), buyer: '0x' + 'b'.repeat(40),
+      seller: '0x' + 's'.repeat(40), cumulativeAmount: 1000n, delta: 1000n,
+      totalSettled: 1000n, platformFee: 10n, metadata: '0x',
+    };
+    const event2: DecodedChannelSettled = {
+      blockNumber: 200, txHash: '0x' + 'c'.repeat(64), logIndex: 0,
+      channelId: '0x' + '2'.repeat(64), buyer: '0x' + 'b'.repeat(40),
+      seller: '0x' + 's'.repeat(40), cumulativeAmount: 3000n, delta: 2000n,
+      totalSettled: 3000n, platformFee: 20n, metadata: '0x',
+    };
+
+    const agentIdBySeller = new Map([[event1.seller, 1]]);
+
+    store.applySettlementBatch(
+      'base', '0xchannels', [event1], new Map(), agentIdBySeller,
+      100, new Map([[100, day1Ts]]), day1Ts,
+    );
+    store.applySettlementBatch(
+      'base', '0xchannels', [event2], new Map(), agentIdBySeller,
+      200, new Map([[200, day2Ts]]), day2Ts,
+    );
+
+    // Query for day 1 only
+    const day1 = store.getLeaderboard('seller', 'day', new Date(Date.UTC(2025, 0, 15)));
+    assert.equal(day1.length, 1);
+    assert.equal(day1[0]!.totalRevenue, '1000');
+
+    // Query for day 2 only
+    const day2 = store.getLeaderboard('seller', 'day', new Date(Date.UTC(2025, 0, 16)));
+    assert.equal(day2.length, 1);
+    assert.equal(day2[0]!.totalRevenue, '2000');
+
+    // All time should sum both
+    const all = store.getLeaderboard('seller', 'all');
+    assert.equal(all.length, 1);
+    assert.equal(all[0]!.totalRevenue, '3000');
+
+    store.close();
+  });
+
+  it('getLeaderboard filters by month', () => {
+    const store = new SqliteStore(':memory:');
+    store.init();
+
+    const janTs = Math.floor(Date.UTC(2025, 0, 15) / 1000); // Jan 15
+    const febTs = Math.floor(Date.UTC(2025, 1, 10) / 1000); // Feb 10
+
+    const event1: DecodedChannelSettled = {
+      blockNumber: 100, txHash: '0x' + 'a'.repeat(64), logIndex: 0,
+      channelId: '0x' + '1'.repeat(64), buyer: '0x' + 'b'.repeat(40),
+      seller: '0x' + 's'.repeat(40), cumulativeAmount: 500n, delta: 500n,
+      totalSettled: 500n, platformFee: 5n, metadata: '0x',
+    };
+    const event2: DecodedChannelSettled = {
+      blockNumber: 200, txHash: '0x' + 'c'.repeat(64), logIndex: 0,
+      channelId: '0x' + '2'.repeat(64), buyer: '0x' + 'b'.repeat(40),
+      seller: '0x' + 's'.repeat(40), cumulativeAmount: 1500n, delta: 1000n,
+      totalSettled: 1500n, platformFee: 10n, metadata: '0x',
+    };
+
+    const agentIdBySeller = new Map([[event1.seller, 1]]);
+
+    store.applySettlementBatch(
+      'base', '0xchannels', [event1], new Map(), agentIdBySeller,
+      100, new Map([[100, janTs]]), janTs,
+    );
+    store.applySettlementBatch(
+      'base', '0xchannels', [event2], new Map(), agentIdBySeller,
+      200, new Map([[200, febTs]]), febTs,
+    );
+
+    const jan = store.getLeaderboard('seller', 'month', new Date(Date.UTC(2025, 0, 1)));
+    assert.equal(jan.length, 1);
+    assert.equal(jan[0]!.totalRevenue, '500');
+
+    const feb = store.getLeaderboard('seller', 'month', new Date(Date.UTC(2025, 1, 1)));
+    assert.equal(feb.length, 1);
+    assert.equal(feb[0]!.totalRevenue, '1000');
+
+    store.close();
+  });
+
+  it('getLeaderboard ranks multiple sellers correctly', () => {
+    const store = new SqliteStore(':memory:');
+    store.init();
+
+    const ts = Math.floor(Date.UTC(2025, 0, 15) / 1000);
+
+    const events: DecodedChannelSettled[] = [
+      {
+        blockNumber: 100, txHash: '0x' + 'a'.repeat(64), logIndex: 0,
+        channelId: '0x' + '1'.repeat(64), buyer: '0x' + 'b'.repeat(40),
+        seller: '0x' + '1'.repeat(40), cumulativeAmount: 3000n, delta: 3000n,
+        totalSettled: 3000n, platformFee: 30n, metadata: '0x',
+      },
+      {
+        blockNumber: 100, txHash: '0x' + 'a'.repeat(64), logIndex: 1,
+        channelId: '0x' + '2'.repeat(64), buyer: '0x' + 'b'.repeat(40),
+        seller: '0x' + '2'.repeat(40), cumulativeAmount: 5000n, delta: 5000n,
+        totalSettled: 5000n, platformFee: 50n, metadata: '0x',
+      },
+      {
+        blockNumber: 100, txHash: '0x' + 'a'.repeat(64), logIndex: 2,
+        channelId: '0x' + '3'.repeat(64), buyer: '0x' + 'b'.repeat(40),
+        seller: '0x' + '3'.repeat(40), cumulativeAmount: 1000n, delta: 1000n,
+        totalSettled: 1000n, platformFee: 10n, metadata: '0x',
+      },
+    ];
+
+    const agentIdBySeller = new Map([
+      [events[0]!.seller, 10],
+      [events[1]!.seller, 20],
+      [events[2]!.seller, 30],
+    ]);
+
+    store.applySettlementBatch(
+      'base', '0xchannels', events, new Map(), agentIdBySeller,
+      100, new Map([[100, ts]]), ts,
+    );
+
+    const sellers = store.getLeaderboard('seller', 'all');
+    assert.equal(sellers.length, 3);
+    // Should be ranked by revenue DESC
+    assert.equal(sellers[0]!.id, '20'); // 5000
+    assert.equal(sellers[1]!.id, '10'); // 3000
+    assert.equal(sellers[2]!.id, '30'); // 1000
+
+    store.close();
+  });
+
+  it('applySettlementBatch deduplicates on (tx_hash, log_index)', () => {
+    const store = new SqliteStore(':memory:');
+    store.init();
+
+    const event: DecodedChannelSettled = {
+      blockNumber: 100, txHash: '0x' + 'a'.repeat(64), logIndex: 0,
+      channelId: '0x' + '1'.repeat(64), buyer: '0x' + 'b'.repeat(40),
+      seller: '0x' + 's'.repeat(40), cumulativeAmount: 5000n, delta: 5000n,
+      totalSettled: 5000n, platformFee: 50n, metadata: '0x',
+    };
+
+    const agentIdBySeller = new Map([[event.seller, 1]]);
+    const blockTimestamps = new Map([[100, 1700000000]]);
+
+    // Insert same event twice
+    store.applySettlementBatch(
+      'base', '0xchannels', [event], new Map(), agentIdBySeller,
+      100, blockTimestamps, 1700000000,
+    );
+    store.applySettlementBatch(
+      'base', '0xchannels', [event], new Map(), agentIdBySeller,
+      100, blockTimestamps, 1700000000,
+    );
+
+    // Should only have one entry
+    const sellers = store.getLeaderboard('seller', 'all');
+    assert.equal(sellers.length, 1);
+    assert.equal(sellers[0]!.totalRevenue, '5000'); // not doubled
     store.close();
   });
 

--- a/apps/network-stats/src/store.ts
+++ b/apps/network-stats/src/store.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3';
-import type { DecodedMetadataRecorded } from '@antseed/node';
+import type { DecodedMetadataRecorded, DecodedChannelSettled } from '@antseed/node';
 
 export interface SellerTotals {
   totalRequests: bigint;
@@ -35,6 +35,30 @@ interface BuyerOrChannelRow {
   first_settled_block: number;
 }
 
+export interface LeaderboardEntry {
+  /** agent_id for sellers, buyer address for buyers */
+  id: string;
+  totalRevenue: string;   // USDC amount as string (bigint)
+  totalFees: string;      // platform fees as string (bigint)
+  totalInputTokens: string;
+  totalOutputTokens: string;
+  totalRequests: string;
+  settlementCount: number;
+}
+
+export type LeaderboardPeriod = 'day' | 'month' | 'all';
+export type LeaderboardRole = 'seller' | 'buyer';
+
+interface LeaderboardRow {
+  id: string;
+  total_revenue: string;
+  total_fees: string;
+  total_input_tokens: string;
+  total_output_tokens: string;
+  total_requests: string;
+  settlement_count: number;
+}
+
 interface SellerTotalsRow {
   total_request_count: string;
   total_input_tokens: string;
@@ -64,6 +88,11 @@ export class SqliteStore {
   private _selectSellerTotals!: Database.Statement<[number], SellerTotalsRow>;
   private _countBuyers!: Database.Statement<[number], { c: number }>;
   private _countChannels!: Database.Statement<[number], { c: number }>;
+  private _insertSettlement!: Database.Statement<[number, number, string, number, string, number, string, string, string, string, string, string, string, string]>;
+  private _leaderboardSeller!: Database.Statement<[number, number, number], LeaderboardRow>;
+  private _leaderboardSellerAll!: Database.Statement<[number], LeaderboardRow>;
+  private _leaderboardBuyer!: Database.Statement<[number, number, number], LeaderboardRow>;
+  private _leaderboardBuyerAll!: Database.Statement<[number], LeaderboardRow>;
 
   constructor(dbPath: string) {
     this.db = new Database(dbPath);
@@ -117,6 +146,32 @@ export class SqliteStore {
         last_block_timestamp INTEGER,
         PRIMARY KEY (chain_id, contract_address)
       );
+
+      CREATE TABLE IF NOT EXISTS settlement_events (
+        id              INTEGER PRIMARY KEY AUTOINCREMENT,
+        block_number    INTEGER NOT NULL,
+        block_timestamp INTEGER NOT NULL,
+        tx_hash         TEXT NOT NULL,
+        log_index       INTEGER NOT NULL,
+        channel_id      TEXT NOT NULL,
+        agent_id        INTEGER NOT NULL,
+        seller          TEXT NOT NULL,
+        buyer           TEXT NOT NULL,
+        delta_amount    TEXT NOT NULL,
+        cumulative_amount TEXT NOT NULL,
+        platform_fee    TEXT NOT NULL,
+        input_tokens    TEXT NOT NULL DEFAULT '0',
+        output_tokens   TEXT NOT NULL DEFAULT '0',
+        request_count   TEXT NOT NULL DEFAULT '0',
+        UNIQUE(tx_hash, log_index)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_settlement_events_timestamp
+        ON settlement_events (block_timestamp);
+      CREATE INDEX IF NOT EXISTS idx_settlement_events_agent
+        ON settlement_events (agent_id, block_timestamp);
+      CREATE INDEX IF NOT EXISTS idx_settlement_events_buyer
+        ON settlement_events (buyer, block_timestamp);
     `);
 
     this._selectCheckpoint = this.db.prepare(
@@ -175,6 +230,76 @@ export class SqliteStore {
 
     this._countChannels = this.db.prepare(
       'SELECT COUNT(*) AS c FROM seller_channel_totals WHERE agent_id = ?',
+    );
+
+    this._insertSettlement = this.db.prepare(
+      `INSERT OR IGNORE INTO settlement_events
+         (block_number, block_timestamp, tx_hash, log_index, channel_id,
+          agent_id, seller, buyer, delta_amount, cumulative_amount,
+          platform_fee, input_tokens, output_tokens, request_count)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    this._leaderboardSeller = this.db.prepare(
+      `SELECT
+         CAST(agent_id AS TEXT) AS id,
+         COALESCE(SUM(CAST(delta_amount AS INTEGER)), 0) AS total_revenue,
+         COALESCE(SUM(CAST(platform_fee AS INTEGER)), 0) AS total_fees,
+         COALESCE(SUM(CAST(input_tokens AS INTEGER)), 0) AS total_input_tokens,
+         COALESCE(SUM(CAST(output_tokens AS INTEGER)), 0) AS total_output_tokens,
+         COALESCE(SUM(CAST(request_count AS INTEGER)), 0) AS total_requests,
+         COUNT(*) AS settlement_count
+       FROM settlement_events
+       WHERE block_timestamp >= ? AND block_timestamp < ?
+       GROUP BY agent_id
+       ORDER BY total_revenue DESC
+       LIMIT ?`,
+    );
+
+    this._leaderboardSellerAll = this.db.prepare(
+      `SELECT
+         CAST(agent_id AS TEXT) AS id,
+         COALESCE(SUM(CAST(delta_amount AS INTEGER)), 0) AS total_revenue,
+         COALESCE(SUM(CAST(platform_fee AS INTEGER)), 0) AS total_fees,
+         COALESCE(SUM(CAST(input_tokens AS INTEGER)), 0) AS total_input_tokens,
+         COALESCE(SUM(CAST(output_tokens AS INTEGER)), 0) AS total_output_tokens,
+         COALESCE(SUM(CAST(request_count AS INTEGER)), 0) AS total_requests,
+         COUNT(*) AS settlement_count
+       FROM settlement_events
+       GROUP BY agent_id
+       ORDER BY total_revenue DESC
+       LIMIT ?`,
+    );
+
+    this._leaderboardBuyer = this.db.prepare(
+      `SELECT
+         buyer AS id,
+         COALESCE(SUM(CAST(delta_amount AS INTEGER)), 0) AS total_revenue,
+         COALESCE(SUM(CAST(platform_fee AS INTEGER)), 0) AS total_fees,
+         COALESCE(SUM(CAST(input_tokens AS INTEGER)), 0) AS total_input_tokens,
+         COALESCE(SUM(CAST(output_tokens AS INTEGER)), 0) AS total_output_tokens,
+         COALESCE(SUM(CAST(request_count AS INTEGER)), 0) AS total_requests,
+         COUNT(*) AS settlement_count
+       FROM settlement_events
+       WHERE block_timestamp >= ? AND block_timestamp < ?
+       GROUP BY buyer
+       ORDER BY total_revenue DESC
+       LIMIT ?`,
+    );
+
+    this._leaderboardBuyerAll = this.db.prepare(
+      `SELECT
+         buyer AS id,
+         COALESCE(SUM(CAST(delta_amount AS INTEGER)), 0) AS total_revenue,
+         COALESCE(SUM(CAST(platform_fee AS INTEGER)), 0) AS total_fees,
+         COALESCE(SUM(CAST(input_tokens AS INTEGER)), 0) AS total_input_tokens,
+         COALESCE(SUM(CAST(output_tokens AS INTEGER)), 0) AS total_output_tokens,
+         COALESCE(SUM(CAST(request_count AS INTEGER)), 0) AS total_requests,
+         COUNT(*) AS settlement_count
+       FROM settlement_events
+       GROUP BY buyer
+       ORDER BY total_revenue DESC
+       LIMIT ?`,
     );
   }
 
@@ -336,8 +461,129 @@ export class SqliteStore {
     };
   }
 
+  /**
+   * Atomic transaction: inserts settlement events and advances the checkpoint.
+   *
+   * Each ChannelSettled event is correlated with its MetadataRecorded counterpart
+   * (from the same tx) to get token counts. If no matching MetadataRecorded exists
+   * (e.g. metadata recording was silently swallowed), token counts default to 0.
+   *
+   * Events with agentId=0 (unstaked sellers) are stored with agent_id=0 — the
+   * leaderboard can filter these out if needed.
+   *
+   * Uses INSERT OR IGNORE to safely handle re-indexing of already-processed events
+   * (e.g. after a reorg rollback that doesn't fully clear old data).
+   */
+  applySettlementBatch(
+    chainId: string,
+    contractAddress: string,
+    events: DecodedChannelSettled[],
+    metadataByTx: Map<string, DecodedMetadataRecorded[]>,
+    agentIdBySeller: Map<string, number>,
+    newCheckpoint: number,
+    blockTimestamps: Map<number, number>,
+    newCheckpointTimestamp?: number | null,
+  ): void {
+    this.db.transaction(() => {
+      for (const event of events) {
+        const agentId = agentIdBySeller.get(event.seller) ?? 0;
+        const blockTs = blockTimestamps.get(event.blockNumber);
+        if (blockTs === undefined) {
+          console.warn(`[store] missing block timestamp for block ${event.blockNumber} — skipping settlement`);
+          continue;
+        }
+
+        // Find matching MetadataRecorded from the same tx + channelId
+        const txMeta = metadataByTx.get(event.txHash);
+        const matched = txMeta?.find(
+          (m) => m.channelId.toLowerCase() === event.channelId,
+        );
+
+        this._insertSettlement.run(
+          event.blockNumber,
+          blockTs,
+          event.txHash,
+          event.logIndex,
+          event.channelId,
+          agentId,
+          event.seller,
+          event.buyer,
+          event.delta.toString(),
+          event.cumulativeAmount.toString(),
+          event.platformFee.toString(),
+          matched ? matched.inputTokens.toString() : '0',
+          matched ? matched.outputTokens.toString() : '0',
+          matched ? matched.requestCount.toString() : '0',
+        );
+      }
+
+      this._upsertCheckpoint.run(
+        chainId,
+        contractAddress.toLowerCase(),
+        newCheckpoint,
+        newCheckpointTimestamp ?? null,
+      );
+    })();
+  }
+
+  /**
+   * Returns a ranked leaderboard.
+   *
+   * @param role    'seller' groups by agent_id, 'buyer' groups by buyer address
+   * @param period  'day' | 'month' | 'all'
+   * @param date    Reference date for the period window (defaults to now).
+   *                For 'day': that calendar day (UTC). For 'month': that calendar month (UTC).
+   * @param limit   Max entries to return (default 50)
+   */
+  getLeaderboard(
+    role: LeaderboardRole,
+    period: LeaderboardPeriod,
+    date?: Date,
+    limit = 50,
+  ): LeaderboardEntry[] {
+    const ref = date ?? new Date();
+
+    let rows: LeaderboardRow[];
+    if (period === 'all') {
+      rows = role === 'seller'
+        ? this._leaderboardSellerAll.all(limit)
+        : this._leaderboardBuyerAll.all(limit);
+    } else {
+      const { from, to } = periodBounds(period, ref);
+      rows = role === 'seller'
+        ? this._leaderboardSeller.all(from, to, limit)
+        : this._leaderboardBuyer.all(from, to, limit);
+    }
+
+    return rows.map((r) => ({
+      id: r.id,
+      totalRevenue: String(r.total_revenue),
+      totalFees: String(r.total_fees),
+      totalInputTokens: String(r.total_input_tokens),
+      totalOutputTokens: String(r.total_output_tokens),
+      totalRequests: String(r.total_requests),
+      settlementCount: r.settlement_count,
+    }));
+  }
+
   /** Closes the underlying DB handle. */
   close(): void {
     this.db.close();
   }
+}
+
+/** Returns inclusive-start / exclusive-end unix timestamps for the given period. */
+function periodBounds(period: 'day' | 'month', ref: Date): { from: number; to: number } {
+  const y = ref.getUTCFullYear();
+  const m = ref.getUTCMonth();
+  const d = ref.getUTCDate();
+  if (period === 'day') {
+    const from = Date.UTC(y, m, d) / 1000;
+    const to = Date.UTC(y, m, d + 1) / 1000;
+    return { from, to };
+  }
+  // month
+  const from = Date.UTC(y, m, 1) / 1000;
+  const to = Date.UTC(y, m + 1, 1) / 1000;
+  return { from, to };
 }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -38,7 +38,7 @@ export { parsePublicAddress, MAX_PUBLIC_ADDRESS_LENGTH, type ParsedPublicAddress
 export { MeteringStorage } from './metering/storage.js';
 export { BalanceManager } from './payments/balance-manager.js';
 export { DepositsClient, type DepositsClientConfig, type BuyerBalanceInfo } from './payments/evm/deposits-client.js';
-export { ChannelsClient, type ChannelsClientConfig, type ChannelInfo, type AgentStats } from './payments/evm/channels-client.js';
+export { ChannelsClient, type ChannelsClientConfig, type ChannelInfo, type AgentStats, type DecodedChannelSettled } from './payments/evm/channels-client.js';
 export { IdentityClient, type IdentityClientConfig } from './payments/evm/identity-client.js';
 export { StakingClient, type StakingClientConfig } from './payments/evm/staking-client.js';
 export { EmissionsClient, type EmissionsClientConfig } from './payments/evm/emissions-client.js';

--- a/packages/node/src/payments/evm/channels-client.ts
+++ b/packages/node/src/payments/evm/channels-client.ts
@@ -40,7 +40,22 @@ const CHANNELS_ABI = [
   'function domainSeparator() external view returns (bytes32)',
   'function FIRST_SIGN_CAP() external view returns (uint256)',
   'event CloseRequested(bytes32 indexed channelId, address indexed buyer, address indexed seller, uint256 gracePeriodEnd)',
+  'event ChannelSettled(bytes32 indexed channelId, address indexed buyer, address indexed seller, uint128 cumulativeAmount, uint128 delta, uint128 totalSettled, uint256 platformFee, bytes metadata)',
 ] as const;
+
+export interface DecodedChannelSettled {
+  blockNumber: number;
+  txHash: string;
+  logIndex: number;
+  channelId: string;   // 0x-prefixed hex, 32 bytes
+  buyer: string;       // lowercased EVM address
+  seller: string;      // lowercased EVM address
+  cumulativeAmount: bigint;  // cumulative USDC on this channel
+  delta: bigint;             // USDC delta this settlement
+  totalSettled: bigint;      // running total across all channels for this seller
+  platformFee: bigint;
+  metadata: string;          // raw metadata bytes
+}
 
 export interface CloseRequestedEvent {
   channelId: string;
@@ -156,6 +171,48 @@ export class ChannelsClient extends BaseEvmClient {
       totalVolumeUsdc: result[2] as bigint,
       lastSettledAt: Number(result[3]),
     };
+  }
+
+  /**
+   * Fetch and decode all ChannelSettled logs in the inclusive block range
+   * [fromBlock, toBlock]. Returns events sorted by (blockNumber, logIndex) ascending.
+   */
+  async getChannelSettledEvents(params: {
+    fromBlock: number;
+    toBlock: number;
+  }): Promise<DecodedChannelSettled[]> {
+    const iface = new ethers.Interface(CHANNELS_ABI);
+    const topic = iface.getEvent('ChannelSettled')!.topicHash;
+
+    const logs = await this._provider.getLogs({
+      address: this._contractAddress,
+      fromBlock: params.fromBlock,
+      toBlock: params.toBlock,
+      topics: [topic],
+    });
+
+    const out: DecodedChannelSettled[] = [];
+    for (const log of logs) {
+      const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
+      if (!parsed || parsed.name !== 'ChannelSettled') continue;
+      out.push({
+        blockNumber: log.blockNumber,
+        txHash: log.transactionHash,
+        logIndex: log.index,
+        channelId: (parsed.args[0] as string).toLowerCase(),
+        buyer: (parsed.args[1] as string).toLowerCase(),
+        seller: (parsed.args[2] as string).toLowerCase(),
+        cumulativeAmount: parsed.args[3] as bigint,
+        delta: parsed.args[4] as bigint,
+        totalSettled: parsed.args[5] as bigint,
+        platformFee: parsed.args[6] as bigint,
+        metadata: parsed.args[7] as string,
+      });
+    }
+    out.sort((a, b) =>
+      a.blockNumber !== b.blockNumber ? a.blockNumber - b.blockNumber : a.logIndex - b.logIndex,
+    );
+    return out;
   }
 
   /**

--- a/packages/node/src/payments/index.ts
+++ b/packages/node/src/payments/index.ts
@@ -22,7 +22,7 @@ export type { DepositsClientConfig, BuyerBalanceInfo } from './evm/deposits-clie
 
 // Channels client (reserve, settle, timeout)
 export { ChannelsClient } from './evm/channels-client.js';
-export type { ChannelsClientConfig, ChannelInfo, AgentStats, CloseRequestedEvent } from './evm/channels-client.js';
+export type { ChannelsClientConfig, ChannelInfo, AgentStats, CloseRequestedEvent, DecodedChannelSettled } from './evm/channels-client.js';
 
 // Identity client (ERC-8004 IdentityRegistry)
 export { IdentityClient } from './evm/identity-client.js';


### PR DESCRIPTION
## Summary

- **Index `ChannelSettled` events** from the Channels contract alongside the existing `MetadataRecorded` indexer, storing per-event data with USDC amounts, token counts, and block timestamps
- **New `GET /leaderboard` endpoint** with query params: `role` (seller|buyer), `period` (day|month|all), `date` (YYYY-MM-DD), `limit` — returns ranked entries by USDC volume
- **Correlates settlement and metadata events** from the same transaction to capture both financial (delta, fees) and usage (tokens, requests) data in a single `settlement_events` table

### Changes by package

**`@antseed/node`** — `getChannelSettledEvents()` added to `ChannelsClient`, `DecodedChannelSettled` type exported

**`apps/network-stats`**:
- `store.ts` — new `settlement_events` table with timestamp indexes, `applySettlementBatch()`, `getLeaderboard()` with `periodBounds()` helper
- `settlement-indexer.ts` — new indexer that fetches `ChannelSettled` + `MetadataRecorded` events, resolves seller→agentId, stores atomically
- `server.ts` — new `GET /leaderboard` endpoint with validation and settlement indexer sync status
- `index.ts` — wires up `SettlementIndexer` when `channelsDeployBlock` is configured
- `store.test.ts` — 5 new tests (batch insert, day/month filtering, ranking, deduplication)

## Test plan

- [x] All 41 existing + new tests pass (`node --test dist/*.test.js`)
- [x] TypeScript strict mode passes for both `@antseed/node` and `apps/network-stats`
- [ ] Manual: deploy and verify `GET /leaderboard?role=seller&period=day` returns ranked results
- [ ] Manual: verify settlement indexer catches up from `channelsDeployBlock` on first run