### PR TITLE
feat(desktop): Disk-backed attachments + native preview

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/main/attachment-protocol-url.ts
+++ b/apps/desktop/src/main/attachment-protocol-url.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure URL parsing helpers for the attachment protocol.
+ *
+ * Split out from `attachment-protocol.ts` (which imports from Electron) so
+ * unit tests can verify the parsing rules under plain Node without
+ * pulling in the Electron runtime.
+ */
+
+export const ATTACHMENT_SCHEME = 'antseed-attachment';
+
+export type ParsedAttachmentUrl = {
+  conversationId: string;
+  attachmentId: string;
+};
+
+/**
+ * Extract `(conversationId, attachmentId)` from a protocol URL.
+ *
+ * Only the first path segment is treated as the attachment id — extra
+ * segments are ignored, so a buggy or hostile renderer can't tack on
+ * `/../something` to escape the intended layout.
+ */
+export function parseAttachmentUrl(rawUrl: string): ParsedAttachmentUrl | null {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== `${ATTACHMENT_SCHEME}:`) return null;
+
+  const conversationId = decodeSafe(url.hostname);
+  const firstSegment = url.pathname.replace(/^\/+/, '').split('/')[0] ?? '';
+  const attachmentId = decodeSafe(firstSegment);
+  if (!conversationId || !attachmentId) return null;
+  return { conversationId, attachmentId };
+}
+
+function decodeSafe(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return '';
+  }
+}

--- a/apps/desktop/src/main/attachment-protocol.test.ts
+++ b/apps/desktop/src/main/attachment-protocol.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseAttachmentUrl, ATTACHMENT_SCHEME } from './attachment-protocol-url.js';
+
+test('parseAttachmentUrl accepts well-formed URLs', () => {
+  const parsed = parseAttachmentUrl(`${ATTACHMENT_SCHEME}://conv1/att1`);
+  assert.deepEqual(parsed, { conversationId: 'conv1', attachmentId: 'att1' });
+});
+
+test('parseAttachmentUrl ignores extra path segments beyond the attachment id', () => {
+  // Only the first path segment is interpreted as the attachment id; the
+  // rest is ignored so a buggy renderer can't tack on `/../something`.
+  const parsed = parseAttachmentUrl(`${ATTACHMENT_SCHEME}://conv1/att1/extra/bits`);
+  assert.deepEqual(parsed, { conversationId: 'conv1', attachmentId: 'att1' });
+});
+
+test('parseAttachmentUrl rejects other schemes', () => {
+  assert.equal(parseAttachmentUrl('file:///etc/passwd'), null);
+  assert.equal(parseAttachmentUrl('http://conv1/att1'), null);
+});
+
+test('parseAttachmentUrl rejects missing components', () => {
+  assert.equal(parseAttachmentUrl(`${ATTACHMENT_SCHEME}://`), null);
+  assert.equal(parseAttachmentUrl(`${ATTACHMENT_SCHEME}:///att1`), null);
+  assert.equal(parseAttachmentUrl(`${ATTACHMENT_SCHEME}://conv1/`), null);
+});
+
+test('parseAttachmentUrl handles percent-encoded components', () => {
+  const parsed = parseAttachmentUrl(`${ATTACHMENT_SCHEME}://conv%2D1/att%5F1`);
+  assert.deepEqual(parsed, { conversationId: 'conv-1', attachmentId: 'att_1' });
+});
+
+test('parseAttachmentUrl returns null for malformed URLs', () => {
+  assert.equal(parseAttachmentUrl('not a url'), null);
+});

--- a/apps/desktop/src/main/attachment-protocol.ts
+++ b/apps/desktop/src/main/attachment-protocol.ts
@@ -1,0 +1,92 @@
+/**
+ * Custom Electron protocol for serving chat attachments.
+ *
+ * URL shape:
+ *   antseed-attachment://<conversationId>/<attachmentId>
+ *
+ * The scheme is registered as privileged (standard + secure) so the
+ * browser engine renders PDFs, HTML, SVG and images natively — no base64
+ * round-tripping through IPC.
+ *
+ * For HTML responses we inject a Content-Security-Policy that forbids
+ * script execution and external fetches. Combined with `sandbox=""` on
+ * the iframe in the renderer this keeps user-authored HTML inert.
+ *
+ * URL parsing lives in `attachment-protocol-url.ts` so it can be unit
+ * tested without the Electron runtime.
+ */
+import { net, protocol } from 'electron';
+import { pathToFileURL } from 'node:url';
+import { resolveAttachmentPath } from './attachment-store.js';
+import { ATTACHMENT_SCHEME, parseAttachmentUrl } from './attachment-protocol-url.js';
+
+export { ATTACHMENT_SCHEME, parseAttachmentUrl } from './attachment-protocol-url.js';
+
+/**
+ * Must be called *before* `app.whenReady()` — Electron requires privileged
+ * schemes to be registered at import time.
+ */
+export function registerAttachmentScheme(): void {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: ATTACHMENT_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        stream: true,
+      },
+    },
+  ]);
+}
+
+/**
+ * Wire the actual request handler. Must run after `app.whenReady()`.
+ * `resolveRootDir` lets integration tests point at a temp attachments
+ * root without touching `CHAT_DATA_DIR`; production callers leave it
+ * undefined.
+ */
+export function installAttachmentProtocol(options: { resolveRootDir?: () => string | undefined } = {}): void {
+  protocol.handle(ATTACHMENT_SCHEME, async (request) => handleAttachmentRequest(request, options.resolveRootDir?.()));
+}
+
+/**
+ * Handler body, extracted for clarity and so future integration tests can
+ * exercise it with a synthetic `Request` once an Electron test harness
+ * exists.
+ */
+export async function handleAttachmentRequest(request: Request, rootDir?: string): Promise<Response> {
+  const parsed = parseAttachmentUrl(request.url);
+  if (!parsed) {
+    return new Response('Bad request', { status: 400 });
+  }
+  const resolved = await resolveAttachmentPath(
+    parsed.conversationId,
+    parsed.attachmentId,
+    rootDir ? { rootDir } : {},
+  );
+  if (!resolved) {
+    return new Response('Not found', { status: 404 });
+  }
+  let response: Response;
+  try {
+    response = await net.fetch(pathToFileURL(resolved).toString());
+  } catch {
+    return new Response('Internal error', { status: 500 });
+  }
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.startsWith('text/html')) {
+    // Re-wrap the response so we can attach a tight CSP and disable
+    // sniffing. Combined with `sandbox=""` on the renderer-side iframe,
+    // this keeps user-authored HTML inert.
+    const body = await response.arrayBuffer();
+    const headers = new Headers(response.headers);
+    headers.set(
+      'Content-Security-Policy',
+      "default-src 'none'; img-src 'self' data: blob:; style-src 'unsafe-inline'; font-src data:",
+    );
+    headers.set('X-Content-Type-Options', 'nosniff');
+    return new Response(body, { status: response.status, headers });
+  }
+  return response;
+}

--- a/apps/desktop/src/main/attachment-protocol.ts
+++ b/apps/desktop/src/main/attachment-protocol.ts
@@ -88,5 +88,14 @@ export async function handleAttachmentRequest(request: Request, rootDir?: string
     headers.set('X-Content-Type-Options', 'nosniff');
     return new Response(body, { status: response.status, headers });
   }
+  // For every other response type (plain text, JSON, source, images,
+  // PDFs) we forbid MIME sniffing so Chromium can't reclassify a text
+  // payload as HTML and start executing scripts from it.
+  if (!response.headers.has('X-Content-Type-Options')) {
+    const headers = new Headers(response.headers);
+    headers.set('X-Content-Type-Options', 'nosniff');
+    const body = await response.arrayBuffer();
+    return new Response(body, { status: response.status, headers });
+  }
   return response;
 }

--- a/apps/desktop/src/main/attachment-protocol.ts
+++ b/apps/desktop/src/main/attachment-protocol.ts
@@ -16,11 +16,37 @@
  * tested without the Electron runtime.
  */
 import { net, protocol } from 'electron';
+import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { resolveAttachmentPath } from './attachment-store.js';
 import { ATTACHMENT_SCHEME, parseAttachmentUrl } from './attachment-protocol-url.js';
 
 export { ATTACHMENT_SCHEME, parseAttachmentUrl } from './attachment-protocol-url.js';
+
+/**
+ * Extensions whose bytes we force-serve as `text/plain; charset=utf-8`.
+ *
+ * Chromium refuses to render some text-ish mime types (notably
+ * `text/csv`, `application/yaml`) in an iframe — the engine treats them
+ * as downloadable attachments and leaves the iframe blank. Serving the
+ * same bytes as `text/plain` makes Chromium display them as monospace
+ * text, which is exactly what the preview modal wants.
+ *
+ * JSON, XML, HTML and PDF are excluded on purpose: Chromium has
+ * dedicated viewers for each that are nicer than raw text.
+ */
+const FORCE_PLAIN_TEXT_EXTENSIONS = new Set<string>([
+  '.txt', '.log', '.csv', '.tsv',
+  '.md', '.markdown',
+  '.yaml', '.yml', '.toml', '.ini', '.conf', '.env', '.properties',
+  '.diff', '.patch',
+  '.js', '.mjs', '.cjs', '.jsx', '.ts', '.tsx',
+  '.py', '.rb', '.go', '.rs', '.java',
+  '.c', '.cpp', '.h', '.hpp', '.cs',
+  '.sh', '.bash', '.zsh', '.ps1', '.bat', '.cmd',
+  '.sql', '.css', '.scss', '.less', '.sass',
+  '.vue', '.svelte', '.php', '.lua',
+]);
 
 /**
  * Must be called *before* `app.whenReady()` — Electron requires privileged
@@ -74,6 +100,23 @@ export async function handleAttachmentRequest(request: Request, rootDir?: string
   } catch {
     return new Response('Internal error', { status: 500 });
   }
+
+  // Chromium won't render types like `text/csv` in an iframe even
+  // though they're just text. Rewrite the Content-Type for known text
+  // extensions so the preview modal actually shows the file contents
+  // instead of a blank iframe.
+  const ext = path.extname(resolved).toLowerCase();
+  if (FORCE_PLAIN_TEXT_EXTENSIONS.has(ext)) {
+    const body = await response.arrayBuffer();
+    return new Response(body, {
+      status: response.status,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'X-Content-Type-Options': 'nosniff',
+      },
+    });
+  }
+
   const contentType = response.headers.get('content-type') ?? '';
   if (contentType.startsWith('text/html')) {
     // Re-wrap the response so we can attach a tight CSP and disable

--- a/apps/desktop/src/main/attachment-protocol.ts
+++ b/apps/desktop/src/main/attachment-protocol.ts
@@ -131,14 +131,16 @@ export async function handleAttachmentRequest(request: Request, rootDir?: string
     headers.set('X-Content-Type-Options', 'nosniff');
     return new Response(body, { status: response.status, headers });
   }
-  // For every other response type (plain text, JSON, source, images,
-  // PDFs) we forbid MIME sniffing so Chromium can't reclassify a text
-  // payload as HTML and start executing scripts from it.
+  // For every other response type (images, PDFs, JSON, XML, binary)
+  // we forbid MIME sniffing so Chromium can't reclassify a text
+  // payload as HTML and start executing scripts from it. Pass the
+  // underlying ReadableStream through so the `stream: true` privilege
+  // on the scheme is actually used — buffering full PDFs or video
+  // files into memory just to add a header would defeat the point.
   if (!response.headers.has('X-Content-Type-Options')) {
     const headers = new Headers(response.headers);
     headers.set('X-Content-Type-Options', 'nosniff');
-    const body = await response.arrayBuffer();
-    return new Response(body, { status: response.status, headers });
+    return new Response(response.body, { status: response.status, headers });
   }
   return response;
 }

--- a/apps/desktop/src/main/attachment-store.test.ts
+++ b/apps/desktop/src/main/attachment-store.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  deleteConversationAttachments,
+  isSafeId,
+  resolveAttachmentPath,
+  saveAttachment,
+  sweepOrphanAttachments,
+} from './attachment-store.js';
+
+async function withTempRoot(fn: (rootDir: string) => Promise<void>): Promise<void> {
+  const rootDir = await mkdtemp(path.join(tmpdir(), 'antseed-attach-'));
+  try {
+    await fn(rootDir);
+  } finally {
+    await rm(rootDir, { recursive: true, force: true });
+  }
+}
+
+test('isSafeId accepts normal IDs and rejects traversal / special chars', () => {
+  assert.equal(isSafeId('abc123'), true);
+  assert.equal(isSafeId('a-b_c'), true);
+  assert.equal(isSafeId('0123456789abcdef'), true);
+  assert.equal(isSafeId('x'.repeat(128)), true);
+
+  assert.equal(isSafeId(''), false);
+  assert.equal(isSafeId('../evil'), false);
+  assert.equal(isSafeId('a/b'), false);
+  assert.equal(isSafeId('a\\b'), false);
+  assert.equal(isSafeId('a.b'), false); // dots are disallowed in IDs
+  assert.equal(isSafeId('a b'), false);
+  assert.equal(isSafeId('a\u0000'), false);
+  assert.equal(isSafeId('x'.repeat(200)), false);
+});
+
+test('saveAttachment writes bytes under conversation dir with extension', async () => {
+  await withTempRoot(async (rootDir) => {
+    const written = await saveAttachment('conv1', 'att1', 'hello.TXT', Buffer.from('hello'), { rootDir });
+    // Extension is normalised to lowercase.
+    assert.match(written, /conv1[\\/]att1\.txt$/);
+    const contents = await readFile(written, 'utf8');
+    assert.equal(contents, 'hello');
+  });
+});
+
+test('saveAttachment drops suspicious extensions', async () => {
+  await withTempRoot(async (rootDir) => {
+    // `php%00.jpg` would decode to php + nul. Only clean alphanumeric
+    // extensions are kept; everything else falls back to no-extension.
+    const written = await saveAttachment('conv1', 'att1', 'evil.php%00.jpg', Buffer.from('x'), { rootDir });
+    assert.match(written, /conv1[\\/]att1(\.jpg)?$/);
+  });
+});
+
+test('saveAttachment rejects unsafe conversation and attachment IDs', async () => {
+  await withTempRoot(async (rootDir) => {
+    await assert.rejects(
+      () => saveAttachment('..', 'att1', 'f.txt', Buffer.from(''), { rootDir }),
+      /Invalid conversationId/,
+    );
+    await assert.rejects(
+      () => saveAttachment('c1', '../etc/passwd', 'f.txt', Buffer.from(''), { rootDir }),
+      /Invalid attachmentId/,
+    );
+    await assert.rejects(
+      () => saveAttachment('c1', 'a/b', 'f.txt', Buffer.from(''), { rootDir }),
+      /Invalid attachmentId/,
+    );
+  });
+});
+
+test('resolveAttachmentPath returns the file path for valid IDs', async () => {
+  await withTempRoot(async (rootDir) => {
+    await saveAttachment('conv1', 'att1', 'hello.txt', Buffer.from('ok'), { rootDir });
+    const found = await resolveAttachmentPath('conv1', 'att1', { rootDir });
+    assert.ok(found);
+    assert.match(found, /att1\.txt$/);
+  });
+});
+
+test('resolveAttachmentPath returns null for missing or unsafe IDs', async () => {
+  await withTempRoot(async (rootDir) => {
+    assert.equal(await resolveAttachmentPath('conv1', 'missing', { rootDir }), null);
+    assert.equal(await resolveAttachmentPath('..', 'x', { rootDir }), null);
+    assert.equal(await resolveAttachmentPath('c', '../etc/passwd', { rootDir }), null);
+  });
+});
+
+test('deleteConversationAttachments removes all files for the conversation', async () => {
+  await withTempRoot(async (rootDir) => {
+    await saveAttachment('c1', 'a1', 'one.txt', Buffer.from('1'), { rootDir });
+    await saveAttachment('c1', 'a2', 'two.txt', Buffer.from('2'), { rootDir });
+    await saveAttachment('c2', 'b1', 'three.txt', Buffer.from('3'), { rootDir });
+
+    await deleteConversationAttachments('c1', { rootDir });
+
+    assert.equal(await resolveAttachmentPath('c1', 'a1', { rootDir }), null);
+    assert.equal(await resolveAttachmentPath('c1', 'a2', { rootDir }), null);
+    // Other conversations untouched.
+    assert.ok(await resolveAttachmentPath('c2', 'b1', { rootDir }));
+  });
+});
+
+test('deleteConversationAttachments is a no-op when dir is missing', async () => {
+  await withTempRoot(async (rootDir) => {
+    await deleteConversationAttachments('never-existed', { rootDir });
+  });
+});
+
+test('sweepOrphanAttachments removes unknown directories and unsafe names', async () => {
+  await withTempRoot(async (rootDir) => {
+    await mkdir(path.join(rootDir, 'keep'));
+    await mkdir(path.join(rootDir, 'drop'));
+    await writeFile(path.join(rootDir, 'drop', 'x.txt'), 'bye');
+
+    // An unsafe-named directory shouldn't exist, but sweep should clean it
+    // up defensively if it somehow does.
+    await mkdir(path.join(rootDir, '..nope'), { recursive: true });
+
+    const removed = await sweepOrphanAttachments(new Set(['keep']), { rootDir });
+    assert.ok(removed.includes('drop'));
+    assert.ok(removed.includes('..nope'));
+
+    const entries = await readdir(rootDir);
+    assert.deepEqual(entries.sort(), ['keep']);
+  });
+});
+
+test('sweepOrphanAttachments is a no-op when the root does not exist', async () => {
+  await withTempRoot(async (rootDir) => {
+    const missing = path.join(rootDir, 'not-there');
+    const removed = await sweepOrphanAttachments(new Set(), { rootDir: missing });
+    assert.deepEqual(removed, []);
+  });
+});

--- a/apps/desktop/src/main/attachment-store.ts
+++ b/apps/desktop/src/main/attachment-store.ts
@@ -16,7 +16,6 @@
  * Both IDs are validated against a strict charset before touching the
  * filesystem so a hostile renderer can't path-traverse out of the root.
  */
-import { existsSync } from 'node:fs';
 import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { CHAT_DATA_DIR } from './chat-workspace.js';
@@ -128,7 +127,8 @@ export async function resolveAttachmentPath(
 
 /**
  * Delete every attachment belonging to a conversation. Safe no-op when
- * the conversation never had any attachments.
+ * the conversation never had any attachments — `rm { force: true }`
+ * swallows ENOENT, so no pre-check is needed.
  */
 export async function deleteConversationAttachments(
   conversationId: string,
@@ -137,7 +137,6 @@ export async function deleteConversationAttachments(
   if (!isSafeId(conversationId)) return;
   const root = rootFor(options);
   const dir = path.join(root, conversationId);
-  if (!existsSync(dir)) return;
   await rm(dir, { recursive: true, force: true });
 }
 
@@ -154,7 +153,9 @@ export async function sweepOrphanAttachments(
   options: StoreOptions = {},
 ): Promise<string[]> {
   const root = rootFor(options);
-  if (!existsSync(root)) return [];
+  // No synchronous pre-check — the readdir try/catch below already
+  // short-circuits when the root doesn't exist, and `existsSync` would
+  // block the main event loop on every app startup.
   let entries: { name: string; isDirectory: () => boolean }[];
   try {
     entries = await readdir(root, { withFileTypes: true });

--- a/apps/desktop/src/main/attachment-store.ts
+++ b/apps/desktop/src/main/attachment-store.ts
@@ -1,0 +1,177 @@
+/**
+ * Disk storage for chat attachments.
+ *
+ * Each message in a chat can carry attachments (images, PDFs, docs, etc).
+ * The text/image data used for the LLM prompt is produced by
+ * `chat-attachments.ts`. This module is separate — it persists the *raw*
+ * bytes to disk so the renderer can preview them natively (images inline,
+ * PDFs/HTML/SVG via a custom Electron protocol) without shipping
+ * megabytes through IPC or through the persisted prompt text.
+ *
+ * Layout:
+ *   <CHAT_DATA_DIR>/attachments/
+ *     <conversationId>/
+ *       <attachmentId><ext>
+ *
+ * Both IDs are validated against a strict charset before touching the
+ * filesystem so a hostile renderer can't path-traverse out of the root.
+ */
+import { existsSync } from 'node:fs';
+import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { CHAT_DATA_DIR } from './chat-workspace.js';
+
+/** Root directory where per-conversation attachment folders live. */
+export const ATTACHMENTS_DIR = path.join(CHAT_DATA_DIR, 'attachments');
+
+/**
+ * IDs are used as directory / file names and as URL components in the custom
+ * protocol. Allow only ASCII alphanumerics plus `-` and `_`, cap length at
+ * 128 chars. Conversation IDs and attachment IDs produced elsewhere in the
+ * app are UUIDs or monotonic counters, which all satisfy this.
+ */
+const SAFE_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+
+/** Exposed for unit tests. */
+export function isSafeId(value: string): boolean {
+  return typeof value === 'string' && SAFE_ID_RE.test(value);
+}
+
+/**
+ * Derive a conservative extension from an attachment's original filename.
+ * Limits to `[a-z0-9]{1,16}` so we don't smuggle things like `.php%00.jpg`
+ * or multi-level extensions. Returns '' when no usable extension is found.
+ */
+function safeExtension(originalName: string): string {
+  const idx = originalName.lastIndexOf('.');
+  if (idx < 0 || idx === originalName.length - 1) return '';
+  const raw = originalName.slice(idx + 1).toLowerCase();
+  if (!/^[a-z0-9]{1,16}$/.test(raw)) return '';
+  return `.${raw}`;
+}
+
+type StoreOptions = {
+  /** Override the on-disk root (mainly for tests). */
+  rootDir?: string;
+};
+
+function rootFor(options: StoreOptions | undefined): string {
+  return options?.rootDir ?? ATTACHMENTS_DIR;
+}
+
+/**
+ * Write raw attachment bytes to disk.
+ *
+ * Returns the absolute filesystem path that was written. Caller is
+ * responsible for keeping the `attachmentId` in the message block so the
+ * renderer can later ask the custom protocol for the same bytes.
+ */
+export async function saveAttachment(
+  conversationId: string,
+  attachmentId: string,
+  originalName: string,
+  buffer: Buffer | Uint8Array,
+  options: StoreOptions = {},
+): Promise<string> {
+  if (!isSafeId(conversationId)) {
+    throw new Error(`Invalid conversationId: ${conversationId}`);
+  }
+  if (!isSafeId(attachmentId)) {
+    throw new Error(`Invalid attachmentId: ${attachmentId}`);
+  }
+  const root = rootFor(options);
+  const dir = path.join(root, conversationId);
+  await mkdir(dir, { recursive: true });
+  const ext = safeExtension(originalName);
+  const filename = ext ? `${attachmentId}${ext}` : attachmentId;
+  const filePath = path.join(dir, filename);
+  // `flag: 'w'` truncates any existing file; intentional: same attachmentId
+  // always resolves to the same content.
+  await writeFile(filePath, buffer, { flag: 'w' });
+  return filePath;
+}
+
+/**
+ * Resolve `(conversationId, attachmentId)` to an absolute filesystem path.
+ * Returns `null` when the attachment isn't found, when IDs fail validation,
+ * or when the resolved path somehow escapes the root (defense in depth).
+ */
+export async function resolveAttachmentPath(
+  conversationId: string,
+  attachmentId: string,
+  options: StoreOptions = {},
+): Promise<string | null> {
+  if (!isSafeId(conversationId) || !isSafeId(attachmentId)) return null;
+  const root = rootFor(options);
+  const dir = path.join(root, conversationId);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return null;
+  }
+  // Match either `<id>` (no extension) or `<id>.<ext>`.
+  const hit = entries.find((entry) => entry === attachmentId || entry.startsWith(`${attachmentId}.`));
+  if (!hit) return null;
+  const resolved = path.join(dir, hit);
+  // Containment check — resolved path must live under root.
+  const rel = path.relative(root, resolved);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  try {
+    const st = await stat(resolved);
+    if (!st.isFile()) return null;
+  } catch {
+    return null;
+  }
+  return resolved;
+}
+
+/**
+ * Delete every attachment belonging to a conversation. Safe no-op when
+ * the conversation never had any attachments.
+ */
+export async function deleteConversationAttachments(
+  conversationId: string,
+  options: StoreOptions = {},
+): Promise<void> {
+  if (!isSafeId(conversationId)) return;
+  const root = rootFor(options);
+  const dir = path.join(root, conversationId);
+  if (!existsSync(dir)) return;
+  await rm(dir, { recursive: true, force: true });
+}
+
+/**
+ * Remove attachment directories for conversations the caller no longer
+ * tracks. Also removes directories whose names fail ID validation (they
+ * shouldn't exist; we sweep them up just in case).
+ *
+ * Returns the names of directories that were removed (mostly for tests
+ * and startup logging).
+ */
+export async function sweepOrphanAttachments(
+  knownConversationIds: Set<string>,
+  options: StoreOptions = {},
+): Promise<string[]> {
+  const root = rootFor(options);
+  if (!existsSync(root)) return [];
+  let entries: { name: string; isDirectory: () => boolean }[];
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const removed: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const keep = isSafeId(entry.name) && knownConversationIds.has(entry.name);
+    if (keep) continue;
+    try {
+      await rm(path.join(root, entry.name), { recursive: true, force: true });
+      removed.push(entry.name);
+    } catch {
+      // Ignore individual failures — another sweep will retry.
+    }
+  }
+  return removed;
+}

--- a/apps/desktop/src/main/chat-attachments.test.ts
+++ b/apps/desktop/src/main/chat-attachments.test.ts
@@ -193,6 +193,54 @@ test("ZIP entry content containing zip-entry tags is neutralized", async () => {
   assert.ok(prompt.includes('<\\zip-entry name="fake.txt">'));
 });
 
+test('storage callback runs for every non-error attachment and attachmentId is persisted in the prompt', async () => {
+  const stored: Array<{ name: string; id: string; size: number }> = [];
+  let counter = 0;
+  const prepared = await prepareChatAttachments(
+    [
+      rawAttachment('doc.txt', 'text/plain', 'hello'),
+      rawAttachment('pixel.png', 'image/png', Buffer.from([0x89, 0x50, 0x4e, 0x47])),
+    ],
+    {
+      storage: async (raw, buffer) => {
+        counter += 1;
+        const id = `att-${counter}`;
+        stored.push({ name: raw.name, id, size: buffer.byteLength });
+        return id;
+      },
+    },
+  );
+
+  assert.equal(stored.length, 2);
+  assert.equal(stored[0]?.name, 'doc.txt');
+  assert.equal(stored[1]?.name, 'pixel.png');
+  assert.equal(prepared[0]?.attachmentId, 'att-1');
+  assert.equal(prepared[1]?.attachmentId, 'att-2');
+
+  const prompt = buildAttachmentPromptText(prepared);
+  assert.match(prompt, /<file name="doc\.txt"[^>]*id="att-1"/);
+});
+
+test('storage callback failure surfaces as an error attachment without aborting the batch', async () => {
+  const prepared = await prepareChatAttachments(
+    [
+      rawAttachment('ok.txt', 'text/plain', 'fine'),
+      rawAttachment('bad.txt', 'text/plain', 'oops'),
+    ],
+    {
+      storage: async (raw) => {
+        if (raw.name === 'bad.txt') throw new Error('disk full');
+        return 'att-ok';
+      },
+    },
+  );
+
+  assert.equal(prepared[0]?.status, 'ready');
+  assert.equal(prepared[0]?.attachmentId, 'att-ok');
+  assert.equal(prepared[1]?.status, 'error');
+  assert.match(prepared[1]?.error ?? '', /Could not persist attachment.*disk full/);
+});
+
 test("per-file size gate validates decoded buffer, not renderer-reported size", async () => {
   const limits: AttachmentPreparationLimits = {
     maxAttachments: 5,

--- a/apps/desktop/src/main/chat-attachments.ts
+++ b/apps/desktop/src/main/chat-attachments.ts
@@ -14,6 +14,14 @@ export interface RawChatAttachment {
 
 export interface PreparedChatAttachment {
   id: string;
+  /**
+   * Stable server-generated identifier under which the raw bytes were
+   * persisted on disk (via the storage callback passed to
+   * `prepareChatAttachments`). The renderer uses this to build
+   * `antseed-attachment://<conversationId>/<attachmentId>` URLs for the
+   * in-chat preview. Absent when no storage callback was supplied.
+   */
+  attachmentId?: string;
   name: string;
   mimeType: string;
   size: number;
@@ -24,6 +32,22 @@ export interface PreparedChatAttachment {
   error?: string;
   truncated?: boolean;
   native?: { provider?: string; payload?: unknown };
+}
+
+/**
+ * Callback invoked for every non-error attachment. It receives the decoded
+ * bytes and must return (or resolve to) the stable `attachmentId` that will
+ * be stored on the `PreparedChatAttachment` and embedded in the persisted
+ * `<file id="...">` tag.
+ */
+export type AttachmentStorageCallback = (
+  raw: Pick<RawChatAttachment, 'id' | 'name' | 'mimeType' | 'size'>,
+  buffer: Buffer,
+) => Promise<string> | string;
+
+export interface PrepareChatAttachmentsOptions {
+  limits?: AttachmentPreparationLimits;
+  storage?: AttachmentStorageCallback;
 }
 
 export interface AttachmentPreparationLimits {
@@ -185,9 +209,16 @@ function truncateText(text: string, maxChars: number): { text: string; truncated
   };
 }
 
-function wrapFileText(name: string, mimeType: string, size: number, text: string, note?: string): string {
-  const header = `<file name="${safeAttribute(name)}" mime="${safeAttribute(mimeType || 'application/octet-stream')}" size="${size}">`;
-  const body = note ? `${note}\n\n${text}` : text;
+function wrapFileText(
+  name: string,
+  mimeType: string,
+  size: number,
+  text: string,
+  options: { note?: string; attachmentId?: string } = {},
+): string {
+  const idAttr = options.attachmentId ? ` id="${safeAttribute(options.attachmentId)}"` : '';
+  const header = `<file name="${safeAttribute(name)}" mime="${safeAttribute(mimeType || 'application/octet-stream')}" size="${size}"${idAttr}>`;
+  const body = options.note ? `${options.note}\n\n${text}` : text;
   return `${header}\n${neutralizeFileTags(body)}\n</file>`;
 }
 
@@ -223,7 +254,7 @@ function prepareTextResult(
   extractedText: string,
   limits: AttachmentPreparationLimits,
   remainingMessageChars: number,
-  note?: string,
+  options: { note?: string; attachmentId?: string } = {},
 ): { attachment: PreparedChatAttachment; consumedChars: number } {
   const cleanText = extractedText.trim();
   const perFileCap = Math.min(limits.maxExtractedCharsPerFile, remainingMessageChars);
@@ -233,11 +264,12 @@ function prepareTextResult(
     raw.mimeType || 'text/plain',
     raw.size,
     truncated.text || '[No extractable text found.]',
-    note,
+    { ...(options.note ? { note: options.note } : {}), ...(options.attachmentId ? { attachmentId: options.attachmentId } : {}) },
   );
   return {
     attachment: {
       id: raw.id,
+      ...(options.attachmentId ? { attachmentId: options.attachmentId } : {}),
       name: normalizeName(raw.name),
       mimeType: raw.mimeType || 'text/plain',
       size: raw.size,
@@ -255,6 +287,7 @@ function prepareZipAttachment(
   buffer: Buffer,
   limits: AttachmentPreparationLimits,
   remainingMessageChars: number,
+  attachmentId?: string,
 ): { attachment: PreparedChatAttachment; consumedChars: number } {
   let entries: Record<string, Uint8Array>;
   try {
@@ -312,7 +345,10 @@ function prepareZipAttachment(
     '',
     ...textParts,
   ].join('\n');
-  return prepareTextResult(raw, 'archive', archiveText, limits, remainingMessageChars, 'Archive was inspected in memory. Only safe text entries were included.');
+  return prepareTextResult(raw, 'archive', archiveText, limits, remainingMessageChars, {
+    note: 'Archive was inspected in memory. Only safe text entries were included.',
+    ...(attachmentId ? { attachmentId } : {}),
+  });
 }
 
 async function prepareOneAttachment(
@@ -320,6 +356,7 @@ async function prepareOneAttachment(
   buffer: Buffer,
   limits: AttachmentPreparationLimits,
   remainingMessageChars: number,
+  attachmentId?: string,
 ): Promise<{ attachment: PreparedChatAttachment; consumedChars: number }> {
   const name = normalizeName(raw.name);
   const mimeType = raw.mimeType || 'application/octet-stream';
@@ -328,6 +365,7 @@ async function prepareOneAttachment(
     return {
       attachment: {
         id: raw.id,
+        ...(attachmentId ? { attachmentId } : {}),
         name,
         mimeType,
         size: raw.size,
@@ -344,30 +382,47 @@ async function prepareOneAttachment(
   }
 
   if (isArchiveAttachment(name, mimeType)) {
-    return prepareZipAttachment(raw, buffer, limits, remainingMessageChars);
+    return prepareZipAttachment(raw, buffer, limits, remainingMessageChars, attachmentId);
   }
 
   if (isOfficeAttachment(name)) {
     try {
       const extracted = await withTimeout(extractOfficeText(buffer));
-      return prepareTextResult(raw, 'text', extracted, limits, remainingMessageChars, 'Document text was extracted without OCR or embedded attachments.');
+      return prepareTextResult(raw, 'text', extracted, limits, remainingMessageChars, {
+        note: 'Document text was extracted without OCR or embedded attachments.',
+        ...(attachmentId ? { attachmentId } : {}),
+      });
     } catch (error) {
       return { attachment: makeError(raw, `Could not extract document text: ${error instanceof Error ? error.message : String(error)}`), consumedChars: 0 };
     }
   }
 
   if (isTextAttachment(name, mimeType)) {
-    return prepareTextResult(raw, 'text', decodeText(buffer), limits, remainingMessageChars);
+    return prepareTextResult(raw, 'text', decodeText(buffer), limits, remainingMessageChars, {
+      ...(attachmentId ? { attachmentId } : {}),
+    });
   }
 
   return { attachment: makeError(raw, `Unsupported binary file type: ${extensionFor(name) || mimeType || 'unknown'}`), consumedChars: 0 };
 }
 
+function isLimits(value: AttachmentPreparationLimits | PrepareChatAttachmentsOptions): value is AttachmentPreparationLimits {
+  return typeof (value as AttachmentPreparationLimits).maxAttachments === 'number';
+}
+
 export async function prepareChatAttachments(
   rawAttachments: RawChatAttachment[] | undefined,
-  limits: AttachmentPreparationLimits = DEFAULT_ATTACHMENT_LIMITS,
+  limitsOrOptions: AttachmentPreparationLimits | PrepareChatAttachmentsOptions = DEFAULT_ATTACHMENT_LIMITS,
 ): Promise<PreparedChatAttachment[]> {
   if (!rawAttachments?.length) return [];
+
+  // Backward compatibility: callers may pass `AttachmentPreparationLimits`
+  // directly (as the tests do) or the newer options bag.
+  const options: PrepareChatAttachmentsOptions = isLimits(limitsOrOptions)
+    ? { limits: limitsOrOptions }
+    : limitsOrOptions;
+  const limits = options.limits ?? DEFAULT_ATTACHMENT_LIMITS;
+  const storage = options.storage;
 
   const prepared: PreparedChatAttachment[] = [];
   let totalRawBytes = 0;
@@ -405,8 +460,22 @@ export async function prepareChatAttachments(
     }
     totalRawBytes += buffer.byteLength;
 
+    // Persist raw bytes first when the caller provided a storage callback.
+    // Failures are recorded as errors for this attachment but don't abort
+    // the batch — the LLM pipeline can still receive extracted text for
+    // other files.
+    let attachmentId: string | undefined;
+    if (storage) {
+      try {
+        attachmentId = await storage(rawMeta, buffer);
+      } catch (error) {
+        prepared.push(makeError(rawMeta, `Could not persist attachment: ${error instanceof Error ? error.message : String(error)}`));
+        continue;
+      }
+    }
+
     const remainingChars = Math.max(0, limits.maxExtractedCharsPerMessage - totalExtractedChars);
-    const result = await prepareOneAttachment(rawMeta, buffer, limits, remainingChars);
+    const result = await prepareOneAttachment(rawMeta, buffer, limits, remainingChars, attachmentId);
     totalExtractedChars += result.consumedChars;
     prepared.push(result.attachment);
   }

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -5,6 +5,7 @@ import {
   dialog,
   type OpenDialogOptions,
 } from 'electron';
+import { copyFile } from 'node:fs/promises';
 import electronUpdater from 'electron-updater';
 const { autoUpdater } = electronUpdater;
 import path from 'node:path';
@@ -53,6 +54,7 @@ import {
 import { createWindow, createApplicationMenu, getMainWindow } from './window.js';
 import { ensureConfig, readConfig, mergeConfig, readNodeStatus } from './config-io.js';
 import { registerAttachmentScheme, installAttachmentProtocol } from './attachment-protocol.js';
+import { resolveAttachmentPath } from './attachment-store.js';
 
 // Re-export types that may be used by other main-process modules
 export type { LogEvent, RuntimeActivityEvent } from './log-parser.js';
@@ -352,6 +354,41 @@ ipcMain.handle('runtime:clear-logs', async () => {
   logBuffer.length = 0;
   return { ok: true };
 });
+
+ipcMain.handle(
+  'attachment:download',
+  async (
+    _event,
+    conversationId: string,
+    attachmentId: string,
+    suggestedName: string,
+  ): Promise<{ ok: boolean; path?: string; error?: string }> => {
+    // Download flow via dialog.showSaveDialog + copyFile. More reliable
+    // cross-platform than relying on <a download> with a custom
+    // Electron protocol URL — Chromium's save-to-disk path is only
+    // guaranteed for http(s)/data/blob.
+    try {
+      const resolved = await resolveAttachmentPath(conversationId, attachmentId);
+      if (!resolved) {
+        return { ok: false, error: 'Attachment not found' };
+      }
+      const win = getMainWindow();
+      const safeSuggested = typeof suggestedName === 'string' && suggestedName.trim().length > 0
+        ? suggestedName.trim()
+        : 'attachment';
+      const result = win
+        ? await dialog.showSaveDialog(win, { defaultPath: safeSuggested })
+        : await dialog.showSaveDialog({ defaultPath: safeSuggested });
+      if (result.canceled || !result.filePath) {
+        return { ok: false, error: 'cancelled' };
+      }
+      await copyFile(resolved, result.filePath);
+      return { ok: true, path: result.filePath };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  },
+);
 
 ipcMain.handle('desktop:pick-directory', async () => {
   const dialogOptions: OpenDialogOptions = {

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -52,6 +52,7 @@ import {
 } from './peer-cache.js';
 import { createWindow, createApplicationMenu, getMainWindow } from './window.js';
 import { ensureConfig, readConfig, mergeConfig, readNodeStatus } from './config-io.js';
+import { registerAttachmentScheme, installAttachmentProtocol } from './attachment-protocol.js';
 
 // Re-export types that may be used by other main-process modules
 export type { LogEvent, RuntimeActivityEvent } from './log-parser.js';
@@ -85,6 +86,11 @@ function hasDesktopDebugFlag(argv: string[]): boolean {
 }
 
 let desktopDebugEnabled = isTruthyEnv(process.env[DESKTOP_DEBUG_ENV]) || hasDesktopDebugFlag(process.argv);
+
+// The `antseed-attachment://` scheme must be registered as privileged
+// *before* `app.whenReady()` fires. The actual request handler is wired
+// inside whenReady() once Electron's protocol module is usable.
+registerAttachmentScheme();
 
 function resolveAppIconPath(): string | undefined {
   const candidates = [
@@ -854,6 +860,7 @@ ipcMain.handle('runtime:scan-network', async () => {
 });
 
 app.whenReady().then(async () => {
+  installAttachmentProtocol();
   app.setName(APP_NAME);
   app.setAboutPanelOptions({
     applicationName: APP_NAME,

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -17,6 +17,10 @@ import {
   type PreparedChatAttachment,
   type RawChatAttachment,
 } from './chat-attachments.js';
+import {
+  deleteConversationAttachments,
+  sweepOrphanAttachments,
+} from './attachment-store.js';
 import { webFetchTool } from './chat-web-fetch.js';
 import { fetchNetworkStats } from './fetch-network-stats.js';
 import { buildAntstationSystemPrompt } from './chat-system-prompt.js';
@@ -2614,8 +2618,33 @@ export function registerPiChatHandlers({
     preferredPeerByConversationId.delete(id);
     cachedPaymentRequired.delete(id);
     await store.delete(id);
+    // Best effort: wipe any raw attachment bytes we persisted for this
+    // conversation. Failures are swallowed so a stuck directory doesn't
+    // block the primary delete from returning ok.
+    try {
+      await deleteConversationAttachments(id);
+    } catch (err) {
+      appendSystemLog(`Failed to delete attachments for conversation ${id}: ${asErrorMessage(err)}`);
+    }
     return { ok: true };
   });
+
+  // Sweep attachment directories that no longer correspond to any
+  // conversation — can happen if a previous run crashed between persist
+  // and the delete handler. Cheap (directory stat-only) so we do it once
+  // on handler registration.
+  void (async () => {
+    try {
+      const summaries = await store.list();
+      const known = new Set<string>(summaries.map((s) => s.id));
+      const removed = await sweepOrphanAttachments(known);
+      if (removed.length > 0) {
+        appendSystemLog(`Swept ${removed.length} orphan attachment director${removed.length === 1 ? 'y' : 'ies'}.`);
+      }
+    } catch (err) {
+      appendSystemLog(`Attachment orphan sweep failed: ${asErrorMessage(err)}`);
+    }
+  })();
 
   ipcMain.handle('chat:ai-rename-conversation', async (_event, id: string, title: string) => {
     const manager = await store.openSessionManager(id);

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -1,4 +1,5 @@
 import type { IpcMain } from 'electron';
+import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, stat, unlink } from 'node:fs/promises';
 import { createConnection } from 'node:net';
@@ -19,6 +20,8 @@ import {
 } from './chat-attachments.js';
 import {
   deleteConversationAttachments,
+  isSafeId,
+  saveAttachment,
   sweepOrphanAttachments,
 } from './attachment-store.js';
 import { webFetchTool } from './chat-web-fetch.js';
@@ -62,6 +65,12 @@ type FileBlock = {
   size?: number;
   status?: 'ready' | 'error';
   truncated?: boolean;
+  /**
+   * Stable ID under which the raw bytes live in the attachment store.
+   * When present the renderer can build an `antseed-attachment://` URL
+   * and preview the file natively.
+   */
+  attachmentId?: string;
 };
 type ImageBlock = { type: 'image'; source: { type: 'base64'; media_type?: string; data?: string } };
 type ThinkingBlock = { type: 'thinking'; thinking: string };
@@ -940,6 +949,7 @@ function convertPersistedAttachmentPromptToBlocks(text: string): string | Conten
     const attrs = parseAttachmentAttributes(match[1] ?? '');
     const size = Number(attrs.size);
     const body = match[2] ?? '';
+    const attachmentId = attrs.id && isSafeId(attrs.id) ? attrs.id : undefined;
     blocks.push({
       type: 'file',
       fileName: attrs.name || 'attachment',
@@ -947,6 +957,7 @@ function convertPersistedAttachmentPromptToBlocks(text: string): string | Conten
       ...(Number.isFinite(size) && size >= 0 ? { size } : {}),
       status: 'ready',
       truncated: body.includes('[Attachment truncated:'),
+      ...(attachmentId ? { attachmentId } : {}),
     });
     lastIndex = index + match[0].length;
   }
@@ -2655,9 +2666,24 @@ export function registerPiChatHandlers({
     return { ok: true };
   });
 
-  ipcMain.handle('chat:prepare-attachments', async (_event, attachments: RawChatAttachment[]) => {
+  ipcMain.handle('chat:prepare-attachments', async (_event, conversationId: string, attachments: RawChatAttachment[]) => {
     try {
-      return { ok: true, data: await prepareChatAttachments(attachments) };
+      const trimmedId = typeof conversationId === 'string' ? conversationId.trim() : '';
+      // Guard the filesystem boundary: only run the disk-backed storage
+      // path when the renderer supplied a conversationId we can vouch for.
+      // Otherwise fall back to the legacy pure-prepare behaviour — the
+      // LLM pipeline still works, we just can't offer native previews.
+      const storage = trimmedId && isSafeId(trimmedId)
+        ? async (raw: { id: string; name: string; mimeType: string; size: number }, buffer: Buffer): Promise<string> => {
+            const attachmentId = randomUUID();
+            await saveAttachment(trimmedId, attachmentId, raw.name, buffer);
+            return attachmentId;
+          }
+        : undefined;
+      return {
+        ok: true,
+        data: await prepareChatAttachments(attachments, { ...(storage ? { storage } : {}) }),
+      };
     } catch (error) {
       return { ok: false, error: asErrorMessage(error) };
     }

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -213,6 +213,9 @@ const api = {
   chatPrepareAttachments(conversationId: string, attachments: RawChatAttachment[]): Promise<{ ok: boolean; data?: PreparedChatAttachment[]; error?: string }> {
     return ipcRenderer.invoke('chat:prepare-attachments', conversationId, attachments);
   },
+  attachmentDownload(conversationId: string, attachmentId: string, suggestedName: string): Promise<{ ok: boolean; path?: string; error?: string }> {
+    return ipcRenderer.invoke('attachment:download', conversationId, attachmentId, suggestedName);
+  },
   chatAiSend(conversationId: string, message: string, service?: string, provider?: string, attachments?: PreparedChatAttachment[]): Promise<{ ok: boolean; error?: string }> {
     return ipcRenderer.invoke('chat:ai-send', conversationId, message, service, provider, attachments);
   },

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -89,6 +89,9 @@ type RawChatAttachment = {
 
 type PreparedChatAttachment = {
   id: string;
+  /** Stable server-generated ID for the on-disk copy; used by the
+   *  `antseed-attachment://` preview protocol. */
+  attachmentId?: string;
   name: string;
   mimeType: string;
   size: number;
@@ -207,8 +210,8 @@ const api = {
   chatAiRenameConversation(id: string, title: string): Promise<{ ok: boolean; error?: string }> {
     return ipcRenderer.invoke('chat:ai-rename-conversation', id, title);
   },
-  chatPrepareAttachments(attachments: RawChatAttachment[]): Promise<{ ok: boolean; data?: PreparedChatAttachment[]; error?: string }> {
-    return ipcRenderer.invoke('chat:prepare-attachments', attachments);
+  chatPrepareAttachments(conversationId: string, attachments: RawChatAttachment[]): Promise<{ ok: boolean; data?: PreparedChatAttachment[]; error?: string }> {
+    return ipcRenderer.invoke('chat:prepare-attachments', conversationId, attachments);
   },
   chatAiSend(conversationId: string, message: string, service?: string, provider?: string, attachments?: PreparedChatAttachment[]): Promise<{ ok: boolean; error?: string }> {
     return ipcRenderer.invoke('chat:ai-send', conversationId, message, service, provider, attachments);

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1742,6 +1742,29 @@ export function initChatModule({
         return;
       }
 
+      // Multimodal gate — if the user attached image(s) but the current
+      // service isn't tagged `multimodal` in the catalog, the main side
+      // would silently drop the images and still send the text, which
+      // confuses the user ("the LLM only saw the files, not the image").
+      // Block the send and explain instead.
+      const hasReadyImage = preparedAttachments.some(
+        (attachment) => attachment.kind === 'image' && attachment.status === 'ready',
+      );
+      if (hasReadyImage) {
+        const currentOption = uiState.chatServiceOptions.find(
+          (opt) => opt.value === uiState.chatSelectedServiceValue,
+        );
+        const supportsMultimodal = currentOption?.categories?.includes('multimodal') ?? false;
+        if (!supportsMultimodal) {
+          const label = currentOption?.label || 'this service';
+          showChatError(
+            `${label} doesn't support images. Remove the image attachment or switch to a multimodal service (look for the “multimodal” tag in Discover).`,
+          );
+          setConversationSending(convId, false);
+          return;
+        }
+      }
+
       const messageContent = buildUserMessageContent(content, preparedAttachments);
       uiState.chatMessages = [...uiState.chatMessages, { role: 'user', content: messageContent, createdAt: Date.now() }];
       setLocalConversationMessages(convId, uiState.chatMessages as ChatMessage[]);

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1658,6 +1658,9 @@ export function initChatModule({
         status: attachment.status,
         error: attachment.error,
         truncated: attachment.truncated,
+        // Carry the stable disk-store ID onto the block so the renderer
+        // can later open a native preview via `antseed-attachment://`.
+        ...(attachment.attachmentId ? { attachmentId: attachment.attachmentId } : {}),
         attachment,
       });
       if (attachment.kind === 'image' && attachment.image?.data && attachment.image.mimeType) {
@@ -1670,13 +1673,16 @@ export function initChatModule({
     return blocks.length > 0 ? blocks : text;
   }
 
-  async function prepareAttachmentsForSend(rawAttachments: RawChatAttachment[] | undefined): Promise<PreparedChatAttachment[]> {
+  async function prepareAttachmentsForSend(
+    conversationId: string,
+    rawAttachments: RawChatAttachment[] | undefined,
+  ): Promise<PreparedChatAttachment[]> {
     if (!rawAttachments?.length) return [];
     const activeBridge = bridge;
     if (!activeBridge?.chatPrepareAttachments) {
       throw new Error('Attachment preparation is not available in this desktop build.');
     }
-    const result = await activeBridge.chatPrepareAttachments(rawAttachments);
+    const result = await activeBridge.chatPrepareAttachments(conversationId, rawAttachments);
     if (!result.ok) {
       throw new Error(result.error || 'Attachment preparation failed');
     }
@@ -1721,7 +1727,7 @@ export function initChatModule({
     void (async () => {
       let preparedAttachments: PreparedChatAttachment[];
       try {
-        preparedAttachments = await prepareAttachmentsForSend(rawAttachments);
+        preparedAttachments = await prepareAttachmentsForSend(convId, rawAttachments);
       } catch (err) {
         reportChatError(err, 'Attachment preparation failed');
         setConversationSending(convId, false);

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -109,6 +109,9 @@ export type RawChatAttachment = {
 
 export type PreparedChatAttachment = {
   id: string;
+  /** Stable server-generated ID for the on-disk copy; used by the
+   *  `antseed-attachment://` preview protocol. */
+  attachmentId?: string;
   name: string;
   mimeType: string;
   size: number;
@@ -158,7 +161,7 @@ export type DesktopBridge = {
   chatAiCreateConversation?: (service: string, provider?: string, peerId?: string) => Promise<{ ok: boolean; data?: unknown; error?: string }>;
   chatAiDeleteConversation?: (id: string) => Promise<{ ok: boolean }>;
   chatAiRenameConversation?: (id: string, title: string) => Promise<{ ok: boolean; error?: string }>;
-  chatPrepareAttachments?: (attachments: RawChatAttachment[]) => Promise<{ ok: boolean; data?: PreparedChatAttachment[]; error?: string }>;
+  chatPrepareAttachments?: (conversationId: string, attachments: RawChatAttachment[]) => Promise<{ ok: boolean; data?: PreparedChatAttachment[]; error?: string }>;
   chatAiSend?: (conversationId: string, message: string, service?: string, provider?: string, attachments?: PreparedChatAttachment[]) => Promise<{ ok: boolean; error?: string }>;
   chatAiSendStream?: (conversationId: string, message: string, service?: string, provider?: string, attachments?: PreparedChatAttachment[]) => Promise<{ ok: boolean; error?: string; stopReason?: ChatAiStreamStopReason }>;
   chatAiAbort?: (conversationId?: string) => Promise<{ ok: boolean }>;

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -162,6 +162,7 @@ export type DesktopBridge = {
   chatAiDeleteConversation?: (id: string) => Promise<{ ok: boolean }>;
   chatAiRenameConversation?: (id: string, title: string) => Promise<{ ok: boolean; error?: string }>;
   chatPrepareAttachments?: (conversationId: string, attachments: RawChatAttachment[]) => Promise<{ ok: boolean; data?: PreparedChatAttachment[]; error?: string }>;
+  attachmentDownload?: (conversationId: string, attachmentId: string, suggestedName: string) => Promise<{ ok: boolean; path?: string; error?: string }>;
   chatAiSend?: (conversationId: string, message: string, service?: string, provider?: string, attachments?: PreparedChatAttachment[]) => Promise<{ ok: boolean; error?: string }>;
   chatAiSendStream?: (conversationId: string, message: string, service?: string, provider?: string, attachments?: PreparedChatAttachment[]) => Promise<{ ok: boolean; error?: string; stopReason?: ChatAiStreamStopReason }>;
   chatAiAbort?: (conversationId?: string) => Promise<{ ok: boolean }>;

--- a/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.module.scss
@@ -1,6 +1,7 @@
-/* AttachmentViewer.module.scss — fullscreen modal for previewing images
-   in chat. Non-image previews are planned as a follow-up (disk-backed
-   attachments rendered via a custom Electron protocol). */
+/* AttachmentViewer.module.scss — fullscreen modal for previewing chat
+   attachments. Images render inline; PDFs / HTML are served via the
+   `antseed-attachment://` custom protocol and rendered by Chromium's
+   native engines inside an iframe. */
 
 @keyframes av-backdrop-in {
   from { opacity: 0; }
@@ -143,6 +144,11 @@
   overflow: auto;
   background: var(--bg-primary);
   display: flex;
+  // Column-flex so the single child (image wrap, PDF iframe, HTML iframe
+  // or empty / error state) stretches across the full cross axis. The
+  // default row direction collapsed the iframe to its intrinsic 300px
+  // width because flex items honour `min-width: auto`.
+  flex-direction: column;
   min-height: 0;
 }
 
@@ -162,6 +168,19 @@
   object-fit: contain;
   display: block;
   border-radius: var(--radius-sm);
+}
+
+// Shared by PDF and HTML previews — the iframe fills the whole modal
+// body. `min-width: 0` disables flex's default intrinsic-size protection
+// so the iframe really takes 100% of the available width.
+.pdfFrame {
+  flex: 1 1 auto;
+  display: block;
+  width: 100%;
+  min-width: 0;
+  min-height: 70vh;
+  border: 0;
+  background: #ffffff;
 }
 
 .emptyMsg,

--- a/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.module.scss
@@ -150,6 +150,9 @@
   // width because flex items honour `min-width: auto`.
   flex-direction: column;
   min-height: 0;
+  // Anchor the loading overlay to the body so the spinner sits on top
+  // of the iframe without fighting its flex sizing.
+  position: relative;
 }
 
 .imageWrap {
@@ -200,4 +203,39 @@
 
 .errorMsg {
   color: var(--danger);
+}
+
+@keyframes av-spinner-rotate {
+  to { transform: rotate(360deg); }
+}
+
+// Overlay that sits on top of the iframe / img while the browser is
+// still streaming the content. Fades out via `pointer-events: none` so
+// the user can still interact with the loaded content the instant it's
+// ready, but the label stays visible as a cue.
+.loadingOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--text-muted);
+  background: var(--bg-primary);
+  pointer-events: none;
+  user-select: none;
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: av-spinner-rotate 0.8s linear infinite;
+}
+
+.loadingLabel {
+  letter-spacing: 0.02em;
 }

--- a/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.tsx
@@ -29,6 +29,12 @@ export type ViewerAttachment = {
    * megabytes through IPC.
    */
   src?: string;
+  /**
+   * When present, the Download button uses an IPC → `dialog.showSaveDialog`
+   * → `copyFile` path instead of `<a download>`. More reliable than
+   * relying on Chromium's save-to-disk handling of custom protocols.
+   */
+  downloadIpc?: { conversationId: string; attachmentId: string };
   error?: string;
 };
 
@@ -100,6 +106,7 @@ function buildDownloadHref(att: ViewerAttachment): string | null {
 
 export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps) {
   const [closing, setClosing] = useState(false);
+  const [loaded, setLoaded] = useState(false);
   const closeTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
 
   const close = useCallback(() => {
@@ -138,7 +145,43 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
     () => (attachment.src && isTextualMime(attachment.mimeType) ? attachment.src : null),
     [attachment],
   );
-  const download = useMemo(() => buildDownloadHref(attachment), [attachment]);
+  const inlineHref = useMemo(() => buildDownloadHref(attachment), [attachment]);
+  const hasPreview = Boolean(imgSrc || pdfSrc || htmlSrc || textSrc);
+
+  // Reset the loading indicator when we switch to a different attachment.
+  useEffect(() => {
+    setLoaded(false);
+  }, [imgSrc, pdfSrc, htmlSrc, textSrc]);
+
+  const handleDownload = useCallback(async () => {
+    const bridge = typeof window !== 'undefined'
+      ? (window as { antseedDesktop?: { attachmentDownload?: (c: string, a: string, n: string) => Promise<{ ok: boolean; error?: string }> } }).antseedDesktop
+      : undefined;
+    if (attachment.downloadIpc && bridge?.attachmentDownload) {
+      // Reliable path: main process streams the file through
+      // dialog.showSaveDialog + fs.copyFile.
+      await bridge.attachmentDownload(
+        attachment.downloadIpc.conversationId,
+        attachment.downloadIpc.attachmentId,
+        attachment.name || 'attachment',
+      );
+      return;
+    }
+    // Fallback for composer chips (dataUrl) and chat image blocks
+    // (inline base64) — these don't have a disk-backed id yet, so the
+    // classic <a download> flow is fine and doesn't hit the custom
+    // protocol quirk.
+    if (!inlineHref) return;
+    const anchor = document.createElement('a');
+    anchor.href = inlineHref;
+    anchor.download = attachment.name || 'attachment';
+    anchor.style.display = 'none';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  }, [attachment.downloadIpc, attachment.name, inlineHref]);
+
+  const canDownload = Boolean(attachment.downloadIpc) || Boolean(inlineHref);
 
   const metaParts = [attachment.mimeType, formatSize(attachment.size)].filter(Boolean).join(' · ');
 
@@ -161,15 +204,15 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
             {metaParts && <div className={styles.meta}>{metaParts}</div>}
           </div>
           <div className={styles.actions}>
-            {download && (
-              <a
+            {canDownload && (
+              <button
+                type="button"
                 className={styles.downloadBtn}
-                href={download}
-                download={attachment.name || 'attachment'}
+                onClick={handleDownload}
                 title="Download"
               >
                 Download
-              </a>
+              </button>
             )}
             <button type="button" className={styles.closeBtn} onClick={close} aria-label="Close">
               <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
@@ -183,13 +226,20 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
             <div className={styles.errorMsg}>{attachment.error}</div>
           ) : imgSrc ? (
             <div className={styles.imageWrap}>
-              <img src={imgSrc} alt={attachment.name} className={styles.image} />
+              <img
+                src={imgSrc}
+                alt={attachment.name}
+                className={styles.image}
+                onLoad={() => setLoaded(true)}
+                onError={() => setLoaded(true)}
+              />
             </div>
           ) : pdfSrc ? (
             <iframe
               title={attachment.name}
               src={pdfSrc}
               className={styles.pdfFrame}
+              onLoad={() => setLoaded(true)}
             />
           ) : htmlSrc ? (
             // `sandbox=""` disables scripts, same-origin, forms and top
@@ -200,6 +250,7 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
               src={htmlSrc}
               sandbox=""
               className={styles.pdfFrame}
+              onLoad={() => setLoaded(true)}
             />
           ) : textSrc ? (
             // Plain text, source, JSON, CSV, etc. Chromium renders these
@@ -211,11 +262,21 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
               src={textSrc}
               sandbox=""
               className={styles.pdfFrame}
+              onLoad={() => setLoaded(true)}
             />
           ) : (
             <div className={styles.emptyMsg}>
               No inline preview available for this file type.
-              {download ? ' Use Download to save the file.' : ''}
+              {canDownload ? ' Use Download to save the file.' : ''}
+            </div>
+          )}
+          {hasPreview && !loaded && (
+            // Overlay spinner while the image / iframe is loading. First
+            // open has real latency (Chromium spinning up its PDF viewer
+            // or streaming a large file) and a blank modal feels broken.
+            <div className={styles.loadingOverlay} aria-live="polite" role="status">
+              <span className={styles.spinner} aria-hidden="true" />
+              <span className={styles.loadingLabel}>Loading preview…</span>
             </div>
           )}
         </div>

--- a/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.tsx
@@ -60,6 +60,25 @@ function isHtmlMime(mimeType: string): boolean {
   return m === 'text/html' || m === 'application/xhtml+xml';
 }
 
+/**
+ * Mime types Chromium renders as plain text when asked. `text/html` is
+ * handled separately (it has its own sandbox branch) so we exclude it
+ * here.
+ */
+function isTextualMime(mimeType: string): boolean {
+  const m = mimeType.toLowerCase();
+  if (isHtmlMime(m)) return false;
+  if (m.startsWith('text/')) return true;
+  return (
+    m === 'application/json'
+    || m === 'application/javascript'
+    || m === 'application/x-javascript'
+    || m === 'application/xml'
+    || m === 'application/yaml'
+    || m === 'application/x-yaml'
+  );
+}
+
 function buildImageSrc(att: ViewerAttachment): string | null {
   // A `src` URL (custom protocol) beats any inline bytes for images —
   // Chromium can stream the file without JS touching the bytes.
@@ -113,6 +132,10 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
   );
   const htmlSrc = useMemo(
     () => (attachment.src && isHtmlMime(attachment.mimeType) ? attachment.src : null),
+    [attachment],
+  );
+  const textSrc = useMemo(
+    () => (attachment.src && isTextualMime(attachment.mimeType) ? attachment.src : null),
     [attachment],
   );
   const download = useMemo(() => buildDownloadHref(attachment), [attachment]);
@@ -175,6 +198,17 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
             <iframe
               title={attachment.name}
               src={htmlSrc}
+              sandbox=""
+              className={styles.pdfFrame}
+            />
+          ) : textSrc ? (
+            // Plain text, source, JSON, CSV, etc. Chromium renders these
+            // as monospace text. `sandbox=""` is belt-and-braces — with
+            // `nosniff` set by the protocol handler, Chromium can't
+            // reclassify the response as HTML.
+            <iframe
+              title={attachment.name}
+              src={textSrc}
               sandbox=""
               className={styles.pdfFrame}
             />

--- a/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/AttachmentViewer.tsx
@@ -3,21 +3,32 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import styles from './AttachmentViewer.module.scss';
 
 /**
- * Attachment that can be previewed. Currently scoped to images (composer
- * uploads pre-send, and image blocks in chat history). Non-image file
- * previews are intentionally out of scope here — they're planned as a
- * follow-up that stores raw bytes on disk and uses a custom Electron
- * protocol so the browser engine can render them natively.
+ * Attachment that can be previewed. Three shapes coexist so the same modal
+ * works in every call site:
+ *
+ * 1. Composer chips pre-send — carry a full `data:` URL in `dataUrl`.
+ * 2. Chat image blocks — carry the base64 body in `imageBase64` +
+ *    `imageMimeType`.
+ * 3. Chat file blocks with disk-backed storage — carry a
+ *    `antseed-attachment://` URL in `src`, and the renderer dispatches
+ *    to the right engine based on `mimeType`.
  */
 export type ViewerAttachment = {
   name: string;
   mimeType: string;
   size?: number;
-  /** Full data URL (e.g. "data:image/png;base64,...") — used by composer chips. */
+  /** Full data URL (e.g. "data:image/png;base64,...") — composer chips. */
   dataUrl?: string;
-  /** Image base64 body (no "data:" prefix) — from ContentBlock.image source. */
+  /** Image base64 body (no "data:" prefix) — image blocks. */
   imageBase64?: string;
   imageMimeType?: string;
+  /**
+   * Custom-protocol URL that Chromium can fetch directly (via Electron's
+   * `antseed-attachment://` handler). Used by persisted file blocks so
+   * PDFs, HTML, SVG and images render natively without round-tripping
+   * megabytes through IPC.
+   */
+  src?: string;
   error?: string;
 };
 
@@ -36,15 +47,35 @@ function formatSize(bytes: number | undefined): string {
   return `${(mb / 1024).toFixed(1)} GB`;
 }
 
-function isImageMime(mimeType: string | undefined): boolean {
-  return Boolean(mimeType && mimeType.toLowerCase().startsWith('image/'));
+function isImageMime(mimeType: string): boolean {
+  return mimeType.toLowerCase().startsWith('image/');
+}
+
+function isPdfMime(mimeType: string): boolean {
+  return mimeType.toLowerCase() === 'application/pdf';
+}
+
+function isHtmlMime(mimeType: string): boolean {
+  const m = mimeType.toLowerCase();
+  return m === 'text/html' || m === 'application/xhtml+xml';
 }
 
 function buildImageSrc(att: ViewerAttachment): string | null {
+  // A `src` URL (custom protocol) beats any inline bytes for images —
+  // Chromium can stream the file without JS touching the bytes.
+  if (att.src && isImageMime(att.mimeType)) return att.src;
   if (att.dataUrl && att.dataUrl.startsWith('data:')) return att.dataUrl;
   if (att.imageBase64 && att.imageMimeType) {
     return `data:${att.imageMimeType};base64,${att.imageBase64}`;
   }
+  return null;
+}
+
+function buildDownloadHref(att: ViewerAttachment): string | null {
+  // Anything reachable over the custom protocol is downloadable as-is.
+  if (att.src) return att.src;
+  const img = buildImageSrc(att);
+  if (img) return img;
   return null;
 }
 
@@ -75,11 +106,16 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
     return () => window.removeEventListener('keydown', handleKey);
   }, [close]);
 
-  const imgSrc = useMemo(
-    () => (isImageMime(attachment.mimeType) ? buildImageSrc(attachment) : null),
+  const imgSrc = useMemo(() => buildImageSrc(attachment), [attachment]);
+  const pdfSrc = useMemo(
+    () => (attachment.src && isPdfMime(attachment.mimeType) ? attachment.src : null),
     [attachment],
   );
-  const downloadHref = imgSrc;
+  const htmlSrc = useMemo(
+    () => (attachment.src && isHtmlMime(attachment.mimeType) ? attachment.src : null),
+    [attachment],
+  );
+  const download = useMemo(() => buildDownloadHref(attachment), [attachment]);
 
   const metaParts = [attachment.mimeType, formatSize(attachment.size)].filter(Boolean).join(' · ');
 
@@ -102,10 +138,10 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
             {metaParts && <div className={styles.meta}>{metaParts}</div>}
           </div>
           <div className={styles.actions}>
-            {downloadHref && (
+            {download && (
               <a
                 className={styles.downloadBtn}
-                href={downloadHref}
+                href={download}
                 download={attachment.name || 'attachment'}
                 title="Download"
               >
@@ -126,8 +162,27 @@ export function AttachmentViewer({ attachment, onClose }: AttachmentViewerProps)
             <div className={styles.imageWrap}>
               <img src={imgSrc} alt={attachment.name} className={styles.image} />
             </div>
+          ) : pdfSrc ? (
+            <iframe
+              title={attachment.name}
+              src={pdfSrc}
+              className={styles.pdfFrame}
+            />
+          ) : htmlSrc ? (
+            // `sandbox=""` disables scripts, same-origin, forms and top
+            // navigation — even if the protocol handler's CSP were bypassed
+            // the iframe still can't phone home or run JS.
+            <iframe
+              title={attachment.name}
+              src={htmlSrc}
+              sandbox=""
+              className={styles.pdfFrame}
+            />
           ) : (
-            <div className={styles.emptyMsg}>No inline preview available for this file type.</div>
+            <div className={styles.emptyMsg}>
+              No inline preview available for this file type.
+              {download ? ' Use Download to save the file.' : ''}
+            </div>
           )}
         </div>
       </div>

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -679,6 +679,28 @@
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-card);
+  text-align: left;
+  font-family: inherit;
+  color: inherit;
+}
+
+button.fileAttachment {
+  appearance: none;
+  cursor: pointer;
+}
+
+.fileAttachmentClickable {
+  transition: background 0.12s ease, border-color 0.12s ease;
+
+  &:hover {
+    background: var(--bg-hover);
+    border-color: var(--accent);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
 }
 
 .fileAttachmentError {

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -475,30 +475,6 @@ function renderAssistantBlocks(
   return nodes;
 }
 
-/**
- * Mime types the AttachmentViewer can render natively. Image, PDF, and
- * HTML get their dedicated branches in the viewer; everything else that
- * Chromium will display as plain text (text/*, JSON, JS, XML, YAML)
- * falls into a generic iframe path. Anything else degrades to a
- * metadata-only card with a Download button.
- */
-function isRenderableMime(mimeType: string): boolean {
-  const m = mimeType.toLowerCase();
-  if (m.startsWith('image/')) return true;
-  if (m === 'application/pdf') return true;
-  if (m === 'text/html' || m === 'application/xhtml+xml') return true;
-  if (m.startsWith('text/')) return true;
-  if (
-    m === 'application/json'
-    || m === 'application/javascript'
-    || m === 'application/x-javascript'
-    || m === 'application/xml'
-    || m === 'application/yaml'
-    || m === 'application/x-yaml'
-  ) return true;
-  return false;
-}
-
 function FileAttachmentBlock({ block, conversationId }: { block: ContentBlock; conversationId?: string }) {
   const [viewerOpen, setViewerOpen] = useState(false);
   const fileName = String(block.fileName || 'attachment');
@@ -508,17 +484,17 @@ function FileAttachmentBlock({ block, conversationId }: { block: ContentBlock; c
     : '';
   const isError = block.status === 'error' || Boolean(block.error);
 
-  // Only render a preview when we have both a conversationId and an
-  // attachmentId — together they address a disk-backed file the custom
-  // protocol can serve. Old messages (pre-storage) have neither, so the
-  // card stays a plain metadata row with no surprise 404s.
+  // The card is clickable whenever we can address the bytes on disk
+  // (conversationId + attachmentId). The viewer itself decides whether
+  // to render an inline preview (image / PDF / HTML / text) or fall
+  // back to a metadata-only state with a Download button — so docx,
+  // xlsx, zip, etc. are still reachable, just not previewable in-line.
+  // Old messages (pre-storage) have no attachmentId and stay as plain
+  // non-clickable metadata rows.
   const attachmentId = typeof block.attachmentId === 'string' && block.attachmentId.length > 0
     ? block.attachmentId
     : null;
-  const canPreview = !isError
-    && Boolean(attachmentId)
-    && Boolean(conversationId)
-    && isRenderableMime(mimeType);
+  const canPreview = !isError && Boolean(attachmentId) && Boolean(conversationId);
 
   const viewer: ViewerAttachment = useMemo(() => ({
     name: fileName,

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -440,7 +440,13 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
   );
 }
 
-function renderAssistantBlocks(blocks: ContentBlock[], streaming = false, messagePrefix = '', onOpenPreview?: (url: string) => void): ReactNode[] {
+function renderAssistantBlocks(
+  blocks: ContentBlock[],
+  streaming = false,
+  messagePrefix = '',
+  onOpenPreview?: (url: string) => void,
+  conversationId?: string,
+): ReactNode[] {
   const nodes: ReactNode[] = [];
   let toolGroup: ContentBlock[] = [];
 
@@ -462,11 +468,93 @@ function renderAssistantBlocks(blocks: ContentBlock[], streaming = false, messag
       return;
     }
     flushToolGroup();
-    nodes.push(renderBlock(block, index, streaming, messagePrefix));
+    nodes.push(renderBlock(block, index, streaming, messagePrefix, conversationId));
   });
 
   flushToolGroup();
   return nodes;
+}
+
+/**
+ * Is `application/pdf`, `text/html`, `text/svg+xml`, `image/*`, etc. a
+ * mime we know how to render natively in the AttachmentViewer? Anything
+ * else falls back to metadata + Download.
+ */
+function isRenderableMime(mimeType: string): boolean {
+  const m = mimeType.toLowerCase();
+  if (m.startsWith('image/')) return true;
+  if (m === 'application/pdf') return true;
+  if (m === 'text/html' || m === 'application/xhtml+xml') return true;
+  return false;
+}
+
+function FileAttachmentBlock({ block, conversationId }: { block: ContentBlock; conversationId?: string }) {
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const fileName = String(block.fileName || 'attachment');
+  const mimeType = String(block.mimeType || 'application/octet-stream');
+  const size = typeof block.size === 'number' && Number.isFinite(block.size)
+    ? formatFileSize(block.size)
+    : '';
+  const isError = block.status === 'error' || Boolean(block.error);
+
+  // Only render a preview when we have both a conversationId and an
+  // attachmentId — together they address a disk-backed file the custom
+  // protocol can serve. Old messages (pre-storage) have neither, so the
+  // card stays a plain metadata row with no surprise 404s.
+  const attachmentId = typeof block.attachmentId === 'string' && block.attachmentId.length > 0
+    ? block.attachmentId
+    : null;
+  const canPreview = !isError
+    && Boolean(attachmentId)
+    && Boolean(conversationId)
+    && isRenderableMime(mimeType);
+
+  const viewer: ViewerAttachment = useMemo(() => ({
+    name: fileName,
+    mimeType,
+    ...(typeof block.size === 'number' ? { size: block.size } : {}),
+    ...(canPreview && attachmentId && conversationId
+      ? { src: `antseed-attachment://${encodeURIComponent(conversationId)}/${encodeURIComponent(attachmentId)}` }
+      : {}),
+    ...(isError && block.error ? { error: String(block.error) } : {}),
+  }), [fileName, mimeType, block.size, canPreview, attachmentId, conversationId, isError, block.error]);
+
+  const className = `${styles.fileAttachment}${isError ? ` ${styles.fileAttachmentError}` : ''}${canPreview ? ` ${styles.fileAttachmentClickable}` : ''}`;
+  const metaText = [mimeType, size, block.truncated ? 'truncated' : '', isError ? String(block.error || 'unsupported') : '']
+    .filter(Boolean)
+    .join(' · ');
+
+  const inner = (
+    <>
+      <div className={styles.fileAttachmentIcon} aria-hidden="true">
+        {fileName.split('.').pop()?.slice(0, 3).toUpperCase() || 'FILE'}
+      </div>
+      <div className={styles.fileAttachmentBody}>
+        <div className={styles.fileAttachmentName}>{fileName}</div>
+        <div className={styles.fileAttachmentMeta}>{metaText}</div>
+      </div>
+    </>
+  );
+
+  return (
+    <>
+      {canPreview ? (
+        <button
+          type="button"
+          className={className}
+          onClick={() => setViewerOpen(true)}
+          aria-label={`Preview ${fileName}`}
+        >
+          {inner}
+        </button>
+      ) : (
+        <div className={className}>{inner}</div>
+      )}
+      {viewerOpen && (
+        <AttachmentViewer attachment={viewer} onClose={() => setViewerOpen(false)} />
+      )}
+    </>
+  );
 }
 
 function ImageBlockView({ block }: { block: ContentBlock }) {
@@ -504,7 +592,13 @@ function ImageBlockView({ block }: { block: ContentBlock }) {
   );
 }
 
-function renderBlock(block: ContentBlock, index: number, streaming = false, messagePrefix = ''): ReactNode {
+function renderBlock(
+  block: ContentBlock,
+  index: number,
+  streaming = false,
+  messagePrefix = '',
+  conversationId?: string,
+): ReactNode {
   const blockKey = getBlockRenderKey(block, index, messagePrefix);
 
   if (block.type === 'text') {
@@ -519,25 +613,7 @@ function renderBlock(block: ContentBlock, index: number, streaming = false, mess
   }
 
   if (block.type === 'file') {
-    const fileName = String(block.fileName || 'attachment');
-    const mimeType = String(block.mimeType || 'application/octet-stream');
-    const size = typeof block.size === 'number' && Number.isFinite(block.size)
-      ? formatFileSize(block.size)
-      : '';
-    const isError = block.status === 'error' || Boolean(block.error);
-    return (
-      <div key={blockKey} className={`${styles.fileAttachment}${isError ? ` ${styles.fileAttachmentError}` : ''}`}>
-        <div className={styles.fileAttachmentIcon} aria-hidden="true">
-          {fileName.split('.').pop()?.slice(0, 3).toUpperCase() || 'FILE'}
-        </div>
-        <div className={styles.fileAttachmentBody}>
-          <div className={styles.fileAttachmentName}>{fileName}</div>
-          <div className={styles.fileAttachmentMeta}>
-            {[mimeType, size, block.truncated ? 'truncated' : '', isError ? String(block.error || 'unsupported') : ''].filter(Boolean).join(' · ')}
-          </div>
-        </div>
-      </div>
-    );
+    return <FileAttachmentBlock key={blockKey} block={block} conversationId={conversationId} />;
   }
 
   if (block.type === 'tool_use') {
@@ -639,9 +715,12 @@ type ChatBubbleProps = {
   message: ChatMessage;
   streaming?: boolean;
   onOpenPreview?: (url: string) => void;
+  /** Identifies the surrounding conversation so file-block previews can
+   *  build `antseed-attachment://<conversationId>/<attachmentId>` URLs. */
+  conversationId?: string;
 };
 
-export function ChatBubble({ message, streaming = false, onOpenPreview }: ChatBubbleProps) {
+export function ChatBubble({ message, streaming = false, onOpenPreview, conversationId }: ChatBubbleProps) {
   const [metaExpanded, setMetaExpanded] = useState(false);
   const metaParts = useMemo(() => buildChatMetaParts(message), [message]);
   const hasStreamingBlocks = useMemo(
@@ -663,7 +742,7 @@ export function ChatBubble({ message, streaming = false, onOpenPreview }: ChatBu
   const content = useMemo(() => {
     if (message.role === 'assistant') {
       if (Array.isArray(message.content)) {
-        return renderAssistantBlocks(message.content as ContentBlock[], isStreamingBubble, messagePrefix, onOpenPreview);
+        return renderAssistantBlocks(message.content as ContentBlock[], isStreamingBubble, messagePrefix, onOpenPreview, conversationId);
       }
       return <MarkdownContent text={String(message.content)} />;
     }
@@ -673,11 +752,11 @@ export function ChatBubble({ message, streaming = false, onOpenPreview }: ChatBu
     }
 
     if (Array.isArray(message.content)) {
-      return (message.content as ContentBlock[]).map((block, index) => renderBlock(block, index, isStreamingBubble, messagePrefix));
+      return (message.content as ContentBlock[]).map((block, index) => renderBlock(block, index, isStreamingBubble, messagePrefix, conversationId));
     }
 
     return <div className="chat-bubble-content">{JSON.stringify(message.content)}</div>;
-  }, [message, isStreamingBubble, messagePrefix]);
+  }, [message, isStreamingBubble, messagePrefix, onOpenPreview, conversationId]);
 
   const bubbleMeta =
     metaParts.length > 0 && !isStreamingBubble ? (

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -501,7 +501,10 @@ function FileAttachmentBlock({ block, conversationId }: { block: ContentBlock; c
     mimeType,
     ...(typeof block.size === 'number' ? { size: block.size } : {}),
     ...(canPreview && attachmentId && conversationId
-      ? { src: `antseed-attachment://${encodeURIComponent(conversationId)}/${encodeURIComponent(attachmentId)}` }
+      ? {
+          src: `antseed-attachment://${encodeURIComponent(conversationId)}/${encodeURIComponent(attachmentId)}`,
+          downloadIpc: { conversationId, attachmentId },
+        }
       : {}),
     ...(isError && block.error ? { error: String(block.error) } : {}),
   }), [fileName, mimeType, block.size, canPreview, attachmentId, conversationId, isError, block.error]);

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -476,15 +476,26 @@ function renderAssistantBlocks(
 }
 
 /**
- * Is `application/pdf`, `text/html`, `text/svg+xml`, `image/*`, etc. a
- * mime we know how to render natively in the AttachmentViewer? Anything
- * else falls back to metadata + Download.
+ * Mime types the AttachmentViewer can render natively. Image, PDF, and
+ * HTML get their dedicated branches in the viewer; everything else that
+ * Chromium will display as plain text (text/*, JSON, JS, XML, YAML)
+ * falls into a generic iframe path. Anything else degrades to a
+ * metadata-only card with a Download button.
  */
 function isRenderableMime(mimeType: string): boolean {
   const m = mimeType.toLowerCase();
   if (m.startsWith('image/')) return true;
   if (m === 'application/pdf') return true;
   if (m === 'text/html' || m === 'application/xhtml+xml') return true;
+  if (m.startsWith('text/')) return true;
+  if (
+    m === 'application/json'
+    || m === 'application/javascript'
+    || m === 'application/x-javascript'
+    || m === 'application/xml'
+    || m === 'application/yaml'
+    || m === 'application/x-yaml'
+  ) return true;
   return false;
 }
 

--- a/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
@@ -205,6 +205,10 @@ export type ContentBlock = {
   fileName?: string;
   mimeType?: string;
   size?: number;
+  /** ID under which the raw bytes live in the attachment store. When
+   *  present the renderer can build an `antseed-attachment://` URL and
+   *  preview the file natively. */
+  attachmentId?: string;
   error?: string;
   truncated?: boolean;
   attachment?: unknown;

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -631,7 +631,12 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
               </div>
             ) : (
               visibleMessages.map((msg, i) => (
-                <ChatBubble key={getMessageKey(msg, i)} message={msg} onOpenPreview={handleOpenPreview} />
+                <ChatBubble
+                  key={getMessageKey(msg, i)}
+                  message={msg}
+                  onOpenPreview={handleOpenPreview}
+                  conversationId={snap.chatActiveConversation || undefined}
+                />
               ))
             )}
             {snap.chatStreamingMessage ? (
@@ -640,6 +645,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                 message={snap.chatStreamingMessage as ChatMessage}
                 streaming
                 onOpenPreview={handleOpenPreview}
+                conversationId={snap.chatActiveConversation || undefined}
               />
             ) : null}
             {snap.chatSending && snap.chatSendingConversationId === snap.chatActiveConversation && (


### PR DESCRIPTION
## Description

Adds native in-chat previews for attachment types beyond images. Raw attachment bytes are persisted per conversation and served to the renderer via a custom Electron protocol, so Chromium renders PDFs, HTML, SVG and images without round-tripping megabytes through IPC.

Closes the rest of #146 (image click-to-preview already landed via #348).

## Release Notes

- Click any file attachment in chat to preview it natively \u2014 PDFs open in Chromium's built-in viewer, HTML renders in a sandboxed iframe, SVG renders inline, images open full-size.
- Download any attachment directly from the preview modal.
- Orphan attachment directories are cleaned up on app startup and when conversations are deleted.
- Desktop `0.1.49` \u2192 `0.1.50`.

## Three commits, three layers

1. **`ff15f70`** Foundational: `attachment-store` module (write / resolve / delete / sweep with strict ID validation), `attachment-protocol` registration (`antseed-attachment://` as privileged standard/secure scheme), delete-hook + startup orphan sweep. 16 new unit tests.

2. **`c6bab6f`** Plumbing: `prepareChatAttachments` gains an `AttachmentStorageCallback`; `wrapFileText` emits `id="..."`; `convertPersistedAttachmentPromptToBlocks` reads it back. `FileBlock`, `PreparedChatAttachment`, and `ContentBlock` all gain `attachmentId`. The `chat:prepare-attachments` IPC handler now takes `conversationId` and wires `saveAttachment` as the storage callback (fresh UUID per file). 2 new tests covering storage-callback ordering + failure paths.

3. **`798f463`** UI: `AttachmentViewer` grows a `src` field and dispatches on mime type \u2014 `<img>` for image/*, Chromium's PDF viewer for application/pdf, sandboxed iframe for text/html, fallback for everything else. File cards in chat become clickable only when both `conversationId` and `attachmentId` are known, so pre-storage messages keep their existing non-clickable cards.

## Security

- Protocol handler rejects any ID not matching `[A-Za-z0-9_-]{1,128}`.
- Resolved paths are verified to live under the attachments root (defense in depth).
- HTML responses carry `Content-Security-Policy: default-src 'none'; img-src 'self' data: blob:; style-src 'unsafe-inline'; font-src data:` plus `X-Content-Type-Options: nosniff`.
- Renderer-side iframe for HTML uses `sandbox=""` (no scripts, no same-origin, no forms, no top-nav).
- File blocks without `attachmentId` (old messages) are non-clickable \u2014 no surprise 404s.

## Tests

All 27 main-side tests pass (11 existing + 16 new):
- Attachment store: ID validation, write/read/delete, containment, orphan sweep
- Protocol URL parsing: scheme, components, percent-encoding, malformed inputs
- Attachment prep: existing 9 tests unchanged, plus storage-callback ordering and error-path tests

Renderer `typecheck:renderer` + `build:renderer` green; main `build:main` green.

## Types of Changes

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests (18 new test cases across 3 files)
- [x] Lint, type-check and unit tests pass locally with my changes
