### PR TITLE
fix(node,cli): stabilise peer discovery against scan jitter

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -96,7 +96,7 @@ test('selectCandidatePeersForRouting can still include peers without service pro
 // blocking on DHT discovery.
 
 const validPeerId = 'a'.repeat(40)
-const MAX_AGE_MS = 30 * 60_000
+const MAX_AGE_MS = 2 * 60 * 60_000
 const NOW = 1_700_000_000_000
 
 test('parsePersistedPeers returns [] for null/undefined/junk input', () => {

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -139,13 +139,68 @@ test('parsePersistedPeers drops entries with non-array providers', () => {
   assert.equal(result.length, 0)
 })
 
-test('parsePersistedPeers drops entries with stale or missing lastSeen', () => {
+test('parsePersistedPeers drops entries with stale or missing freshness anchors', () => {
   const result = parsePersistedPeers(
     {
       discoveredPeers: [
         { peerId: validPeerId, providers: ['openai'], lastSeen: NOW - MAX_AGE_MS },
         { peerId: 'b'.repeat(40), providers: ['openai'] },
         { peerId: 'c'.repeat(40), providers: ['openai'], lastSeen: 'nope' },
+      ],
+    },
+    NOW,
+  )
+  assert.equal(result.length, 0)
+})
+
+test('parsePersistedPeers keeps peer with stale lastSeen but recent lastReachedAt', () => {
+  // A peer whose DHT announcement record aged out but the buyer recently
+  // transported a request through is known-alive locally — survive.
+  const result = parsePersistedPeers(
+    {
+      discoveredPeers: [
+        {
+          peerId: validPeerId,
+          providers: ['openai'],
+          lastSeen: NOW - MAX_AGE_MS - 60_000,
+          lastReachedAt: NOW - 60_000,
+        },
+      ],
+    },
+    NOW,
+  )
+  assert.equal(result.length, 1)
+  assert.equal(result[0]?.lastReachedAt, NOW - 60_000)
+})
+
+test('parsePersistedPeers keeps peer with missing lastSeen but valid lastReachedAt', () => {
+  const result = parsePersistedPeers(
+    {
+      discoveredPeers: [
+        {
+          peerId: validPeerId,
+          providers: ['openai'],
+          // lastSeen omitted entirely — freshness anchor comes solely from lastReachedAt.
+          lastReachedAt: NOW - 10_000,
+        },
+      ],
+    },
+    NOW,
+  )
+  assert.equal(result.length, 1)
+  assert.equal(result[0]?.lastReachedAt, NOW - 10_000)
+})
+
+test('parsePersistedPeers drops peer when both lastSeen and lastReachedAt are stale', () => {
+  const result = parsePersistedPeers(
+    {
+      discoveredPeers: [
+        {
+          peerId: validPeerId,
+          providers: ['openai'],
+          lastSeen: NOW - MAX_AGE_MS - 1,
+          lastReachedAt: NOW - MAX_AGE_MS - 1,
+        },
       ],
     },
     NOW,

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -86,8 +86,14 @@ export interface BuyerProxyConfig {
 }
 
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504])
-/** Max age for carrying forward peers not seen in the latest DHT scan. */
-const CARRY_FORWARD_TTL_MS = 30 * 60_000
+/**
+ * Max age for carrying forward peers not seen in the latest DHT scan.
+ * Intentionally longer than `peer-lookup.ts` `maxAnnouncementAgeMs` (30 min) so
+ * a peer that misses one reannounce cycle doesn't hit both cliffs at once.
+ * For peers we have recently reached over the transport, we trust local
+ * liveness (`lastReachedAt`) even if the DHT record is older.
+ */
+const CARRY_FORWARD_TTL_MS = 2 * 60 * 60_000
 
 type TransformResult = { request: SerializedHttpRequest; streamRequested: boolean; requestedModel: string | null }
 type AdaptResponseMeta = { streamRequested: boolean; fallbackModel: string | null }
@@ -222,13 +228,19 @@ export function parsePersistedPeers(
     const lastSeen = typeof entry.lastSeen === 'number' && Number.isFinite(entry.lastSeen)
       ? entry.lastSeen
       : 0
-    if (lastSeen <= 0 || nowMs - lastSeen >= maxAgeMs) continue
+    const lastReachedAt = typeof entry.lastReachedAt === 'number' && Number.isFinite(entry.lastReachedAt)
+      ? entry.lastReachedAt
+      : 0
+    // Keep if either DHT observation or successful transport contact is within window.
+    const freshnessAnchor = Math.max(lastSeen, lastReachedAt)
+    if (freshnessAnchor <= 0 || nowMs - freshnessAnchor >= maxAgeMs) continue
 
     const peer: PeerInfo = {
       peerId: peerId as PeerInfo['peerId'],
       lastSeen,
       providers,
     }
+    if (lastReachedAt > 0) peer.lastReachedAt = lastReachedAt
     if (typeof entry.displayName === 'string') peer.displayName = entry.displayName
     if (typeof entry.publicAddress === 'string') peer.publicAddress = entry.publicAddress
     if (entry.providerPricing && typeof entry.providerPricing === 'object') {
@@ -451,14 +463,29 @@ export class BuyerProxy {
 
   private _replacePeers(incoming: PeerInfo[]): void {
     const incomingById = new Map(incoming.map((p) => [p.peerId, p]))
+    const prevById = new Map(this._cachedPeers.map((p) => [p.peerId, p]))
     const now = Date.now()
 
-    // Carry forward previously known peers that are missing from this scan,
-    // preserving their lastSeen timestamp. A missed DHT scan doesn't mean
-    // the peer is unavailable — it just wasn't discovered this time.
-    const merged = [...incoming]
+    // For peers re-observed in this scan, preserve `lastReachedAt` from the
+    // previous cache entry — the DHT announcement doesn't carry that field,
+    // and losing it on each refresh would defeat the carry-forward tracking.
+    const merged: PeerInfo[] = incoming.map((peer) => {
+      const prev = prevById.get(peer.peerId)
+      if (prev?.lastReachedAt && (!peer.lastReachedAt || prev.lastReachedAt > peer.lastReachedAt)) {
+        return { ...peer, lastReachedAt: prev.lastReachedAt }
+      }
+      return peer
+    })
+
+    // Carry forward previously known peers that are missing from this scan.
+    // A missed DHT scan doesn't mean the peer is unavailable — it just wasn't
+    // discovered this time. Use the fresher of `lastSeen` and `lastReachedAt`
+    // as the liveness anchor: a recently-contacted peer survives even if its
+    // DHT record has aged out.
     for (const prev of this._cachedPeers) {
-      if (!incomingById.has(prev.peerId) && now - prev.lastSeen < CARRY_FORWARD_TTL_MS) {
+      if (incomingById.has(prev.peerId)) continue
+      const freshnessAnchor = Math.max(prev.lastSeen, prev.lastReachedAt ?? 0)
+      if (freshnessAnchor > 0 && now - freshnessAnchor < CARRY_FORWARD_TTL_MS) {
         merged.push({ ...prev })
       }
     }
@@ -495,6 +522,7 @@ export class BuyerProxy {
         defaultOutputUsdPerMillion: p.defaultOutputUsdPerMillion ?? 0,
         maxConcurrency: p.maxConcurrency ?? 0,
         lastSeen: p.lastSeen,
+        lastReachedAt: p.lastReachedAt ?? null,
       }
     })
     this._mergeStateFile({ discoveredPeers: peers, peersUpdatedAt: Date.now() })
@@ -521,6 +549,15 @@ export class BuyerProxy {
       if (typeof oldestKey === 'string') {
         this._lastSuccessfulPeerByRouteKey.delete(oldestKey)
       }
+    }
+
+    // Stamp the cached peer's `lastReachedAt` so carry-forward can trust local
+    // transport liveness even when the DHT record grows stale. Persist so the
+    // signal survives restarts.
+    const cached = this._cachedPeers.find((p) => p.peerId === peerId)
+    if (cached) {
+      cached.lastReachedAt = Date.now()
+      this._persistPeersToState()
     }
   }
 

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -72,6 +72,7 @@ export class PeerAnnouncer {
   private intervalHandle: ReturnType<typeof setInterval> | null = null;
   private retryHandle: ReturnType<typeof setTimeout> | null = null;
   private retryAttempt = 0;
+  private stopped = false;
   private readonly loadMap: Map<string, number> = new Map();
   private _latestMetadata: PeerMetadata | null = null;
 
@@ -86,7 +87,7 @@ export class PeerAnnouncer {
     const failures = await this._announceTopics(metadata.providers);
     if (failures > 0) {
       this._scheduleRetryAfterFailure(failures);
-    } else if (this.retryAttempt > 0 || this.retryHandle) {
+    } else {
       // Recovered — cancel any pending retry and reset backoff.
       this._cancelRetry();
     }
@@ -104,6 +105,7 @@ export class PeerAnnouncer {
     if (this.intervalHandle) {
       return;
     }
+    this.stopped = false;
     // Announce immediately, then on interval
     void this.announce().catch((err) => {
       debugWarn(`[Announcer] Initial announce failed: ${err instanceof Error ? err.message : err}`);
@@ -116,6 +118,7 @@ export class PeerAnnouncer {
   }
 
   stopPeriodicAnnounce(): void {
+    this.stopped = true;
     if (this.intervalHandle) {
       clearInterval(this.intervalHandle);
       this.intervalHandle = null;
@@ -132,8 +135,8 @@ export class PeerAnnouncer {
   }
 
   private _scheduleRetryAfterFailure(failures: number): void {
-    if (this.retryHandle) {
-      // A retry is already scheduled for this cycle; don't stack.
+    if (this.stopped || this.retryHandle) {
+      // Already stopped, or a retry is already scheduled — don't arm a new timer.
       return;
     }
     const idx = Math.min(this.retryAttempt, ANNOUNCE_RETRY_BACKOFFS_MS.length - 1);

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -20,6 +20,7 @@ import { debugWarn } from "../utils/debug.js";
 import { bytesToHex } from "../utils/hex.js";
 import type { StakingClient } from "../payments/evm/staking-client.js";
 import type { ChannelsClient } from "../payments/evm/channels-client.js";
+import type { DHTHealthMonitor } from "./dht-health.js";
 
 export interface AnnouncerConfig {
   identity: Identity;
@@ -54,11 +55,23 @@ export interface AnnouncerConfig {
   stakingClient?: StakingClient;
   reannounceIntervalMs: number;
   signalingPort: number;
+  /** Optional health monitor — if supplied, announce outcomes are recorded. */
+  healthMonitor?: DHTHealthMonitor;
 }
+
+/**
+ * Retry schedule when one or more canonical service topics fail to announce.
+ * Silent 15-min waits used to be the failure mode; these short backoffs let
+ * a seller recover from transient DHT hiccups before buyers decide the peer
+ * has disappeared (buyer staleness cutoff is 30 min).
+ */
+const ANNOUNCE_RETRY_BACKOFFS_MS = [60_000, 120_000, 300_000, 600_000];
 
 export class PeerAnnouncer {
   private readonly config: AnnouncerConfig;
   private intervalHandle: ReturnType<typeof setInterval> | null = null;
+  private retryHandle: ReturnType<typeof setTimeout> | null = null;
+  private retryAttempt = 0;
   private readonly loadMap: Map<string, number> = new Map();
   private _latestMetadata: PeerMetadata | null = null;
 
@@ -70,7 +83,13 @@ export class PeerAnnouncer {
     const metadata = await this._buildSignedMetadata(true);
     this._latestMetadata = metadata;
 
-    await this._announceTopics(metadata.providers);
+    const failures = await this._announceTopics(metadata.providers);
+    if (failures > 0) {
+      this._scheduleRetryAfterFailure(failures);
+    } else if (this.retryAttempt > 0 || this.retryHandle) {
+      // Recovered — cancel any pending retry and reset backoff.
+      this._cancelRetry();
+    }
   }
 
   /**
@@ -101,6 +120,38 @@ export class PeerAnnouncer {
       clearInterval(this.intervalHandle);
       this.intervalHandle = null;
     }
+    this._cancelRetry();
+  }
+
+  private _cancelRetry(): void {
+    if (this.retryHandle) {
+      clearTimeout(this.retryHandle);
+      this.retryHandle = null;
+    }
+    this.retryAttempt = 0;
+  }
+
+  private _scheduleRetryAfterFailure(failures: number): void {
+    if (this.retryHandle) {
+      // A retry is already scheduled for this cycle; don't stack.
+      return;
+    }
+    const idx = Math.min(this.retryAttempt, ANNOUNCE_RETRY_BACKOFFS_MS.length - 1);
+    const delayMs = Math.min(
+      ANNOUNCE_RETRY_BACKOFFS_MS[idx] ?? ANNOUNCE_RETRY_BACKOFFS_MS[ANNOUNCE_RETRY_BACKOFFS_MS.length - 1]!,
+      // Never wait longer than the next periodic cycle — the interval will retry anyway.
+      this.config.reannounceIntervalMs,
+    );
+    this.retryAttempt += 1;
+    debugWarn(
+      `[Announcer] ${failures} topic announce(s) failed; retry #${this.retryAttempt} in ${Math.round(delayMs / 1000)}s`,
+    );
+    this.retryHandle = setTimeout(() => {
+      this.retryHandle = null;
+      void this.announce().catch((err) => {
+        debugWarn(`[Announcer] Retry announce failed: ${err instanceof Error ? err.message : err}`);
+      });
+    }, delayMs);
   }
 
   updateLoad(providerName: string, currentLoad: number): void {
@@ -183,8 +234,9 @@ export class PeerAnnouncer {
     return metadata;
   }
 
-  private async _announceTopics(providers: ProviderAnnouncement[]): Promise<void> {
+  private async _announceTopics(providers: ProviderAnnouncement[]): Promise<number> {
     const announcedServiceTopics = new Set<string>();
+    let failures = 0;
 
     for (const p of providers) {
       for (const service of p.services) {
@@ -195,7 +247,7 @@ export class PeerAnnouncer {
         const canonicalTopic = serviceTopic(canonicalServiceKey);
         if (!announcedServiceTopics.has(canonicalTopic)) {
           announcedServiceTopics.add(canonicalTopic);
-          await this._tryAnnounceTopic(canonicalTopic);
+          if (!(await this._tryAnnounceTopic(canonicalTopic))) failures += 1;
         }
 
         const compactServiceKey = normalizeServiceSearchTopicKey(service);
@@ -203,36 +255,46 @@ export class PeerAnnouncer {
           const compactTopic = serviceSearchTopic(compactServiceKey);
           if (!announcedServiceTopics.has(compactTopic)) {
             announcedServiceTopics.add(compactTopic);
-            await this._tryAnnounceTopic(compactTopic);
+            if (!(await this._tryAnnounceTopic(compactTopic))) failures += 1;
           }
         }
       }
     }
 
-    await this._tryAnnounceTopic(ANTSEED_WILDCARD_TOPIC);
+    if (!(await this._tryAnnounceTopic(ANTSEED_WILDCARD_TOPIC))) failures += 1;
 
     if (this.config.offerings) {
       const announcedCapabilities = new Set<string>();
       for (const offering of this.config.offerings) {
-        await this._tryAnnounceTopic(capabilityTopic(offering.capability, offering.name));
+        if (!(await this._tryAnnounceTopic(capabilityTopic(offering.capability, offering.name)))) {
+          failures += 1;
+        }
         const normalizedCapability = offering.capability.trim().toLowerCase();
         if (!normalizedCapability) {
           continue;
         }
         if (!announcedCapabilities.has(normalizedCapability)) {
           announcedCapabilities.add(normalizedCapability);
-          await this._tryAnnounceTopic(capabilityTopic(normalizedCapability));
+          if (!(await this._tryAnnounceTopic(capabilityTopic(normalizedCapability)))) {
+            failures += 1;
+          }
         }
       }
     }
+
+    return failures;
   }
 
-  private async _tryAnnounceTopic(topic: string): Promise<void> {
+  private async _tryAnnounceTopic(topic: string): Promise<boolean> {
     try {
       const infoHash = topicToInfoHash(topic);
       await this.config.dht.announce(infoHash, this.config.signalingPort);
-    } catch {
-      // DHT may not have peers yet — will retry on next cycle
+      this.config.healthMonitor?.recordAnnounce(true);
+      return true;
+    } catch (err) {
+      this.config.healthMonitor?.recordAnnounce(false);
+      debugWarn(`[Announcer] Announce failed for ${topic}: ${err instanceof Error ? err.message : err}`);
+      return false;
     }
   }
 

--- a/packages/node/src/types/peer.ts
+++ b/packages/node/src/types/peer.ts
@@ -52,6 +52,13 @@ export interface PeerInfo {
   publicAddress?: string;
   /** Last seen timestamp (Unix ms). */
   lastSeen: number;
+  /**
+   * Last timestamp (Unix ms) at which the buyer successfully reached this peer
+   * over the transport (e.g. a completed request). Decoupled from `lastSeen`,
+   * which reflects DHT announcements, so a peer known to be alive survives
+   * transient DHT staleness.
+   */
+  lastReachedAt?: number;
   /** LLM providers this peer is offering (empty if buyer-only). */
   providers: string[];
   /** Reputation score (0-100). */

--- a/packages/node/tests/announcer-retry.test.ts
+++ b/packages/node/tests/announcer-retry.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { randomBytes } from 'node:crypto';
+import { Wallet } from 'ethers';
+import { PeerAnnouncer, type AnnouncerConfig } from '../src/discovery/announcer.js';
+import { DHTHealthMonitor } from '../src/discovery/dht-health.js';
+import { bytesToHex } from '../src/p2p/identity.js';
+import { toPeerId } from '../src/types/peer.js';
+
+function makeConfig(overrides: Partial<AnnouncerConfig> = {}): {
+  config: AnnouncerConfig;
+  dht: { announce: ReturnType<typeof vi.fn> };
+} {
+  const privateKey = randomBytes(32);
+  const wallet = new Wallet('0x' + bytesToHex(privateKey));
+  const peerId = toPeerId(wallet.address.slice(2).toLowerCase());
+
+  const dht = {
+    announce: vi.fn().mockResolvedValue(undefined),
+  };
+
+  const config: AnnouncerConfig = {
+    identity: { peerId, privateKey, wallet },
+    dht: dht as unknown as AnnouncerConfig['dht'],
+    providers: [
+      {
+        provider: 'anthropic',
+        services: ['claude-sonnet'],
+        maxConcurrency: 5,
+      },
+    ],
+    region: 'us',
+    pricing: new Map([
+      ['anthropic', { defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 1 } }],
+    ]),
+    reannounceIntervalMs: 60 * 60_000,
+    signalingPort: 6882,
+    ...overrides,
+  };
+
+  return { config, dht };
+}
+
+describe('PeerAnnouncer retry on announce failure', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('schedules a retry within the reannounce interval after any announce failure', async () => {
+    const { config, dht } = makeConfig();
+    dht.announce.mockRejectedValue(new Error('dht down'));
+    const announcer = new PeerAnnouncer(config);
+
+    await announcer.announce();
+    const callsAfterFirst = dht.announce.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+
+    // First backoff is 60s — advance and let the retry fire.
+    await vi.advanceTimersByTimeAsync(60_000 + 100);
+    expect(dht.announce.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+
+    announcer.stopPeriodicAnnounce();
+  });
+
+  it('backs off exponentially across repeated failures', async () => {
+    const { config, dht } = makeConfig();
+    dht.announce.mockRejectedValue(new Error('dht down'));
+    const announcer = new PeerAnnouncer(config);
+
+    await announcer.announce();
+    const callsAfterFirst = dht.announce.mock.calls.length;
+
+    // First retry fires ~60s after the original failure.
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(dht.announce.mock.calls.length).toBe(callsAfterFirst);
+    await vi.advanceTimersByTimeAsync(30_100);
+    const callsAfterFirstRetry = dht.announce.mock.calls.length;
+    expect(callsAfterFirstRetry).toBeGreaterThan(callsAfterFirst);
+
+    // Second retry scheduled with the next backoff (120s) relative to the first
+    // retry firing. Confirm 119s isn't enough and ~121s is.
+    await vi.advanceTimersByTimeAsync(119_000);
+    expect(dht.announce.mock.calls.length).toBe(callsAfterFirstRetry);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(dht.announce.mock.calls.length).toBeGreaterThan(callsAfterFirstRetry);
+
+    announcer.stopPeriodicAnnounce();
+  });
+
+  it('cancels the pending retry and resets the backoff when an announce succeeds', async () => {
+    const { config, dht } = makeConfig();
+    dht.announce.mockRejectedValueOnce(new Error('transient'));
+    dht.announce.mockResolvedValue(undefined);
+    const announcer = new PeerAnnouncer(config);
+
+    await announcer.announce();
+    const callsAfterFail = dht.announce.mock.calls.length;
+
+    // Succeed on the next cycle before the 60s retry fires.
+    await announcer.announce();
+    const callsAfterSuccess = dht.announce.mock.calls.length;
+
+    // Advance past the original retry window — no extra calls should happen.
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(dht.announce.mock.calls.length).toBe(callsAfterSuccess);
+    expect(callsAfterSuccess).toBeGreaterThan(callsAfterFail);
+
+    announcer.stopPeriodicAnnounce();
+  });
+
+  it('stopPeriodicAnnounce prevents a pending retry from firing', async () => {
+    const { config, dht } = makeConfig();
+    dht.announce.mockRejectedValue(new Error('dht down'));
+    const announcer = new PeerAnnouncer(config);
+
+    await announcer.announce();
+    const callsAfterFail = dht.announce.mock.calls.length;
+
+    announcer.stopPeriodicAnnounce();
+
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(dht.announce.mock.calls.length).toBe(callsAfterFail);
+  });
+
+  it('does not arm a retry when an announce fails after stopPeriodicAnnounce', async () => {
+    // The race this guards: stop runs while an announce() is mid-flight;
+    // when the announce eventually fails, _scheduleRetryAfterFailure must
+    // not arm a new timer. Directly exercise the post-stop path by calling
+    // announce() after stop and confirming no retry fires.
+    const { config, dht } = makeConfig();
+    dht.announce.mockRejectedValue(new Error('late failure'));
+    const announcer = new PeerAnnouncer(config);
+
+    announcer.stopPeriodicAnnounce();
+    await announcer.announce();
+
+    const callsAfterStop = dht.announce.mock.calls.length;
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(dht.announce.mock.calls.length).toBe(callsAfterStop);
+  });
+
+  it('records announce outcomes to the provided DHTHealthMonitor', async () => {
+    const monitor = new DHTHealthMonitor(() => 10);
+    const { config, dht } = makeConfig({ healthMonitor: monitor });
+    dht.announce
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue(undefined);
+    const announcer = new PeerAnnouncer(config);
+
+    await announcer.announce();
+    const snap = monitor.getSnapshot();
+    expect(snap.totalAnnounces).toBeGreaterThan(0);
+    expect(snap.failedAnnounces).toBeGreaterThan(0);
+    expect(snap.successfulAnnounces).toBeGreaterThan(0);
+
+    announcer.stopPeriodicAnnounce();
+  });
+});


### PR DESCRIPTION
## Summary

Peers were disappearing from the buyer when a single DHT scan happened to miss them. Two cliffs lined up:

- Buyer-side `CARRY_FORWARD_TTL_MS` (30 min) equalled `PeerLookup.maxAnnouncementAgeMs` (30 min), so one unlucky scan evicted the peer until the next successful cycle.
- Announce-side failures in `PeerAnnouncer._tryAnnounceTopic` were swallowed silently and waited the full 15-min reannounce interval before retrying, leaving the seller off the DHT long enough to hit the buyer staleness cutoff.

We verified the failure mode live: `The Seeder` was absent from `buyer.state.json` at one point but three back-to-back cold DHT lookups found it, and its `/metadata` endpoint was healthy the whole time — classic scan jitter colliding with a tight carry-forward window.

### Changes

**Buyer cache decouples from DHT staleness** — `apps/cli/src/proxy/buyer-proxy.ts`, `packages/node/src/types/peer.ts`
- `CARRY_FORWARD_TTL_MS`: 30 min → 2 h. Still bounded, but no longer cliff-aligned with the 30-min staleness cutoff.
- New optional `PeerInfo.lastReachedAt`, stamped in `_rememberSuccessfulPeer` on every successful transport contact and persisted to `buyer.state.json`.
- `parsePersistedPeers` and `_replacePeers` anchor freshness on `max(lastSeen, lastReachedAt)`, so a peer we've actually talked to survives transient DHT staleness even when its announcement record ages out.
- `_replacePeers` preserves the prior `lastReachedAt` when a peer is re-observed from DHT (the announce doesn't carry it).

**Announce failures stop being silent** — `packages/node/src/discovery/announcer.ts`
- `_tryAnnounceTopic` now returns `boolean`, logs failures via `debugWarn`, and optionally calls `DHTHealthMonitor.recordAnnounce` (new `healthMonitor?` field on `AnnouncerConfig`).
- `_announceTopics` aggregates per-cycle failures.
- New `_scheduleRetryAfterFailure` schedules an exponential-backoff retry (60s → 120s → 5m → 10m, capped at `reannounceIntervalMs`) when any topic fails; success resets the backoff; `stopPeriodicAnnounce` clears any pending retry.

## Test plan

- [x] `pnpm --filter @antseed/node typecheck` — clean
- [x] `pnpm --filter @antseed/cli typecheck` — clean (after node rebuild)
- [x] `pnpm --filter @antseed/node test` — 537/537 pass
- [x] `pnpm --filter @antseed/cli test` — 64/64 pass (incl. updated `parsePersistedPeers` staleness test for the new 2h window)
- [x] `apps/desktop` main `tsc -p tsconfig.main.json` — clean
- [ ] Manual: run a buyer for >1 h, confirm peers that flicker out of individual DHT scans no longer disappear from `buyer.state.json`

## Follow-ups (not in this PR)

- Wire a `DHTHealthMonitor` instance in `node.ts` so `recordAnnounce` is actually consumed, and trigger a DHT re-bootstrap when the routing table collapses.
- Tighten `HttpMetadataResolver` cooldown — the current 30s → 30min exponential blackout can silently suppress a recovered peer for up to 30 min per lookup.
- Consider a cheap liveness probe on carry-forward peers before marking them `online` in the dashboard (today `online` is derived from `lastSeen` alone).