### PR TITLE
fix(desktop): classify SSE stream stop reasons

### DIFF
--- a/apps/desktop/src/main/chat-stream-stop.test.ts
+++ b/apps/desktop/src/main/chat-stream-stop.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { classifyChatStreamFailure } from './chat-stream-stop.js';
+import { classifyChatStreamFailure, formatChatStreamStopForLog } from './chat-stream-stop.js';
 
 test('classifyChatStreamFailure detects retryable upstream 502 failures', () => {
   const reason = classifyChatStreamFailure({
@@ -44,4 +44,103 @@ test('classifyChatStreamFailure preserves explicit aborts', () => {
 
   assert.equal(reason.kind, 'aborted');
   assert.equal(reason.retryable, false);
+});
+
+test('classifyChatStreamFailure does not treat transport-side aborts as user aborts', () => {
+  // "Connection aborted by remote" should be a retryable transport failure,
+  // not a user-initiated abort.
+  const reason = classifyChatStreamFailure({
+    error: { message: 'Connection aborted by remote', code: 'ECONNRESET' },
+    stopReason: 'error',
+  });
+
+  assert.notEqual(reason.kind, 'aborted');
+  assert.equal(reason.kind, 'network_error');
+  assert.equal(reason.source, 'transport');
+  assert.equal(reason.retryable, true);
+});
+
+test('classifyChatStreamFailure does not leak HTTP response body into user-facing message', () => {
+  const reason = classifyChatStreamFailure({
+    error: {
+      message: 'Upstream request failed',
+      status: 500,
+      body: 'sk-secret-token-LEAKED and internal stack trace',
+    },
+    stopReason: 'error',
+  });
+
+  assert.equal(reason.kind, 'http_error');
+  assert.equal(reason.statusCode, 500);
+  assert.ok(
+    !reason.message.includes('sk-secret-token-LEAKED'),
+    `expected body content not to leak into message, got: ${reason.message}`,
+  );
+});
+
+test('parseStatusCodeFromText does not treat bare leading digits as HTTP status codes', () => {
+  // Previously "128 tokens remaining" would be parsed as HTTP 128 by a bare
+  // /^\s*(\d{3})\b/ heuristic. The regex was removed in favour of patterns
+  // that require an HTTP-shaped context ("status 502", "HTTP 502", etc.).
+  const reason = classifyChatStreamFailure({
+    error: new Error('128 tokens remaining before limit'),
+    stopReason: 'error',
+  });
+
+  assert.notEqual(reason.kind, 'http_error');
+  assert.equal(reason.statusCode, undefined);
+});
+
+test('classifyChatStreamFailure falls back to stream_error when stopReason is error', () => {
+  const reason = classifyChatStreamFailure({
+    error: new Error('Something weird happened upstream'),
+    stopReason: 'error',
+  });
+
+  assert.equal(reason.kind, 'stream_error');
+  assert.equal(reason.source, 'upstream');
+  assert.equal(reason.retryable, false);
+  assert.ok(reason.message.includes('Something weird happened upstream'));
+});
+
+test('classifyChatStreamFailure falls back to unknown when no signals match', () => {
+  const reason = classifyChatStreamFailure({});
+
+  assert.equal(reason.kind, 'unknown');
+  assert.equal(reason.source, 'unknown');
+  assert.equal(reason.retryable, false);
+});
+
+test('classifyChatStreamFailure recurses through `cause` chains', () => {
+  // Plain objects avoid Error.name='Error' being collected as an errorCode.
+  const outer = {
+    message: 'wrapper',
+    cause: {
+      message: 'fetch failed',
+      cause: { message: 'socket hang up', code: 'ECONNRESET' },
+    },
+  };
+
+  const reason = classifyChatStreamFailure({ error: outer, stopReason: 'error' });
+
+  assert.equal(reason.kind, 'network_error');
+  assert.equal(reason.errorCode, 'ECONNRESET');
+  assert.equal(reason.retryable, true);
+});
+
+test('formatChatStreamStopForLog includes kind, status, code, and retryability', () => {
+  const out = formatChatStreamStopForLog({
+    kind: 'http_error',
+    source: 'upstream',
+    retryable: true,
+    message: 'nope',
+    statusCode: 502,
+    errorCode: 'ERR_UPSTREAM',
+  });
+
+  assert.match(out, /http_error/);
+  assert.match(out, /status=502/);
+  assert.match(out, /code=ERR_UPSTREAM/);
+  assert.match(out, /retryable/);
+  assert.match(out, /: nope$/);
 });

--- a/apps/desktop/src/main/chat-stream-stop.test.ts
+++ b/apps/desktop/src/main/chat-stream-stop.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { classifyChatStreamFailure } from './chat-stream-stop.js';
+
+test('classifyChatStreamFailure detects retryable upstream 502 failures', () => {
+  const reason = classifyChatStreamFailure({
+    error: new Error('Upstream request failed with status 502 Bad Gateway'),
+    stopReason: 'error',
+  });
+
+  assert.equal(reason.kind, 'http_error');
+  assert.equal(reason.statusCode, 502);
+  assert.equal(reason.retryable, true);
+});
+
+test('classifyChatStreamFailure detects timeout failures', () => {
+  const reason = classifyChatStreamFailure({
+    error: { message: 'headers timeout', code: 'UND_ERR_HEADERS_TIMEOUT' },
+    stopReason: 'error',
+  });
+
+  assert.equal(reason.kind, 'timeout');
+  assert.equal(reason.errorCode, 'UND_ERR_HEADERS_TIMEOUT');
+  assert.equal(reason.retryable, true);
+});
+
+test('classifyChatStreamFailure detects transport disconnects', () => {
+  const reason = classifyChatStreamFailure({
+    error: { message: 'socket hang up', code: 'ECONNRESET' },
+    stopReason: 'error',
+  });
+
+  assert.equal(reason.kind, 'network_error');
+  assert.equal(reason.errorCode, 'ECONNRESET');
+  assert.equal(reason.retryable, true);
+});
+
+test('classifyChatStreamFailure preserves explicit aborts', () => {
+  const reason = classifyChatStreamFailure({
+    error: new Error('The operation was aborted'),
+    stopReason: 'aborted',
+  });
+
+  assert.equal(reason.kind, 'aborted');
+  assert.equal(reason.retryable, false);
+});

--- a/apps/desktop/src/main/chat-stream-stop.ts
+++ b/apps/desktop/src/main/chat-stream-stop.ts
@@ -1,3 +1,10 @@
+// Note: `payment_required` is part of this union but is intentionally never
+// produced by `classifyChatStreamFailure`. Payment-required stops are emitted
+// via the dedicated `emitPaymentRequiredStreamError` path in pi-chat-engine.
+// This type is also mirrored (for IPC) in:
+//   - apps/desktop/src/main/preload.cts (ChatAiStreamStopReason)
+//   - apps/desktop/src/renderer/types/bridge.ts (ChatAiStreamStopReason)
+// Keep those in sync when fields change.
 export type ChatStreamStopKind =
   | 'payment_required'
   | 'aborted'
@@ -77,7 +84,11 @@ function collectErrorSignals(
 
   const record = value as Record<string, unknown>;
 
-  for (const key of ['message', 'errorMessage', 'finalError', 'statusText', 'body']) {
+  // Note: HTTP response `body` is intentionally excluded from user-facing
+  // message collection — it can contain tokens, API internals, or other
+  // sensitive content. Status codes are still extracted from dedicated
+  // fields (`status`/`statusCode`/`httpStatus`) and via `parseStatusCodeFromText`.
+  for (const key of ['message', 'errorMessage', 'finalError', 'statusText']) {
     const field = record[key];
     if (typeof field === 'string' && field.trim().length > 0) {
       state.messages.push(field.trim());
@@ -123,12 +134,14 @@ function uniqueStrings(values: string[]): string[] {
 }
 
 function parseStatusCodeFromText(text: string): number | undefined {
+  // Only match status codes that appear in an HTTP-shaped context. A bare
+  // leading-digit heuristic (e.g. `/^\s*(\d{3})\b/`) produced false positives
+  // on messages like "128 tokens remaining" — which would be read as HTTP 128.
   const patterns = [
     /\bstatus(?:\s+code)?\s*(?:=|:)?\s*(\d{3})\b/i,
     /\bhttp\s*(\d{3})\b/i,
     /\bresponse failed:\s*(\d{3})\b/i,
     /\b(\d{3})\s+(?:bad gateway|gateway timeout|service unavailable|too many requests|request timeout|internal server error)\b/i,
-    /^\s*(\d{3})\b/,
   ];
 
   for (const pattern of patterns) {
@@ -176,7 +189,13 @@ export function classifyChatStreamFailure({
   const statusCode = signals.statusCodes[0] ?? parseStatusCodeFromText(rawMessage);
   const errorCode = signals.errorCodes.find(Boolean) ?? parseErrorCodeFromText(rawMessage);
 
-  if (stopReason === 'aborted' || errorCode === 'AbortError' || /\brequest aborted\b|\baborted\b/.test(normalized)) {
+  // Keep the text-based abort match narrow so transport-side aborts (e.g.
+  // "connection aborted by remote") aren't misclassified as user-initiated.
+  if (
+    stopReason === 'aborted'
+    || errorCode === 'AbortError'
+    || /\brequest aborted\b|\baborted by user\b|\bthe operation was aborted\b|\boperation was aborted\b/.test(normalized)
+  ) {
     return {
       kind: 'aborted',
       source: 'user',

--- a/apps/desktop/src/main/chat-stream-stop.ts
+++ b/apps/desktop/src/main/chat-stream-stop.ts
@@ -1,0 +1,271 @@
+export type ChatStreamStopKind =
+  | 'payment_required'
+  | 'aborted'
+  | 'timeout'
+  | 'http_error'
+  | 'network_error'
+  | 'stream_error'
+  | 'unknown';
+
+export type ChatStreamStopSource =
+  | 'billing'
+  | 'user'
+  | 'transport'
+  | 'upstream'
+  | 'unknown';
+
+export type ChatStreamStopReason = {
+  kind: ChatStreamStopKind;
+  source: ChatStreamStopSource;
+  retryable: boolean;
+  message: string;
+  statusCode?: number;
+  errorCode?: string;
+};
+
+type ClassifyChatStreamFailureInput = {
+  error?: unknown;
+  message?: string;
+  stopReason?: 'error' | 'aborted';
+};
+
+const COMMON_HTTP_STATUS_TEXT: Record<number, string> = {
+  408: 'Request Timeout',
+  429: 'Too Many Requests',
+  500: 'Internal Server Error',
+  502: 'Bad Gateway',
+  503: 'Service Unavailable',
+  504: 'Gateway Timeout',
+};
+
+function collectErrorSignals(
+  value: unknown,
+  state = {
+    visited: new Set<unknown>(),
+    messages: [] as string[],
+    statusCodes: [] as number[],
+    errorCodes: [] as string[],
+  },
+): typeof state {
+  if (value == null) {
+    return state;
+  }
+
+  if (typeof value === 'string') {
+    const text = value.trim();
+    if (text.length > 0) {
+      state.messages.push(text);
+    }
+    return state;
+  }
+
+  if (typeof value !== 'object') {
+    return state;
+  }
+
+  if (state.visited.has(value)) {
+    return state;
+  }
+  state.visited.add(value);
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectErrorSignals(item, state);
+    }
+    return state;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  for (const key of ['message', 'errorMessage', 'finalError', 'statusText', 'body']) {
+    const field = record[key];
+    if (typeof field === 'string' && field.trim().length > 0) {
+      state.messages.push(field.trim());
+    }
+  }
+
+  for (const key of ['status', 'statusCode', 'httpStatus']) {
+    const field = record[key];
+    const parsed = Number(field);
+    if (Number.isFinite(parsed) && parsed >= 100 && parsed <= 599) {
+      state.statusCodes.push(Math.floor(parsed));
+    }
+  }
+
+  for (const key of ['code', 'errorCode', 'name']) {
+    const field = record[key];
+    if (typeof field === 'string' && field.trim().length > 0) {
+      state.errorCodes.push(field.trim());
+    }
+  }
+
+  for (const key of ['cause', 'error', 'errors', 'details']) {
+    if (key in record) {
+      collectErrorSignals(record[key], state);
+    }
+  }
+
+  return state;
+}
+
+function uniqueStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const key = value.trim();
+    if (key.length === 0 || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(key);
+  }
+  return result;
+}
+
+function parseStatusCodeFromText(text: string): number | undefined {
+  const patterns = [
+    /\bstatus(?:\s+code)?\s*(?:=|:)?\s*(\d{3})\b/i,
+    /\bhttp\s*(\d{3})\b/i,
+    /\bresponse failed:\s*(\d{3})\b/i,
+    /\b(\d{3})\s+(?:bad gateway|gateway timeout|service unavailable|too many requests|request timeout|internal server error)\b/i,
+    /^\s*(\d{3})\b/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = pattern.exec(text);
+    if (!match) {
+      continue;
+    }
+    const parsed = Number(match[1]);
+    if (Number.isFinite(parsed) && parsed >= 100 && parsed <= 599) {
+      return parsed;
+    }
+  }
+
+  return undefined;
+}
+
+function parseErrorCodeFromText(text: string): string | undefined {
+  const match = /\b(UND_ERR_[A-Z_]+|E[A-Z0-9_]+|ERR_[A-Z0-9_]+)\b/.exec(text);
+  return match?.[1];
+}
+
+function describeHttpStatus(statusCode: number): string {
+  return COMMON_HTTP_STATUS_TEXT[statusCode] ?? 'HTTP Error';
+}
+
+function buildHttpErrorMessage(statusCode: number, retryable: boolean): string {
+  const statusText = describeHttpStatus(statusCode);
+  return retryable
+    ? `The stream stopped with HTTP ${String(statusCode)} (${statusText}). You can retry.`
+    : `The stream stopped with HTTP ${String(statusCode)} (${statusText}).`;
+}
+
+export function classifyChatStreamFailure({
+  error,
+  message,
+  stopReason,
+}: ClassifyChatStreamFailureInput): ChatStreamStopReason {
+  const signals = collectErrorSignals(error);
+  if (typeof message === 'string' && message.trim().length > 0) {
+    signals.messages.push(message.trim());
+  }
+
+  const rawMessage = uniqueStrings(signals.messages).join(' | ') || 'The stream stopped before completion.';
+  const normalized = rawMessage.toLowerCase();
+  const statusCode = signals.statusCodes[0] ?? parseStatusCodeFromText(rawMessage);
+  const errorCode = signals.errorCodes.find(Boolean) ?? parseErrorCodeFromText(rawMessage);
+
+  if (stopReason === 'aborted' || errorCode === 'AbortError' || /\brequest aborted\b|\baborted\b/.test(normalized)) {
+    return {
+      kind: 'aborted',
+      source: 'user',
+      retryable: false,
+      message: 'Request aborted.',
+      ...(errorCode ? { errorCode } : {}),
+    };
+  }
+
+  const timeoutLike =
+    /\btimed out\b|\btimeout\b|\btime out\b|\bheaders timeout\b|\bconnect timeout\b|\bgateway timeout\b/.test(normalized)
+    || errorCode === 'ETIMEDOUT'
+    || errorCode === 'UND_ERR_CONNECT_TIMEOUT'
+    || errorCode === 'UND_ERR_HEADERS_TIMEOUT';
+  if (timeoutLike || statusCode === 408 || statusCode === 504) {
+    return {
+      kind: 'timeout',
+      source: statusCode ? 'upstream' : 'transport',
+      retryable: true,
+      message: statusCode
+        ? buildHttpErrorMessage(statusCode, true)
+        : 'The stream timed out before completion. You can retry.',
+      ...(statusCode ? { statusCode } : {}),
+      ...(errorCode ? { errorCode } : {}),
+    };
+  }
+
+  if (typeof statusCode === 'number') {
+    const retryable = statusCode >= 500 || statusCode === 429;
+    return {
+      kind: 'http_error',
+      source: 'upstream',
+      retryable,
+      message: buildHttpErrorMessage(statusCode, retryable),
+      statusCode,
+      ...(errorCode ? { errorCode } : {}),
+    };
+  }
+
+  const networkLike =
+    /\bnetwork error\b|\bfetch failed\b|\bfailed to fetch\b|\bconnection reset\b|\bconnection refused\b|\bsocket hang up\b|\breset before headers\b|\bupstream connect\b|\bterminated\b|\bunexpected end\b|\bstream ended unexpectedly\b|\bincomplete chunked encoding\b/.test(normalized)
+    || errorCode === 'ECONNRESET'
+    || errorCode === 'ECONNREFUSED'
+    || errorCode === 'ENOTFOUND'
+    || errorCode === 'EHOSTUNREACH'
+    || errorCode === 'EPIPE';
+  if (networkLike) {
+    return {
+      kind: 'network_error',
+      source: 'transport',
+      retryable: true,
+      message: errorCode
+        ? `The stream connection ended unexpectedly (${errorCode}). You can retry.`
+        : 'The stream connection ended unexpectedly. You can retry.',
+      ...(errorCode ? { errorCode } : {}),
+    };
+  }
+
+  if (stopReason === 'error') {
+    return {
+      kind: 'stream_error',
+      source: 'upstream',
+      retryable: false,
+      message: rawMessage === 'The stream stopped before completion.'
+        ? rawMessage
+        : `The stream stopped before completion: ${rawMessage}`,
+      ...(errorCode ? { errorCode } : {}),
+    };
+  }
+
+  return {
+    kind: 'unknown',
+    source: 'unknown',
+    retryable: false,
+    message: rawMessage === 'The stream stopped before completion.'
+      ? rawMessage
+      : `The stream stopped before completion: ${rawMessage}`,
+    ...(errorCode ? { errorCode } : {}),
+  };
+}
+
+export function formatChatStreamStopForLog(reason: ChatStreamStopReason): string {
+  const parts: string[] = [reason.kind];
+  if (reason.statusCode) {
+    parts.push(`status=${String(reason.statusCode)}`);
+  }
+  if (reason.errorCode) {
+    parts.push(`code=${reason.errorCode}`);
+  }
+  parts.push(reason.retryable ? 'retryable' : 'non-retryable');
+  return `${parts.join(', ')}: ${reason.message}`;
+}

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -5,6 +5,11 @@ import { createConnection } from 'node:net';
 import path from 'node:path';
 import type { AgentSession, AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import { browserPreviewTool, startDevServerTool } from './chat-dev-tools.js';
+import {
+  classifyChatStreamFailure,
+  formatChatStreamStopForLog,
+  type ChatStreamStopReason,
+} from './chat-stream-stop.js';
 import { webFetchTool } from './chat-web-fetch.js';
 import { fetchNetworkStats } from './fetch-network-stats.js';
 import { buildAntstationSystemPrompt } from './chat-system-prompt.js';
@@ -119,6 +124,12 @@ type RegisterPiChatHandlersOptions = {
   ensureBuyerRuntimeStarted?: () => Promise<boolean>;
   appendSystemLog: (line: string) => void;
   getNetworkPeers?: () => Promise<NetworkPeerAddress[]>;
+};
+
+type ChatStreamErrorPayload = {
+  conversationId: string;
+  error: string;
+  stopReason: ChatStreamStopReason;
 };
 
 type SessionPathInfo = {
@@ -1548,6 +1559,29 @@ export function registerPiChatHandlers({
     });
   };
 
+  const emitChatStreamError = (
+    payload: ChatStreamErrorPayload,
+  ): ChatStreamStopReason => {
+    sendToRenderer('chat:ai-stream-error', payload);
+    return payload.stopReason;
+  };
+
+  const emitPaymentRequiredStreamError = (
+    conversationId: string,
+    suggestedAmount: string,
+  ): ChatStreamStopReason => {
+    return emitChatStreamError({
+      conversationId,
+      error: `payment_required:${suggestedAmount}`,
+      stopReason: {
+        kind: 'payment_required',
+        source: 'billing',
+        retryable: false,
+        message: 'Payment is required before the stream can continue.',
+      },
+    });
+  };
+
   const clearActiveRun = (run: ActiveRun | null): void => {
     if (!run) {
       return;
@@ -1610,7 +1644,7 @@ export function registerPiChatHandlers({
     providerOverride?: string,
     imageBase64?: string,
     imageMimeType?: string,
-  ): Promise<{ ok: boolean; error?: string }> => {
+  ): Promise<{ ok: boolean; error?: string; stopReason?: ChatStreamStopReason }> => {
     const trimmedMessage = userMessage.trim();
     if (trimmedMessage.length === 0 && !imageBase64) {
       return { ok: false, error: 'Empty message' };
@@ -1724,6 +1758,8 @@ export function registerPiChatHandlers({
     let userPersisted = false;
     let streamDone = false;
     let pendingAssistantMessage: AiChatMessage | null = null;
+    let terminalStreamError: string | null = null;
+    let terminalStreamFailure: ChatStreamStopReason | null = null;
 
     const unsubscribe = session.subscribe((event: AgentSessionEvent) => {
       if (event.type === 'turn_start') {
@@ -1925,10 +1961,7 @@ export function registerPiChatHandlers({
             } else {
               cacheFallbackPaymentRequired(conversationId, suggestedAmount);
             }
-            sendToRenderer('chat:ai-stream-error', {
-              conversationId,
-              error: `payment_required:${suggestedAmount}`,
-            });
+            emitPaymentRequiredStreamError(conversationId, suggestedAmount);
             const activeRun = activeRunsByConversation.get(conversationId);
             if (activeRun) void abortAndClearActiveRun(activeRun);
             return;
@@ -1943,12 +1976,22 @@ export function registerPiChatHandlers({
               ? paymentBody.suggestedAmount : '100000';
             // Cache payment info so the approve IPC handler can build the SpendingAuth
             cachedPaymentRequired.set(conversationId, paymentBody);
-            sendToRenderer('chat:ai-stream-error', {
-              conversationId,
-              error: `payment_required:${suggestedAmount}`,
-            });
+            emitPaymentRequiredStreamError(conversationId, suggestedAmount);
             const activeRun = activeRunsByConversation.get(conversationId);
             if (activeRun) void abortAndClearActiveRun(activeRun);
+            return;
+          }
+
+          if (message.stopReason === 'error' || message.stopReason === 'aborted') {
+            terminalStreamError = errorMsg || rawContent || (message.stopReason === 'aborted'
+              ? 'Request aborted'
+              : 'The stream stopped before completion.');
+            terminalStreamFailure = classifyChatStreamFailure({
+              error: message,
+              message: terminalStreamError,
+              stopReason: message.stopReason,
+            });
+            pendingAssistantMessage = null;
             return;
           }
 
@@ -1974,6 +2017,34 @@ export function registerPiChatHandlers({
         return;
       }
 
+      if (event.type === 'auto_retry_start') {
+        const reason = classifyChatStreamFailure({
+          error: event.errorMessage,
+          message: event.errorMessage,
+          stopReason: 'error',
+        });
+        appendSystemLog(
+          `AI stream interrupted. Retrying in ${(event.delayMs / 1000).toFixed(1)}s `
+          + `(${String(event.attempt)}/${String(event.maxAttempts)}) `
+          + `[${formatChatStreamStopForLog(reason)}]`,
+        );
+        return;
+      }
+
+      if (event.type === 'auto_retry_end') {
+        if (event.success) {
+          appendSystemLog(`AI stream retry succeeded on attempt ${String(event.attempt)}.`);
+        } else if (event.finalError) {
+          const reason = classifyChatStreamFailure({
+            error: event.finalError,
+            message: event.finalError,
+            stopReason: 'error',
+          });
+          appendSystemLog(`AI stream retry exhausted: ${formatChatStreamStopForLog(reason)}`);
+        }
+        return;
+      }
+
       if (event.type === 'agent_end') {
         // Don't finalize here — auto-retry may follow with a new agent_start.
         // The post-session.prompt code handles final chat:ai-done / chat:ai-stream-done.
@@ -1988,6 +2059,21 @@ export function registerPiChatHandlers({
         ? [{ type: 'image', data: imageBase64, mimeType: imageMimeType }]
         : [];
       await session.prompt(trimmedMessage || ' ', { images: images.length > 0 ? images : undefined });
+
+      if (terminalStreamFailure !== null) {
+        const streamFailure = terminalStreamFailure as ChatStreamStopReason;
+        const reason = emitChatStreamError({
+          conversationId,
+          error: terminalStreamError ?? streamFailure.message,
+          stopReason: streamFailure,
+        });
+        appendSystemLog(`Pi chat error: ${formatChatStreamStopForLog(reason)}`);
+        return {
+          ok: false,
+          error: terminalStreamError ?? streamFailure.message,
+          stopReason: reason,
+        };
+      }
 
       // Check if the agent received a 402 payment_required response.
       // The node returns JSON with "error":"payment_required" which the agent
@@ -2009,11 +2095,8 @@ export function registerPiChatHandlers({
             cacheFallbackPaymentRequired(conversationId, amt);
           }
           pendingAssistantMessage = null;
-          sendToRenderer('chat:ai-stream-error', {
-            conversationId,
-            error: `payment_required:${amt}`,
-          });
-          return { ok: false, error: 'Payment required' };
+          const reason = emitPaymentRequiredStreamError(conversationId, amt);
+          return { ok: false, error: 'Payment required', stopReason: reason };
         }
       }
 
@@ -2033,8 +2116,16 @@ export function registerPiChatHandlers({
       // Always discard any buffered assistant message on error — it will not be committed.
       pendingAssistantMessage = null;
       if ((error as Error).name === 'AbortError') {
-        sendToRenderer('chat:ai-stream-error', { conversationId, error: 'Request aborted' });
-        return { ok: false, error: 'Aborted' };
+        const reason = emitChatStreamError({
+          conversationId,
+          error: 'Request aborted',
+          stopReason: classifyChatStreamFailure({
+            error,
+            message: 'Request aborted',
+            stopReason: 'aborted',
+          }),
+        });
+        return { ok: false, error: 'Aborted', stopReason: reason };
       }
       const message = asErrorMessage(error);
       // Map insufficient balance / 402 errors to payment_required format
@@ -2059,12 +2150,21 @@ export function registerPiChatHandlers({
             suggestedAmount: amt,
           });
         }
-        sendToRenderer('chat:ai-stream-error', { conversationId, error: `payment_required:${amt}` });
+        const reason = emitPaymentRequiredStreamError(conversationId, amt);
+        return { ok: false, error: message, stopReason: reason };
       } else {
-        sendToRenderer('chat:ai-stream-error', { conversationId, error: message });
+        const reason = emitChatStreamError({
+          conversationId,
+          error: message,
+          stopReason: classifyChatStreamFailure({
+            error,
+            message,
+            stopReason: 'error',
+          }),
+        });
+        appendSystemLog(`Pi chat error: ${formatChatStreamStopForLog(reason)}`);
+        return { ok: false, error: message, stopReason: reason };
       }
-      appendSystemLog(`Pi chat error: ${message}`);
-      return { ok: false, error: message };
     } finally {
       clearActiveRun(run);
       store.markPersistedIfAvailable(conversationId);

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -1559,27 +1559,26 @@ export function registerPiChatHandlers({
     });
   };
 
-  const emitChatStreamError = (
-    payload: ChatStreamErrorPayload,
-  ): ChatStreamStopReason => {
+  const emitChatStreamError = (payload: ChatStreamErrorPayload): void => {
     sendToRenderer('chat:ai-stream-error', payload);
-    return payload.stopReason;
   };
 
   const emitPaymentRequiredStreamError = (
     conversationId: string,
     suggestedAmount: string,
   ): ChatStreamStopReason => {
-    return emitChatStreamError({
+    const stopReason: ChatStreamStopReason = {
+      kind: 'payment_required',
+      source: 'billing',
+      retryable: false,
+      message: 'Payment is required before the stream can continue.',
+    };
+    emitChatStreamError({
       conversationId,
       error: `payment_required:${suggestedAmount}`,
-      stopReason: {
-        kind: 'payment_required',
-        source: 'billing',
-        retryable: false,
-        message: 'Payment is required before the stream can continue.',
-      },
+      stopReason,
     });
+    return stopReason;
   };
 
   const clearActiveRun = (run: ActiveRun | null): void => {
@@ -2061,17 +2060,21 @@ export function registerPiChatHandlers({
       await session.prompt(trimmedMessage || ' ', { images: images.length > 0 ? images : undefined });
 
       if (terminalStreamFailure !== null) {
+        // `terminalStreamFailure` is mutated inside the subscribe callback,
+        // which TypeScript can't see — control-flow analysis narrows it to
+        // `never` here. Cast back to the real type (we already guarded on
+        // `!== null` above).
         const streamFailure = terminalStreamFailure as ChatStreamStopReason;
-        const reason = emitChatStreamError({
+        emitChatStreamError({
           conversationId,
           error: terminalStreamError ?? streamFailure.message,
           stopReason: streamFailure,
         });
-        appendSystemLog(`Pi chat error: ${formatChatStreamStopForLog(reason)}`);
+        appendSystemLog(`Pi chat error: ${formatChatStreamStopForLog(streamFailure)}`);
         return {
           ok: false,
           error: terminalStreamError ?? streamFailure.message,
-          stopReason: reason,
+          stopReason: streamFailure,
         };
       }
 
@@ -2116,14 +2119,15 @@ export function registerPiChatHandlers({
       // Always discard any buffered assistant message on error — it will not be committed.
       pendingAssistantMessage = null;
       if ((error as Error).name === 'AbortError') {
-        const reason = emitChatStreamError({
+        const reason = classifyChatStreamFailure({
+          error,
+          message: 'Request aborted',
+          stopReason: 'aborted',
+        });
+        emitChatStreamError({
           conversationId,
           error: 'Request aborted',
-          stopReason: classifyChatStreamFailure({
-            error,
-            message: 'Request aborted',
-            stopReason: 'aborted',
-          }),
+          stopReason: reason,
         });
         return { ok: false, error: 'Aborted', stopReason: reason };
       }
@@ -2153,14 +2157,15 @@ export function registerPiChatHandlers({
         const reason = emitPaymentRequiredStreamError(conversationId, amt);
         return { ok: false, error: message, stopReason: reason };
       } else {
-        const reason = emitChatStreamError({
+        const reason = classifyChatStreamFailure({
+          error,
+          message,
+          stopReason: 'error',
+        });
+        emitChatStreamError({
           conversationId,
           error: message,
-          stopReason: classifyChatStreamFailure({
-            error,
-            message,
-            stopReason: 'error',
-          }),
+          stopReason: reason,
         });
         appendSystemLog(`Pi chat error: ${formatChatStreamStopForLog(reason)}`);
         return { ok: false, error: message, stopReason: reason };

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -86,6 +86,11 @@ type PluginInstallResult = {
   error: string | null;
 };
 
+// NOTE: Source of truth lives in apps/desktop/src/main/chat-stream-stop.ts
+// (`ChatStreamStopReason`). This preload runs in a sandboxed context and
+// cannot import from main, so the shape is mirrored here for IPC. Keep the
+// `kind`, `source`, and field set in sync with the source-of-truth type —
+// and with the renderer copy in apps/desktop/src/renderer/types/bridge.ts.
 type ChatAiStreamStopReason = {
   kind: 'payment_required' | 'aborted' | 'timeout' | 'http_error' | 'network_error' | 'stream_error' | 'unknown';
   source: 'billing' | 'user' | 'transport' | 'upstream' | 'unknown';

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -86,6 +86,15 @@ type PluginInstallResult = {
   error: string | null;
 };
 
+type ChatAiStreamStopReason = {
+  kind: 'payment_required' | 'aborted' | 'timeout' | 'http_error' | 'network_error' | 'stream_error' | 'unknown';
+  source: 'billing' | 'user' | 'transport' | 'upstream' | 'unknown';
+  retryable: boolean;
+  message: string;
+  statusCode?: number;
+  errorCode?: string;
+};
+
 const api = {
   getState(): Promise<RuntimeSnapshot> {
     return ipcRenderer.invoke('runtime:get-state') as Promise<RuntimeSnapshot>;
@@ -174,7 +183,7 @@ const api = {
   chatAiSend(conversationId: string, message: string, service?: string, provider?: string, imageBase64?: string, imageMimeType?: string): Promise<{ ok: boolean; error?: string }> {
     return ipcRenderer.invoke('chat:ai-send', conversationId, message, service, provider, imageBase64, imageMimeType);
   },
-  chatAiSendStream(conversationId: string, message: string, service?: string, provider?: string, imageBase64?: string, imageMimeType?: string): Promise<{ ok: boolean; error?: string }> {
+  chatAiSendStream(conversationId: string, message: string, service?: string, provider?: string, imageBase64?: string, imageMimeType?: string): Promise<{ ok: boolean; error?: string; stopReason?: ChatAiStreamStopReason }> {
     return ipcRenderer.invoke('chat:ai-send-stream', conversationId, message, service, provider, imageBase64, imageMimeType);
   },
   chatAiAbort(): Promise<{ ok: boolean }> {
@@ -263,8 +272,8 @@ const api = {
     ipcRenderer.on('chat:ai-stream-done', listener);
     return () => ipcRenderer.off('chat:ai-stream-done', listener);
   },
-  onChatAiStreamError(handler: (data: { conversationId: string; error: string }) => void): () => void {
-    const listener = (_: unknown, data: { conversationId: string; error: string }) => handler(data);
+  onChatAiStreamError(handler: (data: { conversationId: string; error: string; stopReason?: ChatAiStreamStopReason }) => void): () => void {
+    const listener = (_: unknown, data: { conversationId: string; error: string; stopReason?: ChatAiStreamStopReason }) => handler(data);
     ipcRenderer.on('chat:ai-stream-error', listener);
     return () => ipcRenderer.off('chat:ai-stream-error', listener);
   },

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1562,7 +1562,9 @@ export function initChatModule({
               setChatSending(false);
               void handlePaymentRequired(paymentMatch[1]);
             } else {
-              reportChatError(result.error, 'Request failed');
+              if (!uiState.chatError) {
+                reportChatError(result.stopReason?.message ?? result.error, 'Request failed');
+              }
               setChatSending(false);
             }
           }
@@ -2155,6 +2157,15 @@ export function initChatModule({
     if (bridge.onChatAiStreamError) {
       bridge.onChatAiStreamError((data) => {
         const shouldClearSending = data.conversationId === uiState.chatSendingConversationId;
+        const stopReason = data.stopReason;
+        const stopReasonSummary = stopReason
+          ? [
+              stopReason.kind,
+              stopReason.statusCode ? `status=${String(stopReason.statusCode)}` : null,
+              stopReason.errorCode ? `code=${stopReason.errorCode}` : null,
+              stopReason.retryable ? 'retryable' : 'non-retryable',
+            ].filter(Boolean).join(', ')
+          : 'unknown';
         setConversationStreamingMessage(data.conversationId, null);
 
         if (data.conversationId === uiState.chatActiveConversation) {
@@ -2174,9 +2185,9 @@ export function initChatModule({
               void handlePaymentRequired(paymentMatch[1]);
               if (bridge.chatAiAbort) void bridge.chatAiAbort().catch(() => {});
             } else {
-              showChatError(data.error);
+              showChatError(stopReason?.message ?? data.error);
             }
-            appendSystemLog(`AI Chat error: ${data.error}`);
+            appendSystemLog(`AI Chat error (${stopReasonSummary}): ${data.error}`);
           }
         } else if (shouldClearSending) {
           setChatSending(false);

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -86,6 +86,15 @@ export type ChatWorkspaceGitStatus = {
   error: string | null;
 };
 
+export type ChatAiStreamStopReason = {
+  kind: 'payment_required' | 'aborted' | 'timeout' | 'http_error' | 'network_error' | 'stream_error' | 'unknown';
+  source: 'billing' | 'user' | 'transport' | 'upstream' | 'unknown';
+  retryable: boolean;
+  message: string;
+  statusCode?: number;
+  errorCode?: string;
+};
+
 export type StartOptions = {
   mode: RuntimeMode;
   router?: string;
@@ -124,7 +133,7 @@ export type DesktopBridge = {
   chatAiDeleteConversation?: (id: string) => Promise<{ ok: boolean }>;
   chatAiRenameConversation?: (id: string, title: string) => Promise<{ ok: boolean; error?: string }>;
   chatAiSend?: (conversationId: string, message: string, service?: string, provider?: string, imageBase64?: string, imageMimeType?: string) => Promise<{ ok: boolean; error?: string }>;
-  chatAiSendStream?: (conversationId: string, message: string, service?: string, provider?: string, imageBase64?: string, imageMimeType?: string) => Promise<{ ok: boolean; error?: string }>;
+  chatAiSendStream?: (conversationId: string, message: string, service?: string, provider?: string, imageBase64?: string, imageMimeType?: string) => Promise<{ ok: boolean; error?: string; stopReason?: ChatAiStreamStopReason }>;
   chatAiAbort?: () => Promise<{ ok: boolean }>;
   chatAiSelectPeer?: (peerId: string | null) => Promise<{ ok: boolean; error?: string }>;
   chatAiGetProxyStatus?: () => Promise<{ ok: boolean; data: { running: boolean; port: number } }>;
@@ -147,7 +156,7 @@ export type DesktopBridge = {
   onChatAiStreamBlockStart?: (handler: (data: { conversationId: string; index: number; blockType: string; toolId?: string; toolName?: string }) => void) => () => void;
   onChatAiStreamBlockStop?: (handler: (data: { conversationId: string; index: number; blockType: string; toolId?: string; toolName?: string; input?: Record<string, unknown> }) => void) => () => void;
   onChatAiStreamDone?: (handler: (data: { conversationId: string }) => void) => () => void;
-  onChatAiStreamError?: (handler: (data: { conversationId: string; error: string }) => void) => () => void;
+  onChatAiStreamError?: (handler: (data: { conversationId: string; error: string; stopReason?: ChatAiStreamStopReason }) => void) => () => void;
   onChatAiToolExecuting?: (handler: (data: { conversationId: string; toolUseId: string; name: string; input: Record<string, unknown> }) => void) => () => void;
   onChatAiToolUpdate?: (handler: (data: { conversationId: string; toolUseId: string; name: string; input: Record<string, unknown>; output: string; details?: Record<string, unknown> }) => void) => () => void;
   onChatAiToolResult?: (handler: (data: { conversationId: string; toolUseId: string; output: string; isError: boolean; details?: Record<string, unknown> }) => void) => () => void;

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -86,6 +86,10 @@ export type ChatWorkspaceGitStatus = {
   error: string | null;
 };
 
+// NOTE: Source of truth lives in apps/desktop/src/main/chat-stream-stop.ts
+// (`ChatStreamStopReason`). The renderer cannot import from main, so the
+// shape is mirrored here for IPC. Keep in sync with that file and with
+// apps/desktop/src/main/preload.cts when fields change.
 export type ChatAiStreamStopReason = {
   kind: 'payment_required' | 'aborted' | 'timeout' | 'http_error' | 'network_error' | 'stream_error' | 'unknown';
   source: 'billing' | 'user' | 'transport' | 'upstream' | 'unknown';


### PR DESCRIPTION
Adds structured stream stop classification for desktop chat SSE failures.

Includes:
- classifies aborts, timeouts, HTTP errors, transport disconnects, payment-required stops, and unknown failures
- carries retryability/source metadata through preload and renderer bridge types
- shows clearer UI/log messages for stream failures
- adds focused main-process tests for stream-stop classification

Validation:
- `pnpm --filter=@antseed/desktop test`
- `pnpm --filter=@antseed/desktop run typecheck:renderer`
- `pnpm --filter=@antseed/desktop run build`
