### PR TITLE
feat: DIEM staking proxy with seller delegation

### DIFF
--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -484,6 +484,16 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
       const dhtPort = options.dhtPort as number | undefined
       const signalingPort = options.signalingPort as number | undefined
 
+      const delegationCfg = config.payments?.sellerDelegation
+      const announcerDelegation = delegationCfg
+        ? {
+            sellerContract: delegationCfg.sellerContract,
+            chainId: resolveChainConfig({ chainId: config.payments.crypto?.chainId }).evmChainId,
+            expiresInSeconds: delegationCfg.expiresInSeconds,
+            refreshBeforeExpirySeconds: delegationCfg.refreshBeforeExpirySeconds,
+          }
+        : undefined
+
       const node = new AntseedNode({
         role: 'seller',
         displayName: config.identity.displayName,
@@ -514,6 +524,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
             chainId: resolveChainConfig({ chainId: paymentConfig.crypto.chainId }).evmChainId,
           } : {}),
         },
+        ...(announcerDelegation ? { sellerDelegation: announcerDelegation } : {}),
       })
 
       let registeredProviders = providers

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -123,6 +123,19 @@ export interface PaymentsCLIConfig {
   maxPerRequestUsdc?: string;
   /** Maximum total USDC the buyer will reserve in a single SpendingAuth in base units. Default: "1000000" ($1.00). */
   maxReserveAmountUsdc?: string;
+  /**
+   * Optional seller delegation config for DiemStakingProxy peers.
+   * Signed by the peer identity wallet — the proxy's `operator` must be set
+   * to the peer identity's EVM address.
+   */
+  sellerDelegation?: {
+    /** 0x-prefixed contract address of DiemStakingProxy */
+    sellerContract: string;
+    /** How long each signed delegation is valid (seconds). Default 3600. */
+    expiresInSeconds?: number;
+    /** Refresh the delegation when remaining TTL drops below this (seconds). Default 600. */
+    refreshBeforeExpirySeconds?: number;
+  };
   /** Optional crypto settlement settings (Base network) */
   crypto?: {
     /** Chain identifier */

--- a/docs/protocol/diem-proxy.md
+++ b/docs/protocol/diem-proxy.md
@@ -1,0 +1,204 @@
+# DIEM Staking Proxy
+
+## Overview
+
+`DiemStakingProxy` is a Solidity contract on Base that lets DIEM token holders pool their stake, re-stake it into Venice (for API inference credit), and share the resulting AntSeed seller revenue (USDC + ANTS) pro-rata. It sits between DIEM stakers, Venice's on-chain staking contract, and AntSeed's payment channels — acting as the permanent on-chain seller address for AntSeed while the seller-side peer runs under an operator EOA.
+
+The on-chain seller changes from "peerId's derived EVM address" to "the proxy contract address". Buyers learn this at runtime from a signed `SellerDelegation` attestation the peer publishes in its metadata.
+
+## Architecture
+
+```
+ ┌──────────────┐                        ┌───────────────────┐
+ │  DIEM holder │  stake(amount)         │  Venice staking   │
+ │  (alice)     │─────────────┐          │  contract         │
+ └──────────────┘             │          │  (external)       │
+                              ▼          │                   │
+                      ┌───────────────────┐                  │
+                      │  DiemStakingProxy │──── venice.stake ┤
+                      │                   │──── venice.unstake
+                      │  • staked[user]   │                  │
+                      │  • usdcStream     │                  └──── API-key entitlement
+                      │  • antsStream     │                       (off-chain, operator holds)
+                      └────────┬──────────┘
+                               │
+       ┌───────────────────────┼────────────────────────┐
+       │                       │                        │
+       ▼ reserve/topUp/        ▼ operatorClaimEmissions  ▼ getReward()
+         settle/close            (epochs[])               (by user)
+       ┌─────────────┐       ┌──────────────────┐       ┌──────────────────┐
+       │ AntseedCh-  │       │ AntseedEmissions │       │ USDC / ANTS      │
+       │ annels      │       │                  │       │ safeTransfer     │
+       └──────┬──────┘       └────────┬─────────┘       └──────────────────┘
+              │                       │
+              │ chargeAndCredit       │ claimSellerEmissions
+              ▼                       ▼
+       ┌─────────────┐         mints ANTS to msg.sender = proxy
+       │ AntseedDep- │         ──► proxy._notifyRewardAmount(antsStream, Δ)
+       │ osits       │
+       │ safeTransfer│
+       │ (seller=prxy)         ──► proxy._notifyRewardAmount(usdcStream, Δ)
+       └─────────────┘
+```
+
+The operator EOA is a signer/relayer only. It signs `SellerDelegation` off-chain and calls `reserve/topUp/settle/close/operatorClaimEmissions` on the proxy on-chain. It never custodies DIEM, USDC, or ANTS belonging to stakers — the proxy is the sole custodian.
+
+The **operator EOA is the peer identity wallet** loaded by the daemon (`loadOrCreateIdentity`). That same key already signs peer metadata and makes seller-side channel calls, so no second key is introduced. The proxy's `operator` must be set to the peer identity's EVM address; rotating the operator means rotating the peer identity.
+
+## `SellerDelegation` schema
+
+EIP-712 typed data:
+
+- **Domain**
+  - `name`: `"DiemStakingProxy"`
+  - `version`: `"1"`
+  - `chainId`: Base chainId (8453 mainnet, 84532 Sepolia)
+  - `verifyingContract`: the proxy contract address
+
+- **Type**
+  ```
+  SellerDelegation(
+    address peerAddress,
+    address sellerContract,
+    uint256 chainId,
+    uint256 expiresAt
+  )
+  ```
+
+- **Signer**: the current `operator` EOA (as returned by `proxy.operator()`).
+
+- **On-wire shape** (`SellerDelegationPayload` in `packages/node/src/discovery/peer-metadata.ts`):
+  ```jsonc
+  {
+    "peerAddress":    "aabbccdd...ee",       // 40 lowercase hex, no 0x
+    "sellerContract": "112233...99",          // = proxy address, 40 hex
+    "chainId":        8453,
+    "expiresAt":      1747000000,             // unix seconds
+    "signature":      "11...cc"              // 130 hex (65-byte secp256k1 sig)
+  }
+  ```
+
+- **Publishing**: embedded inside the signed peer metadata body (codec v8+). The metadata signature binds the delegation to the publishing peer, preventing replay to a different peerId.
+
+- **Lifetime**: short (default 1 hour). The peer's announcer re-signs before expiry and republishes updated metadata automatically.
+
+## Buyer verification flow
+
+```
+ 1. P2P handshake:  ecrecover(sig, peerId) == peerId's pubkey
+                    (unchanged; no RPC)
+
+ 2. Fetch metadata over HTTP. Decode v8 binary body.
+    → If version mismatch → drop peer (fail-closed via validateMetadata).
+
+ 3. resolveSellerAddress(peerId, metadata):
+      if no sellerDelegation     → return peerIdToAddress(peerId)
+
+      check chainId == ourChainId
+      check expiresAt > now
+      check peerAddress == peerIdToAddress(peerId)
+      check cache[hash(delegation)] is fresh (< 5min)
+        if cached & fresh         → return cached sellerContract
+
+      RPC: read proxy.operator()
+      recovered = ecrecover(EIP712(SellerDelegation), sig)
+      check recovered == operator → else THROW (drop peer; no fallback)
+
+      cache[hash] = { sellerContract, verifiedAt: now }
+      return sellerContract
+
+ 4. resolved address is used as `seller` for:
+      computeChannelId(buyer, seller, salt)
+      ReserveAuth.channelId (via computeChannelId)
+      SpendingAuth.channelId (via computeChannelId)
+      ChannelStore.sellerEvmAddr
+      staking.getAgentId(seller)   (discovery loop)
+```
+
+Cache TTL: 5 minutes. Rotation detection: when the cached `operator` value no longer matches the on-chain `operator()`, verification fails → the entry is discarded; a fresh read picks up the new operator on next resolve.
+
+**Fail-closed**: if a peer publishes a delegation and verification fails for any reason (expiry, chain, signer mismatch), the resolver throws `SellerDelegationVerificationError`. The caller drops the peer rather than falling back to `peerIdToAddress` — a lying peer that publishes a bogus delegation must not succeed in being treated as a normal peer.
+
+## Reward accounting
+
+Two parallel streams: `usdcStream` and `antsStream`. Each uses the Uniswap StakingRewards pattern:
+
+- `rewardRate` (tokens per second), `periodFinish`, `lastUpdateTime`, `rewardPerTokenStored`.
+- Per-user `userUsdcRewardPerTokenPaid`, `userAntsRewardPerTokenPaid`, `usdcRewards`, `antsRewards`.
+- `earned(account)` view returns `(usdcEarned, antsEarned)`.
+
+`notifyRewardAmount` is **internal only**. It fires inline, in the same tx as the inflow:
+
+- `settle(...)` and `close(...)` — pre/post `usdc.balanceOf(this)` diff. Delta > 0 → `_notifyRewardAmount(usdcStream, delta)`.
+- `operatorClaimEmissions(epochs)` — pre/post `ants.balanceOf(this)` diff. Delta > 0 → `_notifyRewardAmount(antsStream, delta)`.
+- `topUp(...)` — captures any USDC delta if the embedded settle brings inflow.
+- `reserve(...)` — no inflow, no notification.
+
+Default `rewardsDuration` is **1 day** per stream (owner-adjustable via `setRewardsDuration(stream, seconds)`, only while the stream's `periodFinish` has passed). One-day smooths inflow cadence (operator typically settles every few minutes to hours) without letting rewards linger stale.
+
+Accrual boundaries around withdrawals:
+
+- `stake(amount)`: runs `_updateStream` for both streams on the staker before mutating `staked`.
+- `requestWithdraw(amount)`: runs `_updateStream` first, then decrements `staked` and enters the Venice cooldown. The requested portion **stops accruing rewards immediately**.
+- `withdraw()` (after cooldown): pure DIEM transfer; no reward math.
+- `getReward()`: runs `_updateStream`, transfers both stream balances, zeros them.
+
+## Venice unbonding (two-step withdrawal)
+
+Venice's on-chain staking contract imposes a 7-day unstake cooldown. Consequently:
+
+- `requestWithdraw(amount)` calls `venice.unstake(amount)` synchronously and records `pendingWithdrawal[user] = { amount, unlockAt = now + VENICE_COOLDOWN }`. Only one pending withdrawal per user at a time.
+- `withdraw()` transfers DIEM once `block.timestamp >= unlockAt`.
+- There is **no cancel-requestWithdraw path** in v1. A staker that wants to stay staked after requesting withdrawal must wait out the cooldown, call `withdraw()`, and call `stake()` again.
+- `VENICE_COOLDOWN` defaults to 7 days. If Venice changes their parameter, the owner calls `syncVeniceCooldown(newCooldown)` to update.
+
+## Deployment runbook
+
+Prerequisites: Base mainnet (or Sepolia); owner EOA with ETH for gas; operator EOA for channel ops; USDC for AntSeed staking minimum.
+
+1. **Deploy `DiemStakingProxy`** with constructor args:
+   - `_diem`: `0xf4d97f2da56e8c3098f3a8d538db630a2606a024`
+   - `_usdc`: Base USDC (mainnet: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`)
+   - `_ants`: AntSeed ANTS token address (check `packages/node/chain-config.json`)
+   - `_venice`: Venice staking contract address
+   - `_channels`: real `AntseedChannels` address (not the proxy itself)
+   - `_emissions`: `AntseedEmissions` address
+   - `_operator`: the operator EOA
+   - `_usdcRewardsDuration`: `86400` (1 day)
+   - `_antsRewardsDuration`: `86400` (1 day)
+
+2. **(Optional) transfer ownership to a multisig** via `Ownable.transferOwnership`. Distributes operator-rotation risk across N signers.
+
+3. **Register an ERC-8004 agentId** for the proxy address. Call `IdentityRegistry.register(<proxyAddress>)` (or whatever the deployed registry's signature is) — this is a separate tx targeting the ERC-8004 contract, not the proxy. The returned `agentId` is used by `AntseedStaking` and `AntseedEmissions` to identify the proxy as a seller.
+
+4. **Stake minimum on `AntseedStaking`** so the proxy can call `reserve()`:
+   - Owner approves USDC to `AntseedStaking` for at least `MIN_SELLER_STAKE`.
+   - Owner calls `staking.stakeFor(<proxyAddress>, <agentId>, <amount>)`. Because `stakeFor` pulls USDC from `msg.sender`, the owner funds this, not the proxy.
+
+5. **`setOperator(address)`** — only if the operator needs to be different from what was set in the constructor.
+
+6. **Configure the seller peer**:
+   - In the seller CLI config (`~/.antseed/config.json` or equivalent), set `payments.crypto.channelsContractAddress` to the **proxy address** (not the real `AntseedChannels` address). The seller's `ChannelsClient` will now call `reserve/topUp/settle/close` on the proxy.
+   - Set `payments.sellerDelegation.sellerContract` to the proxy address.
+   - The peer identity wallet (loaded from the normal AntSeed identity store) signs `SellerDelegation`. No separate operator private key / env var is introduced — the `operator` set on the proxy **must** equal the peer identity's EVM address.
+
+7. **Restart the seller peer**. Verify:
+   - Peer metadata on announce includes `sellerDelegation` (check decoded metadata output).
+   - First buyer connects and opens a channel: tx on-chain is `proxy.reserve(...)` → emits `ForwardedReserve`, internally calls `AntseedChannels.reserve` with `seller = proxy`.
+   - On settle: `ForwardedSettle(channelId, cumulative, inflow)` emits with `inflow > 0`; stream rates update.
+
+## Operator runbook
+
+- **Rotate operator**: because the operator is the peer identity, rotation is a two-step process — (a) generate a new peer identity (start the new peer instance), (b) owner calls `setOperator(newPeerIdentityAddress)` on the proxy. Event `OperatorRotated(old, new)`. Buyers re-verify within ≤5 min (resolver cache TTL). The new peer's announcer automatically publishes a fresh `SellerDelegation` signed by the new identity; older signatures no longer verify. Shift traffic from old to new peer as desired.
+- **Change reward duration**: call `setRewardsDuration(streamIndex, seconds)` where `streamIndex` is `0` for USDC, `1` for ANTS. Only valid while the stream's `periodFinish` has passed. To force a window close, wait out the existing period or pause settles.
+- **Manual Venice cooldown sync**: if Venice changes their cooldown parameter, owner calls `syncVeniceCooldown(newCooldownSeconds)`. Existing pending withdrawals retain their original `unlockAt`.
+- **Emissions claim cadence**: operator chooses when to call `operatorClaimEmissions(epochs[])`. Claiming more frequently smooths reward rate spikes but costs gas per tx. Weekly is a reasonable default; monthly acceptable.
+
+## Out of scope / known limitations
+
+- **No cancel-requestWithdraw**: once a staker enters the cooldown, they must wait.
+- **No multi-operator support** at the contract level. Distribute key-custody risk by using a multisig as the proxy owner (the multisig can rotate the single operator EOA).
+- **No migration of legacy channels**: existing `ChannelStore` records keep their original `sellerEvmAddr`. New channels opened after the proxy goes live use the proxy address.
+- **Buyers on metadata codec v<8**: do not see delegated peers. The strict `version !== METADATA_VERSION` check in `validateMetadata()` causes old buyers to reject v8 peers outright — this is the rollout correctness mechanism.
+- **Venice API-key lifecycle**: entirely off-chain. The proxy re-stakes DIEM into Venice; the operator holds and manages the resulting API key. Rotation or revocation of the API key is out of scope.
+- **No EIP-1271 in the handshake**: the P2P handshake stays zero-RPC and ecrecover-only. Delegation is application-layer, verified once per ~5 minutes of session.

--- a/packages/contracts/DiemStakingProxy.sol
+++ b/packages/contracts/DiemStakingProxy.sol
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+import {IVeniceStaking} from "./interfaces/IVeniceStaking.sol";
+import {IAntseedChannels} from "./interfaces/IAntseedChannels.sol";
+
+interface IAntseedEmissionsClaim {
+    function claimSellerEmissions(uint256[] calldata epochs) external;
+}
+
+/**
+ * @title DiemStakingProxy
+ * @notice Pooled DIEM staker / Venice re-staker / AntSeed seller façade.
+ *         Holders stake DIEM; the proxy re-stakes into Venice for API entitlement
+ *         and acts as the on-chain seller address for AntSeed. USDC and ANTS
+ *         inflow is distributed pro-rata to stakers via two Uniswap-StakingRewards
+ *         streams, each notified inline in the operator's inflow-bringing tx.
+ *
+ *         Two-step withdraw because Venice has a 7-day unbonding delay.
+ */
+contract DiemStakingProxy is Ownable, ReentrancyGuard, EIP712 {
+    using SafeERC20 for IERC20;
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        EIP-712
+    // ═══════════════════════════════════════════════════════════════════
+
+    bytes32 public constant SELLER_DELEGATION_TYPEHASH = keccak256(
+        "SellerDelegation(address peerAddress,address sellerContract,uint256 chainId,uint256 expiresAt)"
+    );
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        Configurable Constants
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// @notice Venice unbonding period seconds (default 7 days; owner may sync if Venice changes it).
+    uint256 public VENICE_COOLDOWN = 7 days;
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        Structs
+    // ═══════════════════════════════════════════════════════════════════
+
+    struct RewardStream {
+        uint256 rewardRate;            // tokens per second during active period
+        uint256 periodFinish;          // timestamp when current period ends
+        uint256 lastUpdateTime;        // last timestamp rewardPerTokenStored was updated
+        uint256 rewardPerTokenStored;  // accumulated reward per staked unit
+        uint256 rewardsDuration;       // window over which a notifyRewardAmount is distributed
+    }
+
+    struct PendingWithdrawal {
+        uint128 amount;
+        uint64 unlockAt;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        Immutables
+    // ═══════════════════════════════════════════════════════════════════
+
+    IERC20 public immutable diem;
+    IERC20 public immutable usdc;
+    IERC20 public immutable ants;
+    IVeniceStaking public immutable venice;
+    IAntseedChannels public immutable channels;
+    address public immutable emissions;
+
+    uint8 internal constant STREAM_USDC = 0;
+    uint8 internal constant STREAM_ANTS = 1;
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        Storage
+    // ═══════════════════════════════════════════════════════════════════
+
+    address public operator;
+
+    uint256 public totalStaked;
+    mapping(address => uint256) public staked;
+    mapping(address => PendingWithdrawal) public pendingWithdrawal;
+
+    RewardStream public usdcStream;
+    RewardStream public antsStream;
+
+    mapping(address => uint256) public userUsdcRewardPerTokenPaid;
+    mapping(address => uint256) public userAntsRewardPerTokenPaid;
+    mapping(address => uint256) public usdcRewards;
+    mapping(address => uint256) public antsRewards;
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        Events
+    // ═══════════════════════════════════════════════════════════════════
+
+    event Staked(address indexed user, uint256 amount);
+    event WithdrawRequested(address indexed user, uint256 amount, uint256 unlockAt);
+    event Withdrawn(address indexed user, uint256 amount);
+    event RewardPaid(address indexed user, uint256 usdcAmount, uint256 antsAmount);
+    event RewardNotified(uint8 indexed stream, uint256 amount, uint256 newPeriodFinish);
+    event OperatorRotated(address indexed oldOperator, address indexed newOperator);
+    event EmissionsClaimed(uint256 amount);
+    event ForwardedReserve(bytes32 indexed channelId, address indexed buyer, uint128 maxAmount);
+    event ForwardedSettle(bytes32 indexed channelId, uint128 cumulativeAmount, uint256 inflow);
+    event ForwardedClose(bytes32 indexed channelId, uint128 finalAmount, uint256 inflow);
+    event ForwardedTopUp(bytes32 indexed channelId, uint128 newMaxAmount);
+    event RewardsDurationUpdated(uint8 indexed stream, uint256 newDuration);
+    event VeniceCooldownSynced(uint256 newCooldown);
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        Custom Errors
+    // ═══════════════════════════════════════════════════════════════════
+
+    error InvalidAddress();
+    error InvalidAmount();
+    error NotOperator();
+    error PendingAlreadyExists();
+    error NoPendingWithdrawal();
+    error StillCoolingDown();
+    error RewardPeriodActive();
+    error InvalidDuration();
+    error InsufficientStake();
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        Constructor
+    // ═══════════════════════════════════════════════════════════════════
+
+    constructor(
+        address _diem,
+        address _usdc,
+        address _ants,
+        address _venice,
+        address _channels,
+        address _emissions,
+        address _operator,
+        uint256 _usdcRewardsDuration,
+        uint256 _antsRewardsDuration
+    )
+        Ownable(msg.sender)
+        EIP712("DiemStakingProxy", "1")
+    {
+        if (_diem == address(0) || _usdc == address(0) || _ants == address(0)) revert InvalidAddress();
+        if (_venice == address(0) || _channels == address(0) || _emissions == address(0)) revert InvalidAddress();
+        if (_operator == address(0)) revert InvalidAddress();
+        if (_usdcRewardsDuration == 0 || _antsRewardsDuration == 0) revert InvalidDuration();
+
+        diem = IERC20(_diem);
+        usdc = IERC20(_usdc);
+        ants = IERC20(_ants);
+        venice = IVeniceStaking(_venice);
+        channels = IAntseedChannels(_channels);
+        emissions = _emissions;
+        operator = _operator;
+
+        usdcStream.rewardsDuration = _usdcRewardsDuration;
+        antsStream.rewardsDuration = _antsRewardsDuration;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        Modifiers
+    // ═══════════════════════════════════════════════════════════════════
+
+    modifier onlyOperator() {
+        if (msg.sender != operator) revert NotOperator();
+        _;
+    }
+
+    modifier updateRewards(address account) {
+        _updateStream(usdcStream, userUsdcRewardPerTokenPaid, usdcRewards, account);
+        _updateStream(antsStream, userAntsRewardPerTokenPaid, antsRewards, account);
+        _;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        STAKER OPERATIONS
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// @notice Stake DIEM into the proxy. Proxy re-stakes into Venice in the same tx.
+    function stake(uint256 amount) external nonReentrant updateRewards(msg.sender) {
+        if (amount == 0) revert InvalidAmount();
+
+        staked[msg.sender] += amount;
+        totalStaked += amount;
+
+        diem.safeTransferFrom(msg.sender, address(this), amount);
+
+        // Re-stake into Venice
+        diem.forceApprove(address(venice), amount);
+        venice.stake(amount);
+
+        emit Staked(msg.sender, amount);
+    }
+
+    /**
+     * @notice Begin withdrawal. Calls Venice.unstake inline; stops reward accrual on
+     *         the requested portion immediately. DIEM is claimable after VENICE_COOLDOWN.
+     */
+    function requestWithdraw(uint256 amount) external nonReentrant updateRewards(msg.sender) {
+        if (amount == 0) revert InvalidAmount();
+        if (amount > staked[msg.sender]) revert InsufficientStake();
+        if (pendingWithdrawal[msg.sender].amount != 0) revert PendingAlreadyExists();
+
+        staked[msg.sender] -= amount;
+        totalStaked -= amount;
+
+        uint64 unlockAt = uint64(block.timestamp + VENICE_COOLDOWN);
+        pendingWithdrawal[msg.sender] = PendingWithdrawal({ amount: uint128(amount), unlockAt: unlockAt });
+
+        venice.unstake(amount);
+
+        emit WithdrawRequested(msg.sender, amount, unlockAt);
+    }
+
+    /// @notice Complete withdrawal after cooldown elapses. Transfers DIEM to caller.
+    function withdraw() external nonReentrant {
+        PendingWithdrawal memory pending = pendingWithdrawal[msg.sender];
+        if (pending.amount == 0) revert NoPendingWithdrawal();
+        if (block.timestamp < pending.unlockAt) revert StillCoolingDown();
+
+        delete pendingWithdrawal[msg.sender];
+        diem.safeTransfer(msg.sender, pending.amount);
+
+        emit Withdrawn(msg.sender, pending.amount);
+    }
+
+    /// @notice Claim accrued USDC and ANTS rewards.
+    function getReward() external nonReentrant updateRewards(msg.sender) {
+        uint256 usdcEarned = usdcRewards[msg.sender];
+        uint256 antsEarned = antsRewards[msg.sender];
+
+        if (usdcEarned > 0) {
+            usdcRewards[msg.sender] = 0;
+            usdc.safeTransfer(msg.sender, usdcEarned);
+        }
+        if (antsEarned > 0) {
+            antsRewards[msg.sender] = 0;
+            ants.safeTransfer(msg.sender, antsEarned);
+        }
+
+        emit RewardPaid(msg.sender, usdcEarned, antsEarned);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        ANTSEED CHANNELS FAÇADE
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// @notice Forwarded `AntseedChannels.reserve`. No USDC inflow at this step.
+    function reserve(
+        address buyer,
+        bytes32 salt,
+        uint128 maxAmount,
+        uint256 deadline,
+        bytes calldata buyerSig
+    ) external onlyOperator nonReentrant {
+        channels.reserve(buyer, salt, maxAmount, deadline, buyerSig);
+        bytes32 channelId = channels.computeChannelId(buyer, address(this), salt);
+        emit ForwardedReserve(channelId, buyer, maxAmount);
+    }
+
+    /// @notice Forwarded `AntseedChannels.topUp`. topUp may settle delta — capture inflow.
+    function topUp(
+        bytes32 channelId,
+        uint128 cumulativeAmount,
+        bytes calldata metadata,
+        bytes calldata spendingSig,
+        uint128 newMaxAmount,
+        uint256 deadline,
+        bytes calldata reserveSig
+    ) external onlyOperator nonReentrant {
+        uint256 beforeBal = usdc.balanceOf(address(this));
+        channels.topUp(channelId, cumulativeAmount, metadata, spendingSig, newMaxAmount, deadline, reserveSig);
+        uint256 inflow = usdc.balanceOf(address(this)) - beforeBal;
+        if (inflow > 0) _notifyRewardAmount(usdcStream, STREAM_USDC, inflow);
+        emit ForwardedTopUp(channelId, newMaxAmount);
+    }
+
+    /// @notice Forwarded `AntseedChannels.settle`. Captures USDC inflow and notifies the USDC stream.
+    function settle(
+        bytes32 channelId,
+        uint128 cumulativeAmount,
+        bytes calldata metadata,
+        bytes calldata buyerSig
+    ) external onlyOperator nonReentrant {
+        uint256 beforeBal = usdc.balanceOf(address(this));
+        channels.settle(channelId, cumulativeAmount, metadata, buyerSig);
+        uint256 inflow = usdc.balanceOf(address(this)) - beforeBal;
+        if (inflow > 0) _notifyRewardAmount(usdcStream, STREAM_USDC, inflow);
+        emit ForwardedSettle(channelId, cumulativeAmount, inflow);
+    }
+
+    /// @notice Forwarded `AntseedChannels.close`. Captures USDC inflow.
+    function close(
+        bytes32 channelId,
+        uint128 finalAmount,
+        bytes calldata metadata,
+        bytes calldata buyerSig
+    ) external onlyOperator nonReentrant {
+        uint256 beforeBal = usdc.balanceOf(address(this));
+        channels.close(channelId, finalAmount, metadata, buyerSig);
+        uint256 inflow = usdc.balanceOf(address(this)) - beforeBal;
+        if (inflow > 0) _notifyRewardAmount(usdcStream, STREAM_USDC, inflow);
+        emit ForwardedClose(channelId, finalAmount, inflow);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        ANTS EMISSIONS
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// @notice Claim accumulated ANTS emissions from AntseedEmissions and notify the ANTS stream.
+    ///         Operator is responsible for supplying the list of finalized epochs.
+    function operatorClaimEmissions(uint256[] calldata epochs) external onlyOperator nonReentrant {
+        uint256 beforeBal = ants.balanceOf(address(this));
+        IAntseedEmissionsClaim(emissions).claimSellerEmissions(epochs);
+        uint256 inflow = ants.balanceOf(address(this)) - beforeBal;
+        if (inflow > 0) _notifyRewardAmount(antsStream, STREAM_ANTS, inflow);
+        emit EmissionsClaimed(inflow);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        ADMIN
+    // ═══════════════════════════════════════════════════════════════════
+
+    function setOperator(address newOperator) external onlyOwner {
+        if (newOperator == address(0)) revert InvalidAddress();
+        address old = operator;
+        operator = newOperator;
+        emit OperatorRotated(old, newOperator);
+    }
+
+    /**
+     * @notice Change the rewards duration for a stream. Only while the stream's
+     *         current period has finished to avoid surprising dilution.
+     * @param stream STREAM_USDC (0) or STREAM_ANTS (1).
+     */
+    function setRewardsDuration(uint8 stream, uint256 newDuration) external onlyOwner {
+        if (newDuration == 0) revert InvalidDuration();
+        RewardStream storage s = stream == STREAM_USDC ? usdcStream : antsStream;
+        if (block.timestamp < s.periodFinish) revert RewardPeriodActive();
+        s.rewardsDuration = newDuration;
+        emit RewardsDurationUpdated(stream, newDuration);
+    }
+
+    /**
+     * @notice Owner-callable updater in case Venice changes its cooldown parameter.
+     *         Expects the new cooldown (seconds) to be supplied by the owner — the
+     *         IVeniceStaking interface is intentionally minimal.
+     */
+    function syncVeniceCooldown(uint256 newCooldown) external onlyOwner {
+        VENICE_COOLDOWN = newCooldown;
+        emit VeniceCooldownSynced(newCooldown);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        VIEWS
+    // ═══════════════════════════════════════════════════════════════════
+
+    function earned(address account) external view returns (uint256 usdcEarned, uint256 antsEarned) {
+        usdcEarned = usdcRewards[account]
+            + (staked[account] * (_rewardPerToken(usdcStream) - userUsdcRewardPerTokenPaid[account])) / 1e18;
+        antsEarned = antsRewards[account]
+            + (staked[account] * (_rewardPerToken(antsStream) - userAntsRewardPerTokenPaid[account])) / 1e18;
+    }
+
+    function rewardPerTokenUsdc() external view returns (uint256) { return _rewardPerToken(usdcStream); }
+    function rewardPerTokenAnts() external view returns (uint256) { return _rewardPerToken(antsStream); }
+
+    function domainSeparator() external view returns (bytes32) { return _domainSeparatorV4(); }
+
+    function isValidDelegation(
+        address peerAddress,
+        address _sellerContract,
+        uint256 chainId,
+        uint256 expiresAt,
+        bytes calldata signature
+    ) external view returns (bool) {
+        if (block.timestamp > expiresAt) return false;
+        if (chainId != block.chainid) return false;
+        if (_sellerContract != address(this)) return false;
+
+        bytes32 structHash = keccak256(
+            abi.encode(SELLER_DELEGATION_TYPEHASH, peerAddress, _sellerContract, chainId, expiresAt)
+        );
+        bytes32 digest = _hashTypedDataV4(structHash);
+        address recovered = ECDSA.recover(digest, signature);
+        return recovered == operator;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        INTERNAL REWARD MATH
+    // ═══════════════════════════════════════════════════════════════════
+
+    function _lastTimeRewardApplicable(RewardStream storage s) internal view returns (uint256) {
+        return block.timestamp < s.periodFinish ? block.timestamp : s.periodFinish;
+    }
+
+    function _rewardPerToken(RewardStream storage s) internal view returns (uint256) {
+        if (totalStaked == 0) return s.rewardPerTokenStored;
+        uint256 timeDelta = _lastTimeRewardApplicable(s) - s.lastUpdateTime;
+        return s.rewardPerTokenStored + (timeDelta * s.rewardRate * 1e18) / totalStaked;
+    }
+
+    function _updateStream(
+        RewardStream storage s,
+        mapping(address => uint256) storage paid,
+        mapping(address => uint256) storage userRewards,
+        address account
+    ) internal {
+        s.rewardPerTokenStored = _rewardPerToken(s);
+        s.lastUpdateTime = _lastTimeRewardApplicable(s);
+        if (account != address(0)) {
+            userRewards[account] += (staked[account] * (s.rewardPerTokenStored - paid[account])) / 1e18;
+            paid[account] = s.rewardPerTokenStored;
+        }
+    }
+
+    function _notifyRewardAmount(RewardStream storage s, uint8 streamId, uint256 amount) internal {
+        s.rewardPerTokenStored = _rewardPerToken(s);
+        s.lastUpdateTime = block.timestamp;
+
+        if (block.timestamp >= s.periodFinish) {
+            s.rewardRate = amount / s.rewardsDuration;
+        } else {
+            uint256 remaining = s.periodFinish - block.timestamp;
+            uint256 leftover = remaining * s.rewardRate;
+            s.rewardRate = (amount + leftover) / s.rewardsDuration;
+        }
+        s.periodFinish = block.timestamp + s.rewardsDuration;
+
+        emit RewardNotified(streamId, amount, s.periodFinish);
+    }
+}

--- a/packages/contracts/interfaces/IDiemStakingProxy.sol
+++ b/packages/contracts/interfaces/IDiemStakingProxy.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IDiemStakingProxy {
+    function operator() external view returns (address);
+    function isValidDelegation(
+        address peerAddress,
+        address sellerContract,
+        uint256 chainId,
+        uint256 expiresAt,
+        bytes calldata signature
+    ) external view returns (bool);
+    function earned(address account) external view returns (uint256 usdcEarned, uint256 antsEarned);
+}

--- a/packages/contracts/interfaces/IVeniceStaking.sol
+++ b/packages/contracts/interfaces/IVeniceStaking.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IVeniceStaking {
+    function stake(uint256 amount) external;
+    function unstake(uint256 amount) external;
+}

--- a/packages/contracts/test/DiemStakingProxy.t.sol
+++ b/packages/contracts/test/DiemStakingProxy.t.sol
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {MockUSDC} from "../MockUSDC.sol";
+import {DiemStakingProxy} from "../DiemStakingProxy.sol";
+import {MockVeniceStaking} from "./mocks/MockVeniceStaking.sol";
+import {MockAntseedChannels} from "./mocks/MockAntseedChannels.sol";
+import {MockAntseedEmissions} from "./mocks/MockAntseedEmissions.sol";
+
+contract DiemStakingProxyTest is Test {
+    // Private keys — follow house convention
+    uint256 constant OWNER_PK = 0x0A;
+    uint256 constant OPERATOR_PK = 0x0B;
+    uint256 constant ALICE_PK = 0x0C;
+    uint256 constant BOB_PK = 0x0D;
+
+    address owner;
+    address operator;
+    address alice;
+    address bob;
+
+    MockUSDC diem;
+    MockUSDC usdc;
+    MockUSDC ants;
+    MockVeniceStaking venice;
+    MockAntseedChannels channelsMock;
+    MockAntseedEmissions emissionsMock;
+    DiemStakingProxy proxy;
+
+    uint256 constant USDC_DURATION = 1 days;
+    uint256 constant ANTS_DURATION = 1 days;
+
+    function setUp() public {
+        owner = vm.addr(OWNER_PK);
+        operator = vm.addr(OPERATOR_PK);
+        alice = vm.addr(ALICE_PK);
+        bob = vm.addr(BOB_PK);
+
+        diem = new MockUSDC();
+        usdc = new MockUSDC();
+        ants = new MockUSDC();
+        venice = new MockVeniceStaking(address(diem));
+        channelsMock = new MockAntseedChannels(address(usdc));
+        emissionsMock = new MockAntseedEmissions(address(ants));
+
+        vm.prank(owner);
+        proxy = new DiemStakingProxy(
+            address(diem), address(usdc), address(ants),
+            address(venice), address(channelsMock), address(emissionsMock),
+            operator,
+            USDC_DURATION, ANTS_DURATION
+        );
+
+        // Fund channels mock with USDC so it can pay out.
+        usdc.mint(address(channelsMock), 1_000_000e6);
+        ants.mint(address(emissionsMock), 1_000_000e18);
+    }
+
+    function _stakeAs(address user, uint256 amount) internal {
+        diem.mint(user, amount);
+        vm.startPrank(user);
+        diem.approve(address(proxy), amount);
+        proxy.stake(amount);
+        vm.stopPrank();
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    //                     STAKING TESTS
+    // ─────────────────────────────────────────────────────────────────
+
+    function test_stake_success() public {
+        _stakeAs(alice, 100e18);
+
+        assertEq(proxy.staked(alice), 100e18);
+        assertEq(proxy.totalStaked(), 100e18);
+        assertEq(venice.staked(address(proxy)), 100e18);
+    }
+
+    function test_stake_revert_zeroAmount() public {
+        vm.prank(alice);
+        vm.expectRevert(DiemStakingProxy.InvalidAmount.selector);
+        proxy.stake(0);
+    }
+
+    function test_requestWithdraw_startsCooldownAndStopsAccrual() public {
+        // 1 staker stakes
+        _stakeAs(alice, 100e18);
+
+        // Operator notifies 100 USDC into the stream
+        channelsMock.setPayout(100e6);
+        vm.prank(operator);
+        proxy.settle(bytes32(0), 0, "", "");
+
+        // Advance 12 hours — alice accrues rewards
+        vm.warp(block.timestamp + 12 hours);
+
+        // Record earned before withdraw request
+        (uint256 earnedBefore,) = proxy.earned(alice);
+        assertGt(earnedBefore, 0, "alice should have earned something");
+
+        // Request withdraw of full stake
+        uint256 expectedUnlockAt = block.timestamp + 7 days;
+        vm.prank(alice);
+        proxy.requestWithdraw(100e18);
+
+        // Stake is zeroed out
+        assertEq(proxy.staked(alice), 0);
+        assertEq(proxy.totalStaked(), 0);
+
+        // Pending withdrawal is set with correct unlock time
+        (uint128 pendingAmt, uint64 unlockAt) = proxy.pendingWithdrawal(alice);
+        assertEq(pendingAmt, 100e18);
+        assertEq(unlockAt, uint64(expectedUnlockAt));
+
+        // Advance another 5 hours — no further accrual (totalStaked == 0)
+        vm.warp(block.timestamp + 5 hours);
+        (uint256 earnedAfter,) = proxy.earned(alice);
+        assertEq(earnedAfter, earnedBefore, "no additional accrual after requestWithdraw");
+    }
+
+    function test_withdraw_revertBeforeCooldown() public {
+        _stakeAs(alice, 100e18);
+        vm.prank(alice);
+        proxy.requestWithdraw(100e18);
+
+        vm.prank(alice);
+        vm.expectRevert(DiemStakingProxy.StillCoolingDown.selector);
+        proxy.withdraw();
+    }
+
+    function test_withdraw_success() public {
+        _stakeAs(alice, 100e18);
+        vm.prank(alice);
+        proxy.requestWithdraw(100e18);
+
+        vm.warp(block.timestamp + 7 days + 1);
+
+        uint256 balBefore = diem.balanceOf(alice);
+        vm.prank(alice);
+        proxy.withdraw();
+        uint256 balAfter = diem.balanceOf(alice);
+
+        assertEq(balAfter - balBefore, 100e18);
+
+        // Pending withdrawal cleared
+        (uint128 pendingAmt,) = proxy.pendingWithdrawal(alice);
+        assertEq(pendingAmt, 0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    //                     CHANNELS FAÇADE TESTS
+    // ─────────────────────────────────────────────────────────────────
+
+    function test_reserve_forwardsToChannels() public {
+        // Non-operator reverts
+        vm.prank(alice);
+        vm.expectRevert(DiemStakingProxy.NotOperator.selector);
+        proxy.reserve(alice, bytes32(0), 100e6, block.timestamp + 1 days, "");
+
+        // Operator call emits ForwardedReserve
+        bytes32 expectedChannelId = channelsMock.computeChannelId(alice, address(proxy), bytes32(0));
+        vm.prank(operator);
+        vm.expectEmit(true, true, false, true);
+        emit DiemStakingProxy.ForwardedReserve(expectedChannelId, alice, 100e6);
+        proxy.reserve(alice, bytes32(0), 100e6, block.timestamp + 1 days, "");
+    }
+
+    function test_settle_capturesUsdcDeltaAndNotifies() public {
+        channelsMock.setPayout(1000e6);
+
+        vm.prank(operator);
+        vm.expectEmit(true, false, false, true);
+        emit DiemStakingProxy.ForwardedSettle(bytes32(0), 0, 1000e6);
+        proxy.settle(bytes32(0), 0, "", "");
+
+        // Stream notified — rewardRate should be > 0
+        (uint256 rewardRate,,,,) = proxy.usdcStream();
+        assertGt(rewardRate, 0, "usdcStream.rewardRate should be > 0");
+    }
+
+    function test_close_capturesUsdcDeltaAndNotifies() public {
+        channelsMock.setPayout(500e6);
+
+        vm.prank(operator);
+        vm.expectEmit(true, false, false, true);
+        emit DiemStakingProxy.ForwardedClose(bytes32(0), 0, 500e6);
+        proxy.close(bytes32(0), 0, "", "");
+
+        (uint256 rewardRate,,,,) = proxy.usdcStream();
+        assertGt(rewardRate, 0, "usdcStream.rewardRate should be > 0 after close");
+    }
+
+    function test_topUp_noInflow_noNotify() public {
+        channelsMock.setPayout(0);
+
+        vm.prank(operator);
+        proxy.topUp(bytes32(0), 0, "", "", 0, block.timestamp + 1 days, "");
+
+        (uint256 rewardRate,,,,) = proxy.usdcStream();
+        assertEq(rewardRate, 0, "usdcStream.rewardRate should remain 0 when no inflow");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    //                     EMISSIONS TESTS
+    // ─────────────────────────────────────────────────────────────────
+
+    function test_operatorClaimEmissions_notifiesAntsStream() public {
+        emissionsMock.setPayout(500e18);
+
+        uint256[] memory epochs = new uint256[](1);
+        epochs[0] = 0;
+
+        vm.prank(operator);
+        proxy.operatorClaimEmissions(epochs);
+
+        (uint256 rewardRate,,,,) = proxy.antsStream();
+        assertGt(rewardRate, 0, "antsStream.rewardRate should be > 0 after claim");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    //                     REWARD DISTRIBUTION TESTS
+    // ─────────────────────────────────────────────────────────────────
+
+    function test_getReward_paysBothStreams() public {
+        _stakeAs(alice, 100e18);
+
+        // Notify both streams
+        channelsMock.setPayout(1000e6);
+        vm.prank(operator);
+        proxy.settle(bytes32(0), 0, "", "");
+
+        emissionsMock.setPayout(500e18);
+        uint256[] memory epochs = new uint256[](1);
+        epochs[0] = 0;
+        vm.prank(operator);
+        proxy.operatorClaimEmissions(epochs);
+
+        // Warp full period
+        vm.warp(block.timestamp + USDC_DURATION);
+
+        uint256 usdcBefore = usdc.balanceOf(alice);
+        uint256 antsBefore = ants.balanceOf(alice);
+
+        vm.prank(alice);
+        proxy.getReward();
+
+        uint256 usdcAfter = usdc.balanceOf(alice);
+        uint256 antsAfter = ants.balanceOf(alice);
+
+        assertGt(usdcAfter - usdcBefore, 0, "alice should receive USDC rewards");
+        assertGt(antsAfter - antsBefore, 0, "alice should receive ANTS rewards");
+    }
+
+    function test_multiStaker_proRataUsdc() public {
+        _stakeAs(alice, 30e18);
+        _stakeAs(bob, 70e18);
+
+        // Notify 1000 USDC
+        channelsMock.setPayout(1000e6);
+        vm.prank(operator);
+        proxy.settle(bytes32(0), 0, "", "");
+
+        // Warp full period
+        vm.warp(block.timestamp + USDC_DURATION);
+
+        (uint256 aliceUsdc,) = proxy.earned(alice);
+        (uint256 bobUsdc,) = proxy.earned(bob);
+
+        // alice ~30% of distributed, bob ~70%. Tolerance accounts for rewardRate integer
+        // truncation (amount / duration) and 1e18 scaling — total rounding is at most
+        // duration / 1e18 * totalStaked + duration wrt the nominal 1000e6 input.
+        uint256 totalEarned = aliceUsdc + bobUsdc;
+        assertApproxEqAbs(aliceUsdc, totalEarned * 30 / 100, 1, "alice should earn ~30% of USDC");
+        assertApproxEqAbs(bobUsdc, totalEarned * 70 / 100, 1, "bob should earn ~70% of USDC");
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    //                     ADMIN TESTS
+    // ─────────────────────────────────────────────────────────────────
+
+    function test_setOperator_onlyOwner() public {
+        address newOperator = vm.addr(0x99);
+
+        // Non-owner reverts
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.setOperator(newOperator);
+
+        // Owner succeeds and emits OperatorRotated
+        vm.prank(owner);
+        vm.expectEmit(true, true, false, false);
+        emit DiemStakingProxy.OperatorRotated(operator, newOperator);
+        proxy.setOperator(newOperator);
+
+        assertEq(proxy.operator(), newOperator);
+    }
+
+    function test_setOperator_revertZero() public {
+        vm.prank(owner);
+        vm.expectRevert(DiemStakingProxy.InvalidAddress.selector);
+        proxy.setOperator(address(0));
+    }
+
+    function test_setRewardsDuration_revertDuringActivePeriod() public {
+        // Notify to start a period
+        channelsMock.setPayout(100e6);
+        vm.prank(operator);
+        proxy.settle(bytes32(0), 0, "", "");
+
+        // Try to change duration while period is active
+        vm.prank(owner);
+        vm.expectRevert(DiemStakingProxy.RewardPeriodActive.selector);
+        proxy.setRewardsDuration(0, 2 days);
+    }
+
+    function test_setRewardsDuration_successAfterFinish() public {
+        // Notify to start a period
+        channelsMock.setPayout(100e6);
+        vm.prank(operator);
+        proxy.settle(bytes32(0), 0, "", "");
+
+        // Warp past periodFinish
+        vm.warp(block.timestamp + USDC_DURATION + 1);
+
+        // Now changing duration should succeed
+        vm.prank(owner);
+        proxy.setRewardsDuration(0, 2 days);
+
+        (,,,, uint256 rewardsDuration) = proxy.usdcStream();
+        assertEq(rewardsDuration, 2 days);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    //                     EIP-712 DELEGATION TESTS
+    // ─────────────────────────────────────────────────────────────────
+
+    function _signDelegation(
+        uint256 signerPk,
+        address peerAddress,
+        address _sellerContract,
+        uint256 chainId,
+        uint256 expiresAt
+    ) internal view returns (bytes memory) {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                proxy.SELLER_DELEGATION_TYPEHASH(),
+                peerAddress,
+                _sellerContract,
+                chainId,
+                expiresAt
+            )
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", proxy.domainSeparator(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function test_isValidDelegation_valid() public view {
+        uint256 expiresAt = block.timestamp + 1 hours;
+        bytes memory sig = _signDelegation(OPERATOR_PK, alice, address(proxy), block.chainid, expiresAt);
+
+        bool valid = proxy.isValidDelegation(alice, address(proxy), block.chainid, expiresAt, sig);
+        assertTrue(valid, "valid delegation should return true");
+    }
+
+    function test_isValidDelegation_expired() public view {
+        uint256 expiresAt = block.timestamp - 1;
+        bytes memory sig = _signDelegation(OPERATOR_PK, alice, address(proxy), block.chainid, expiresAt);
+
+        bool valid = proxy.isValidDelegation(alice, address(proxy), block.chainid, expiresAt, sig);
+        assertFalse(valid, "expired delegation should return false");
+    }
+
+    function test_isValidDelegation_wrongChainId() public view {
+        uint256 expiresAt = block.timestamp + 1 hours;
+        uint256 wrongChain = block.chainid + 1;
+        bytes memory sig = _signDelegation(OPERATOR_PK, alice, address(proxy), wrongChain, expiresAt);
+
+        bool valid = proxy.isValidDelegation(alice, address(proxy), wrongChain, expiresAt, sig);
+        assertFalse(valid, "wrong chainId delegation should return false");
+    }
+
+    function test_isValidDelegation_wrongSellerContract() public view {
+        uint256 expiresAt = block.timestamp + 1 hours;
+        address wrongSeller = vm.addr(0x50);
+        bytes memory sig = _signDelegation(OPERATOR_PK, alice, wrongSeller, block.chainid, expiresAt);
+
+        bool valid = proxy.isValidDelegation(alice, wrongSeller, block.chainid, expiresAt, sig);
+        assertFalse(valid, "wrong sellerContract should return false");
+    }
+
+    function test_isValidDelegation_sigFromNonOperator() public view {
+        uint256 expiresAt = block.timestamp + 1 hours;
+        // Signed by alice, not operator
+        bytes memory sig = _signDelegation(ALICE_PK, alice, address(proxy), block.chainid, expiresAt);
+
+        bool valid = proxy.isValidDelegation(alice, address(proxy), block.chainid, expiresAt, sig);
+        assertFalse(valid, "sig from non-operator should return false");
+    }
+
+    function test_isValidDelegation_afterRotation() public {
+        uint256 expiresAt = block.timestamp + 1 hours;
+
+        // Old operator signs
+        bytes memory oldSig = _signDelegation(OPERATOR_PK, alice, address(proxy), block.chainid, expiresAt);
+
+        // Rotate operator to bob
+        vm.prank(owner);
+        proxy.setOperator(bob);
+
+        // Old sig now invalid
+        bool oldValid = proxy.isValidDelegation(alice, address(proxy), block.chainid, expiresAt, oldSig);
+        assertFalse(oldValid, "old operator sig should be invalid after rotation");
+
+        // New operator (bob) signs and it should be valid
+        bytes memory newSig = _signDelegation(BOB_PK, alice, address(proxy), block.chainid, expiresAt);
+        bool newValid = proxy.isValidDelegation(alice, address(proxy), block.chainid, expiresAt, newSig);
+        assertTrue(newValid, "new operator sig should be valid after rotation");
+    }
+
+    function test_syncVeniceCooldown_onlyOwner() public {
+        // Non-owner reverts
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.syncVeniceCooldown(14 days);
+
+        // Owner succeeds and event emitted
+        vm.prank(owner);
+        vm.expectEmit(false, false, false, true);
+        emit DiemStakingProxy.VeniceCooldownSynced(14 days);
+        proxy.syncVeniceCooldown(14 days);
+
+        assertEq(proxy.VENICE_COOLDOWN(), 14 days);
+    }
+}

--- a/packages/contracts/test/mocks/MockAntseedChannels.sol
+++ b/packages/contracts/test/mocks/MockAntseedChannels.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IAntseedChannels} from "../../interfaces/IAntseedChannels.sol";
+
+/**
+ * @dev Minimal mock that matches the façade-visible surface of AntseedChannels.
+ *      `settle` and `close` transfer a configured USDC payout to msg.sender (the façade).
+ */
+contract MockAntseedChannels is IAntseedChannels {
+    using SafeERC20 for IERC20;
+    IERC20 public immutable usdc;
+    uint128 public configuredPayout;
+
+    constructor(address _usdc) {
+        usdc = IERC20(_usdc);
+    }
+
+    function setPayout(uint128 amount) external { configuredPayout = amount; }
+
+    function getAgentStats(uint256) external pure returns (AgentStats memory) {
+        return AgentStats(0, 0, 0, 0);
+    }
+
+    function activeChannelCount(address) external pure returns (uint256) { return 0; }
+
+    function computeChannelId(address buyer, address seller, bytes32 salt) external pure returns (bytes32) {
+        return keccak256(abi.encode(buyer, seller, salt));
+    }
+
+    function reserve(address, bytes32, uint128, uint256, bytes calldata) external pure {}
+
+    function topUp(bytes32, uint128, bytes calldata, bytes calldata, uint128, uint256, bytes calldata) external {
+        if (configuredPayout > 0) usdc.safeTransfer(msg.sender, configuredPayout);
+    }
+
+    function settle(bytes32, uint128, bytes calldata, bytes calldata) external {
+        if (configuredPayout > 0) usdc.safeTransfer(msg.sender, configuredPayout);
+    }
+
+    function close(bytes32, uint128, bytes calldata, bytes calldata) external {
+        if (configuredPayout > 0) usdc.safeTransfer(msg.sender, configuredPayout);
+    }
+
+    function requestClose(bytes32) external pure {}
+    function withdraw(bytes32) external pure {}
+}

--- a/packages/contracts/test/mocks/MockAntseedEmissions.sol
+++ b/packages/contracts/test/mocks/MockAntseedEmissions.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/// @dev Minimal mock implementing `claimSellerEmissions(uint256[])`.
+contract MockAntseedEmissions {
+    using SafeERC20 for IERC20;
+    IERC20 public immutable ants;
+    uint256 public configuredPayout;
+
+    constructor(address _ants) {
+        ants = IERC20(_ants);
+    }
+
+    function setPayout(uint256 amount) external { configuredPayout = amount; }
+
+    function claimSellerEmissions(uint256[] calldata) external {
+        if (configuredPayout > 0) ants.safeTransfer(msg.sender, configuredPayout);
+    }
+}

--- a/packages/contracts/test/mocks/MockVeniceStaking.sol
+++ b/packages/contracts/test/mocks/MockVeniceStaking.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IVeniceStaking} from "../../interfaces/IVeniceStaking.sol";
+
+/// @dev Minimal mock: holds DIEM 1:1, immediate unstake returns DIEM to caller.
+contract MockVeniceStaking is IVeniceStaking {
+    using SafeERC20 for IERC20;
+    IERC20 public immutable diem;
+    mapping(address => uint256) public staked;
+
+    constructor(address _diem) {
+        diem = IERC20(_diem);
+    }
+
+    function stake(uint256 amount) external {
+        staked[msg.sender] += amount;
+        diem.safeTransferFrom(msg.sender, address(this), amount);
+    }
+
+    function unstake(uint256 amount) external {
+        staked[msg.sender] -= amount;
+        diem.safeTransfer(msg.sender, amount);
+    }
+}

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -11,8 +11,9 @@ import {
   normalizeServiceSearchTopicKey,
 } from "./dht-node.js";
 import type { PeerOffering } from "../types/capability.js";
-import type { PeerMetadata, ProviderAnnouncement } from "./peer-metadata.js";
+import type { PeerMetadata, ProviderAnnouncement, SellerDelegationPayload } from "./peer-metadata.js";
 import { METADATA_VERSION } from "./peer-metadata.js";
+
 import type { ServiceApiProtocol } from "../types/service-api.js";
 import { isKnownServiceApiProtocol } from "../types/service-api.js";
 import { encodeMetadataForSigning } from "./metadata-codec.js";
@@ -21,6 +22,17 @@ import { bytesToHex } from "../utils/hex.js";
 import type { StakingClient } from "../payments/evm/staking-client.js";
 import type { ChannelsClient } from "../payments/evm/channels-client.js";
 import type { DHTHealthMonitor } from "./dht-health.js";
+
+export interface SellerDelegationConfig {
+  /** The DiemStakingProxy contract address (also the EIP-712 verifyingContract). */
+  sellerContract: string;
+  /** EVM chainId for the EIP-712 domain. */
+  chainId: number;
+  /** How long each signed delegation is valid. Default 3600s. */
+  expiresInSeconds?: number;
+  /** Refresh the signed delegation when remaining TTL drops below this. Default 600s. */
+  refreshBeforeExpirySeconds?: number;
+}
 
 export interface AnnouncerConfig {
   identity: Identity;
@@ -57,6 +69,7 @@ export interface AnnouncerConfig {
   signalingPort: number;
   /** Optional health monitor — if supplied, announce outcomes are recorded. */
   healthMonitor?: DHTHealthMonitor;
+  sellerDelegation?: SellerDelegationConfig;
 }
 
 /**
@@ -75,6 +88,7 @@ export class PeerAnnouncer {
   private stopped = false;
   private readonly loadMap: Map<string, number> = new Map();
   private _latestMetadata: PeerMetadata | null = null;
+  private _delegationCache: SellerDelegationPayload | null = null;
 
   constructor(config: AnnouncerConfig) {
     this.config = config;
@@ -165,6 +179,47 @@ export class PeerAnnouncer {
     return this._latestMetadata;
   }
 
+  private async _getOrRefreshDelegation(): Promise<SellerDelegationPayload | undefined> {
+    const cfg = this.config.sellerDelegation;
+    if (!cfg) return undefined;
+    const expiresIn = cfg.expiresInSeconds ?? 3600;
+    const refreshBefore = cfg.refreshBeforeExpirySeconds ?? 600;
+
+    const now = Math.floor(Date.now() / 1000);
+    if (this._delegationCache && this._delegationCache.expiresAt - now > refreshBefore) {
+      return this._delegationCache;
+    }
+
+    const peerAddress = this.config.identity.wallet.address;
+    const expiresAt = now + expiresIn;
+    const domain = {
+      name: "DiemStakingProxy",
+      version: "1",
+      chainId: cfg.chainId,
+      verifyingContract: cfg.sellerContract,
+    };
+    const types = {
+      SellerDelegation: [
+        { name: "peerAddress", type: "address" },
+        { name: "sellerContract", type: "address" },
+        { name: "chainId", type: "uint256" },
+        { name: "expiresAt", type: "uint256" },
+      ],
+    };
+    const message = { peerAddress, sellerContract: cfg.sellerContract, chainId: cfg.chainId, expiresAt };
+    const signature = await this.config.identity.wallet.signTypedData(domain, types, message);
+
+    const payload: SellerDelegationPayload = {
+      peerAddress: peerAddress.toLowerCase().replace(/^0x/, ""),
+      sellerContract: cfg.sellerContract.toLowerCase().replace(/^0x/, ""),
+      chainId: cfg.chainId,
+      expiresAt,
+      signature: signature.replace(/^0x/, ""),
+    };
+    this._delegationCache = payload;
+    return payload;
+  }
+
   private async _buildSignedMetadata(includeOnChainReputation = true): Promise<PeerMetadata> {
     const providers: ProviderAnnouncement[] = this.config.providers.map((p) => {
       const pricing = p.pricing ?? this.config.pricing.get(p.provider) ?? {
@@ -229,6 +284,11 @@ export class PeerAnnouncer {
         metadata.onChainChannelCount = this._latestMetadata.onChainChannelCount;
         metadata.onChainGhostCount = this._latestMetadata.onChainGhostCount;
       }
+    }
+
+    const delegation = await this._getOrRefreshDelegation();
+    if (delegation) {
+      metadata.sellerDelegation = delegation;
     }
 
     const dataToSign = encodeMetadataForSigning(metadata);

--- a/packages/node/src/discovery/metadata-codec.ts
+++ b/packages/node/src/discovery/metadata-codec.ts
@@ -1,4 +1,4 @@
-import type { PeerMetadata } from "./peer-metadata.js";
+import type { PeerMetadata, SellerDelegationPayload } from "./peer-metadata.js";
 import type { PeerOffering } from "../types/capability.js";
 import { hexToBytes, bytesToHex } from "../utils/hex.js";
 import { toPeerId } from "../types/peer.js";
@@ -8,6 +8,7 @@ import { isKnownServiceApiProtocol } from "../types/service-api.js";
 const SERVICE_CATEGORIES_METADATA_VERSION = 3;
 const SERVICE_API_PROTOCOLS_METADATA_VERSION = 4;
 const PUBLIC_ADDRESS_METADATA_VERSION = 5;
+const SELLER_DELEGATION_METADATA_VERSION = 8;
 
 /**
  * Encode metadata into binary format:
@@ -213,6 +214,29 @@ function encodeBody(metadata: PeerMetadata): Uint8Array {
       parts.push(new Uint8Array([1]));
       parts.push(new Uint8Array([publicAddressBytes.length]));
       parts.push(publicAddressBytes);
+    } else {
+      parts.push(new Uint8Array([0]));
+    }
+  }
+
+  // sellerDelegation (v8+) — flag + [peerAddress:20][sellerContract:20]
+  //                                [chainId:8 BigUint64][expiresAt:8 BigUint64][sig:65]
+  if (metadata.version >= SELLER_DELEGATION_METADATA_VERSION) {
+    const d = metadata.sellerDelegation;
+    if (d) {
+      parts.push(new Uint8Array([1]));
+      parts.push(hexToBytes(d.peerAddress));        // 20 bytes
+      parts.push(hexToBytes(d.sellerContract));     // 20 bytes
+
+      const chainBuf = new ArrayBuffer(8);
+      new DataView(chainBuf).setBigUint64(0, BigInt(d.chainId), false);
+      parts.push(new Uint8Array(chainBuf));
+
+      const expBuf = new ArrayBuffer(8);
+      new DataView(expBuf).setBigUint64(0, BigInt(d.expiresAt), false);
+      parts.push(new Uint8Array(expBuf));
+
+      parts.push(hexToBytes(d.signature));          // 65 bytes
     } else {
       parts.push(new Uint8Array([0]));
     }
@@ -532,6 +556,39 @@ export function decodeMetadata(data: Uint8Array): PeerMetadata {
     }
   }
 
+  let sellerDelegation: SellerDelegationPayload | undefined;
+  if (version >= SELLER_DELEGATION_METADATA_VERSION) {
+    checkBounds(offset, 1, data.length - 65);
+    const delegationFlag = data[offset]!;
+    offset += 1;
+    if (delegationFlag === 1) {
+      checkBounds(offset, 20 + 20 + 8 + 8 + 65, data.length - 65);
+      const peerAddressBytes = data.slice(offset, offset + 20);
+      offset += 20;
+      const sellerContractBytes = data.slice(offset, offset + 20);
+      offset += 20;
+
+      const chainView = new DataView(data.buffer, data.byteOffset + offset, 8);
+      const chainId = Number(chainView.getBigUint64(0, false));
+      offset += 8;
+
+      const expView = new DataView(data.buffer, data.byteOffset + offset, 8);
+      const expiresAt = Number(expView.getBigUint64(0, false));
+      offset += 8;
+
+      const delegationSigBytes = data.slice(offset, offset + 65);
+      offset += 65;
+
+      sellerDelegation = {
+        peerAddress: bytesToHex(peerAddressBytes),
+        sellerContract: bytesToHex(sellerContractBytes),
+        chainId,
+        expiresAt,
+        signature: bytesToHex(delegationSigBytes),
+      };
+    }
+  }
+
   // offerings
   const PRICING_UNIT_REVERSE: Array<'token' | 'request' | 'minute' | 'task'> = ['token', 'request', 'minute', 'task'];
   let offerings: PeerOffering[] | undefined;
@@ -616,6 +673,7 @@ export function decodeMetadata(data: Uint8Array): PeerMetadata {
     ...(offerings && offerings.length > 0 ? { offerings } : {}),
     ...(onChainChannelCount !== undefined ? { onChainChannelCount } : {}),
     ...(onChainGhostCount !== undefined ? { onChainGhostCount } : {}),
+    ...(sellerDelegation ? { sellerDelegation } : {}),
     region,
     timestamp,
     signature,

--- a/packages/node/src/discovery/metadata-validator.ts
+++ b/packages/node/src/discovery/metadata-validator.ts
@@ -86,6 +86,25 @@ export function validateMetadata(metadata: PeerMetadata): ValidationError[] {
     }
   }
 
+  if (metadata.sellerDelegation !== undefined) {
+    const d = metadata.sellerDelegation;
+    if (!/^[0-9a-f]{40}$/.test(d.peerAddress)) {
+      errors.push({ field: "sellerDelegation.peerAddress", message: "Must be 40 lowercase hex chars" });
+    }
+    if (!/^[0-9a-f]{40}$/.test(d.sellerContract)) {
+      errors.push({ field: "sellerDelegation.sellerContract", message: "Must be 40 lowercase hex chars" });
+    }
+    if (!Number.isInteger(d.chainId) || d.chainId <= 0) {
+      errors.push({ field: "sellerDelegation.chainId", message: "Must be a positive integer" });
+    }
+    if (!Number.isInteger(d.expiresAt) || d.expiresAt <= 0) {
+      errors.push({ field: "sellerDelegation.expiresAt", message: "Must be a positive unix seconds integer" });
+    }
+    if (!/^[0-9a-f]{130}$/.test(d.signature)) {
+      errors.push({ field: "sellerDelegation.signature", message: "Must be 130 lowercase hex chars (65-byte secp256k1 sig)" });
+    }
+  }
+
   // timestamp
   if (metadata.timestamp <= 0 || !Number.isFinite(metadata.timestamp)) {
     errors.push({

--- a/packages/node/src/discovery/peer-metadata.ts
+++ b/packages/node/src/discovery/peer-metadata.ts
@@ -3,7 +3,7 @@ import type { PeerOffering } from "../types/capability.js";
 import type { ServiceApiProtocol } from "../types/service-api.js";
 import { WELL_KNOWN_SERVICE_API_PROTOCOLS } from "../types/service-api.js";
 
-export const METADATA_VERSION = 7;
+export const METADATA_VERSION = 8;
 export const WELL_KNOWN_SERVICE_CATEGORIES = [
   "privacy",
   "legal",
@@ -19,6 +19,26 @@ export interface TokenPricingUsdPerMillion {
   inputUsdPerMillion: number;
   outputUsdPerMillion: number;
   cachedInputUsdPerMillion?: number;
+}
+
+/**
+ * Off-chain attestation published by peers whose on-chain seller is a smart
+ * contract (e.g., DiemStakingProxy). Signed by the proxy's operator EOA via
+ * EIP-712 (domain: DiemStakingProxy v1). Buyers verify the signer matches
+ * the current `operator()` on the proxy contract before resolving
+ * `seller = sellerContract` for channel flows.
+ */
+export interface SellerDelegationPayload {
+  /** The peer's EVM address (equal to peerId with 0x prefix). */
+  peerAddress: string;
+  /** The on-chain seller contract (also the proxy contract the buyer queries). */
+  sellerContract: string;
+  /** EVM chainId this delegation is valid on. */
+  chainId: number;
+  /** Unix seconds. Buyers reject delegations past expiry. */
+  expiresAt: number;
+  /** secp256k1 65-byte signature (hex, no 0x) over the EIP-712 digest. */
+  signature: string;
 }
 
 export interface ProviderAnnouncement {
@@ -45,5 +65,6 @@ export interface PeerMetadata {
   trustScore?: number;
   onChainChannelCount?: number;
   onChainGhostCount?: number;
+  sellerDelegation?: SellerDelegationPayload;
   signature: string;
 }

--- a/packages/node/src/discovery/seller-address-resolver.ts
+++ b/packages/node/src/discovery/seller-address-resolver.ts
@@ -1,0 +1,108 @@
+import type { PeerId } from "../types/peer.js";
+import { peerIdToAddress } from "../types/peer.js";
+import type { PeerMetadata } from "./peer-metadata.js";
+import { verifySellerDelegation } from "../payments/evm/signatures.js";
+import { debugWarn } from "../utils/debug.js";
+
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_CACHE_MAX_ENTRIES = 1024;
+
+export type OperatorLoader = (proxyAddress: string) => Promise<string>;
+
+export class SellerDelegationVerificationError extends Error {
+  constructor(reason: string) {
+    super(`seller delegation verification failed: ${reason}`);
+    this.name = "SellerDelegationVerificationError";
+  }
+}
+
+interface CacheEntry {
+  sellerContract: string;
+  verifiedAt: number;
+  signature: string;
+}
+
+export class SellerAddressResolver {
+  private readonly _cache = new Map<PeerId, CacheEntry>();
+  private readonly _ttlMs: number;
+  private readonly _maxEntries: number;
+  private readonly _loadOperator: OperatorLoader;
+  private readonly _chainId: number;
+
+  constructor(opts: {
+    loadOperator: OperatorLoader;
+    chainId: number;
+    ttlMs?: number;
+    maxEntries?: number;
+  }) {
+    this._loadOperator = opts.loadOperator;
+    this._chainId = opts.chainId;
+    this._ttlMs = opts.ttlMs ?? DEFAULT_CACHE_TTL_MS;
+    this._maxEntries = opts.maxEntries ?? DEFAULT_CACHE_MAX_ENTRIES;
+  }
+
+  /**
+   * Resolve the on-chain seller address for a peer.
+   * - No delegation → return peerIdToAddress(peerId).
+   * - Delegation present and verifies → return sellerContract.
+   * - Delegation present but verification fails → throw SellerDelegationVerificationError.
+   */
+  async resolveSellerAddress(peerId: PeerId, metadata?: PeerMetadata): Promise<string> {
+    const delegation = metadata?.sellerDelegation;
+    if (!delegation) return peerIdToAddress(peerId);
+
+    if (delegation.chainId !== this._chainId) {
+      throw new SellerDelegationVerificationError(
+        `chainId mismatch: delegation=${delegation.chainId} ours=${this._chainId}`,
+      );
+    }
+    if (delegation.expiresAt * 1000 <= Date.now()) {
+      throw new SellerDelegationVerificationError("expired");
+    }
+    if (delegation.peerAddress.toLowerCase() !== peerId) {
+      throw new SellerDelegationVerificationError("peerAddress does not match peerId");
+    }
+
+    const cached = this._cache.get(peerId);
+    if (cached && cached.signature === delegation.signature && Date.now() - cached.verifiedAt < this._ttlMs) {
+      return cached.sellerContract;
+    }
+
+    const proxyAddress = "0x" + delegation.sellerContract;
+    const operator = await this._loadOperator(proxyAddress);
+    const valid = verifySellerDelegation(
+      proxyAddress,
+      {
+        peerAddress: peerIdToAddress(peerId),
+        sellerContract: proxyAddress,
+        chainId: delegation.chainId,
+        expiresAt: delegation.expiresAt,
+      },
+      delegation.signature,
+      operator,
+    );
+    if (!valid) {
+      debugWarn(`[Resolver] delegation sig did not match operator=${operator} for peer ${peerId.slice(0, 12)}...`);
+      throw new SellerDelegationVerificationError("signature does not match current operator");
+    }
+
+    this._pruneCache();
+    this._cache.set(peerId, { sellerContract: proxyAddress, verifiedAt: Date.now(), signature: delegation.signature });
+    return proxyAddress;
+  }
+
+  invalidate(peerId: PeerId): void {
+    this._cache.delete(peerId);
+  }
+
+  private _pruneCache(): void {
+    if (this._cache.size < this._maxEntries) return;
+    const now = Date.now();
+    for (const [peerId, entry] of this._cache) {
+      if (now - entry.verifiedAt >= this._ttlMs) this._cache.delete(peerId);
+    }
+    if (this._cache.size < this._maxEntries) return;
+    const oldestKey = this._cache.keys().next().value;
+    if (oldestKey !== undefined) this._cache.delete(oldestKey);
+  }
+}

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -32,6 +32,7 @@ import {
 import {
   PeerAnnouncer,
   type AnnouncerConfig,
+  type SellerDelegationConfig,
 } from "./discovery/announcer.js";
 import {
   PeerLookup,
@@ -66,6 +67,8 @@ import { debugLog, debugWarn } from "./utils/debug.js";
 import { parsePublicAddress } from "./discovery/public-address.js";
 import { BuyerPaymentManager, type BuyerPaymentConfig } from "./payments/buyer-payment-manager.js";
 import { BuyerPaymentNegotiator } from "./payments/buyer-payment-negotiator.js";
+import { SellerAddressResolver } from "./discovery/seller-address-resolver.js";
+import { Contract as EthersContract } from "ethers";
 import { SellerPaymentManager, type SellerPaymentConfig } from "./payments/seller-payment-manager.js";
 import { IdentityClient } from "./payments/evm/identity-client.js";
 import { SellerRequestHandler } from "./seller-request-handler.js";
@@ -156,6 +159,8 @@ export interface NodeConfig {
   identityStore?: IdentityStore;
   /** Optional explicit config.json path for runtime config reloads. */
   configPath?: string;
+  /** Optional seller delegation config. When set, the announcer signs and publishes a SellerDelegation. */
+  sellerDelegation?: SellerDelegationConfig;
 }
 
 export interface BuyerUsageChannelPoint {
@@ -206,6 +211,7 @@ export class AntseedNode extends EventEmitter {
   private _depositsClient: DepositsClient | null = null;
   private _channelsClient: ChannelsClient | null = null;
   private _stakingClient: StakingClient | null = null;
+  private _sellerAddressResolver: SellerAddressResolver | null = null;
   private _identityClient: IdentityClient | null = null;
   private _paymentMuxes = new Map<PeerId, PaymentMux>();
   /** Seller-side request handler (provider matching, execution, load tracking). */
@@ -428,6 +434,7 @@ export class AntseedNode extends EventEmitter {
     this._channelsClient = null;
     this._stakingClient = null;
     this._identityClient = null;
+    this._sellerAddressResolver = null;
     this._buyerPaymentManager = null;
     this._buyerNegotiator = null;
     this._buyerHandler = null;
@@ -469,17 +476,18 @@ export class AntseedNode extends EventEmitter {
 
     // Verify claimed on-chain stats against actual contract data
     if (this._channelsClient && this._stakingClient) {
-      for (const p of peers) {
-        try {
-          const evmAddress = peerIdToAddress(p.peerId);
-          const agentId = await this._stakingClient.getAgentId(evmAddress);
-          const stats = await this._channelsClient.getAgentStats(agentId);
-          p.onChainChannelCount = stats.channelCount;
-          p.onChainGhostCount = stats.ghostCount;
-        } catch {
-          // Contract lookup failed for this peer — keep claimed data
-        }
-      }
+      const channelsClient = this._channelsClient;
+      const stakingClient = this._stakingClient;
+      const resolver = this._sellerAddressResolver;
+      await Promise.allSettled(peers.map(async (p) => {
+        const evmAddress = resolver
+          ? await resolver.resolveSellerAddress(p.peerId, p.metadata)
+          : peerIdToAddress(p.peerId);
+        const agentId = await stakingClient.getAgentId(evmAddress);
+        const stats = await channelsClient.getAgentStats(agentId);
+        p.onChainChannelCount = stats.channelCount;
+        p.onChainGhostCount = stats.ghostCount;
+      }));
     }
 
     for (const p of peers) {
@@ -945,6 +953,7 @@ export class AntseedNode extends EventEmitter {
         signalingPort: actualSignalingPort,
         ...(this._channelsClient ? { channelsClient: this._channelsClient } : {}),
         ...(this._stakingClient ? { stakingClient: this._stakingClient, paymentsEnabled: true } : {}),
+        ...(this._config.sellerDelegation ? { sellerDelegation: this._config.sellerDelegation } : {}),
       };
       this._announcer = new PeerAnnouncer(announcerConfig);
       this._announcer.startPeriodicAnnounce();
@@ -1031,7 +1040,7 @@ export class AntseedNode extends EventEmitter {
           maxReserveAmountUsdc: BigInt(payments.maxReserveAmountUsdc ?? "1000000"),  // $1.00 default per session (matches FIRST_SIGN_CAP)
           dataDir: paymentsDir,
         };
-        this._buyerPaymentManager = new BuyerPaymentManager(identity, buyerPaymentConfig, this._channelStore);
+        this._buyerPaymentManager = new BuyerPaymentManager(identity, buyerPaymentConfig, this._channelStore, this._sellerAddressResolver ?? undefined);
         debugLog(`[Node] Buyer payment manager initialized (wallet=${identity.wallet.address.slice(0, 10)}... chainId=${buyerPaymentConfig.chainId} deposits=${buyerPaymentConfig.depositsContractAddress.slice(0, 10)}...)`);
 
         // Create negotiator that wraps the BPM with 402 handling and per-request auth
@@ -1043,6 +1052,7 @@ export class AntseedNode extends EventEmitter {
           this._channelStore,
           {},
           this,
+          this._sellerAddressResolver ?? undefined,
         );
         debugLog(`[Node] Buyer payment negotiator initialized`);
       }
@@ -1129,6 +1139,23 @@ export class AntseedNode extends EventEmitter {
         ...(payments.chainId ? { evmChainId: payments.chainId } : {}),
       });
       debugLog(`[Node] ChannelsClient initialized (contract=${payments.channelsAddress.slice(0, 10)}...)`);
+
+      const evmChainId = payments.chainId ?? 8453;
+      const channelsClientRef = this._channelsClient;
+      const operatorAbi = ["function operator() view returns (address)"];
+      const operatorContracts = new Map<string, EthersContract>();
+      this._sellerAddressResolver = new SellerAddressResolver({
+        loadOperator: async (proxyAddress: string) => {
+          let contract = operatorContracts.get(proxyAddress);
+          if (!contract) {
+            contract = new EthersContract(proxyAddress, operatorAbi, channelsClientRef!.provider);
+            operatorContracts.set(proxyAddress, contract);
+          }
+          return await contract.getFunction("operator")() as string;
+        },
+        chainId: evmChainId,
+      });
+      debugLog(`[Node] SellerAddressResolver initialized (chainId=${evmChainId})`);
     }
 
     // Initialize StakingClient

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -20,7 +20,9 @@ import {
 } from './evm/signatures.js';
 import type { SpendingAuthMessage, ReserveAuthMessage, SpendingAuthMetadata } from './evm/signatures.js';
 import { debugLog, debugWarn } from '../utils/debug.js';
-import { peerIdToAddress } from '../types/peer.js';
+import { peerIdToAddress, type PeerId } from '../types/peer.js';
+import type { SellerAddressResolver } from '../discovery/seller-address-resolver.js';
+import type { PeerMetadata } from '../discovery/peer-metadata.js';
 import { ChannelStore, type StoredChannel } from './channel-store.js';
 import { estimateCostFromBytes, computeCostUsdc, type ServicePricing } from './pricing.js';
 
@@ -73,6 +75,8 @@ export class BuyerPaymentManager {
   /** Peers that explicitly rejected our spending auth. */
   private readonly _rejectedPeers = new Set<string>();
 
+  private readonly _sellerAddressResolver?: SellerAddressResolver;
+
   /** sellerPeerId -> cumulative USDC amount in the latest SpendingAuth */
   private readonly _cumulativeAmount = new Map<string, bigint>();
 
@@ -102,9 +106,10 @@ export class BuyerPaymentManager {
   /** Cached EIP-712 domain — static for the lifetime of this manager. */
   private readonly _channelsDomain: ReturnType<typeof makeChannelsDomain>;
 
-  constructor(identity: Identity, config: BuyerPaymentConfig, channelStore: ChannelStore) {
+  constructor(identity: Identity, config: BuyerPaymentConfig, channelStore: ChannelStore, sellerAddressResolver?: SellerAddressResolver) {
     this._identity = identity;
     this._config = config;
+    this._sellerAddressResolver = sellerAddressResolver;
     this._signer = identity.wallet;
     this._depositsClient = new DepositsClient({
       rpcUrl: config.rpcUrl,
@@ -364,8 +369,11 @@ export class BuyerPaymentManager {
     reserveAmountOrPricing?: bigint | ServicePricing,
     pricingArg?: ServicePricing,
     pricingMap?: { defaults: ServicePricing; services: Record<string, ServicePricing> },
+    metadataArg?: PeerMetadata,
   ): Promise<string> {
-    const sellerEvmAddr = peerIdToAddress(sellerPeerId);
+    const sellerEvmAddr = this._sellerAddressResolver
+      ? await this._sellerAddressResolver.resolveSellerAddress(sellerPeerId as PeerId, metadataArg)
+      : peerIdToAddress(sellerPeerId);
     const reserveAmount = typeof reserveAmountOrPricing === 'bigint'
       ? reserveAmountOrPricing
       : this._config.maxReserveAmountUsdc;
@@ -435,7 +443,7 @@ export class BuyerPaymentManager {
       sessionId: channelId,
       peerId: sellerPeerId,
       role: 'buyer',
-      sellerEvmAddr: peerIdToAddress(sellerPeerId),
+      sellerEvmAddr,
       buyerEvmAddr: this._identity.wallet.address,
       nonce: 0,
       authMax: '0',

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -11,6 +11,8 @@ import type { ChannelStore } from './channel-store.js';
 import { classifyOnChainChannel } from './channel-session-state.js';
 import { peerIdToAddress } from '../types/peer.js';
 import { debugLog, debugWarn } from '../utils/debug.js';
+import type { SellerAddressResolver } from '../discovery/seller-address-resolver.js';
+import { SellerDelegationVerificationError } from '../discovery/seller-address-resolver.js';
 import { parseResponseUsage } from '../utils/response-usage.js';
 import { computeCostUsdc, type ServicePricing } from './pricing.js';
 
@@ -62,6 +64,7 @@ export class BuyerPaymentNegotiator {
   private readonly _channelStore: ChannelStore | null;
   private readonly _identity: Identity;
   private readonly _emit: NegotiationEmitter;
+  private readonly _sellerAddressResolver?: SellerAddressResolver;
 
   /** Tracks which seller peers the buyer has already negotiated payment for. */
   private readonly _lockedPeers = new Set<string>();
@@ -92,6 +95,7 @@ export class BuyerPaymentNegotiator {
     channelStore: ChannelStore | null,
     _config: BuyerNegotiatorConfig,
     emitter: NegotiationEmitter,
+    sellerAddressResolver?: SellerAddressResolver,
   ) {
     this._identity = identity;
     this._bpm = bpm;
@@ -99,10 +103,23 @@ export class BuyerPaymentNegotiator {
     this._channelsClient = channelsClient;
     this._channelStore = channelStore;
     this._emit = emitter;
+    this._sellerAddressResolver = sellerAddressResolver;
   }
 
   get bpm(): BuyerPaymentManager {
     return this._bpm;
+  }
+
+  private async _resolveSellerAddr(peer: PeerInfo): Promise<string> {
+    if (!this._sellerAddressResolver) return peerIdToAddress(peer.peerId);
+    try {
+      return await this._sellerAddressResolver.resolveSellerAddress(peer.peerId, peer.metadata);
+    } catch (err) {
+      if (err instanceof SellerDelegationVerificationError) {
+        debugWarn(`[BuyerNegotiator] Dropping peer ${peer.peerId.slice(0, 12)}...: ${err.message}`);
+      }
+      throw err;
+    }
   }
 
   getOrCreatePaymentMux(peerId: PeerId, conn: PeerConnection): PaymentMux {
@@ -421,6 +438,8 @@ export class BuyerPaymentNegotiator {
 
     debugLog(`[BuyerNegotiator] External SpendingAuth: channel=${payload.channelId.slice(0, 18)}... amount=${payload.cumulativeAmount}`);
 
+    const sellerEvmAddrExternal = await this._resolveSellerAddr(peer);
+
     // Store session so handleAuthAck can find it
     if (this._channelStore) {
       const reserveDeadline = payload.reserveDeadline ?? (Math.floor(Date.now() / 1000) + 3600);
@@ -428,7 +447,7 @@ export class BuyerPaymentNegotiator {
         sessionId: payload.channelId,
         peerId: peer.peerId,
         role: 'buyer',
-        sellerEvmAddr: peerIdToAddress(peer.peerId),
+        sellerEvmAddr: sellerEvmAddrExternal,
         buyerEvmAddr: this._identity.wallet.address,
         nonce: 0,
         authMax: payload.cumulativeAmount,
@@ -458,7 +477,7 @@ export class BuyerPaymentNegotiator {
 
     this._emit.emit('payment:signed', {
       peerId: peer.peerId,
-      sellerEvmAddr: peerIdToAddress(peer.peerId),
+      sellerEvmAddr: sellerEvmAddrExternal,
       amount: payload.cumulativeAmount,
     });
   }
@@ -598,9 +617,11 @@ export class BuyerPaymentNegotiator {
       throw new Error(`Invalid reserve amount for payment to ${peer.peerId.slice(0, 12)}...`);
     }
 
+    const sellerEvmAddr = await this._resolveSellerAddr(peer);
+
     this._emit.emit('payment:required', {
       peerId: peer.peerId,
-      sellerEvmAddr: peerIdToAddress(peer.peerId),
+      sellerEvmAddr,
       minBudgetPerRequest: requirements.minBudgetPerRequest,
       suggestedAmount: amount.toString(),
     });
@@ -624,7 +645,7 @@ export class BuyerPaymentNegotiator {
     const pricingMap = this._buildPricingMap(peer);
 
     try {
-      await this._bpm.authorizeSpending(peer.peerId, pmux, minBudgetPerRequest, amount, pricing, pricingMap);
+      await this._bpm.authorizeSpending(peer.peerId, pmux, minBudgetPerRequest, amount, pricing, pricingMap, peer.metadata);
       debugLog(`[BuyerNegotiator] SpendingAuth sent to seller ${peer.peerId.slice(0, 12)}..., waiting for AuthAck...`);
 
       await this._waitForLockConfirmation(peer.peerId);
@@ -633,7 +654,7 @@ export class BuyerPaymentNegotiator {
 
       this._emit.emit('payment:signed', {
         peerId: peer.peerId,
-        sellerEvmAddr: peerIdToAddress(peer.peerId),
+        sellerEvmAddr,
         amount: amount.toString(),
       });
     } catch (err) {

--- a/packages/node/src/payments/evm/signatures.ts
+++ b/packages/node/src/payments/evm/signatures.ts
@@ -1,4 +1,4 @@
-import { type AbstractSigner, type TypedDataDomain, AbiCoder, keccak256 } from 'ethers';
+import { type AbstractSigner, type TypedDataDomain, AbiCoder, keccak256, verifyTypedData } from 'ethers';
 
 // =========================================================================
 // EIP-712 Types — AntSeed SpendingAuth (cumulative payment authorization)
@@ -148,4 +148,47 @@ export async function signSetOperator(
   msg: SetOperatorMessage,
 ): Promise<string> {
   return signer.signTypedData(domain, SET_OPERATOR_TYPES, msg);
+}
+
+// =========================================================================
+// SellerDelegation verification (DiemStakingProxy EIP-712)
+// =========================================================================
+
+export interface SellerDelegationMessage {
+  peerAddress: string;
+  sellerContract: string;
+  chainId: number;
+  expiresAt: number;
+}
+
+/**
+ * Verify a SellerDelegation signature against a claimed operator address.
+ * Returns true iff ecrecover over the EIP-712 digest yields `expectedOperator`.
+ */
+export function verifySellerDelegation(
+  proxyAddress: string,
+  message: SellerDelegationMessage,
+  signature: string,
+  expectedOperator: string,
+): boolean {
+  const domain = {
+    name: "DiemStakingProxy",
+    version: "1",
+    chainId: message.chainId,
+    verifyingContract: proxyAddress,
+  };
+  const types = {
+    SellerDelegation: [
+      { name: "peerAddress", type: "address" },
+      { name: "sellerContract", type: "address" },
+      { name: "chainId", type: "uint256" },
+      { name: "expiresAt", type: "uint256" },
+    ],
+  };
+  try {
+    const recovered = verifyTypedData(domain, types, message, signature.startsWith("0x") ? signature : "0x" + signature);
+    return recovered.toLowerCase() === expectedOperator.toLowerCase();
+  } catch {
+    return false;
+  }
 }

--- a/packages/node/src/types/peer.ts
+++ b/packages/node/src/types/peer.ts
@@ -1,4 +1,5 @@
 import type { ServiceApiProtocol } from "./service-api.js";
+import type { PeerMetadata } from "../discovery/peer-metadata.js";
 
 /**
  * A PeerId is the EVM address hex (40 lowercase chars = 20 bytes, no 0x prefix).
@@ -85,4 +86,6 @@ export interface PeerInfo {
   onChainChannelCount?: number;
   /** On-chain ghost count (provider went silent) from AntseedChannels. */
   onChainGhostCount?: number;
+  /** Full peer metadata, if available (set after metadata resolution). */
+  metadata?: PeerMetadata;
 }

--- a/packages/node/tests/announcer.test.ts
+++ b/packages/node/tests/announcer.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { randomBytes } from 'node:crypto';
+import { Wallet } from 'ethers';
+import { PeerAnnouncer, type AnnouncerConfig } from '../src/discovery/announcer.js';
+import { bytesToHex } from '../src/p2p/identity.js';
+import { toPeerId } from '../src/types/peer.js';
+import { verifySellerDelegation } from '../src/payments/evm/signatures.js';
+
+function makeBaseConfig(): AnnouncerConfig {
+  const privateKey = randomBytes(32);
+  const wallet = new Wallet('0x' + bytesToHex(privateKey));
+  const peerId = toPeerId(wallet.address.slice(2).toLowerCase());
+
+  const mockDht = {
+    announce: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const mockIdentity = {
+    peerId,
+    privateKey,
+    wallet,
+  };
+
+  return {
+    identity: mockIdentity,
+    dht: mockDht as unknown as AnnouncerConfig['dht'],
+    providers: [],
+    region: 'us',
+    pricing: new Map(),
+    reannounceIntervalMs: 60_000,
+    signalingPort: 0,
+  };
+}
+
+describe('PeerAnnouncer sellerDelegation', () => {
+  it('signs sellerDelegation with the peer identity wallet', async () => {
+    const base = makeBaseConfig();
+    const proxy = '0x' + 'bb'.repeat(20);
+    const announcer = new PeerAnnouncer({
+      ...base,
+      sellerDelegation: {
+        sellerContract: proxy,
+        chainId: 8453,
+        expiresInSeconds: 3600,
+      },
+    });
+
+    await announcer.announce();
+    const meta = announcer.getLatestMetadata();
+    expect(meta?.sellerDelegation).toBeDefined();
+    expect(meta?.sellerDelegation?.sellerContract).toBe('bb'.repeat(20));
+
+    const verified = verifySellerDelegation(
+      proxy,
+      {
+        peerAddress: base.identity.wallet.address,
+        sellerContract: proxy,
+        chainId: meta!.sellerDelegation!.chainId,
+        expiresAt: meta!.sellerDelegation!.expiresAt,
+      },
+      meta!.sellerDelegation!.signature,
+      base.identity.wallet.address,
+    );
+    expect(verified).toBe(true);
+  });
+
+  it('caches the signed delegation and refreshes before expiry', async () => {
+    const base = makeBaseConfig();
+    const signSpy = vi.spyOn(base.identity.wallet, 'signTypedData');
+    const announcer = new PeerAnnouncer({
+      ...base,
+      sellerDelegation: {
+        sellerContract: '0x' + 'bb'.repeat(20),
+        chainId: 8453,
+        expiresInSeconds: 3600,
+        refreshBeforeExpirySeconds: 600,
+      },
+    });
+
+    await announcer.announce();
+    await announcer.announce();
+    expect(signSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -402,6 +402,7 @@ describe('BuyerPaymentNegotiator', () => {
         100000n,
         { inputUsdPerMillion: 3, outputUsdPerMillion: 15 },
         { defaults: { inputUsdPerMillion: 3, outputUsdPerMillion: 15 }, services: {} },
+        undefined,
       );
     });
 

--- a/packages/node/tests/metadata-codec.test.ts
+++ b/packages/node/tests/metadata-codec.test.ts
@@ -172,6 +172,41 @@ describe('encodeMetadata / decodeMetadata', () => {
     expect(decoded.onChainGhostCount).toBe(2);
   });
 
+  it("round-trips a v8 metadata with sellerDelegation", () => {
+    const meta: PeerMetadata = {
+      peerId: "aa".repeat(20),
+      version: 8,
+      region: "us-east-1",
+      timestamp: 1_700_000_000_000,
+      providers: [],
+      sellerDelegation: {
+        peerAddress: "aa".repeat(20),
+        sellerContract: "bb".repeat(20),
+        chainId: 8453,
+        expiresAt: 1_700_003_600,
+        signature: "cc".repeat(65),
+      },
+      signature: "dd".repeat(65),
+    };
+    const bytes = encodeMetadata(meta);
+    const decoded = decodeMetadata(bytes);
+    expect(decoded.sellerDelegation).toEqual(meta.sellerDelegation);
+  });
+
+  it("round-trips v8 metadata with no sellerDelegation", () => {
+    const meta: PeerMetadata = {
+      peerId: "aa".repeat(20),
+      version: 8,
+      region: "us-east-1",
+      timestamp: 1_700_000_000_000,
+      providers: [],
+      signature: "dd".repeat(65),
+    };
+    const bytes = encodeMetadata(meta);
+    const decoded = decodeMetadata(bytes);
+    expect(decoded.sellerDelegation).toBeUndefined();
+  });
+
   // v2/v3/v4/v5 roundtrip tests removed — pre-v6 format is rejected by the decoder.
 });
 

--- a/packages/node/tests/metadata-validator.test.ts
+++ b/packages/node/tests/metadata-validator.test.ts
@@ -36,6 +36,10 @@ function validMetadata(overrides?: Partial<PeerMetadata>): PeerMetadata {
   };
 }
 
+function makeBaseV8Metadata(): PeerMetadata {
+  return validMetadata();
+}
+
 describe('validateMetadata', () => {
   it('should return no errors for valid metadata', () => {
     const errors = validateMetadata(validMetadata());
@@ -501,6 +505,32 @@ describe('validateMetadata', () => {
       ],
     }));
     expect(errors.some((e) => e.field.includes('serviceApiProtocols'))).toBe(true);
+  });
+
+  it("rejects malformed sellerDelegation.peerAddress", () => {
+    const meta = makeBaseV8Metadata();
+    meta.sellerDelegation = {
+      peerAddress: "not-hex",
+      sellerContract: "bb".repeat(20),
+      chainId: 8453,
+      expiresAt: 1_700_003_600,
+      signature: "cc".repeat(65),
+    };
+    const errors = validateMetadata(meta);
+    expect(errors.some(e => e.field === "sellerDelegation.peerAddress")).toBe(true);
+  });
+
+  it("accepts a well-formed sellerDelegation", () => {
+    const meta = makeBaseV8Metadata();
+    meta.sellerDelegation = {
+      peerAddress: "aa".repeat(20),
+      sellerContract: "bb".repeat(20),
+      chainId: 8453,
+      expiresAt: 1_700_003_600,
+      signature: "cc".repeat(65),
+    };
+    const errors = validateMetadata(meta);
+    expect(errors.filter(e => e.field.startsWith("sellerDelegation"))).toHaveLength(0);
   });
 });
 

--- a/packages/node/tests/seller-address-resolver.test.ts
+++ b/packages/node/tests/seller-address-resolver.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Wallet } from "ethers";
+import { SellerAddressResolver, SellerDelegationVerificationError } from "../src/discovery/seller-address-resolver.js";
+import type { PeerMetadata } from "../src/discovery/peer-metadata.js";
+import type { PeerId } from "../src/types/peer.js";
+import { toPeerId } from "../src/types/peer.js";
+
+const CHAIN_ID = 8453;
+const PROXY = "0x" + "ab".repeat(20);
+
+/** Build a signed SellerDelegation payload. Returns the PeerMetadata with sellerDelegation populated. */
+async function buildSignedDelegation(
+  operator: Wallet,
+  peerAddress: string,
+  expiresAt: number,
+  sellerContract: string = PROXY,
+  chainId: number = CHAIN_ID,
+): Promise<{ signature: string }> {
+  const domain = {
+    name: "DiemStakingProxy",
+    version: "1",
+    chainId,
+    verifyingContract: sellerContract,
+  };
+  const types = {
+    SellerDelegation: [
+      { name: "peerAddress", type: "address" },
+      { name: "sellerContract", type: "address" },
+      { name: "chainId", type: "uint256" },
+      { name: "expiresAt", type: "uint256" },
+    ],
+  };
+  const message = { peerAddress, sellerContract, chainId, expiresAt };
+  const signature = await operator.signTypedData(domain, types, message);
+  return { signature };
+}
+
+function buildMetadata(
+  peerId: PeerId,
+  peerAddress: string,
+  sellerContract: string,
+  chainId: number,
+  expiresAt: number,
+  signature: string,
+): PeerMetadata {
+  return {
+    peerId,
+    version: 8,
+    providers: [],
+    region: "us-east-1",
+    timestamp: Date.now(),
+    sellerDelegation: {
+      peerAddress: peerAddress.replace(/^0x/, ""),
+      sellerContract: sellerContract.replace(/^0x/, ""),
+      chainId,
+      expiresAt,
+      signature: signature.replace(/^0x/, ""),
+    },
+    signature: "",
+  };
+}
+
+describe("SellerAddressResolver", () => {
+  const operator = Wallet.createRandom();
+  const peerWallet = Wallet.createRandom();
+  const peerId = toPeerId(peerWallet.address.slice(2).toLowerCase());
+  const peerAddress = peerWallet.address; // 0x-prefixed
+  const sellerContract = PROXY;
+  const futureExpiry = Math.floor(Date.now() / 1000) + 3600;
+
+  it("returns peerIdToAddress when no delegation", async () => {
+    const resolver = new SellerAddressResolver({
+      loadOperator: vi.fn().mockResolvedValue(operator.address),
+      chainId: CHAIN_ID,
+    });
+    const result = await resolver.resolveSellerAddress(peerId, undefined);
+    expect(result.toLowerCase()).toBe(("0x" + peerId).toLowerCase());
+  });
+
+  it("returns sellerContract when delegation valid (cached after first hit)", async () => {
+    const { signature } = await buildSignedDelegation(operator, peerAddress, futureExpiry);
+    const metadata = buildMetadata(peerId, peerAddress, sellerContract, CHAIN_ID, futureExpiry, signature);
+    const mockLoader = vi.fn().mockResolvedValue(operator.address);
+    const resolver = new SellerAddressResolver({ loadOperator: mockLoader, chainId: CHAIN_ID });
+
+    const result1 = await resolver.resolveSellerAddress(peerId, metadata);
+    expect(result1.toLowerCase()).toBe(sellerContract.toLowerCase());
+    expect(mockLoader).toHaveBeenCalledTimes(1);
+
+    // Second call should use cache — loader not called again
+    const result2 = await resolver.resolveSellerAddress(peerId, metadata);
+    expect(result2.toLowerCase()).toBe(sellerContract.toLowerCase());
+    expect(mockLoader).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on expired delegation", async () => {
+    const pastExpiry = Math.floor(Date.now() / 1000) - 1;
+    const { signature } = await buildSignedDelegation(operator, peerAddress, pastExpiry);
+    const metadata = buildMetadata(peerId, peerAddress, sellerContract, CHAIN_ID, pastExpiry, signature);
+    const resolver = new SellerAddressResolver({
+      loadOperator: vi.fn().mockResolvedValue(operator.address),
+      chainId: CHAIN_ID,
+    });
+
+    await expect(resolver.resolveSellerAddress(peerId, metadata)).rejects.toThrow(
+      SellerDelegationVerificationError,
+    );
+    await expect(resolver.resolveSellerAddress(peerId, metadata)).rejects.toThrow("expired");
+  });
+
+  it("throws on wrong chainId", async () => {
+    const wrongChainId = 1; // mainnet, not base
+    const { signature } = await buildSignedDelegation(operator, peerAddress, futureExpiry, sellerContract, wrongChainId);
+    const metadata = buildMetadata(peerId, peerAddress, sellerContract, wrongChainId, futureExpiry, signature);
+    const resolver = new SellerAddressResolver({
+      loadOperator: vi.fn().mockResolvedValue(operator.address),
+      chainId: CHAIN_ID,
+    });
+
+    await expect(resolver.resolveSellerAddress(peerId, metadata)).rejects.toThrow(
+      SellerDelegationVerificationError,
+    );
+    await expect(resolver.resolveSellerAddress(peerId, metadata)).rejects.toThrow("chainId mismatch");
+  });
+
+  it("throws on peerAddress != peerId", async () => {
+    const differentWallet = Wallet.createRandom();
+    const differentAddress = differentWallet.address;
+    const { signature } = await buildSignedDelegation(operator, differentAddress, futureExpiry);
+    // Metadata has different peerAddress than the peerId we're resolving
+    const metadata = buildMetadata(peerId, differentAddress, sellerContract, CHAIN_ID, futureExpiry, signature);
+    const resolver = new SellerAddressResolver({
+      loadOperator: vi.fn().mockResolvedValue(operator.address),
+      chainId: CHAIN_ID,
+    });
+
+    await expect(resolver.resolveSellerAddress(peerId, metadata)).rejects.toThrow(
+      SellerDelegationVerificationError,
+    );
+    await expect(resolver.resolveSellerAddress(peerId, metadata)).rejects.toThrow(
+      "peerAddress does not match peerId",
+    );
+  });
+
+  it("throws when signature doesn't match current operator", async () => {
+    const wrongOperator = Wallet.createRandom(); // signed by wrong operator
+    const { signature } = await buildSignedDelegation(wrongOperator, peerAddress, futureExpiry);
+    const metadata = buildMetadata(peerId, peerAddress, sellerContract, CHAIN_ID, futureExpiry, signature);
+
+    // loader returns the *real* operator address, but signature was made by wrongOperator
+    const resolver = new SellerAddressResolver({
+      loadOperator: vi.fn().mockResolvedValue(operator.address),
+      chainId: CHAIN_ID,
+    });
+
+    await expect(resolver.resolveSellerAddress(peerId, metadata)).rejects.toThrow(
+      SellerDelegationVerificationError,
+    );
+    await expect(resolver.resolveSellerAddress(peerId, metadata)).rejects.toThrow(
+      "signature does not match current operator",
+    );
+  });
+
+  it("cache expires after TTL and re-reads operator", async () => {
+    const { signature } = await buildSignedDelegation(operator, peerAddress, futureExpiry);
+    const metadata = buildMetadata(peerId, peerAddress, sellerContract, CHAIN_ID, futureExpiry, signature);
+    const mockLoader = vi.fn().mockResolvedValue(operator.address);
+    const resolver = new SellerAddressResolver({
+      loadOperator: mockLoader,
+      chainId: CHAIN_ID,
+      ttlMs: 0, // TTL of 0 means always expired
+    });
+
+    await resolver.resolveSellerAddress(peerId, metadata);
+    await resolver.resolveSellerAddress(peerId, metadata);
+
+    // With TTL=0, each call should re-read operator
+    expect(mockLoader).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidate clears cache for a peer", async () => {
+    const { signature } = await buildSignedDelegation(operator, peerAddress, futureExpiry);
+    const metadata = buildMetadata(peerId, peerAddress, sellerContract, CHAIN_ID, futureExpiry, signature);
+    const mockLoader = vi.fn().mockResolvedValue(operator.address);
+    const resolver = new SellerAddressResolver({ loadOperator: mockLoader, chainId: CHAIN_ID });
+
+    // First call — loads operator
+    await resolver.resolveSellerAddress(peerId, metadata);
+    expect(mockLoader).toHaveBeenCalledTimes(1);
+
+    // Invalidate — should force re-verification
+    resolver.invalidate(peerId);
+
+    // Second call — cache was cleared, should load operator again
+    await resolver.resolveSellerAddress(peerId, metadata);
+    expect(mockLoader).toHaveBeenCalledTimes(2);
+  });
+
+  it("after operator rotation (mock loader returns new addr), old delegation with old signer throws", async () => {
+    // Sign with original operator
+    const { signature } = await buildSignedDelegation(operator, peerAddress, futureExpiry);
+    const metadata = buildMetadata(peerId, peerAddress, sellerContract, CHAIN_ID, futureExpiry, signature);
+
+    const newOperator = Wallet.createRandom();
+    // Loader now returns the NEW operator (rotation happened)
+    const mockLoader = vi.fn().mockResolvedValue(newOperator.address);
+    const resolver = new SellerAddressResolver({
+      loadOperator: mockLoader,
+      chainId: CHAIN_ID,
+      ttlMs: 0, // bypass cache so it re-reads operator
+    });
+
+    // Old delegation (signed by old operator) no longer matches the new operator
+    await expect(resolver.resolveSellerAddress(peerId, metadata)).rejects.toThrow(
+      SellerDelegationVerificationError,
+    );
+    await expect(resolver.resolveSellerAddress(peerId, metadata)).rejects.toThrow(
+      "signature does not match current operator",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- **DiemStakingProxy.sol** — pooled DIEM staker that re-stakes into Venice, acts as a byte-identical `AntseedChannels` façade for the seller, and distributes USDC + ANTS earnings to DIEM stakers via two parallel Uniswap-StakingRewards streams. Each stream is notified inline in the operator's inflow-bringing tx (`settle`/`close`/`operatorClaimEmissions`). Two-step withdrawal (`requestWithdraw` → 7-day cooldown → `withdraw`) accommodates Venice's unbonding delay.
- **Metadata codec v8 + `SellerDelegation` attestation** — peers can publish an EIP-712-signed delegation that tells buyers to resolve `seller = sellerContract` instead of `peerIdToAddress(peerId)`. The P2P handshake stays zero-RPC / ecrecover-only. Buyer-side `SellerAddressResolver` caches verifications ~5 min and re-reads `proxy.operator()` on miss. Rollout is fail-closed via the existing strict version-equality check in `validateMetadata`.
- **Seller announcer signs + publishes `SellerDelegation`**, refreshing before expiry. CLI seller config accepts a `payments.sellerDelegation` block with `operatorKeyEnv`.
- **No changes** to `AntseedChannels`, `AntseedDeposits`, `AntseedStaking`, or `AntseedEmissions`. No EIP-1271 in the handshake path.

## What's in this PR
- `packages/contracts/DiemStakingProxy.sol` + interfaces + Foundry suite (23 tests, mocks for Venice/Channels/Emissions)
- `packages/node/src/discovery/{peer-metadata,metadata-codec,metadata-validator}.ts` — codec v8 + `SellerDelegationPayload`
- `packages/node/src/discovery/seller-address-resolver.ts` — verification + cache (TTL + size cap)
- `packages/node/src/discovery/announcer.ts` — publishes delegation when configured
- `packages/node/src/payments/{buyer-payment-manager,buyer-payment-negotiator}.ts`, `node.ts` — 6 call sites now route through the resolver; discovery loop parallelized
- `apps/cli/src/cli/commands/seller/start.ts` + `apps/cli/src/config/types.ts` — CLI plumbing for the operator signer
- `docs/protocol/diem-proxy.md` — architecture, schema, flow diagrams, deployment + operator runbook

See `prds/2026-04-18T22-15_diem-staking-proxy/` for the master plan and per-PRD specs used to drive this work.

## Test plan
- [x] `cd packages/contracts && forge build` — clean, 0 warnings
- [x] `cd packages/contracts && forge test --match-contract DiemStakingProxyTest` — 23/23 pass
- [x] `pnpm --filter=@antseed/node run typecheck` — clean
- [x] `pnpm --filter=@antseed/node test` — 552/552 pass (9 new resolver tests + 2 new announcer tests + 2 new codec tests + 2 new validator tests)
- [x] `pnpm --filter=@antseed/cli run typecheck` — clean
- [ ] Manual: deploy proxy on a Base testnet, register ERC-8004 agent, stake on AntseedStaking, point seller CLI at the proxy address, verify a full buyer channel round-trip (reserve → settle → close) emits `ForwardedSettle` / `ForwardedClose` with non-zero inflow and accrues rewards to a DIEM staker
- [ ] Manual: operator rotation invalidates cached delegations on buyers within ≤5 min