### PR TITLE
fix(desktop): improve workspace picker defaults

### DIFF
--- a/apps/desktop/src/main/chat-workspace.ts
+++ b/apps/desktop/src/main/chat-workspace.ts
@@ -10,6 +10,14 @@ export const ANTSEED_HOME_DIR = path.join(homedir(), '.antseed');
 export const CHAT_DATA_DIR = path.join(ANTSEED_HOME_DIR, 'chat');
 export const CHAT_WORKSPACE_DIR = path.join(ANTSEED_HOME_DIR, 'projects');
 const CHAT_WORKSPACE_STATE_FILE = path.join(CHAT_DATA_DIR, 'workspace.json');
+const WORKSPACE_PICKER_TOOLING_DIRS = new Set([
+  '.claude',
+  '.codex',
+  '.git',
+  '.github',
+  '.vscode',
+  '.agents',
+]);
 
 export type ChatWorkspaceGitStatus = {
   available: boolean;
@@ -28,6 +36,20 @@ const execFileAsync = promisify(execFileCallback);
 
 let currentChatWorkspaceDir = CHAT_WORKSPACE_DIR;
 
+function resolveExistingDirectory(startPath: string): string | null {
+  let current = path.resolve(startPath);
+  for (;;) {
+    if (existsSync(current)) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
 export function getCurrentChatWorkspaceDir(): string {
   return currentChatWorkspaceDir;
 }
@@ -44,6 +66,21 @@ export async function loadChatWorkspaceDir(): Promise<string> {
     // Keep default workspace dir.
   }
   return currentChatWorkspaceDir;
+}
+
+export async function getWorkspacePickerDefaultDir(): Promise<string> {
+  const workspaceDir = await loadChatWorkspaceDir();
+  const existingWorkspaceDir = resolveExistingDirectory(workspaceDir)
+    ?? resolveExistingDirectory(CHAT_WORKSPACE_DIR)
+    ?? homedir();
+  const baseName = path.basename(existingWorkspaceDir).toLowerCase();
+
+  if (WORKSPACE_PICKER_TOOLING_DIRS.has(baseName)) {
+    const parentDir = path.dirname(existingWorkspaceDir);
+    return parentDir;
+  }
+
+  return existingWorkspaceDir;
 }
 
 export async function persistChatWorkspaceDir(workspaceDir: string): Promise<string> {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -55,6 +55,7 @@ import { createWindow, createApplicationMenu, getMainWindow } from './window.js'
 import { ensureConfig, readConfig, mergeConfig, readNodeStatus } from './config-io.js';
 import { registerAttachmentScheme, installAttachmentProtocol } from './attachment-protocol.js';
 import { resolveAttachmentPath } from './attachment-store.js';
+import { getWorkspacePickerDefaultDir } from './chat-workspace.js';
 
 // Re-export types that may be used by other main-process modules
 export type { LogEvent, RuntimeActivityEvent } from './log-parser.js';
@@ -445,10 +446,12 @@ ipcMain.handle(
 );
 
 ipcMain.handle('desktop:pick-directory', async () => {
+  const currentWorkspaceDir = await getWorkspacePickerDefaultDir();
   const dialogOptions: OpenDialogOptions = {
     properties: ['openDirectory'],
     title: 'Select Workspace Folder',
     buttonLabel: 'Use Folder',
+    defaultPath: currentWorkspaceDir,
   };
   const win = getMainWindow();
   const result = win

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
@@ -358,6 +358,7 @@
   align-items: center;
   gap: 6px;
   min-width: 0;
+  max-width: 280px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -373,6 +374,8 @@
   white-space: nowrap;
   font-size: 12px;
   font-family: var(--font-mono, monospace);
+  direction: rtl;
+  text-align: left;
 }
 
 
@@ -381,7 +384,7 @@
   align-items: center;
   gap: 8px;
   min-width: 0;
-  max-width: 100%;
+  max-width: 320px;
   border-radius: 8px;
   border: 1px solid var(--border);
   background: var(--bg-card);
@@ -404,7 +407,9 @@
 } */
 
 .git-status-branch {
+  flex: 0 1 auto;
   min-width: 0;
+  max-width: 96px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -414,9 +419,13 @@
 }
 
 .git-status-summary {
+  flex: 1 1 auto;
+  min-width: 0;
   color: var(--text-muted);
   font-size: 11px;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -74,6 +74,18 @@ function getPathTail(value: string | null | undefined): string {
   return parts[parts.length - 1] || trimmed;
 }
 
+function getPathEnding(value: string | null | undefined): string {
+  const trimmed = String(value || '').trim().replace(/[\\/]+$/, '');
+  if (!trimmed) {
+    return 'No workspace';
+  }
+  const parts = trimmed.split(/[\\/]/).filter(Boolean);
+  if (parts.length <= 1) {
+    return parts[0] || trimmed;
+  }
+  return `${parts[parts.length - 2]}/${parts[parts.length - 1]}`;
+}
+
 function getGitChangeCount(status: ChatWorkspaceGitStatus): number {
   return status.stagedFiles + status.modifiedFiles + status.untrackedFiles;
 }
@@ -84,11 +96,11 @@ function getGitStatusSummary(status: ChatWorkspaceGitStatus): string {
   }
 
   const parts: string[] = [];
-  if (status.ahead > 0) parts.push(`+${status.ahead}`);
-  if (status.behind > 0) parts.push(`-${status.behind}`);
+  if (status.ahead > 0) parts.push(`\u2191${status.ahead}`);
+  if (status.behind > 0) parts.push(`\u2193${status.behind}`);
 
   const changes = getGitChangeCount(status);
-  parts.push(changes > 0 ? `${changes} dirty` : 'clean');
+  parts.push(changes > 0 ? `${changes} changes` : 'clean');
   return parts.join(' ');
 }
 
@@ -560,9 +572,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     !snap.chatStreamingMessage;
 
   const workspacePath = snap.chatWorkspacePath || snap.chatWorkspaceDefaultPath;
-  const workspaceLabel = workspacePath
-    ? workspacePath.split('/').pop() || workspacePath
-    : 'No workspace';
+  const workspaceLabel = getPathEnding(workspacePath);
   const gitStatus = snap.chatWorkspaceGitStatus;
   const gitStatusSummary = getGitStatusSummary(gitStatus);
   const gitStatusBranch = gitStatus.available
@@ -856,10 +866,11 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                 title={gitStatusTitle}
               >
                 <HugeiconsIcon icon={GitBranchIcon} size={14} strokeWidth={1.5} />
-                {/* <span className={styles.gitStatusBranch}>{gitStatusRepoLabel}</span> */}
+                <span className={styles.gitStatusBranch}>{gitStatusRepoLabel}</span>
                 <span className={styles.gitStatusSummary}>{gitStatusDetailLabel}</span>
               </button>
               <button
+                type="button"
                 className={styles.workspaceButton}
                 onClick={() => void actions.chooseWorkspace()}
                 title={workspacePath || 'Choose workspace'}


### PR DESCRIPTION
## What

Improves the desktop workspace picker and the compact workspace/git status UI.

This PR:
- opens the directory picker at the current saved workspace when possible
- avoids defaulting the picker inside tooling folders like `.git`, `.github`, `.vscode`, `.codex`, `.claude`, or `.agents`
- shows a more useful two-level workspace label, like `parent/project`
- restores the repo/branch label next to git status
- tightens workspace and git status text overflow so long paths/branches do not break the input area layout

## Why

The directory open dialog kept feeling “lost” because it did not start from the user’s current workspace. That made users re-navigate to the same project repeatedly.

The workspace/git labels also needed to be more compact and stable so long paths or branch names do not crowd the chat composer area.

## Testing

Validated after rebasing onto latest `origin/main` and resolving the `apps/desktop/src/main/main.ts` import conflict:

- `pnpm --filter=@antseed/desktop run build:main`
- `pnpm --filter=@antseed/desktop run typecheck:renderer`
- `pnpm --filter=@antseed/desktop run build:renderer`

## Scope

Desktop workspace-picker/default-label UI only.
