### PR TITLE
fix(desktop): limit wallet USD amounts to 2 decimals

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
@@ -326,10 +326,10 @@ export function formatCompactNumber(value: unknown): string {
   return Math.floor(num).toLocaleString();
 }
 
-export function formatUsd(value: unknown, maxFractionDigits = 6): string {
+export function formatUsd(value: unknown, fractionDigits = 2): string {
   const num = Number(value);
-  if (!Number.isFinite(num) || num <= 0) return '0';
-  return num.toLocaleString([], { minimumFractionDigits: 0, maximumFractionDigits: maxFractionDigits });
+  if (!Number.isFinite(num) || num <= 0) return '0.00';
+  return num.toLocaleString([], { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits });
 }
 
 export function getMyrmecochoryLabel(indexBase = 0): string {

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -918,9 +918,6 @@ function compactTokensFromFormatted(formatted: string): string {
 function compactUsd(raw: string): string {
   const n = Number(raw);
   if (!Number.isFinite(n)) return `$${raw}`;
-  if (n === 0) return '$0.00';
-  if (n < 0.01) return `$${n.toFixed(4)}`;
-  if (n < 1) return `$${n.toFixed(3)}`;
   return `$${n.toFixed(2)}`;
 }
 
@@ -959,6 +956,7 @@ function ChatSessionStats({
 }) {
   const hasSession = Boolean(sessionCost || sessionTokens);
   const sessionCostLabel = sessionCost ? compactUsd(sessionCost) : '$0.00';
+  const lifetimeCostLabel = lifetimeCost ? compactUsd(lifetimeCost) : '$0.00';
   const sessionTokenLabel = sessionTokens ? compactTokensFromFormatted(sessionTokens) : '0';
   const reservedMaxNum = Number(reserved);
   const sessionCostNum = Number(sessionCost);
@@ -991,7 +989,7 @@ function ChatSessionStats({
           <div className={styles.sessionStatsGroupLabel}>Current payment channel</div>
           <div className={styles.sessionStatsRow}>
             <span>Cost</span>
-            <span>{sessionCost ? `$${sessionCost}` : '—'}</span>
+            <span>{sessionCost ? sessionCostLabel : '—'}</span>
           </div>
           <div className={styles.sessionStatsRow}>
             <span>Tokens</span>
@@ -1002,7 +1000,7 @@ function ChatSessionStats({
           <div className={styles.sessionStatsGroupLabel}>All-time with peer</div>
           <div className={styles.sessionStatsRow}>
             <span>Cost</span>
-            <span>{lifetimeCost ? `$${lifetimeCost}` : '—'}</span>
+            <span>{lifetimeCost ? lifetimeCostLabel : '—'}</span>
           </div>
           <div className={styles.sessionStatsRow}>
             <span>Tokens</span>


### PR DESCRIPTION
## Summary

Fixes #314 by limiting user-facing desktop wallet/session USD amounts to exactly 2 decimal places.

## Changes

- Update desktop `compactUsd()` to always render valid USD numbers with `.toFixed(2)`.
- Format session and lifetime cost values in the ChatView usage popover instead of rendering raw strings.
- Change shared desktop chat `formatUsd()` default formatting to 2 fraction digits.

## Verification

- `pnpm --filter=@antseed/desktop run typecheck:renderer`
- `pnpm --filter=@antseed/desktop run build:renderer`

## Scope

This PR intentionally only touches the desktop app files called out in #314.
