### PR TITLE
fix(desktop): Gate image attachments on multimodal tag

### DIFF
--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -1119,6 +1119,7 @@ function makeProxyService(
   providerHint?: string | null,
   preferredPeerId?: string | null,
   spendingAuth?: string | null,
+  supportsMultimodal: boolean = false,
 ): Model<any> {
   const headers: Record<string, string> = {};
   if (providerHint) headers['x-antseed-provider'] = providerHint;
@@ -1128,13 +1129,19 @@ function makeProxyService(
   // The OpenAI SDK appends API paths (e.g. /responses, /chat/completions)
   // to baseUrl, so include /v1 to match the buyer proxy's expected paths.
   const needsV1 = protocol === 'openai-responses' || protocol === 'openai-chat-completions';
+  // Image input is only enabled when the selected service advertises the
+  // `multimodal` category tag. Otherwise we declare the model as text-only so
+  // pi-ai strips image blocks before hitting the wire (upstream providers
+  // return errors like "Multimodal is not supported for model" for text-only
+  // LLMs even when the provider catalog lists vision-capable siblings).
+  const inputModalities: ('text' | 'image')[] = supportsMultimodal ? ['text', 'image'] : ['text'];
   const base = {
     id: serviceId,
     name: serviceId,
     provider: PROXY_PROVIDER_ID,
     baseUrl: needsV1 ? `http://127.0.0.1:${port}/v1` : `http://127.0.0.1:${port}`,
     reasoning: true,
-    input: ['text', 'image'] as ('text' | 'image')[],
+    input: inputModalities,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: 200_000,
     maxTokens: 16_384,
@@ -1809,7 +1816,38 @@ export function registerPiChatHandlers({
       providerOverride,
     );
     const protocol = await resolveProtocolForSend(serviceId);
-    const proxyModel = makeProxyService(serviceId, proxyPort, protocol, providerHint, preferredPeerId, null);
+    // Determine vision support from the catalog entry for this (service, peer)
+    // pair. We look for a `multimodal` category tag; sellers announce this via
+    // serviceCategories in their peer metadata. Absent catalog info, we fall
+    // back to text-only so we never blindly forward images to a model whose
+    // upstream will reject them (DeepInfra, for example, returns
+    // "Multimodal is not supported for model: …" for text-only LLMs).
+    const normalizedServiceForCatalog = serviceId.trim().toLowerCase();
+    const catalogEntry = lastServiceCatalogEntries.find((entry) => (
+      entry.id.trim().toLowerCase() === normalizedServiceForCatalog
+      && (!preferredPeerId || entry.peerId === preferredPeerId)
+    )) ?? lastServiceCatalogEntries.find((entry) => (
+      entry.id.trim().toLowerCase() === normalizedServiceForCatalog
+    ));
+    const supportsMultimodal = catalogEntry?.categories?.includes('multimodal') ?? false;
+    const droppedImageCount = supportsMultimodal ? 0 : attachmentImages.length;
+    if (droppedImageCount > 0) {
+      appendSystemLog(
+        `Dropping ${String(droppedImageCount)} image attachment(s): service `
+        + `"${serviceId}" is not tagged \`multimodal\` in the catalog. `
+        + 'Other attachment types (pdf/docs/text) are unaffected.',
+      );
+    }
+    const effectiveAttachmentImages = supportsMultimodal ? attachmentImages : [];
+    const proxyModel = makeProxyService(
+      serviceId,
+      proxyPort,
+      protocol,
+      providerHint,
+      preferredPeerId,
+      null,
+      supportsMultimodal,
+    );
 
     const authStorage = AuthStorage.inMemory();
     authStorage.setRuntimeApiKey(PROXY_PROVIDER_ID, PROXY_RUNTIME_API_KEY);
@@ -2166,7 +2204,7 @@ export function registerPiChatHandlers({
 
     try {
       const promptText = [trimmedMessage, attachmentPromptText].filter((part) => part.length > 0).join('\n\n');
-      await session.prompt(promptText || ' ', { images: attachmentImages.length > 0 ? attachmentImages : undefined });
+      await session.prompt(promptText || ' ', { images: effectiveAttachmentImages.length > 0 ? effectiveAttachmentImages : undefined });
 
       if (terminalStreamFailure !== null) {
         // `terminalStreamFailure` is mutated inside the subscribe callback,

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.tsx
@@ -5,6 +5,7 @@ import {
   MAX_INPUT_PRICE_SLIDER_USD, INPUT_PRICE_SLIDER_STEP,
   MAX_OUTPUT_PRICE_SLIDER_USD, OUTPUT_PRICE_SLIDER_STEP,
   MAX_CHANNELS_SLIDER, CHANNELS_SLIDER_STEP,
+  formatCategoryLabel,
   type TimeWindow,
 } from './discover-filter-util';
 import styles from './DiscoverFilters.module.scss';
@@ -94,7 +95,7 @@ export const DiscoverFilters = memo(function DiscoverFilters({ filters }: Props)
                   style={active ? undefined : getTagOutlineTint(c)}
                   onClick={() => filters.toggleCategory(c)}
                 >
-                  {c}
+                  {formatCategoryLabel(c)}
                 </button>
               );
             })}

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -9,6 +9,7 @@ import {
   MAX_INPUT_PRICE_SLIDER_USD,
   MAX_OUTPUT_PRICE_SLIDER_USD,
   DEFAULT_MIN_ON_CHAIN_CHANNELS,
+  formatCategoryLabel,
 } from './discover-filter-util';
 import { DiscoverFilters } from './DiscoverFilters';
 import { getPeerGradient, getPeerDisplayName, formatPerMillionPrice, getTagTint } from '../../../core/peer-utils';
@@ -490,7 +491,7 @@ function Card({
       <div className={styles.cardBody}>
         <div className={styles.cardTags}>
           {item.tags.map((t) => (
-            <span key={t} className={styles.tag} style={getTagTint(t)}>{t}</span>
+            <span key={t} className={styles.tag} style={getTagTint(t)}>{formatCategoryLabel(t)}</span>
           ))}
         </div>
         <div className={styles.cardName}>{item.displayName}</div>

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -15,6 +15,14 @@ import { DiscoverFilters } from './DiscoverFilters';
 import { getPeerGradient, getPeerDisplayName, formatPerMillionPrice, getTagTint } from '../../../core/peer-utils';
 import styles from './DiscoverWelcome.module.scss';
 
+/**
+ * Cap the visible tag count on Discover cards to avoid wrapping onto a
+ * second line when a service has 5+ categories (e.g. anon + chat + coding +
+ * reasoning + multimodal). Overflow is shown as a single “+N” pill whose
+ * tooltip lists the hidden tags.
+ */
+const MAX_VISIBLE_CARD_TAGS = 4;
+
 const SORT_OPTIONS: Array<{ key: DiscoverSortKey; label: string }> = [
   { key: 'channelsDesc',    label: 'Most channels' },
   { key: 'recentlyUsed',    label: 'Recently used' },
@@ -67,7 +75,7 @@ function generateDescription(serviceId: string, categories: string[], provider: 
   if (lower.includes('qwen')) return `Alibaba's Qwen model series. Multilingual and versatile.`;
   if (lower.includes('gemini') || lower.includes('gemma')) return `Google's model. Powered by ${prov}.`;
   if (lower.includes('flux') || lower.includes('sdxl')) return `Image generation model. Served by ${prov}.`;
-  if (categories.length > 0) return `${categories.join(' & ')} service powered by ${prov}.`;
+  if (categories.length > 0) return `${categories.map(formatCategoryLabel).join(' & ')} service powered by ${prov}.`;
   return `AI service powered by ${prov}.`;
 }
 
@@ -490,9 +498,19 @@ function Card({
     >
       <div className={styles.cardBody}>
         <div className={styles.cardTags}>
-          {item.tags.map((t) => (
+          {item.tags.slice(0, MAX_VISIBLE_CARD_TAGS).map((t) => (
             <span key={t} className={styles.tag} style={getTagTint(t)}>{formatCategoryLabel(t)}</span>
           ))}
+          {item.tags.length > MAX_VISIBLE_CARD_TAGS && (
+            <span
+              className={styles.tag}
+              title={item.tags.slice(MAX_VISIBLE_CARD_TAGS).map(formatCategoryLabel).join(', ')}
+              aria-label={`${item.tags.length - MAX_VISIBLE_CARD_TAGS} more categories: `
+                + item.tags.slice(MAX_VISIBLE_CARD_TAGS).map(formatCategoryLabel).join(', ')}
+            >
+              +{item.tags.length - MAX_VISIBLE_CARD_TAGS}
+            </span>
+          )}
         </div>
         <div className={styles.cardName}>{item.displayName}</div>
         <div className={styles.cardDesc}>{item.description}</div>

--- a/apps/desktop/src/renderer/ui/components/chat/ServiceDropdown.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ServiceDropdown.tsx
@@ -3,6 +3,7 @@ import { HugeiconsIcon } from '@hugeicons/react';
 import { ArrowDown01Icon } from '@hugeicons/core-free-icons';
 import type { ChatServiceOptionEntry } from '../../../core/state';
 import { formatPerMillionPrice } from '../../../core/peer-utils';
+import { formatCategoryLabel } from './discover-filter-util';
 import styles from './ServiceDropdown.module.scss';
 
 type ServiceDropdownProps = {
@@ -97,7 +98,7 @@ export function ServiceDropdown({ options, value, disabled, onChange, onFocus, o
                 {tags.length > 0 && (
                   <span className={styles.itemTags}>
                     {tags.map((t) => (
-                      <span key={t} className={styles.itemTag}>{t}</span>
+                      <span key={t} className={styles.itemTag}>{formatCategoryLabel(t)}</span>
                     ))}
                   </span>
                 )}

--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
@@ -26,6 +26,23 @@ export const DEFAULT_MIN_ON_CHAIN_CHANNELS = 20;
 
 export type TimeWindow = 'any' | 'today' | 'week' | 'month';
 
+/**
+ * Friendlier display labels for raw lowercase category tags announced by
+ * sellers. The map is deliberately small — only tags whose raw form is
+ * opaque to end users get a rewrite. Everything else passes through as-is.
+ *
+ * The underlying data (categorySet, row.categories, search matching) still
+ * uses the raw tag — this is purely a render-time convenience.
+ */
+const CATEGORY_DISPLAY_LABELS: Record<string, string> = {
+  multimodal: 'image upload',
+};
+
+export function formatCategoryLabel(category: string): string {
+  const key = category.trim().toLowerCase();
+  return CATEGORY_DISPLAY_LABELS[key] ?? category;
+}
+
 export type DiscoverFilterInputs = {
   search: string;
   categorySet: Set<string>;


### PR DESCRIPTION
## Description

Previously AntStation would forward image attachments to any selected service,
even when the upstream model is text-only. The request silently 405'd upstream
(`Multimodal is not supported for model: {inp.model}`) and the conversation
hung with no user-visible error.

This PR gates image attachments on the catalog's `multimodal` category tag:

- **`pi-chat-engine.ts`**: `makeProxyService` now derives `Model.input` from the
  selected service's categories. When the tag is absent, pi-ai's own transforms
  strip image blocks (including from replayed history) before any request hits
  the wire, so no more upstream 405. Current-turn attachment images are also
  dropped in `runStreamingPrompt` with a system-log note; PDFs / docs / text
  attachments (converted to text via `chat-attachments.ts`) are unaffected.
- **`discover-filter-util.ts`**: added `formatCategoryLabel()`, a tiny
  display-only map that renders the raw `multimodal` tag as *"image upload"*
  in the Discover filter pills, the service dropdown option tags, and the
  Discover welcome cards. The underlying data (filter sets, search matching)
  still uses the raw lowercase tag.

Seller-side tagging for our deployed peers (6 services across Open Forge and
The Seeder) lives in the private `.deployments/` repo and was rolled out
separately — the pods are already announcing the new `multimodal` categories
on the DHT.

Closes #310.

## Release Notes

- Fixed AntStation conversations hanging when an image was attached to a
  text-only model.
- Image attachments are now automatically dropped for services the peer does
  not advertise as `multimodal`; PDFs, text, and document attachments continue
  to work everywhere.
- Services advertised with the `multimodal` category tag now show an
  *"image upload"* pill in the Discover filters, service dropdown, and welcome
  cards.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes