### PR TITLE
fix(desktop): use static imports for buyer.state.json reads on Windows

### DIFF
--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -21,6 +21,7 @@ import {
   loadChatWorkspaceDir,
   persistChatWorkspaceDir,
 } from './chat-workspace.js';
+import { DEFAULT_BUYER_STATE_PATH } from './constants.js';
 import { asErrorMessage } from './utils.js';
 import { StakingClient, ChannelsClient, resolveChainConfig } from '@antseed/node';
 import {
@@ -472,10 +473,16 @@ async function discoverChatServiceCatalog(
 ): Promise<ChatServiceCatalogEntry[]> {
   // Read peers directly from buyer.state.json for immediate availability.
   // Falls back to the getNetworkPeers callback if the file isn't available.
+  //
+  // NOTE: `readFile` and `DEFAULT_BUYER_STATE_PATH` are imported statically
+  // at the top of this file. A previous version used dynamic
+  // `await import('./constants.js')` here, which broke in the packaged
+  // Windows Electron build — dynamic ESM imports of relative specifiers
+  // inside `app.asar` fail URL resolution on Windows, the catch below
+  // swallowed the error, and the chat service catalog silently stayed
+  // empty ("Searching for services..." forever).
   let peers: NetworkPeerAddress[] = [];
   try {
-    const { readFile } = await import('node:fs/promises');
-    const { DEFAULT_BUYER_STATE_PATH } = await import('./constants.js');
     const raw = await readFile(DEFAULT_BUYER_STATE_PATH, 'utf-8');
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     const rawPeers = Array.isArray(parsed.discoveredPeers) ? parsed.discoveredPeers : [];
@@ -2294,8 +2301,9 @@ export function registerPiChatHandlers({
         }
       }));
 
-      const { readFile } = await import('node:fs/promises');
-      const { DEFAULT_BUYER_STATE_PATH } = await import('./constants.js');
+      // Static imports at the top of the file — see note on the
+      // `discoverChatServiceCatalog` read for why these must not be
+      // dynamic in packaged Windows builds.
       let discoveredPeersMap: Record<string, {
         onChainChannelCount: number | null;
         providerPricing?: Record<string, { services?: Record<string, { cachedInputUsdPerMillion?: number }> }>;


### PR DESCRIPTION
## Summary

On the packaged Windows Electron build (v0.1.44), the chat UI gets stuck on `Searching for services...` even when `%USERPROFILE%\.antseed\buyer.state.json` is fully populated with peers and services. The network sidebar (Discover panel) correctly shows peers — so the file itself reads fine — but the chat's service catalog stays empty.

## Root cause

Two readers in `apps/desktop/src/main/pi-chat-engine.ts` used dynamic imports to grab the state-file path:

```ts
const { readFile } = await import('node:fs/promises');
const { DEFAULT_BUYER_STATE_PATH } = await import('./constants.js');
```

In packaged Windows Electron, dynamic ESM imports of **relative** specifiers from inside `app.asar` hit URL-resolution issues that don't occur on macOS or in Windows dev mode — the module paths end up looking like `/C:/…/app.asar/dist/main/constants.js` and Node's ESM loader chokes on the hybrid separator. The throw lands in the surrounding `catch { }`, which silently returns an empty peer list and falls through to an optional `getNetworkPeers` callback that isn't wired up, so the catalog stays empty forever.

The sibling reader in `apps/desktop/src/main/peer-cache.ts` uses a **static** import for the same constant and has always worked on Windows — that asymmetry is exactly why the sidebar shows peers but the chat doesn't.

## Fix

- Add `import { DEFAULT_BUYER_STATE_PATH } from './constants.js';` to the top of `pi-chat-engine.ts`.
- Remove both dynamic `await import('./constants.js')` pairs. `readFile` was already statically imported from `node:fs/promises` at the top, so the dynamic redeclarations were redundant shadows.
- Add inline comments at both former call sites explaining why static imports are required in packaged Windows builds, so nobody reintroduces the dynamic version.

Behavior on macOS and in dev is unchanged — both static and dynamic resolve to the same module on those platforms. This only removes the packaged-Windows failure mode.

## Testing

- `tsc -p tsconfig.main.json --noEmit` clean on this branch.
- Should be verified manually on the next Windows release: open the desktop app on Windows with a populated `buyer.state.json` and confirm the chat service dropdown shows models instead of the "Searching for services..." placeholder.

## Scope

Single-file diff, 12 insertions / 4 deletions. No schema or API changes.