### PR TITLE
feat(desktop): Filter Discover peers below 20 on-chain channels by default

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.tsx
@@ -21,7 +21,7 @@ function formatPriceLabel(value: number, max: number): string {
 
 function formatChannelsLabel(value: number): string {
   if (value <= 0) return 'Any';
-  return `${value}+ channels`;
+  return `${value}+`;
 }
 
 const TIME_WINDOW_OPTIONS: ReadonlyArray<{ value: TimeWindow; label: string }> = [
@@ -147,7 +147,7 @@ export const DiscoverFilters = memo(function DiscoverFilters({ filters }: Props)
       {/* On-chain channel count: simple proxy for whether a peer has a track record. */}
       <div className={styles.field}>
         <div className={styles.sliderHeader}>
-          <span className={styles.label}>On-chain channels</span>
+          <span className={styles.label}>channels</span>
           <span className={styles.sliderValue}>{formatChannelsLabel(filters.minOnChainChannels)}</span>
         </div>
         <div className={styles.sliderWrapper}>

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.tsx
@@ -4,7 +4,7 @@ import { getTagOutlineTint } from '../../../core/peer-utils';
 import {
   MAX_INPUT_PRICE_SLIDER_USD, INPUT_PRICE_SLIDER_STEP,
   MAX_OUTPUT_PRICE_SLIDER_USD, OUTPUT_PRICE_SLIDER_STEP,
-  MAX_VOLUME_SLIDER_USDC, VOLUME_SLIDER_STEP,
+  MAX_CHANNELS_SLIDER, CHANNELS_SLIDER_STEP,
   type TimeWindow,
 } from './discover-filter-util';
 import styles from './DiscoverFilters.module.scss';
@@ -19,14 +19,9 @@ function formatPriceLabel(value: number, max: number): string {
   return `Up to $${value.toFixed(2)}/M`;
 }
 
-function formatVolumeLabel(value: number): string {
+function formatChannelsLabel(value: number): string {
   if (value <= 0) return 'Any';
-  if (value >= 1_000) {
-    const k = value / 1_000;
-    const str = k % 1 === 0 ? k.toFixed(0) : k.toFixed(1);
-    return `$${str}K+`;
-  }
-  return `$${value}+`;
+  return `${value}+ channels`;
 }
 
 const TIME_WINDOW_OPTIONS: ReadonlyArray<{ value: TimeWindow; label: string }> = [
@@ -149,21 +144,21 @@ export const DiscoverFilters = memo(function DiscoverFilters({ filters }: Props)
         </div>
       </div>
 
-      {/* Min volume served slider */}
+      {/* On-chain channel count: simple proxy for whether a peer has a track record. */}
       <div className={styles.field}>
         <div className={styles.sliderHeader}>
-          <span className={styles.label}>Volume served</span>
-          <span className={styles.sliderValue}>{formatVolumeLabel(filters.minVolumeUsdc)}</span>
+          <span className={styles.label}>On-chain channels</span>
+          <span className={styles.sliderValue}>{formatChannelsLabel(filters.minOnChainChannels)}</span>
         </div>
         <div className={styles.sliderWrapper}>
           <input
             type="range"
             className={styles.slider}
             min={0}
-            max={MAX_VOLUME_SLIDER_USDC}
-            step={VOLUME_SLIDER_STEP}
-            value={filters.minVolumeUsdc}
-            onChange={(e) => filters.setMinVolumeUsdc(Number(e.target.value))}
+            max={MAX_CHANNELS_SLIDER}
+            step={CHANNELS_SLIDER_STEP}
+            value={filters.minOnChainChannels}
+            onChange={(e) => filters.setMinOnChainChannels(Number(e.target.value))}
           />
         </div>
       </div>

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -8,13 +8,14 @@ import {
   type DiscoverSortKey,
   MAX_INPUT_PRICE_SLIDER_USD,
   MAX_OUTPUT_PRICE_SLIDER_USD,
+  DEFAULT_MIN_ON_CHAIN_CHANNELS,
 } from './discover-filter-util';
 import { DiscoverFilters } from './DiscoverFilters';
 import { getPeerGradient, getPeerDisplayName, formatPerMillionPrice, getTagTint } from '../../../core/peer-utils';
 import styles from './DiscoverWelcome.module.scss';
 
 const SORT_OPTIONS: Array<{ key: DiscoverSortKey; label: string }> = [
-  { key: 'volumeDesc',      label: 'Most volume' },
+  { key: 'channelsDesc',    label: 'Most channels' },
   { key: 'recentlyUsed',    label: 'Recently used' },
   { key: 'serviceAsc',      label: 'Name A–Z' },
   { key: 'serviceDesc',     label: 'Name Z–A' },
@@ -244,7 +245,7 @@ export function DiscoverWelcome({ serviceOptions, onStartChatting }: DiscoverWel
     filterState.minStakeUsdc > 0 ||
     filterState.lastSeenWindow !== 'any' ||
     filterState.lastSettledWindow !== 'any' ||
-    filterState.minVolumeUsdc > 0;
+    filterState.minOnChainChannels !== DEFAULT_MIN_ON_CHAIN_CHANNELS;
 
   const hasNetworkData = serviceOptions.length > 0 || rows.length > 0;
   const cards = useMemo(() => {
@@ -269,7 +270,7 @@ export function DiscoverWelcome({ serviceOptions, onStartChatting }: DiscoverWel
     filterState.minStakeUsdc,
     filterState.lastSeenWindow,
     filterState.lastSettledWindow,
-    filterState.minVolumeUsdc,
+    filterState.minOnChainChannels,
     filterState.sortKey,
   ]);
 

--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.test.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.test.ts
@@ -4,7 +4,7 @@ import {
   matchesSearch, matchesMaxInputPrice, matchesMaxOutputPrice,
   matchesMinStake,
   matchesLastSeen, matchesLastSettled,
-  matchesMinVolume,
+  matchesMinChannels, rowChannelCount,
   applyFilters, applySort, paginate, totalPagesFor,
   MAX_INPUT_PRICE_SLIDER_USD, MAX_OUTPUT_PRICE_SLIDER_USD,
 } from './discover-filter-util';
@@ -84,11 +84,19 @@ test('matchesLastSettled uses onChainLastSettledAt in seconds', () => {
   assert.ok(!matchesLastSettled(mkRow({ onChainLastSettledAt: monthAgoSec }), 'month', nowMs));
 });
 
-test('matchesMinVolume compares base-6 USDC bigint to slider value', () => {
-  assert.ok(matchesMinVolume(mkRow({ onChainTotalVolumeUsdc: '10000000' }), 10));
-  assert.ok(!matchesMinVolume(mkRow({ onChainTotalVolumeUsdc: '9999999' }), 10));
-  assert.ok(matchesMinVolume(mkRow({ onChainTotalVolumeUsdc: '0' }), 0));
-  assert.ok(!matchesMinVolume(mkRow({ onChainTotalVolumeUsdc: '0' }), 1));
+test('rowChannelCount uses the larger of active vs metadata channel count', () => {
+  assert.equal(rowChannelCount(mkRow({ onChainActiveChannelCount: 20 })), 20);
+  assert.equal(rowChannelCount(mkRow({ onChainActiveChannelCount: 0, onChainChannelCount: 25 })), 25);
+  assert.equal(rowChannelCount(mkRow({ onChainActiveChannelCount: 5, onChainChannelCount: 8 })), 8);
+  assert.equal(rowChannelCount(mkRow({ onChainActiveChannelCount: 0, onChainChannelCount: null })), 0);
+});
+
+test('matchesMinChannels gates rows by channel-count threshold', () => {
+  assert.ok(matchesMinChannels(mkRow({ onChainActiveChannelCount: 20 }), 20));
+  assert.ok(matchesMinChannels(mkRow({ onChainActiveChannelCount: 0, onChainChannelCount: 25 }), 20));
+  assert.ok(!matchesMinChannels(mkRow({ onChainActiveChannelCount: 5, onChainChannelCount: 8 }), 20));
+  // A threshold of zero always passes, regardless of on-chain state
+  assert.ok(matchesMinChannels(mkRow({ onChainActiveChannelCount: 0, onChainChannelCount: null }), 0));
 });
 
 test('applyFilters composes all predicates', () => {
@@ -103,10 +111,20 @@ test('applyFilters composes all predicates', () => {
     chattedOnly: false,
     minStakeUsdc: 0,
     lastSeenWindow: 'any', lastSettledWindow: 'any',
-    minVolumeUsdc: 0,
+    minOnChainChannels: 0,
   });
   assert.equal(filtered.length, 1);
   assert.equal(filtered[0]!.serviceLabel, 'B');
+});
+
+test('applySort channelsDesc orders by channel count', () => {
+  const rows = [
+    mkRow({ serviceLabel: 'A', onChainActiveChannelCount: 5 }),
+    mkRow({ serviceLabel: 'B', onChainActiveChannelCount: 50 }),
+    mkRow({ serviceLabel: 'C', onChainActiveChannelCount: 20 }),
+  ];
+  const sorted = applySort(rows, 'channelsDesc', 'desc');
+  assert.deepEqual(sorted.map((r) => r.serviceLabel), ['B', 'C', 'A']);
 });
 
 test('applySort recentlyUsed floats chatted-with rows, then by lastSession desc', () => {

--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
@@ -5,16 +5,24 @@ export type DiscoverSortKey =
   | 'serviceAsc' | 'serviceDesc'
   | 'priceAsc' | 'priceDesc'
   | 'stakeDesc'
-  | 'volumeDesc'
+  | 'channelsDesc'
   | 'lastSettledDesc';
 
 export const MAX_INPUT_PRICE_SLIDER_USD = 3;
 export const INPUT_PRICE_SLIDER_STEP = 0.1;
 export const MAX_OUTPUT_PRICE_SLIDER_USD = 3;
 export const OUTPUT_PRICE_SLIDER_STEP = 0.1;
-export const MAX_VOLUME_SLIDER_USDC = 100;
-export const VOLUME_SLIDER_STEP = 5;
 export const MAX_STAKE_SLIDER_USDC = 1000;
+
+export const MAX_CHANNELS_SLIDER = 200;
+export const CHANNELS_SLIDER_STEP = 5;
+
+/**
+ * Default minimum on-chain channel count for Discover. 20 hides brand-new peers
+ * that haven't accumulated a track record while still showing modestly-active ones.
+ * Users can lower the slider to 0 to see every peer.
+ */
+export const DEFAULT_MIN_ON_CHAIN_CHANNELS = 20;
 
 export type TimeWindow = 'any' | 'today' | 'week' | 'month';
 
@@ -28,13 +36,8 @@ export type DiscoverFilterInputs = {
   lastSeenWindow: TimeWindow;
   lastSettledWindow: TimeWindow;
   minStakeUsdc: number;
-  minVolumeUsdc: number;
+  minOnChainChannels: number;
 };
-
-function parseBigintSafe(value: string | null | undefined): bigint {
-  if (!value) return 0n;
-  try { return BigInt(value); } catch { return 0n; }
-}
 
 export function hasBeenUsed(row: DiscoverRow): boolean {
   return row.lifetimeRequests > 0
@@ -113,11 +116,20 @@ export function matchesLastSettled(row: DiscoverRow, window: TimeWindow, nowMs?:
   return matchesTimeWindow(row.onChainLastSettledAt, window, 'sec', nowMs);
 }
 
-export function matchesMinVolume(row: DiscoverRow, minVolumeUsdc: number): boolean {
-  if (minVolumeUsdc <= 0) return true;
-  const volume = parseBigintSafe(row.onChainTotalVolumeUsdc);
-  const threshold = BigInt(Math.floor(minVolumeUsdc * 1_000_000));
-  return volume >= threshold;
+/**
+ * Effective on-chain channel count for a peer. Prefers the live value from
+ * AntseedChannels.getAgentStats; falls back to the peer-metadata count while
+ * chain stats haven't loaded yet.
+ */
+export function rowChannelCount(row: DiscoverRow): number {
+  const active = row.onChainActiveChannelCount ?? 0;
+  const meta = row.onChainChannelCount ?? 0;
+  return Math.max(active, meta);
+}
+
+export function matchesMinChannels(row: DiscoverRow, minChannels: number): boolean {
+  if (minChannels <= 0) return true;
+  return rowChannelCount(row) >= minChannels;
 }
 
 export function applyFilters(rows: DiscoverRow[], inputs: DiscoverFilterInputs): DiscoverRow[] {
@@ -132,7 +144,7 @@ export function applyFilters(rows: DiscoverRow[], inputs: DiscoverFilterInputs):
     && matchesMinStake(row, inputs.minStakeUsdc)
     && matchesLastSeen(row, inputs.lastSeenWindow, nowMs)
     && matchesLastSettled(row, inputs.lastSettledWindow, nowMs)
-    && matchesMinVolume(row, inputs.minVolumeUsdc)
+    && matchesMinChannels(row, inputs.minOnChainChannels)
   );
 }
 
@@ -165,8 +177,8 @@ export function applySort(rows: DiscoverRow[], key: DiscoverSortKey, dir: 'asc' 
         return priceOf(a) - priceOf(b);
       case 'stakeDesc':
         return Number(BigInt(b.stakeUsdc) - BigInt(a.stakeUsdc));
-      case 'volumeDesc': {
-        const diff = Number(BigInt(b.onChainTotalVolumeUsdc) - BigInt(a.onChainTotalVolumeUsdc));
+      case 'channelsDesc': {
+        const diff = rowChannelCount(b) - rowChannelCount(a);
         if (diff !== 0) return diff;
         return priceOf(a) - priceOf(b);
       }

--- a/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.test.ts
+++ b/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.test.ts
@@ -32,7 +32,7 @@ test('pipeline: filter → sort → paginate on 25 rows', () => {
     chattedOnly: true,
     minStakeUsdc: 0,
     lastSeenWindow: 'any', lastSettledWindow: 'any',
-    minVolumeUsdc: 0,
+    minOnChainChannels: 0,
   });
   assert.equal(filtered.length, 9);
   const sorted = applySort(filtered, 'recentlyUsed', 'desc');
@@ -51,7 +51,7 @@ test('pipeline: chattedOnly + stake filter', () => {
     chattedOnly: true,
     minStakeUsdc: 50,
     lastSeenWindow: 'any', lastSettledWindow: 'any',
-    minVolumeUsdc: 0,
+    minOnChainChannels: 0,
   });
   assert.equal(filtered.length, 1);
   assert.equal(filtered[0]!.serviceLabel, 'Svc50');

--- a/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.ts
+++ b/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.ts
@@ -2,8 +2,9 @@ import { useMemo, useState, useCallback } from 'react';
 import type { DiscoverRow } from '../../core/state';
 import { getPeerGradient } from '../../core/peer-utils';
 import {
-  applyFilters, applySort,
+  applyFilters, applySort, rowChannelCount,
   MAX_INPUT_PRICE_SLIDER_USD, MAX_OUTPUT_PRICE_SLIDER_USD,
+  DEFAULT_MIN_ON_CHAIN_CHANNELS,
   type DiscoverSortKey, type TimeWindow,
 } from '../components/chat/discover-filter-util';
 
@@ -24,7 +25,7 @@ export type DiscoverFilterState = {
   minStakeUsdc: number;
   lastSeenWindow: TimeWindow;
   lastSettledWindow: TimeWindow;
-  minVolumeUsdc: number;
+  minOnChainChannels: number;
   sortKey: DiscoverSortKey;
 
   sortedRows: DiscoverRow[];
@@ -40,7 +41,7 @@ export type DiscoverFilterState = {
   setMinStakeUsdc: (v: number) => void;
   setLastSeenWindow: (v: TimeWindow) => void;
   setLastSettledWindow: (v: TimeWindow) => void;
-  setMinVolumeUsdc: (v: number) => void;
+  setMinOnChainChannels: (v: number) => void;
   setSortKey: (k: DiscoverSortKey) => void;
   resetAll: () => void;
 };
@@ -55,8 +56,8 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
   const [minStakeUsdc, setMinStakeUsdc] = useState<number>(0);
   const [lastSeenWindow, setLastSeenWindow] = useState<TimeWindow>('any');
   const [lastSettledWindow, setLastSettledWindow] = useState<TimeWindow>('any');
-  const [minVolumeUsdc, setMinVolumeUsdc] = useState<number>(0);
-  const [sortKey, setSortKey] = useState<DiscoverSortKey>('volumeDesc');
+  const [minOnChainChannels, setMinOnChainChannels] = useState<number>(DEFAULT_MIN_ON_CHAIN_CHANNELS);
+  const [sortKey, setSortKey] = useState<DiscoverSortKey>('channelsDesc');
 
   const toggleCategory = useCallback((cat: string) => {
     setCategorySet((prev) => {
@@ -87,8 +88,8 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
     setMinStakeUsdc(0);
     setLastSeenWindow('any');
     setLastSettledWindow('any');
-    setMinVolumeUsdc(0);
-    setSortKey('volumeDesc');
+    setMinOnChainChannels(DEFAULT_MIN_ON_CHAIN_CHANNELS);
+    setSortKey('channelsDesc');
   }, []);
 
   const availableCategories = useMemo(() => {
@@ -98,24 +99,36 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
   }, [rows]);
 
   const availablePeers = useMemo<DiscoverPeerOption[]>(() => {
-    const seen = new Map<string, DiscoverPeerOption>();
+    // One entry per peer, ranked by on-chain channel count so trusted peers float
+    // to the top of the sidebar and brand-new peers sink to the bottom. Channel
+    // count is per-peer, so any row for a given peer produces the same score.
+    const seen = new Map<string, { opt: DiscoverPeerOption; score: number; label: string }>();
     for (const r of rows) {
       if (!r.peerId || seen.has(r.peerId)) continue;
       const label = r.peerDisplayName?.trim() || r.peerLabel?.trim() || r.peerId;
       const gradient = getPeerGradient(r.peerId || r.peerLabel || r.provider || r.serviceId);
       const letter = (label || '?').charAt(0).toUpperCase();
-      seen.set(r.peerId, { peerId: r.peerId, label, letter, gradient });
+      seen.set(r.peerId, {
+        opt: { peerId: r.peerId, label, letter, gradient },
+        score: rowChannelCount(r),
+        label,
+      });
     }
-    return Array.from(seen.values()).sort((a, b) => a.label.localeCompare(b.label));
+    return Array.from(seen.values())
+      .sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score;
+        return a.label.localeCompare(b.label);
+      })
+      .map((e) => e.opt);
   }, [rows]);
 
   const filteredRows = useMemo(
     () => applyFilters(rows, {
       search, categorySet, peerSet, maxInputPrice, maxOutputPrice, chattedOnly, minStakeUsdc,
-      lastSeenWindow, lastSettledWindow, minVolumeUsdc,
+      lastSeenWindow, lastSettledWindow, minOnChainChannels,
     }),
     [rows, search, categorySet, peerSet, maxInputPrice, maxOutputPrice, chattedOnly, minStakeUsdc,
-      lastSeenWindow, lastSettledWindow, minVolumeUsdc],
+      lastSeenWindow, lastSettledWindow, minOnChainChannels],
   );
 
   const sortedRows = useMemo(
@@ -133,7 +146,7 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
     minStakeUsdc,
     lastSeenWindow,
     lastSettledWindow,
-    minVolumeUsdc,
+    minOnChainChannels,
     sortKey,
 
     sortedRows,
@@ -149,7 +162,7 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
     setMinStakeUsdc,
     setLastSeenWindow,
     setLastSettledWindow,
-    setMinVolumeUsdc,
+    setMinOnChainChannels,
     setSortKey,
     resetAll,
   };


### PR DESCRIPTION
## Description

Discover used to surface every peer announced on the network, including brand-new peers with no track record that often fail to serve the request. This adds an "On-chain channels" filter (default `20+`) and a "Most channels" sort (now the default), so trusted peers float to the top of both the service grid and the sidebar peer list, and untested peers can be opted in via the slider.

## Behavior

- New filter `minOnChainChannels` (default `20`, slider 0–200, step 5) gates rows by `max(onChainActiveChannelCount, onChainChannelCount)`.
- New sort key `channelsDesc` ("Most channels"), now the default. Sidebar peer list is ranked by channel count instead of alphabetically.
- "Reset all" returns to the new defaults.
- The filter-trigger dot only lights up when the user has changed the channel-count threshold from `20`.

## Files

- `apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts` — `rowChannelCount`, `matchesMinChannels`, `channelsDesc` sort, constants `MAX_CHANNELS_SLIDER` / `CHANNELS_SLIDER_STEP` / `DEFAULT_MIN_ON_CHAIN_CHANNELS`.
- `apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.ts` — wires `minOnChainChannels` state and ranks `availablePeers` by channel count.
- `apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.tsx` — new "On-chain channels" slider.
- `apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx` — "Most channels" added to sort dropdown; active-filter check and page-reset deps updated.
- Tests updated/added for `rowChannelCount`, `matchesMinChannels`, `applySort 'channelsDesc'`.

## Verification

- \`npm run typecheck:renderer\` passes.
- \`npm run build:main\` passes.
- Against a representative \`buyer.state.json\`: top-of-list becomes The Seeder (160), Dark Signal (47), SecretAI (24), Open Forge (22); peers with <20 channels (Prime Seed at 5, Chaotic PM at 2) are filtered out by default and reappear when the slider is dragged to 0.