### PR TITLE
fix(node): merge services from duplicate provider names in peer metadata

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.90",
+  "version": "0.1.92",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1322,38 +1322,57 @@ export class AntseedNode extends EventEmitter {
     const providerServiceApiProtocolEntries: NonNullable<PeerInfo["providerServiceApiProtocols"]> = {};
 
     for (const providerAnnouncement of result.metadata.providers) {
+      const provName = providerAnnouncement.provider;
       const serviceEntries: Record<string, TokenPricingUsdPerMillion> = {};
       for (const service of providerAnnouncement.services) {
         serviceEntries[service] =
           providerAnnouncement.servicePricing?.[service] ?? providerAnnouncement.defaultPricing;
       }
-      providerPricingEntries[providerAnnouncement.provider] = {
-        defaults: {
-          inputUsdPerMillion: providerAnnouncement.defaultPricing.inputUsdPerMillion,
-          outputUsdPerMillion: providerAnnouncement.defaultPricing.outputUsdPerMillion,
-          ...(providerAnnouncement.defaultPricing.cachedInputUsdPerMillion != null
-            ? { cachedInputUsdPerMillion: providerAnnouncement.defaultPricing.cachedInputUsdPerMillion }
-            : {}),
-        },
-        ...(Object.keys(serviceEntries).length > 0 ? { services: serviceEntries } : {}),
-      };
 
-      if (providerAnnouncement.serviceCategories && Object.keys(providerAnnouncement.serviceCategories).length > 0) {
-        providerServiceCategoryEntries[providerAnnouncement.provider] = {
-          services: Object.fromEntries(
-            Object.entries(providerAnnouncement.serviceCategories)
-              .map(([service, categories]) => [service, [...categories]]),
-          ),
+      const existing = providerPricingEntries[provName];
+      if (existing) {
+        // Merge services from duplicate provider names
+        Object.assign(existing.services ?? {}, serviceEntries);
+        if (!existing.services && Object.keys(serviceEntries).length > 0) {
+          existing.services = serviceEntries;
+        }
+      } else {
+        providerPricingEntries[provName] = {
+          defaults: {
+            inputUsdPerMillion: providerAnnouncement.defaultPricing.inputUsdPerMillion,
+            outputUsdPerMillion: providerAnnouncement.defaultPricing.outputUsdPerMillion,
+            ...(providerAnnouncement.defaultPricing.cachedInputUsdPerMillion != null
+              ? { cachedInputUsdPerMillion: providerAnnouncement.defaultPricing.cachedInputUsdPerMillion }
+              : {}),
+          },
+          ...(Object.keys(serviceEntries).length > 0 ? { services: serviceEntries } : {}),
         };
       }
 
+      if (providerAnnouncement.serviceCategories && Object.keys(providerAnnouncement.serviceCategories).length > 0) {
+        const existingCats = providerServiceCategoryEntries[provName];
+        const newEntries = Object.fromEntries(
+          Object.entries(providerAnnouncement.serviceCategories)
+            .map(([service, categories]) => [service, [...categories]]),
+        );
+        if (existingCats) {
+          Object.assign(existingCats.services, newEntries);
+        } else {
+          providerServiceCategoryEntries[provName] = { services: newEntries };
+        }
+      }
+
       if (providerAnnouncement.serviceApiProtocols && Object.keys(providerAnnouncement.serviceApiProtocols).length > 0) {
-        providerServiceApiProtocolEntries[providerAnnouncement.provider] = {
-          services: Object.fromEntries(
-            Object.entries(providerAnnouncement.serviceApiProtocols)
-              .map(([service, protocols]) => [service, [...protocols]]),
-          ),
-        };
+        const existingProtos = providerServiceApiProtocolEntries[provName];
+        const newEntries = Object.fromEntries(
+          Object.entries(providerAnnouncement.serviceApiProtocols)
+            .map(([service, protocols]) => [service, [...protocols]]),
+        );
+        if (existingProtos) {
+          Object.assign(existingProtos.services, newEntries);
+        } else {
+          providerServiceApiProtocolEntries[provName] = { services: newEntries };
+        }
       }
     }
 

--- a/packages/provider-core/package.json
+++ b/packages/provider-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-core",
-  "version": "0.2.41",
+  "version": "0.2.42",
   "description": "Shared provider infrastructure for Antseed plugins",
   "type": "module",
   "files": [

--- a/plugins/provider-openai/package.json
+++ b/plugins/provider-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-openai",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "description": "OpenAI-compatible provider plugin for Antseed",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

When a peer announces multiple providers with the same name (e.g. two `"openai"` instances pointing at different upstream APIs), the buyer-side `_lookupResultToPeerInfo` keyed pricing, categories, and API protocols by provider name. The second provider overwrote the first, so only one set of services appeared in the desktop app.

Now merges all three maps when multiple providers share the same name.

## Test plan
- [ ] Peer with two same-name providers shows all services in desktop app
- [ ] Existing single-provider peers are unaffected