### PR TITLE
chore(ci): add merge confidence score to Claude PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,19 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          additional_system_prompt: |
+            At the top of your PR review summary, output an overall merge confidence score:
+
+            **Merge Confidence: X/5**
+              5 = Ship it. No blockers, low risk.
+              4 = Likely safe. Minor nits only.
+              3 = Proceed with caution. Non-blocking concerns worth addressing.
+              2 = Hold. Real issues that should be fixed before merge.
+              1 = Do not merge. Blocking bugs, security issues, or broken tests.
+
+            Follow with a one-line justification, then the detailed findings.
+            Base the score on: severity of issues found, blast radius of the change,
+            test coverage of modified code, and reversibility.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Extends the Claude Code Review workflow with an `additional_system_prompt` that asks Claude to emit a **Merge Confidence: X/5** at the top of every PR review summary
- Mirrors the overall merge-safety signal we used to get from Greptile (now canceled)
- Rubric considers severity, blast radius, test coverage, and reversibility

## Test plan
- [ ] Merge and open a test PR to verify the next review renders the `Merge Confidence` line at the top of the summary