### PR TITLE
feat(desktop): Click chat images to view fullscreen

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.module.scss
@@ -1,0 +1,204 @@
+/* AttachmentViewer.module.scss — fullscreen modal for previewing images,
+   PDFs, and text attachments in chat. */
+
+@keyframes av-backdrop-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes av-backdrop-out {
+  from { opacity: 1; }
+  to   { opacity: 0; }
+}
+
+@keyframes av-panel-in {
+  from { opacity: 0; transform: scale(0.95) translateY(8px); }
+  to   { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+@keyframes av-panel-out {
+  from { opacity: 1; transform: scale(1) translateY(0); }
+  to   { opacity: 0; transform: scale(0.95) translateY(8px); }
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9100;
+  background: rgba(0, 0, 0, 0.68);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  animation: av-backdrop-in 0.18s ease forwards;
+  -webkit-app-region: no-drag;
+}
+
+.closing {
+  animation: av-backdrop-out 0.18s ease forwards;
+
+  .panel {
+    animation: av-panel-out 0.18s ease forwards;
+  }
+}
+
+.panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  width: min(1000px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  animation: av-panel-in 0.22s cubic-bezier(0.34, 1.3, 0.64, 1) forwards;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-surface);
+  flex-shrink: 0;
+}
+
+.titleGroup {
+  flex: 1;
+  min-width: 0;
+}
+
+.name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.meta {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.downloadBtn {
+  appearance: none;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card-alt);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+
+  &:hover {
+    background: var(--bg-hover);
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+}
+
+.closeBtn {
+  appearance: none;
+  border: 0;
+  background: none;
+  color: var(--text-muted);
+  padding: 4px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.1s, background 0.1s;
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+}
+
+.body {
+  flex: 1;
+  overflow: auto;
+  background: var(--bg-primary);
+  display: flex;
+  min-height: 0;
+}
+
+.imageWrap {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  min-height: 0;
+  overflow: auto;
+}
+
+.image {
+  max-width: 100%;
+  max-height: calc(90vh - 100px);
+  object-fit: contain;
+  display: block;
+  border-radius: var(--radius-sm);
+}
+
+.pdfFrame {
+  flex: 1;
+  width: 100%;
+  min-height: 70vh;
+  border: 0;
+  background: #ffffff;
+}
+
+.textPreview {
+  flex: 1;
+  margin: 0;
+  padding: 14px 16px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: auto;
+}
+
+.emptyMsg,
+.errorMsg {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+  text-align: center;
+  font-size: 13px;
+}
+
+.emptyMsg {
+  color: var(--text-muted);
+}
+
+.errorMsg {
+  color: var(--danger);
+}

--- a/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.module.scss
@@ -1,5 +1,6 @@
-/* AttachmentViewer.module.scss — fullscreen modal for previewing images,
-   PDFs, and text attachments in chat. */
+/* AttachmentViewer.module.scss — fullscreen modal for previewing images
+   in chat. Non-image previews are planned as a follow-up (disk-backed
+   attachments rendered via a custom Electron protocol). */
 
 @keyframes av-backdrop-in {
   from { opacity: 0; }
@@ -161,27 +162,6 @@
   object-fit: contain;
   display: block;
   border-radius: var(--radius-sm);
-}
-
-.pdfFrame {
-  flex: 1;
-  width: 100%;
-  min-height: 70vh;
-  border: 0;
-  background: #ffffff;
-}
-
-.textPreview {
-  flex: 1;
-  margin: 0;
-  padding: 14px 16px;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  line-height: 1.55;
-  color: var(--text-secondary);
-  white-space: pre-wrap;
-  word-break: break-word;
-  overflow: auto;
 }
 
 .emptyMsg,

--- a/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.tsx
@@ -3,10 +3,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styles from './AttachmentViewer.module.scss';
 
 /**
- * Attachment that can be previewed. Shape is intentionally permissive so this
- * works for both composer chips (raw base64 data URLs) and chat-history file
- * blocks (PreparedChatAttachment, which has `image.data` for images and
- * `text` for parsed text/PDF content).
+ * Attachment that can be previewed. Currently scoped to images (composer
+ * uploads pre-send, and image blocks in chat history). Non-image file
+ * previews are intentionally out of scope here — they're planned as a
+ * follow-up that stores raw bytes on disk and uses a custom Electron
+ * protocol so the browser engine can render them natively.
  */
 export type ViewerAttachment = {
   name: string;
@@ -14,12 +15,9 @@ export type ViewerAttachment = {
   size?: number;
   /** Full data URL (e.g. "data:image/png;base64,...") — used by composer chips. */
   dataUrl?: string;
-  /** Image base64 body (no "data:" prefix) — from PreparedChatAttachment. */
+  /** Image base64 body (no "data:" prefix) — from ContentBlock.image source. */
   imageBase64?: string;
   imageMimeType?: string;
-  /** Extracted text (PDFs, docx, source, etc.). */
-  text?: string;
-  truncated?: boolean;
   error?: string;
 };
 
@@ -27,8 +25,6 @@ type AttachmentViewerProps = {
   attachment: ViewerAttachment;
   onClose: () => void;
 };
-
-const MAX_TEXT_PREVIEW_CHARS = 200_000;
 
 function formatSize(bytes: number | undefined): string {
   if (typeof bytes !== 'number' || !Number.isFinite(bytes)) return '';
@@ -44,33 +40,10 @@ function isImageMime(mimeType: string | undefined): boolean {
   return Boolean(mimeType && mimeType.toLowerCase().startsWith('image/'));
 }
 
-function isPdfMime(mimeType: string | undefined): boolean {
-  return mimeType?.toLowerCase() === 'application/pdf';
-}
-
 function buildImageSrc(att: ViewerAttachment): string | null {
   if (att.dataUrl && att.dataUrl.startsWith('data:')) return att.dataUrl;
   if (att.imageBase64 && att.imageMimeType) {
     return `data:${att.imageMimeType};base64,${att.imageBase64}`;
-  }
-  // If dataUrl is a raw base64 body but mime is image/*, fall back
-  if (att.dataUrl && isImageMime(att.mimeType)) {
-    return att.dataUrl.startsWith('data:') ? att.dataUrl : `data:${att.mimeType};base64,${att.dataUrl}`;
-  }
-  return null;
-}
-
-/**
- * Build a download URL for the attachment. When `isBlob` is true the caller
- * owns the URL and must `URL.revokeObjectURL` it when no longer needed.
- */
-function buildDownloadHref(att: ViewerAttachment): { href: string; isBlob: boolean } | null {
-  if (att.dataUrl && att.dataUrl.startsWith('data:')) return { href: att.dataUrl, isBlob: false };
-  const imgSrc = buildImageSrc(att);
-  if (imgSrc) return { href: imgSrc, isBlob: false };
-  if (typeof att.text === 'string' && att.text.length > 0) {
-    const encoded = new Blob([att.text], { type: 'text/plain;charset=utf-8' });
-    return { href: URL.createObjectURL(encoded), isBlob: true };
   }
   return null;
 }
@@ -102,27 +75,13 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
     return () => window.removeEventListener('keydown', handleKey);
   }, [close]);
 
-  const download = useMemo(() => buildDownloadHref(attachment), [attachment]);
-  useEffect(() => {
-    if (!download?.isBlob) return;
-    return () => {
-      URL.revokeObjectURL(download.href);
-    };
-  }, [download]);
+  const imgSrc = useMemo(
+    () => (isImageMime(attachment.mimeType) ? buildImageSrc(attachment) : null),
+    [attachment],
+  );
+  const downloadHref = imgSrc;
 
-  const imgSrc = isImageMime(attachment.mimeType) ? buildImageSrc(attachment) : null;
-  const pdfSrc = isPdfMime(attachment.mimeType) && attachment.dataUrl?.startsWith('data:')
-    ? attachment.dataUrl
-    : null;
-  const textPreview = attachment.text
-    ? attachment.text.length > MAX_TEXT_PREVIEW_CHARS
-      ? `${attachment.text.slice(0, MAX_TEXT_PREVIEW_CHARS)}\n\n... (truncated for preview)`
-      : attachment.text
-    : null;
-
-  const metaParts = [attachment.mimeType, formatSize(attachment.size), attachment.truncated ? 'truncated' : '']
-    .filter(Boolean)
-    .join(' · ');
+  const metaParts = [attachment.mimeType, formatSize(attachment.size)].filter(Boolean).join(' · ');
 
   return createPortal(
     <div
@@ -143,10 +102,10 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
             {metaParts && <div className={styles.meta}>{metaParts}</div>}
           </div>
           <div className={styles.actions}>
-            {download && (
+            {downloadHref && (
               <a
                 className={styles.downloadBtn}
-                href={download.href}
+                href={downloadHref}
                 download={attachment.name || 'attachment'}
                 title="Download"
               >
@@ -167,19 +126,8 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
             <div className={styles.imageWrap}>
               <img src={imgSrc} alt={attachment.name} className={styles.image} />
             </div>
-          ) : pdfSrc ? (
-            <iframe
-              title={attachment.name}
-              src={pdfSrc}
-              className={styles.pdfFrame}
-            />
-          ) : textPreview ? (
-            <pre className={styles.textPreview}>{textPreview}</pre>
           ) : (
-            <div className={styles.emptyMsg}>
-              No inline preview available for this file type.
-              {download ? ' Use Download to save the file.' : ''}
-            </div>
+            <div className={styles.emptyMsg}>No inline preview available for this file type.</div>
           )}
         </div>
       </div>

--- a/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.tsx
@@ -1,0 +1,189 @@
+import { createPortal } from 'react-dom';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import styles from './AttachmentViewer.module.scss';
+
+/**
+ * Attachment that can be previewed. Shape is intentionally permissive so this
+ * works for both composer chips (raw base64 data URLs) and chat-history file
+ * blocks (PreparedChatAttachment, which has `image.data` for images and
+ * `text` for parsed text/PDF content).
+ */
+export type ViewerAttachment = {
+  name: string;
+  mimeType: string;
+  size?: number;
+  /** Full data URL (e.g. "data:image/png;base64,...") — used by composer chips. */
+  dataUrl?: string;
+  /** Image base64 body (no "data:" prefix) — from PreparedChatAttachment. */
+  imageBase64?: string;
+  imageMimeType?: string;
+  /** Extracted text (PDFs, docx, source, etc.). */
+  text?: string;
+  truncated?: boolean;
+  error?: string;
+};
+
+type AttachmentViewerProps = {
+  attachment: ViewerAttachment;
+  onClose: () => void;
+};
+
+const MAX_TEXT_PREVIEW_CHARS = 200_000;
+
+function formatSize(bytes: number | undefined): string {
+  if (typeof bytes !== 'number' || !Number.isFinite(bytes)) return '';
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(kb < 10 ? 1 : 0)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(mb < 10 ? 1 : 0)} MB`;
+  return `${(mb / 1024).toFixed(1)} GB`;
+}
+
+function isImageMime(mimeType: string | undefined): boolean {
+  return Boolean(mimeType && mimeType.toLowerCase().startsWith('image/'));
+}
+
+function isPdfMime(mimeType: string | undefined): boolean {
+  return mimeType?.toLowerCase() === 'application/pdf';
+}
+
+function buildImageSrc(att: ViewerAttachment): string | null {
+  if (att.dataUrl && att.dataUrl.startsWith('data:')) return att.dataUrl;
+  if (att.imageBase64 && att.imageMimeType) {
+    return `data:${att.imageMimeType};base64,${att.imageBase64}`;
+  }
+  // If dataUrl is a raw base64 body but mime is image/*, fall back
+  if (att.dataUrl && isImageMime(att.mimeType)) {
+    return att.dataUrl.startsWith('data:') ? att.dataUrl : `data:${att.mimeType};base64,${att.dataUrl}`;
+  }
+  return null;
+}
+
+/**
+ * Build a download URL for the attachment. When `isBlob` is true the caller
+ * owns the URL and must `URL.revokeObjectURL` it when no longer needed.
+ */
+function buildDownloadHref(att: ViewerAttachment): { href: string; isBlob: boolean } | null {
+  if (att.dataUrl && att.dataUrl.startsWith('data:')) return { href: att.dataUrl, isBlob: false };
+  const imgSrc = buildImageSrc(att);
+  if (imgSrc) return { href: imgSrc, isBlob: false };
+  if (typeof att.text === 'string' && att.text.length > 0) {
+    const encoded = new Blob([att.text], { type: 'text/plain;charset=utf-8' });
+    return { href: URL.createObjectURL(encoded), isBlob: true };
+  }
+  return null;
+}
+
+export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps) {
+  const [closing, setClosing] = useState(false);
+  const closeTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+
+  const close = useCallback(() => {
+    setClosing(true);
+    if (closeTimerRef.current !== null) window.clearTimeout(closeTimerRef.current);
+    closeTimerRef.current = window.setTimeout(onClose, 180);
+  }, [onClose]);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current !== null) {
+        window.clearTimeout(closeTimerRef.current);
+        closeTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') close();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [close]);
+
+  const download = useMemo(() => buildDownloadHref(attachment), [attachment]);
+  useEffect(() => {
+    if (!download?.isBlob) return;
+    return () => {
+      URL.revokeObjectURL(download.href);
+    };
+  }, [download]);
+
+  const imgSrc = isImageMime(attachment.mimeType) ? buildImageSrc(attachment) : null;
+  const pdfSrc = isPdfMime(attachment.mimeType) && attachment.dataUrl?.startsWith('data:')
+    ? attachment.dataUrl
+    : null;
+  const textPreview = attachment.text
+    ? attachment.text.length > MAX_TEXT_PREVIEW_CHARS
+      ? `${attachment.text.slice(0, MAX_TEXT_PREVIEW_CHARS)}\n\n... (truncated for preview)`
+      : attachment.text
+    : null;
+
+  const metaParts = [attachment.mimeType, formatSize(attachment.size), attachment.truncated ? 'truncated' : '']
+    .filter(Boolean)
+    .join(' · ');
+
+  return createPortal(
+    <div
+      className={`${styles.backdrop}${closing ? ` ${styles.closing}` : ''}`}
+      onClick={close}
+      role="presentation"
+    >
+      <div
+        className={styles.panel}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={attachment.name}
+      >
+        <div className={styles.header}>
+          <div className={styles.titleGroup}>
+            <div className={styles.name} title={attachment.name}>{attachment.name}</div>
+            {metaParts && <div className={styles.meta}>{metaParts}</div>}
+          </div>
+          <div className={styles.actions}>
+            {download && (
+              <a
+                className={styles.downloadBtn}
+                href={download.href}
+                download={attachment.name || 'attachment'}
+                title="Download"
+              >
+                Download
+              </a>
+            )}
+            <button type="button" className={styles.closeBtn} onClick={close} aria-label="Close">
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                <path d="M1 1l12 12M13 1L1 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div className={styles.body}>
+          {attachment.error ? (
+            <div className={styles.errorMsg}>{attachment.error}</div>
+          ) : imgSrc ? (
+            <div className={styles.imageWrap}>
+              <img src={imgSrc} alt={attachment.name} className={styles.image} />
+            </div>
+          ) : pdfSrc ? (
+            <iframe
+              title={attachment.name}
+              src={pdfSrc}
+              className={styles.pdfFrame}
+            />
+          ) : textPreview ? (
+            <pre className={styles.textPreview}>{textPreview}</pre>
+          ) : (
+            <div className={styles.emptyMsg}>
+              No inline preview available for this file type.
+              {download ? ' Use Download to save the file.' : ''}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -234,6 +234,21 @@
         display: block;
         object-fit: contain;
       }
+
+      .chat-image-clickable {
+        cursor: zoom-in;
+        transition: transform 0.12s ease, box-shadow 0.12s ease;
+
+        &:hover {
+          transform: scale(1.01);
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+        }
+
+        &:focus-visible {
+          outline: 2px solid var(--accent);
+          outline-offset: 2px;
+        }
+      }
     }
   }
 
@@ -664,6 +679,28 @@
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-card);
+  text-align: left;
+  font-family: inherit;
+  color: inherit;
+}
+
+button.fileAttachment {
+  appearance: none;
+  cursor: pointer;
+}
+
+.fileAttachmentClickable {
+  transition: background 0.12s ease, border-color 0.12s ease;
+
+  &:hover {
+    background: var(--bg-hover);
+    border-color: var(--accent);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
 }
 
 .fileAttachmentError {

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -679,28 +679,6 @@
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-card);
-  text-align: left;
-  font-family: inherit;
-  color: inherit;
-}
-
-button.fileAttachment {
-  appearance: none;
-  cursor: pointer;
-}
-
-.fileAttachmentClickable {
-  transition: background 0.12s ease, border-color 0.12s ease;
-
-  &:hover {
-    background: var(--bg-hover);
-    border-color: var(--accent);
-  }
-
-  &:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
 }
 
 .fileAttachmentError {

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -6,6 +6,7 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import type { ReactNode } from 'react';
 import { MarkdownContent } from './chat-utils.js';
 import styles from './ChatBubble.module.scss';
+import { AttachmentViewer, type ViewerAttachment } from './AttachmentViewer';
 import type { ChatMessage, ContentBlock } from './chat-shared';
 import {
   buildChatMetaParts,
@@ -468,6 +469,116 @@ function renderAssistantBlocks(blocks: ContentBlock[], streaming = false, messag
   return nodes;
 }
 
+function buildViewerFromFileBlock(block: ContentBlock): ViewerAttachment {
+  const att = (block.attachment && typeof block.attachment === 'object')
+    ? (block.attachment as Record<string, unknown>)
+    : {};
+  const image = (att.image && typeof att.image === 'object')
+    ? (att.image as { data?: unknown; mimeType?: unknown })
+    : null;
+  return {
+    name: String(block.fileName || 'attachment'),
+    mimeType: String(block.mimeType || 'application/octet-stream'),
+    size: typeof block.size === 'number' ? block.size : undefined,
+    imageBase64: typeof image?.data === 'string' ? image.data : undefined,
+    imageMimeType: typeof image?.mimeType === 'string' ? image.mimeType : undefined,
+    text: typeof att.text === 'string' ? att.text : undefined,
+    truncated: block.truncated,
+    error: block.error || (typeof att.error === 'string' ? att.error : undefined),
+  };
+}
+
+function fileBlockIsPreviewable(block: ContentBlock, viewer: ViewerAttachment): boolean {
+  if (block.status === 'error' || block.error) return false;
+  if (viewer.imageBase64 && viewer.imageMimeType) return true;
+  if (typeof viewer.text === 'string' && viewer.text.length > 0) return true;
+  return false;
+}
+
+function FileAttachmentBlock({ block }: { block: ContentBlock }) {
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const fileName = String(block.fileName || 'attachment');
+  const mimeType = String(block.mimeType || 'application/octet-stream');
+  const size = typeof block.size === 'number' && Number.isFinite(block.size)
+    ? formatFileSize(block.size)
+    : '';
+  const isError = block.status === 'error' || Boolean(block.error);
+  const viewer = useMemo(() => buildViewerFromFileBlock(block), [block]);
+  const canPreview = !isError && fileBlockIsPreviewable(block, viewer);
+
+  const className = `${styles.fileAttachment}${isError ? ` ${styles.fileAttachmentError}` : ''}${canPreview ? ` ${styles.fileAttachmentClickable}` : ''}`;
+  const metaText = [mimeType, size, block.truncated ? 'truncated' : '', isError ? String(block.error || 'unsupported') : '']
+    .filter(Boolean)
+    .join(' · ');
+
+  const inner = (
+    <>
+      <div className={styles.fileAttachmentIcon} aria-hidden="true">
+        {fileName.split('.').pop()?.slice(0, 3).toUpperCase() || 'FILE'}
+      </div>
+      <div className={styles.fileAttachmentBody}>
+        <div className={styles.fileAttachmentName}>{fileName}</div>
+        <div className={styles.fileAttachmentMeta}>{metaText}</div>
+      </div>
+    </>
+  );
+
+  return (
+    <>
+      {canPreview ? (
+        <button
+          type="button"
+          className={className}
+          onClick={() => setViewerOpen(true)}
+          aria-label={`Preview ${fileName}`}
+        >
+          {inner}
+        </button>
+      ) : (
+        <div className={className}>{inner}</div>
+      )}
+      {viewerOpen && (
+        <AttachmentViewer attachment={viewer} onClose={() => setViewerOpen(false)} />
+      )}
+    </>
+  );
+}
+
+function ImageBlockView({ block }: { block: ContentBlock }) {
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const mediaType = String(block.source?.media_type || 'image/png');
+  const data = String(block.source?.data || '');
+  if (!data) return null;
+  const src = `data:${mediaType};base64,${data}`;
+  const viewer: ViewerAttachment = {
+    name: 'image',
+    mimeType: mediaType,
+    imageBase64: data,
+    imageMimeType: mediaType,
+  };
+  return (
+    <>
+      <img
+        src={src}
+        className="chat-image-preview chat-image-clickable"
+        alt="Attached image"
+        onClick={() => setViewerOpen(true)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setViewerOpen(true);
+          }
+        }}
+      />
+      {viewerOpen && (
+        <AttachmentViewer attachment={viewer} onClose={() => setViewerOpen(false)} />
+      )}
+    </>
+  );
+}
+
 function renderBlock(block: ContentBlock, index: number, streaming = false, messagePrefix = ''): ReactNode {
   const blockKey = getBlockRenderKey(block, index, messagePrefix);
 
@@ -483,25 +594,7 @@ function renderBlock(block: ContentBlock, index: number, streaming = false, mess
   }
 
   if (block.type === 'file') {
-    const fileName = String(block.fileName || 'attachment');
-    const mimeType = String(block.mimeType || 'application/octet-stream');
-    const size = typeof block.size === 'number' && Number.isFinite(block.size)
-      ? formatFileSize(block.size)
-      : '';
-    const isError = block.status === 'error' || Boolean(block.error);
-    return (
-      <div key={blockKey} className={`${styles.fileAttachment}${isError ? ` ${styles.fileAttachmentError}` : ''}`}>
-        <div className={styles.fileAttachmentIcon} aria-hidden="true">
-          {fileName.split('.').pop()?.slice(0, 3).toUpperCase() || 'FILE'}
-        </div>
-        <div className={styles.fileAttachmentBody}>
-          <div className={styles.fileAttachmentName}>{fileName}</div>
-          <div className={styles.fileAttachmentMeta}>
-            {[mimeType, size, block.truncated ? 'truncated' : '', isError ? String(block.error || 'unsupported') : ''].filter(Boolean).join(' · ')}
-          </div>
-        </div>
-      </div>
-    );
+    return <FileAttachmentBlock key={blockKey} block={block} />;
   }
 
   if (block.type === 'tool_use') {
@@ -523,14 +616,7 @@ function renderBlock(block: ContentBlock, index: number, streaming = false, mess
   }
 
   if (block.type === 'image' && block.source?.data && block.source?.media_type) {
-    return (
-      <img
-        key={blockKey}
-        src={`data:${block.source.media_type};base64,${block.source.data}`}
-        className="chat-image-preview"
-        alt="Attached image"
-      />
-    );
+    return <ImageBlockView key={blockKey} block={block} />;
   }
 
   return null;

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -469,81 +469,6 @@ function renderAssistantBlocks(blocks: ContentBlock[], streaming = false, messag
   return nodes;
 }
 
-function buildViewerFromFileBlock(block: ContentBlock): ViewerAttachment {
-  const att = (block.attachment && typeof block.attachment === 'object')
-    ? (block.attachment as Record<string, unknown>)
-    : {};
-  const image = (att.image && typeof att.image === 'object')
-    ? (att.image as { data?: unknown; mimeType?: unknown })
-    : null;
-  return {
-    name: String(block.fileName || 'attachment'),
-    mimeType: String(block.mimeType || 'application/octet-stream'),
-    size: typeof block.size === 'number' ? block.size : undefined,
-    imageBase64: typeof image?.data === 'string' ? image.data : undefined,
-    imageMimeType: typeof image?.mimeType === 'string' ? image.mimeType : undefined,
-    text: typeof att.text === 'string' ? att.text : undefined,
-    truncated: block.truncated,
-    error: block.error || (typeof att.error === 'string' ? att.error : undefined),
-  };
-}
-
-function fileBlockIsPreviewable(block: ContentBlock, viewer: ViewerAttachment): boolean {
-  if (block.status === 'error' || block.error) return false;
-  if (viewer.imageBase64 && viewer.imageMimeType) return true;
-  if (typeof viewer.text === 'string' && viewer.text.length > 0) return true;
-  return false;
-}
-
-function FileAttachmentBlock({ block }: { block: ContentBlock }) {
-  const [viewerOpen, setViewerOpen] = useState(false);
-  const fileName = String(block.fileName || 'attachment');
-  const mimeType = String(block.mimeType || 'application/octet-stream');
-  const size = typeof block.size === 'number' && Number.isFinite(block.size)
-    ? formatFileSize(block.size)
-    : '';
-  const isError = block.status === 'error' || Boolean(block.error);
-  const viewer = useMemo(() => buildViewerFromFileBlock(block), [block]);
-  const canPreview = !isError && fileBlockIsPreviewable(block, viewer);
-
-  const className = `${styles.fileAttachment}${isError ? ` ${styles.fileAttachmentError}` : ''}${canPreview ? ` ${styles.fileAttachmentClickable}` : ''}`;
-  const metaText = [mimeType, size, block.truncated ? 'truncated' : '', isError ? String(block.error || 'unsupported') : '']
-    .filter(Boolean)
-    .join(' · ');
-
-  const inner = (
-    <>
-      <div className={styles.fileAttachmentIcon} aria-hidden="true">
-        {fileName.split('.').pop()?.slice(0, 3).toUpperCase() || 'FILE'}
-      </div>
-      <div className={styles.fileAttachmentBody}>
-        <div className={styles.fileAttachmentName}>{fileName}</div>
-        <div className={styles.fileAttachmentMeta}>{metaText}</div>
-      </div>
-    </>
-  );
-
-  return (
-    <>
-      {canPreview ? (
-        <button
-          type="button"
-          className={className}
-          onClick={() => setViewerOpen(true)}
-          aria-label={`Preview ${fileName}`}
-        >
-          {inner}
-        </button>
-      ) : (
-        <div className={className}>{inner}</div>
-      )}
-      {viewerOpen && (
-        <AttachmentViewer attachment={viewer} onClose={() => setViewerOpen(false)} />
-      )}
-    </>
-  );
-}
-
 function ImageBlockView({ block }: { block: ContentBlock }) {
   const [viewerOpen, setViewerOpen] = useState(false);
   const mediaType = String(block.source?.media_type || 'image/png');
@@ -594,7 +519,25 @@ function renderBlock(block: ContentBlock, index: number, streaming = false, mess
   }
 
   if (block.type === 'file') {
-    return <FileAttachmentBlock key={blockKey} block={block} />;
+    const fileName = String(block.fileName || 'attachment');
+    const mimeType = String(block.mimeType || 'application/octet-stream');
+    const size = typeof block.size === 'number' && Number.isFinite(block.size)
+      ? formatFileSize(block.size)
+      : '';
+    const isError = block.status === 'error' || Boolean(block.error);
+    return (
+      <div key={blockKey} className={`${styles.fileAttachment}${isError ? ` ${styles.fileAttachmentError}` : ''}`}>
+        <div className={styles.fileAttachmentIcon} aria-hidden="true">
+          {fileName.split('.').pop()?.slice(0, 3).toUpperCase() || 'FILE'}
+        </div>
+        <div className={styles.fileAttachmentBody}>
+          <div className={styles.fileAttachmentName}>{fileName}</div>
+          <div className={styles.fileAttachmentMeta}>
+            {[mimeType, size, block.truncated ? 'truncated' : '', isError ? String(block.error || 'unsupported') : ''].filter(Boolean).join(' · ')}
+          </div>
+        </div>
+      </div>
+    );
   }
 
   if (block.type === 'tool_use') {

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -714,8 +714,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
             {attachedFiles.length > 0 && (
               <div className={styles.chatAttachmentTray}>
                 {attachedFiles.map((file) => {
-                  const canPreview =
-                    file.mimeType.startsWith('image/') || file.mimeType === 'application/pdf';
+                  const isImage = file.mimeType.startsWith('image/');
                   const openPreview = () => {
                     setPreviewAttachment({
                       name: file.name,
@@ -725,8 +724,8 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                     });
                   };
                   return (
-                    <div className={styles.chatAttachmentChip} key={file.id} title={`${file.name} (${formatAttachmentSize(file.size)})${canPreview ? ' — click to preview' : ''}`}>
-                      {file.mimeType.startsWith('image/') ? (
+                    <div className={styles.chatAttachmentChip} key={file.id} title={`${file.name} (${formatAttachmentSize(file.size)})${isImage ? ' — click to preview' : ''}`}>
+                      {isImage ? (
                         <img
                           src={file.base64}
                           alt=""
@@ -735,18 +734,14 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                           style={{ cursor: 'zoom-in' }}
                         />
                       ) : (
-                        <span
-                          className={styles.chatAttachmentFileIcon}
-                          onClick={canPreview ? openPreview : undefined}
-                          style={canPreview ? { cursor: 'pointer' } : undefined}
-                        >
+                        <span className={styles.chatAttachmentFileIcon}>
                           {getAttachmentExtension(file.name)}
                         </span>
                       )}
                       <span
                         className={styles.chatAttachmentName}
-                        onClick={canPreview ? openPreview : undefined}
-                        style={canPreview ? { cursor: 'pointer' } : undefined}
+                        onClick={isImage ? openPreview : undefined}
+                        style={isImage ? { cursor: 'pointer' } : undefined}
                       >
                         {file.name}
                       </span>

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -781,7 +781,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                 placeholder={
                   snap.chatInputDisabled
                     ? 'Type your next message — it will send when the current response finishes…'
-                    : 'Message Community Peers...'
+                    : 'Type a message... (Shift+Enter for newline)'
                 }
                 rows={1}
                 value={inputValue}

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -18,6 +18,7 @@ import { LowBalanceWarning } from '../chat/LowBalanceWarning';
 import { ServiceDropdown } from '../chat/ServiceDropdown';
 import { SwitchServiceDialog } from '../chat/SwitchServiceDialog';
 import { ServiceSwitchTooltip } from '../chat/ServiceSwitchTooltip';
+import { AttachmentViewer, type ViewerAttachment } from '../chat/AttachmentViewer';
 import { BrowserPreview } from '../BrowserPreview';
 import type { ChatMessage } from '../chat/chat-shared';
 import { buildDisplayMessages } from '../chat/chat-shared';
@@ -137,6 +138,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     attachments: RawChatAttachment[];
   };
   const [pendingQueue, setPendingQueue] = useState<PendingDraft[]>([]);
+  const [previewAttachment, setPreviewAttachment] = useState<ViewerAttachment | null>(null);
   const [tooltipDismissed, setTooltipDismissed] = useState<boolean>(() => {
     if (typeof window === 'undefined') return true;
     return window.localStorage.getItem(SWITCH_TOOLTIP_DISMISSED_KEY) === 'true';
@@ -711,25 +713,55 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
 
             {attachedFiles.length > 0 && (
               <div className={styles.chatAttachmentTray}>
-                {attachedFiles.map((file) => (
-                  <div className={styles.chatAttachmentChip} key={file.id} title={`${file.name} (${formatAttachmentSize(file.size)})`}>
-                    {file.mimeType.startsWith('image/') ? (
-                      <img src={file.base64} alt="" className={styles.chatAttachmentThumb} />
-                    ) : (
-                      <span className={styles.chatAttachmentFileIcon}>{getAttachmentExtension(file.name)}</span>
-                    )}
-                    <span className={styles.chatAttachmentName}>{file.name}</span>
-                    <span className={styles.chatAttachmentSize}>{formatAttachmentSize(file.size)}</span>
-                    <button
-                      className={styles.chatAttachmentRemoveBtn}
-                      onClick={() => handleRemoveAttachment(file.id)}
-                      title="Remove attachment"
-                      type="button"
-                    >
-                      x
-                    </button>
-                  </div>
-                ))}
+                {attachedFiles.map((file) => {
+                  const canPreview =
+                    file.mimeType.startsWith('image/') || file.mimeType === 'application/pdf';
+                  const openPreview = () => {
+                    setPreviewAttachment({
+                      name: file.name,
+                      mimeType: file.mimeType,
+                      size: file.size,
+                      dataUrl: file.base64,
+                    });
+                  };
+                  return (
+                    <div className={styles.chatAttachmentChip} key={file.id} title={`${file.name} (${formatAttachmentSize(file.size)})${canPreview ? ' — click to preview' : ''}`}>
+                      {file.mimeType.startsWith('image/') ? (
+                        <img
+                          src={file.base64}
+                          alt=""
+                          className={styles.chatAttachmentThumb}
+                          onClick={openPreview}
+                          style={{ cursor: 'zoom-in' }}
+                        />
+                      ) : (
+                        <span
+                          className={styles.chatAttachmentFileIcon}
+                          onClick={canPreview ? openPreview : undefined}
+                          style={canPreview ? { cursor: 'pointer' } : undefined}
+                        >
+                          {getAttachmentExtension(file.name)}
+                        </span>
+                      )}
+                      <span
+                        className={styles.chatAttachmentName}
+                        onClick={canPreview ? openPreview : undefined}
+                        style={canPreview ? { cursor: 'pointer' } : undefined}
+                      >
+                        {file.name}
+                      </span>
+                      <span className={styles.chatAttachmentSize}>{formatAttachmentSize(file.size)}</span>
+                      <button
+                        className={styles.chatAttachmentRemoveBtn}
+                        onClick={() => handleRemoveAttachment(file.id)}
+                        title="Remove attachment"
+                        type="button"
+                      >
+                        x
+                      </button>
+                    </div>
+                  );
+                })}
               </div>
             )}
 
@@ -826,6 +858,12 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
         onStartNew={handleSwitchStartNew}
         onCancel={handleSwitchCancel}
       />
+      {previewAttachment && (
+        <AttachmentViewer
+          attachment={previewAttachment}
+          onClose={() => setPreviewAttachment(null)}
+        />
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Description

Adds an in-chat fullscreen viewer so images can be opened without leaving the conversation. Clicking a chat image or an image chip in the composer opens a modal with filename, metadata, and a Download action.

Scope was deliberately narrowed to images only. Previewing non-image attachments (PDFs, HTML, docx, etc.) is planned as a follow-up that persists raw bytes to disk and renders them via a custom Electron protocol — which will give us native browser rendering for free without bloating the renderer's memory.

Related: #146 (tracks the broader "click any attachment to preview" work; this PR only lands the image slice).

## Release Notes

- Click any image in chat to open it in a fullscreen viewer with download
- Click an uploaded image chip in the composer to preview before sending
- ESC or backdrop click dismisses the preview
- Restored original chat input placeholder: `Type a message... (Shift+Enter for newline)`
- Desktop `0.1.48` \u2192 `0.1.49`

## What changed

- **New `AttachmentViewer` component** (`AttachmentViewer.tsx` + `.module.scss`) \u2014 portal-based modal for image preview with Download, ESC, backdrop-close, and enter/exit animations.
- **`ChatBubble.tsx`** \u2014 `ImageBlockView` wraps image blocks with click + Enter/Space keyboard activation. File attachment cards are unchanged from `main`.
- **`ChatView.tsx`** \u2014 image chips in the composer open the viewer using their raw base64 data URL. Non-image chips behave as before.
- **`ChatBubble.module.scss`** \u2014 adds `.chat-image-clickable` hover/focus styles.
- **`ChatView.tsx`** \u2014 placeholder reverted to `Type a message... (Shift+Enter for newline)`.
- **`package.json`** \u2014 bump to `0.1.49`.

## Types of Changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the code style of this project
- [x] Lint and unit tests pass locally with my changes (`typecheck:renderer` + `build:renderer` pass)
