### PR TITLE
fix(node): diagnose buyer lock-confirmation failures

### DIFF
--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -15,6 +15,7 @@ import type { SellerAddressResolver } from '../discovery/seller-address-resolver
 import { SellerAuthorizationError } from '../discovery/seller-address-resolver.js';
 import { parseResponseUsage } from '../utils/response-usage.js';
 import { computeCostUsdc, type ServicePricing } from './pricing.js';
+import { formatUsdc } from './usdc-utils.js';
 
 export interface BuyerNegotiatorConfig {}
 
@@ -471,7 +472,15 @@ export class BuyerPaymentNegotiator {
     pmux.sendSpendingAuth(payload);
     debugLog(`[BuyerNegotiator] External SpendingAuth sent to seller ${peer.peerId.slice(0, 12)}..., waiting for AuthAck...`);
 
-    await this._waitForLockConfirmation(peer.peerId);
+    let reserveCtxAmount: bigint | undefined;
+    try {
+      reserveCtxAmount = payload.reserveMaxAmount != null
+        ? BigInt(payload.reserveMaxAmount)
+        : BigInt(payload.cumulativeAmount);
+    } catch {
+      reserveCtxAmount = undefined;
+    }
+    await this._waitForLockConfirmation(peer.peerId, { requestedReserve: reserveCtxAmount });
     debugLog(`[BuyerNegotiator] AuthAck received from seller ${peer.peerId.slice(0, 12)}...`);
     this._lockedPeers.add(peer.peerId);
 
@@ -648,7 +657,7 @@ export class BuyerPaymentNegotiator {
       await this._bpm.authorizeSpending(peer.peerId, pmux, minBudgetPerRequest, amount, pricing, pricingMap, peer.metadata);
       debugLog(`[BuyerNegotiator] SpendingAuth sent to seller ${peer.peerId.slice(0, 12)}..., waiting for AuthAck...`);
 
-      await this._waitForLockConfirmation(peer.peerId);
+      await this._waitForLockConfirmation(peer.peerId, { requestedReserve: amount, minBudgetPerRequest });
       debugLog(`[BuyerNegotiator] AuthAck received from seller ${peer.peerId.slice(0, 12)}...`);
       this._lockedPeers.add(peer.peerId);
 
@@ -764,7 +773,9 @@ export class BuyerPaymentNegotiator {
       if (this._bpm.canReplayReserveAuth(peer.peerId)) {
         const pmux = this.getOrCreatePaymentMux(peer.peerId, conn);
         await this._bpm.resendReserveAuth(peer.peerId, pmux);
-        await this._waitForLockConfirmation(peer.peerId);
+        await this._waitForLockConfirmation(peer.peerId, {
+          minBudgetPerRequest: minBudgetPerRequest ?? undefined,
+        });
         this._lockedPeers.add(peer.peerId);
         return true;
       }
@@ -809,7 +820,9 @@ export class BuyerPaymentNegotiator {
     } else {
       await this._bpm.resendCurrentSpendingAuth(peer.peerId, pmux);
     }
-    await this._waitForLockConfirmation(peer.peerId);
+    await this._waitForLockConfirmation(peer.peerId, {
+      minBudgetPerRequest: minBudgetPerRequest ?? undefined,
+    });
     this._lockedPeers.add(peer.peerId);
     return true;
   }
@@ -849,7 +862,10 @@ export class BuyerPaymentNegotiator {
     }
   }
 
-  private async _waitForLockConfirmation(sellerPeerId: string): Promise<void> {
+  private async _waitForLockConfirmation(
+    sellerPeerId: string,
+    ctx?: { requestedReserve?: bigint; minBudgetPerRequest?: bigint },
+  ): Promise<void> {
     const pollIntervalMs = 200;
     const timeoutMs = 30_000;
     const deadline = Date.now() + timeoutMs;
@@ -857,12 +873,59 @@ export class BuyerPaymentNegotiator {
     while (Date.now() < deadline) {
       if (this._bpm.isLockConfirmed(sellerPeerId)) return;
       if (this._bpm.isLockRejected(sellerPeerId)) {
-        throw new Error(`Lock rejected by seller ${sellerPeerId.slice(0, 12)}...`);
+        throw new Error(
+          `Lock rejected by seller ${sellerPeerId.slice(0, 12)}...${this._buildLockFailureHint(ctx)}`,
+        );
       }
       await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
     }
 
-    throw new Error(`Lock confirmation timed out for seller ${sellerPeerId.slice(0, 12)}... (${timeoutMs}ms)`);
+    throw new Error(
+      `Lock confirmation timed out for seller ${sellerPeerId.slice(0, 12)}... (${timeoutMs}ms).${this._buildLockFailureHint(ctx)}`,
+    );
+  }
+
+  /**
+   * Build a human-readable hint appended to lock-confirmation failures,
+   * listing the most likely causes so operators don't have to guess.
+   *
+   * Note: this intentionally does NOT call the buyer's RPC. The buyer's RPC
+   * is typically less reliable than the seller's, and the seller is the one
+   * making the on-chain call that is failing — it has the exact revert reason
+   * and a fresh deposits snapshot. A follow-up will plumb a structured
+   * AuthNack frame from the seller carrying that information; this hint
+   * exists so the surrounding error shape is already in place when that
+   * lands.
+   */
+  private _buildLockFailureHint(
+    ctx?: { requestedReserve?: bigint; minBudgetPerRequest?: bigint },
+  ): string {
+    const lines: string[] = [];
+
+    // We don't know the buyer's live balance here — only what we asked for.
+    // The binding on-chain constraint is lockForChannel(buyer, maxAmount) in
+    // reserve() / topUp(); settle()/close() cannot throw InsufficientBalance
+    // because their charges come from already-locked reserve. So the ceiling
+    // we need the buyer to have covered is requestedReserve.
+    const reserve = ctx?.requestedReserve;
+    const min = ctx?.minBudgetPerRequest;
+    if (reserve != null && reserve > 0n) {
+      lines.push(
+        `- Deposits may be below the reserve ceiling the seller will lock ` +
+        `(${formatUsdc(reserve)} USDC). The seller's on-chain reserve() reverts ` +
+        `with InsufficientBalance before AuthAck. ` +
+        `Check with "antseed buyer status"; top up with "antseed buyer deposit <amount>".`,
+      );
+    } else if (min != null && min > 0n) {
+      lines.push(
+        `- Deposits may be below seller minBudgetPerRequest (${formatUsdc(min)} USDC). ` +
+        `Check with "antseed buyer status"; top up with "antseed buyer deposit <amount>".`,
+      );
+    }
+    lines.push('- Seller may be overloaded or gated on subscription (try another peer).');
+    lines.push('- Seller may be online but the payment process stalled (retry, or pin a different peer).');
+
+    return `\nLikely causes:\n  ${lines.join('\n  ')}`;
   }
 
 }

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -435,6 +435,95 @@ describe('BuyerPaymentNegotiator', () => {
     });
   });
 
+  describe('lock failure diagnostics (issue #333)', () => {
+    // These tests cover the enriched error messages that surface likely causes
+    // when the seller fails to confirm a payment lock. The enrichment is
+    // intentionally built from data the buyer already has locally (the reserve
+    // amount it authorized, the seller's minBudgetPerRequest) — no extra RPC
+    // calls to the buyer's (typically less reliable) endpoint. A follow-up
+    // plumbs a structured AuthNack from the seller so the buyer can render the
+    // exact revert reason and a fresh deposits snapshot instead.
+
+    it('enriches "Lock rejected" errors with the reserve ceiling hint and generic causes', async () => {
+      bufferPaymentRequired(negotiator, peer.peerId, conn);
+      (bpm.isLockRejected as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      let message = '';
+      try {
+        await negotiator.handle402(make402Response(), peer, conn, makeRequest());
+      } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+      }
+
+      expect(message).toContain('Lock rejected by seller');
+      expect(message).toContain('Likely causes:');
+      // suggestedAmount=100_000 → 0.1 USDC reserve ceiling hint.
+      expect(message).toContain('reserve ceiling the seller will lock (0.1 USDC)');
+      expect(message).toContain("reserve() reverts");
+      expect(message).toContain('antseed buyer status');
+      expect(message).toContain('antseed buyer deposit');
+      expect(message).toContain('overloaded or gated on subscription');
+    });
+
+    it('enriches "Lock confirmation timed out" errors with likely causes', async () => {
+      vi.useFakeTimers();
+      try {
+        bufferPaymentRequired(negotiator, peer.peerId, conn);
+        // Seller neither confirms nor rejects — the 30s timeout fires.
+        (bpm.isLockConfirmed as ReturnType<typeof vi.fn>).mockReturnValue(false);
+        (bpm.isLockRejected as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+        const pending = negotiator.handle402(make402Response(), peer, conn, makeRequest());
+        // Suppress unhandled-rejection noise before the timers advance
+        pending.catch(() => undefined);
+
+        // Allow microtasks (handle402's internal balance check promise) to flush.
+        await vi.advanceTimersByTimeAsync(1);
+        // Advance past the 30s lock-confirmation deadline.
+        await vi.advanceTimersByTimeAsync(31_000);
+
+        await expect(pending).rejects.toThrow(/Lock confirmation timed out for seller/);
+        await expect(pending).rejects.toThrow(/Likely causes:/);
+        await expect(pending).rejects.toThrow(/reserve ceiling the seller will lock/);
+        await expect(pending).rejects.toThrow(/overloaded or gated on subscription/);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not call the buyer RPC during or after a failed lock confirmation', async () => {
+      // The whole point of the zero-RPC design: surface the hint from local
+      // context (reserve, minBudget) without calling the buyer's less-reliable
+      // RPC endpoint. The only balance check that should ever fire is the
+      // pre-existing handle402 "available <= 0" gate, which runs once up front.
+      const balanceSpy = vi.fn().mockResolvedValue({
+        available: 1_000_000n,
+        reserved: 0n,
+        lastActivityAt: 0n,
+      });
+      depositsClient = { getBuyerBalance: balanceSpy } as unknown as DepositsClient;
+      negotiator = new BuyerPaymentNegotiator(
+        identity,
+        bpm as unknown as BuyerPaymentManager,
+        depositsClient,
+        channelsClient,
+        channelStore,
+        config,
+        emitter,
+      );
+      bufferPaymentRequired(negotiator, peer.peerId, conn);
+      (bpm.isLockRejected as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      await expect(
+        negotiator.handle402(make402Response(), peer, conn, makeRequest()),
+      ).rejects.toThrow(/Lock rejected/);
+
+      // Exactly one call — the pre-existing insufficient-credits gate. No extra
+      // RPC load from the enriched hint, and no pre-flight reserve-ceiling check.
+      expect(balanceSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('cost tracking', () => {
     it('estimateCostFromResponse stores estimated cost', () => {
       const response: SerializedHttpResponse = {


### PR DESCRIPTION
## Summary

The buyer's payment negotiation used to swallow the real cause of a failed payment lock behind a generic one-line error:

```
502 P2P request failed: Lock confirmation timed out for seller <peerId>... (30000ms)
```

This was indistinguishable from a seller that was offline, overloaded, or hitting a transient network hiccup, and operators burned hours looking in the wrong place (see #333).

This PR enriches the lock-failure error with a `Likely causes` block assembled from data the buyer already has locally (the reserve ceiling it authorized, the seller's `minBudgetPerRequest`) so operators get an actionable explanation without any extra RPC round-trips on the buyer side.

## Why zero buyer-side RPC calls

An earlier revision of this PR pre-checked the buyer's deposit balance before signing, and re-fetched it on every failure for the hint. That added up to 3 `getBuyerBalance` calls per negotiation on the buyer's endpoint, which is typically less reliable than the seller's. Reviewer feedback (thanks!) flagged this correctly.

The right place for that data is the seller:

- The seller is the one making the on-chain `reserve()` / `topUp()` / `settle()` calls.
- The seller has a reliable RPC endpoint (required for normal operation).
- The seller knows the exact revert reason and can fetch a fresh deposits snapshot cheaply.

So this PR's scope is narrowed to the buyer-local error-message enrichment. The protocol change that makes the seller send a structured `AuthNack` frame is tracked as **#341** and will plug into the error throw paths introduced here.

## Technical details

- `_waitForLockConfirmation` now takes a `{ requestedReserve, minBudgetPerRequest }` context and synthesizes the `Likely causes` block on timeout / rejection.
- Context is threaded into every call site: `_doNegotiatePayment`, `applyExternalSpendingAuth`, and both `_recoverExistingSession` paths (reserve replay + extend/resend current auth).
- No new RPC calls. The pre-existing `handle402` "available <= 0" credit gate still runs once up front, exactly as before.

## Example output

**Before:**
```
Lock confirmation timed out for seller 4668854ba3e8... (30000ms)
```

**After:**
```
Lock confirmation timed out for seller 4668854ba3e8... (30000ms).
Likely causes:
  - Deposits may be below the reserve ceiling the seller will lock (10 USDC).
    The seller's on-chain reserve() reverts with InsufficientBalance before AuthAck.
    Check with "antseed buyer status"; top up with "antseed buyer deposit <amount>".
  - Seller may be overloaded or gated on subscription (try another peer).
  - Seller may be online but the payment process stalled (retry, or pin a different peer).
```

Once #341 lands, the first bullet will be replaced by the seller's exact revert reason + a deposits snapshot the buyer didn't have to fetch.

## Test plan

`packages/node`: `pnpm test` \u2014 54 files / 561 tests pass. Three focused tests in `describe('lock failure diagnostics (issue #333)')`:

- `Lock rejected` errors include the reserve-ceiling hint and generic causes
- `Lock confirmation timed out` errors include the same hint block (verified with `vi.useFakeTimers`)
- The enriched hint never triggers additional buyer-side `getBuyerBalance` calls

`pnpm run build` \u2014 full workspace build passes.

Refs #333. Follow-up: #341.