### PR TITLE
fix(ci): inline merge confidence instruction into prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,9 +38,10 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          additional_system_prompt: |
-            At the top of your PR review summary, output an overall merge confidence score:
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            Additional instruction: at the top of the PR review summary, output an overall merge confidence score:
 
             **Merge Confidence: X/5**
               5 = Ship it. No blockers, low risk.


### PR DESCRIPTION
## Summary
- Follow-up to #326. `additional_system_prompt` is not a valid input for `anthropics/claude-code-action@v1` — the action failed with `Unexpected input(s) 'additional_system_prompt'`.
- Moves the merge confidence instruction into the `prompt` field, appended after the `/code-review:code-review` slash command invocation.

## Test plan
- [ ] Merge and verify the next PR's Claude review starts with `**Merge Confidence: X/5**`