### PR TITLE
fix(buyer): make `connection set` reach the running daemon; require explicit peer pin in docs

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http'
 import { randomUUID } from 'node:crypto'
-import { watch, type FSWatcher } from 'node:fs'
+import { watchFile, unwatchFile } from 'node:fs'
 import { readFile, writeFile, rename, mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import type {
@@ -294,9 +294,9 @@ export class BuyerProxy {
   private readonly _peerCacheTtlMs: number
   private readonly _stateDir: string
   private readonly _stateFile: string
+  private _stateFileWatching = false
   private _pinnedPeer: string | null
   private _pinnedService: string | null
-  private _stateFileWatcher: FSWatcher | null = null
   private _stateWatchDebounce: ReturnType<typeof setTimeout> | null = null
 
   private _stateWriteChain: Promise<void> = Promise.resolve()
@@ -334,6 +334,12 @@ export class BuyerProxy {
     // startup route from the warm cache without blocking on DHT discovery.
     // The background refresh still runs to pick up fresh peers and IP changes.
     await this._hydratePeersFromStateFile()
+    // If the CLI didn't pass --peer/--service, adopt whatever a previous
+    // `antseed buyer connection set` wrote to buyer.state.json so the pin
+    // survives daemon restart.
+    if (this._pinnedPeer === null && this._pinnedService === null) {
+      await this._reloadSessionOverrides()
+    }
     await new Promise<void>((resolve, reject) => {
       this._server.once('error', reject)
       this._server.listen(this._port, '127.0.0.1', () => {
@@ -377,9 +383,9 @@ export class BuyerProxy {
       clearTimeout(this._stateWatchDebounce)
       this._stateWatchDebounce = null
     }
-    if (this._stateFileWatcher) {
-      this._stateFileWatcher.close()
-      this._stateFileWatcher = null
+    if (this._stateFileWatching) {
+      unwatchFile(this._stateFile)
+      this._stateFileWatching = false
     }
     if (this._bgRefreshHandle) {
       clearInterval(this._bgRefreshHandle)
@@ -392,17 +398,21 @@ export class BuyerProxy {
   }
 
   private _watchStateFile(): void {
+    // Use watchFile (stat polling) rather than watch(): we rewrite
+    // buyer.state.json via rename(tmp, stateFile), and fs.watch on Linux is
+    // bound to the original inode — after the atomic rename it stops firing,
+    // silently breaking `antseed buyer connection set`. watchFile compares
+    // stat each tick and works across inode replacement.
     try {
-      this._stateFileWatcher = watch(this._stateFile, { persistent: false }, () => {
+      watchFile(this._stateFile, { persistent: false, interval: 1000 }, (curr, prev) => {
+        if (curr.mtimeMs === prev.mtimeMs && curr.ino === prev.ino) return
         if (this._stateWatchDebounce) clearTimeout(this._stateWatchDebounce)
         this._stateWatchDebounce = setTimeout(() => {
           this._stateWatchDebounce = null
           void this._reloadSessionOverrides().catch(() => {})
         }, 50)
       })
-      this._stateFileWatcher.on('error', () => {
-        // watcher error is non-fatal
-      })
+      this._stateFileWatching = true
     } catch {
       // watcher setup failed; non-fatal
     }

--- a/apps/website/docs/faq.md
+++ b/apps/website/docs/faq.md
@@ -77,7 +77,7 @@ AntSeed automatically detects provider failures and reroutes to the next best sp
 
 ### Do I need to sign up or create an account?
 
-No account required. Install the CLI, run `antseed buyer start`, and you are live on the network. Any tool that speaks the OpenAI API format works immediately.
+No account required. Install the CLI, run `antseed buyer start`, pick a peer with `antseed network browse` + `antseed buyer connection set --peer <peerId>`, and you are live on the network. Any tool that speaks the OpenAI API format works immediately.
 
 ### How do I install AntSeed?
 

--- a/apps/website/docs/guides/using-the-api.md
+++ b/apps/website/docs/guides/using-the-api.md
@@ -22,10 +22,16 @@ export ANTSEED_IDENTITY_HEX=<your-private-key-hex>
 antseed buyer start
 # Proxy listening on http://localhost:8377
 
-# 4. Deposit USDC when you want to pay providers
+# 4. Pick a peer to route through
+antseed network browse                              # list peers + services
+antseed buyer connection set --peer <40-char-hex>   # pin one
+
+# 5. Deposit USDC when you want to pay providers
 antseed payments
 # Open http://localhost:3118, connect a funded wallet, deposit USDC
 ```
+
+Until a peer is pinned, every request returns `no_peer_pinned` — there is no auto-selection. See [Pick a peer](#pick-a-peer) below.
 
 `antseed buyer start` does not require a pre-existing `~/.antseed/config.json`. If the file is missing, the CLI starts with built-in defaults such as router `local` and proxy port `8377`.
 
@@ -107,45 +113,37 @@ curl http://localhost:8377/v1/chat/completions \
   }'
 ```
 
+## Pick a peer
+
+The buyer proxy does not auto-select peers. Every request returns `no_peer_pinned` until you pin one — this keeps routing predictable and puts pricing/quality choice in your hands.
+
+```bash
+# List peers and the services each one offers
+antseed network browse
+
+# Inspect one peer in detail (pricing, protocols, on-chain stats)
+antseed network peer <40-char-hex-peer-id>
+
+# Pin a peer for the session (survives daemon restart)
+antseed buyer connection set --peer <40-char-hex-peer-id>
+
+# Pin a service too — overrides the `model` field in all requests
+antseed buyer connection set --service claude-opus-4-6
+
+# Clear pins
+antseed buyer connection clear
+```
+
+You can also pin per-request by sending the `x-antseed-pin-peer: <peerId>` header — useful when different calls should go to different peers.
+
 ## How Routing Works
 
 When you send a request:
 
-1. The proxy extracts the `model` field as the service name
-2. The router queries the DHT for peers offering that service
-3. Peers are scored by price, latency, capacity, and reputation
-4. The request is forwarded to the best peer via encrypted WebRTC
-5. The response streams back through the proxy
-
-If a peer fails or is unavailable, the router retries with the next best peer.
-
-## Session Overrides
-
-Pin requests to a specific service or peer without restarting:
-
-```bash
-# Pin to a service (overrides the model field in all requests)
-antseed buyer connection set --service claude-opus-4-6
-
-# Pin to a specific peer
-antseed buyer connection set --peer <40-char-hex-peer-id>
-
-# Check current overrides
-antseed buyer connection get
-
-# Clear overrides
-antseed buyer connection clear
-```
-
-## Browse Available Services
-
-See what's available on the network before connecting:
-
-```bash
-antseed network browse
-```
-
-This shows all discoverable providers, their services, pricing, and capacity.
+1. The proxy verifies a peer is pinned; if not, it returns `no_peer_pinned`.
+2. It checks the pinned peer's metadata for the requested `model` (the service name).
+3. The request is forwarded to that peer via encrypted WebRTC.
+4. The response streams back through the proxy.
 
 ## No API Key Needed
 

--- a/skills/hermes-antseed/SKILL.md
+++ b/skills/hermes-antseed/SKILL.md
@@ -173,6 +173,22 @@ Give the user `http://127.0.0.1:3118/?token=<hex>` (the URL from the portal log)
 
 If `ssh -L` fails with `channel 1: open failed: administratively prohibited`, the remote sshd has `AllowTcpForwarding no`. Enable it in `/etc/ssh/sshd_config` (or a drop-in under `/etc/ssh/sshd_config.d/`), run `sudo sshd -t` to validate, then `sudo systemctl reload sshd`. Existing SSH sessions are not dropped by the reload.
 
+## Pick a peer
+
+The buyer proxy does not auto-select peers. Every request is rejected with `no_peer_pinned` until a peer is pinned — you must pick one explicitly.
+
+List the network, find a peer that serves the model you want, and pin it:
+
+```bash
+antseed network browse                              # table of peers and their services
+antseed network peer <peerId>                       # full details for one peer
+antseed buyer connection set --peer <peerId>        # pin it for this session
+```
+
+Alternatively, pass `x-antseed-pin-peer: <peerId>` as a per-request header if the caller can inject headers.
+
+For persistent systemd deployments, put `--peer <peerId>` in the `ExecStart=` line instead — it survives restarts and avoids a stale state file.
+
 ## Wiring Hermes to the buyer proxy
 
 Register AntSeed as a custom provider in `~/.hermes/config.yaml` and point `model.default` at an AntSeed service ID. Hermes reads this file at startup; nothing needs to be in `.env` for the AntSeed route itself.
@@ -205,7 +221,7 @@ Notes:
 
 ### Swapping the routed model
 
-Edit `model.default` (and the `models` list if needed) and restart the Hermes systemd unit — the buyer proxy stays up, no CLI change, no contract call:
+If you switch to a model the currently-pinned peer doesn't serve, re-pin to a peer that does (`antseed network browse` → `antseed buyer connection set --peer <peerId>`) before the next request. Then edit `model.default` (and the `models` list if needed) and restart the Hermes systemd unit — the buyer proxy stays up, no CLI change, no contract call:
 
 ```bash
 sudo systemctl restart hermes

--- a/skills/join-buyer/SKILL.md
+++ b/skills/join-buyer/SKILL.md
@@ -198,15 +198,17 @@ response = client.chat.completions.create(
 
 The API key value doesn't matter when going through the proxy — set it to any non-empty string.
 
-## Step 10: Browse available services
+## Step 10: Browse available services and pick a peer
 
-Before connecting, or while connected, browse what's available on the network:
+The buyer proxy does not auto-select peers — every request returns `no_peer_pinned` until you pin one. Browse the network, pick a peer that offers the service you want, and pin it:
 
 ```bash
-antseed network browse
+antseed network browse                              # peers + their services
+antseed network peer <peerId>                       # full pricing/metadata for one peer
+antseed buyer connection set --peer <peerId>        # pin for this session (survives restart)
 ```
 
-This shows available peers, their services, pricing, and reputation.
+Or pass `x-antseed-pin-peer: <peerId>` as a per-request header if the caller can inject headers.
 
 ## Step 11: Monitor usage
 
@@ -248,6 +250,7 @@ All signing happens with the identity key. No additional wallets or browser exte
 
 - **"Payment setup failed"**: Check `antseed buyer balance` — you need deposited USDC. Run `antseed buyer deposit <amount>`.
 - **"No peers found"**: The network may be sparse. Try `antseed network browse` to check. Add bootstrap nodes to config if needed.
+- **`no_peer_pinned`**: Pin a peer with `antseed buyer connection set --peer <peerId>` (see Step 10) or send the `x-antseed-pin-peer` header.
 - **"Lock confirmation timed out"**: The provider's on-chain reserve is slow. This is usually a testnet issue — retry the request.
 - **"Connection refused on 8377"**: Make sure `antseed buyer start` is still running.
 - **Tool says "invalid API key"**: Set the API key env var to any non-empty value (e.g., `antseed`).


### PR DESCRIPTION
## Summary

- `antseed buyer connection set --peer <id>` wrote `buyer.state.json` but the running daemon didn't pick up the change. Root cause: `fs.watch` on Linux is bound to the original inode, and our state writer replaces the inode via `rename(tmp, stateFile)`. After the first write, the watcher silently stops firing.
- A daemon restart didn't rescue the pin either: `start.ts` only adopts `--peer`, and `_hydratePeersFromStateFile` never looked at `pinnedPeerId` / `pinnedService`.
- Hit in production on the Hermes buyer box (52.210.48.107) after upgrading to @antseed/cli v0.1.96 — `connection set` appeared to succeed but every request still returned `no_peer_pinned`.

## Fix

- `apps/cli/src/proxy/buyer-proxy.ts`
  - Swap `fs.watch` → `fs.watchFile` (stat polling, 1s interval). Survives inode replacement; still debounced by 50ms so bursty writes collapse to one reload.
  - On `start()`, if the CLI didn't pass `--peer` / `--service`, adopt whatever `buyer.state.json` has so a prior `connection set` survives restart.

## Docs

Auto-selection is disabled in the current CLI — this wasn't loud enough in the docs. Updated:

- `apps/website/docs/guides/using-the-api.md` — Quick Start now includes peer-pin step; rewrote "How Routing Works" and replaced "Session Overrides" with a clearer "Pick a peer" section.
- `apps/website/docs/faq.md` — "live on the network" answer now mentions `network browse` + `connection set --peer`.
- `skills/hermes-antseed/SKILL.md` — new "Pick a peer" section before the Hermes wiring section; "Swapping the routed model" now reminds users to re-pin if the new model isn't on the pinned peer.
- `skills/join-buyer/SKILL.md` — Step 10 renamed "Browse available services and pick a peer"; added `no_peer_pinned` troubleshooting entry.

## Test plan

- [x] `pnpm --filter=@antseed/cli run typecheck` — passes
- [x] `pnpm run typecheck` (full workspace) — passes
- [x] `pnpm --filter=@antseed/cli test` — 67/67 pass
- [ ] Manual: on a running buyer daemon, run `antseed buyer connection set --peer <id>` and confirm the next request routes without a restart (previously required restart with `--peer` flag).
- [ ] Manual: restart the daemon without `--peer` and confirm the pin is re-adopted from `buyer.state.json`.