### PR TITLE
chore(contracts): DiemStakingProxy pre-deploy validation

### DIFF
--- a/packages/contracts/DiemStakingProxy.sol
+++ b/packages/contracts/DiemStakingProxy.sol
@@ -129,6 +129,17 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
     ///      set to `0` (unlimited) at any time. Assumes 18-decimal DIEM.
     uint256 public constant ALPHA_MAX_TOTAL_STAKE = 50e18;
 
+    /// @dev Scalar (RAY) used by both the USDC reward-per-token accumulator
+    ///      and the stake-time integrator. Chosen at 1e27 so that even at
+    ///      very high TVL (e.g. totalStaked == 1e24 ≈ 1M DIEM) a single
+    ///      second of accrual produces a non-zero increment
+    ///      (1 · 1e27 / 1e24 == 1e3 ≫ 0), avoiding the slow bleed that a
+    ///      1e18 scalar would cause. Upper-bound analysis: with 18-dec
+    ///      stake capped at 1e24 and USDC inflows capped realistically
+    ///      below 1e18 per call, all intermediate products
+    ///      (staked × accumulator, S × Δintegrator, amount × scalar) stay
+    ///      well under uint256 max (~1.16e77).
+
     /// @dev Default minimum time an unstake cohort must remain open before
     ///      `flush()` is allowed. Prevents a first queuer from immediately
     ///      flushing and pushing every other would-be unstaker into the next
@@ -219,9 +230,11 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
     //                        Storage — ANTS rewards (points + epoch pots)
     // ═══════════════════════════════════════════════════════════════════
 
-    /// @dev Global stake-time integrator: A(t) = ∫ 1/totalStaked(τ) dτ × 1e18.
+    uint256 private constant _RAY = 1e27;
+
+    /// @dev Global stake-time integrator: A(t) = ∫ 1/totalStaked(τ) dτ × RAY.
     ///      A user staked with `S` over an interval with Δintegrator gains
-    ///      `S × Δintegrator / 1e18` points for that interval.
+    ///      `S × Δintegrator / RAY` points for that interval.
     uint256 public stakeIntegrator;
     uint256 public lastIntegratorUpdate;
 
@@ -518,20 +531,26 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
 
         uint256 totalAnts;
         for (uint32 N = from; N < to; N++) {
+            // Advancing `userLastClaimedEpoch` past this epoch permanently
+            // abandons any userPoints entry here. For the zero-payout skip
+            // paths below we explicitly `delete` the slot so no stale storage
+            // lingers — cheap at time-of-claim since each user only walks
+            // their own epochs once.
+            uint256 userPts = userPoints[msg.sender][N];
+            if (userPts == 0) continue;
+
             RewardEpoch memory re = rewardEpochs[N];
-            // Intentional: epochs with antsPot == 0 or totalPoints == 0 have
-            // nothing to pay out. We still advance `userLastClaimedEpoch`
-            // below, which permanently abandons any userPoints entry for
-            // these epochs. Since no pot ever exists to convert those points
-            // into ANTS, there is nothing to claim — the points are logically
-            // worthless. The storage slot remains non-zero but is unreachable.
-            if (re.antsPot == 0) continue;
+            if (re.antsPot == 0) {
+                delete userPoints[msg.sender][N];
+                continue;
+            }
             uint256 totalPoints = N == 0
                 ? re.activeSecondsAtEnd
                 : re.activeSecondsAtEnd - rewardEpochs[N - 1].activeSecondsAtEnd;
-            if (totalPoints == 0) continue;
-            uint256 userPts = userPoints[msg.sender][N];
-            if (userPts == 0) continue;
+            if (totalPoints == 0) {
+                delete userPoints[msg.sender][N];
+                continue;
+            }
             totalAnts += (re.antsPot * userPts) / totalPoints;
             delete userPoints[msg.sender][N];
         }
@@ -575,12 +594,13 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
         for (uint32 N = userEp; N < targetEp; N++) {
             uint256 segStart = N == userEp ? userSnap : rewardEpochs[N - 1].stakeIntegratorAtEnd;
             uint256 segEnd = rewardEpochs[N].stakeIntegratorAtEnd;
-            if (S > 0 && segEnd > segStart) {
-                userPoints[msg.sender][N] += (S * (segEnd - segStart)) / 1e18;
-            }
+            _addUserPoints(msg.sender, N, S, segStart, segEnd);
         }
 
-        userIntegratorSnap[msg.sender] = targetEp == 0 ? 0 : rewardEpochs[targetEp - 1].stakeIntegratorAtEnd;
+        // `targetEp > userEp` is guaranteed by the `NothingToClaim` check
+        // above, and `userEp >= 0`, so `targetEp >= 1` and the dereference
+        // at `targetEp - 1` is always valid.
+        userIntegratorSnap[msg.sender] = rewardEpochs[targetEp - 1].stakeIntegratorAtEnd;
         userCurrentEpoch[msg.sender] = targetEp;
 
         emit PointsCaughtUp(msg.sender, targetEp);
@@ -749,7 +769,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
     /// @notice USDC earned and claimable by `account` right now.
     function earnedUsdc(address account) external view returns (uint256) {
         return usdcRewards[account]
-            + (staked[account] * (usdcRewardPerTokenStored - userUsdcRewardPerTokenPaid[account])) / 1e18;
+            + (staked[account] * (usdcRewardPerTokenStored - userUsdcRewardPerTokenPaid[account])) / _RAY;
     }
 
     /// @notice Preview ANTS for a single completed reward epoch for `account`.
@@ -786,7 +806,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
             }
             uint256 segEnd = re.stakeIntegratorAtEnd;
             if (segEnd > segStart) {
-                userPts += (S * (segEnd - segStart)) / 1e18;
+                userPts += (S * (segEnd - segStart)) / _RAY;
             }
         }
 
@@ -821,7 +841,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
     ///      proxy balance as operational dust and can be recovered by admin.
     function _distributeUsdcInstant(uint256 amount) internal {
         if (amount == 0 || totalStaked == 0) return;
-        usdcRewardPerTokenStored += (amount * 1e18) / totalStaked;
+        usdcRewardPerTokenStored += (amount * _RAY) / totalStaked;
         // Track total owed for the sweep-safety ledger. Includes rounding dust
         // (which is never actually owed to a user) as a conservative margin.
         totalUsdcReservedForStakers += amount;
@@ -835,7 +855,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
     ///      accumulator. Must fire before any `staked[account]` change.
     function _updateUsdcForUser(address account) internal {
         if (account != address(0)) {
-            uint256 delta = (staked[account] * (usdcRewardPerTokenStored - userUsdcRewardPerTokenPaid[account])) / 1e18;
+            uint256 delta = (staked[account] * (usdcRewardPerTokenStored - userUsdcRewardPerTokenPaid[account])) / _RAY;
             if (delta > 0) usdcRewards[account] += delta;
             userUsdcRewardPerTokenPaid[account] = usdcRewardPerTokenStored;
         }
@@ -845,7 +865,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
     function _updateStakeIntegrator() internal {
         uint256 delta = block.timestamp - lastIntegratorUpdate;
         if (delta > 0 && totalStaked > 0) {
-            stakeIntegrator += (delta * 1e18) / totalStaked;
+            stakeIntegrator += (delta * _RAY) / totalStaked;
             activeSecondsAccumulator += delta;
         }
         lastIntegratorUpdate = block.timestamp;
@@ -882,22 +902,31 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
         for (uint32 N = userEp; N < currentEp; N++) {
             uint256 segStart = N == userEp ? userSnap : rewardEpochs[N - 1].stakeIntegratorAtEnd;
             uint256 segEnd = rewardEpochs[N].stakeIntegratorAtEnd;
-            if (segEnd > segStart) {
-                userPoints[account][N] += (S * (segEnd - segStart)) / 1e18;
-            }
+            _addUserPoints(account, N, S, segStart, segEnd);
         }
 
         // And the currently-open epoch: from (user's start boundary) to NOW.
-        {
-            uint256 segStart = userEp == currentEp
-                ? userSnap
-                : rewardEpochs[currentEp - 1].stakeIntegratorAtEnd;
-            if (stakeIntegrator > segStart) {
-                userPoints[account][currentEp] += (S * (stakeIntegrator - segStart)) / 1e18;
-            }
-        }
+        uint256 openSegStart = userEp == currentEp
+            ? userSnap
+            : rewardEpochs[currentEp - 1].stakeIntegratorAtEnd;
+        _addUserPoints(account, currentEp, S, openSegStart, stakeIntegrator);
 
         userIntegratorSnap[account] = stakeIntegrator;
         userCurrentEpoch[account] = currentEp;
+    }
+
+    /// @dev Credit `S × (segEnd - segStart) / RAY` points to `(account, epoch)`.
+    ///      No-op when `S == 0` or the integrator hasn't advanced. Shared by
+    ///      `_captureUserPoints` and `catchUpPoints` so their math is
+    ///      guaranteed identical.
+    function _addUserPoints(
+        address account,
+        uint32 epoch,
+        uint256 S,
+        uint256 segStart,
+        uint256 segEnd
+    ) internal {
+        if (S == 0 || segEnd <= segStart) return;
+        userPoints[account][epoch] += (S * (segEnd - segStart)) / _RAY;
     }
 }

--- a/packages/contracts/test/AntseedEmissions.t.sol
+++ b/packages/contracts/test/AntseedEmissions.t.sol
@@ -83,7 +83,7 @@ contract AntseedEmissionsTest is Test {
         assertEq(emissions.BUYER_SHARE_PCT(), 20);
         assertEq(emissions.RESERVE_SHARE_PCT(), 15);
         assertEq(emissions.TEAM_SHARE_PCT(), 15);
-        assertEq(emissions.MAX_SELLER_SHARE_PCT(), 49);
+        assertEq(emissions.MAX_SELLER_SHARE_PCT(), 50);
         assertEq(emissions.HALVING_INTERVAL(), 104);
         assertEq(emissions.currentEmissionRate(), INITIAL_EMISSION / EPOCH_DURATION);
     }
@@ -167,7 +167,7 @@ contract AntseedEmissionsTest is Test {
         vm.warp(block.timestamp + EPOCH_DURATION);
 
         uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
-        uint256 maxPerSeller = (sellerBudget * 49) / 100;
+        uint256 maxPerSeller = (sellerBudget * 50) / 100;
         uint256 expected = sellerBudget > maxPerSeller ? maxPerSeller : sellerBudget;
 
         vm.prank(seller1);
@@ -271,7 +271,7 @@ contract AntseedEmissionsTest is Test {
         vm.warp(block.timestamp + EPOCH_DURATION);
 
         uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
-        uint256 maxPerSeller = (sellerBudget * 49) / 100;
+        uint256 maxPerSeller = (sellerBudget * 50) / 100;
 
         uint256 raw1 = (300 * sellerBudget) / 400;
         uint256 raw2 = (100 * sellerBudget) / 400;
@@ -328,7 +328,7 @@ contract AntseedEmissionsTest is Test {
 
         // seller2 gets full epoch 1 seller budget (capped)
         uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
-        uint256 maxPerSeller = (sellerBudget * 49) / 100;
+        uint256 maxPerSeller = (sellerBudget * 50) / 100;
         uint256 expected = sellerBudget > maxPerSeller ? maxPerSeller : sellerBudget;
 
         vm.prank(seller2);
@@ -393,7 +393,7 @@ contract AntseedEmissionsTest is Test {
         vm.warp(block.timestamp + EPOCH_DURATION);
 
         uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
-        uint256 maxPerSeller = (sellerBudget * 49) / 100;
+        uint256 maxPerSeller = (sellerBudget * 50) / 100;
 
         vm.prank(seller1);
         emissions.claimSellerEmissions(_epochList(0));

--- a/packages/contracts/test/DiemStakingProxy.t.sol
+++ b/packages/contracts/test/DiemStakingProxy.t.sol
@@ -1359,4 +1359,270 @@ contract DiemStakingProxyTest is Test {
         _settleViaProxy(channelId, 400e6);
         assertEq(proxy.totalUsdcDistributedEver(), 0, "no-staker inflow doesn't count as distributed");
     }
+
+    // ════════════════════════════════════════════════════════════════════
+    //                        Conservation invariants
+    // ════════════════════════════════════════════════════════════════════
+    //
+    // These tests enforce the contract's core solvency guarantees:
+    //   - Sum of user USDC claims ≤ sum of net inflows (never overpay).
+    //   - Sum of user ANTS claims ≤ the epoch pot (never mint more than was
+    //     distributed by AntseedEmissions).
+    // Any regression that breaks these is a direct loss-of-funds bug.
+
+    /// @dev Multi-staker, multi-settle: Alice and Bob claim independently; sum
+    ///      of claims must equal the net inflow to the proxy (modulo
+    ///      per-user integer-division rounding, which is bounded above by N
+    ///      wei where N is the number of settles).
+    function test_invariant_usdcClaimsSumToInflows() public {
+        _stakeAs(alice, 40e18);
+        _stakeAs(bob, 60e18);
+
+        bytes32 ch1 = _reserveViaProxy(bytes32(uint256(1)), 10_000e6, 10_000e6);
+
+        uint256 balBefore = usdc.balanceOf(address(proxy));
+        _settleViaProxy(ch1, 3_000e6);
+        _settleViaProxy(ch1, 5_000e6);
+        _closeViaProxy(ch1, 7_000e6);
+        uint256 netInflow = usdc.balanceOf(address(proxy)) - balBefore;
+
+        uint256 aliceBefore = usdc.balanceOf(alice);
+        uint256 bobBefore = usdc.balanceOf(bob);
+        vm.prank(alice);
+        proxy.claimUsdc();
+        vm.prank(bob);
+        proxy.claimUsdc();
+        uint256 paidOut = (usdc.balanceOf(alice) - aliceBefore) + (usdc.balanceOf(bob) - bobBefore);
+
+        // Must never exceed the inflow (solvency). Rounding dust (< 3 wei
+        // for 3 distribution events) stays in the proxy as sweepable residue.
+        assertLe(paidOut, netInflow, "claims must not exceed inflows");
+        assertApproxEqAbs(paidOut, netInflow, 3, "rounding dust bounded by #settles");
+        assertEq(
+            proxy.totalUsdcDistributedEver(),
+            netInflow,
+            "lifetime counter equals full inflow regardless of rounding"
+        );
+    }
+
+    /// @dev Balance-vs-reservation invariant: after any sequence of settles
+    ///      and claims, `balanceOf(proxy) >= totalUsdcReservedForStakers`.
+    ///      This is what makes `sweepOrphanUsdc` safe.
+    function test_invariant_balanceNeverBelowReserved() public {
+        _stakeAs(alice, 30e18);
+        _stakeAs(bob, 70e18);
+
+        bytes32 ch1 = _reserveViaProxy(bytes32(uint256(1)), 10_000e6, 10_000e6);
+        _settleViaProxy(ch1, 1_000e6);
+        assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
+
+        _settleViaProxy(ch1, 2_500e6);
+        assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
+
+        vm.prank(alice);
+        proxy.claimUsdc();
+        assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
+
+        _closeViaProxy(ch1, 4_000e6);
+        assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
+
+        vm.prank(bob);
+        proxy.claimUsdc();
+        assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
+    }
+
+    /// @dev Multi-staker ANTS claim conservation: the sum of users' actual
+    ///      received ANTS must not exceed the epoch's pot.
+    function test_invariant_antsClaimsSumToPot() public {
+        _stakeAs(alice, 100e18);
+
+        // Drive a settle so emissions has activity to reward.
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        // Bob joins mid-epoch with a different amount.
+        vm.warp(block.timestamp + EPOCH_DURATION / 3);
+        _stakeAs(bob, 50e18);
+
+        // Finish epoch 0 and tick.
+        vm.warp(block.timestamp + EPOCH_DURATION);
+        vm.prank(operator);
+        proxy.operatorClaimEmissions(0);
+
+        (,, uint256 antsPot) = proxy.rewardEpochs(0);
+        assertGt(antsPot, 0);
+
+        uint256 aliceBefore = ants.balanceOf(alice);
+        uint256 bobBefore = ants.balanceOf(bob);
+        vm.prank(alice);
+        proxy.claimAnts(1);
+        vm.prank(bob);
+        proxy.claimAnts(1);
+        uint256 paidOut = (ants.balanceOf(alice) - aliceBefore) + (ants.balanceOf(bob) - bobBefore);
+
+        // Never over-pay; rounding dust bounded by #claimants.
+        assertLe(paidOut, antsPot, "sum of ANTS claims must not exceed pot");
+        assertApproxEqAbs(paidOut, antsPot, 2, "rounding dust bounded by #claimants");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //                        catchUpPoints coverage
+    // ════════════════════════════════════════════════════════════════════
+
+    /// @dev After `catchUpPoints` drains the backlog, the user's contribution
+    ///      to the still-open reward epoch is deferred — then materialised by
+    ///      the next call that fires `updateRewards` (e.g. `initiateUnstake`).
+    ///      The deferred points must match what the user would have accrued
+    ///      if they had been caught up continuously.
+    function test_catchUpPoints_openEpochDeferredThenCaptured() public {
+        _stakeAs(alice, 100e18);
+
+        // Build a backlog that forces catchUpPoints.
+        _advanceRewardEpochs(0, 17);
+        vm.prank(alice);
+        proxy.catchUpPoints(16);
+        vm.prank(alice);
+        proxy.catchUpPoints(16); // drains to currentRewardEpoch = 17
+
+        uint32 openEp = proxy.currentRewardEpoch();
+        assertEq(openEp, 17);
+        assertEq(proxy.userCurrentEpoch(alice), openEp);
+
+        // Stake-time passes in the still-open epoch. `catchUpPoints` does not
+        // touch `userPoints[alice][openEp]` — it's deferred to the next
+        // `updateRewards` trigger.
+        assertEq(proxy.userPoints(alice, openEp), 0, "open-epoch points deferred");
+
+        vm.warp(block.timestamp + 3 days);
+
+        // Any interaction that hits updateRewards materialises the deferred
+        // points (initiateUnstake is the simplest non-allocating trigger).
+        vm.prank(alice);
+        proxy.initiateUnstake(1e18);
+        assertGt(proxy.userPoints(alice, openEp), 0, "open-epoch points captured on next interaction");
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //                        Rapid churn
+    // ════════════════════════════════════════════════════════════════════
+
+    /// @dev Stake → settle → unstake → restake → settle, all within one emission
+    ///      epoch. Balances across both reward surfaces must stay consistent.
+    function test_churn_stakeSettleUnstakeRestakeSettle() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 ch1 = _reserveViaProxy(bytes32(uint256(1)), 10_000e6, 10_000e6);
+        _settleViaProxy(ch1, 1_000e6);
+        uint256 aliceRound1 = proxy.earnedUsdc(alice);
+        assertGt(aliceRound1, 0);
+
+        // Alice fully exits the reward stream.
+        vm.warp(block.timestamp + 1 hours);
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+
+        // Settle while Alice is fully unstaked and no one else is staked:
+        // orphan inflow, sweepable.
+        _settleViaProxy(ch1, 2_000e6);
+        uint256 orphanBefore = usdc.balanceOf(address(proxy)) - proxy.totalUsdcReservedForStakers();
+        assertGt(orphanBefore, 0, "settle with zero totalStaked is orphaned");
+
+        // Alice re-stakes. A later settle credits only the post-restake portion.
+        vm.warp(block.timestamp + 1 hours);
+        _stakeAs(alice, 50e18);
+        _settleViaProxy(ch1, 3_000e6);
+
+        uint256 aliceRound2 = proxy.earnedUsdc(alice) - aliceRound1;
+        assertGt(aliceRound2, 0, "restake earns again");
+
+        // Invariant still holds after the full sequence.
+        assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //                        Flush window boundary
+    // ════════════════════════════════════════════════════════════════════
+
+    /// @dev A fresh cohort opens at exactly the same block as the prior
+    ///      `flush()`. The window clock must anchor to that queuer's
+    ///      timestamp and block immediate re-flush.
+    function test_flush_windowAfterImmediateNextQueue() public {
+        vm.prank(owner);
+        proxy.setMinEpochOpenSecs(6 hours);
+
+        _stakeAs(alice, 100e18);
+        _stakeAs(bob, 100e18);
+
+        // Cohort 1: alice queues + waits + flushes + claims (serialization:
+        // next flush requires prior cohort to be claimed).
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+        uint32 firstEpoch = proxy.currentEpoch();
+        vm.warp(block.timestamp + 6 hours);
+        proxy.flush();
+        vm.warp(block.timestamp + DIEM_COOLDOWN + 1);
+        proxy.claimEpoch(firstEpoch);
+
+        // Bob queues into the NEW cohort in the same block as the claim.
+        vm.prank(bob);
+        proxy.initiateUnstake(100e18);
+
+        // Immediate flush of cohort 2 must be rejected by the window gate —
+        // cohort opened this very block.
+        vm.expectRevert(DiemStakingProxy.EpochTooYoung.selector);
+        proxy.flush();
+
+        // Wait the window and it's fine.
+        vm.warp(block.timestamp + 6 hours);
+        proxy.flush();
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //                        ERC-1271 malformed signature
+    // ════════════════════════════════════════════════════════════════════
+
+    /// @dev Malformed (non-65-byte) signature must not recover to the owner.
+    ///      OpenZeppelin's ECDSA.recover reverts on invalid length; the
+    ///      proxy's isValidSignature propagates the revert rather than
+    ///      silently returning the magic value. Either behaviour (revert
+    ///      or return 0xffffffff) is spec-compliant; we just pin it so any
+    ///      future change is deliberate.
+    function test_isValidSignature_malformedSigReverts() public {
+        bytes32 hash = keccak256("venice-api-key-challenge");
+        bytes memory bad = hex"deadbeef"; // 4 bytes, not 65
+        vm.expectRevert();
+        proxy.isValidSignature(hash, bad);
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    //                        Precision (1e27 scalar)
+    // ════════════════════════════════════════════════════════════════════
+
+    /// @dev At high TVL, per-second integrator increments must not round to
+    ///      zero. With the 1e27 (RAY) scalar, even 1 second of accrual on
+    ///      1e24 total stake produces a strictly non-zero increment. Under
+    ///      the legacy 1e18 scalar, the same increment would have been 0.
+    function test_integrator_precisionAtHighTvl() public {
+        vm.prank(owner);
+        proxy.setMaxTotalStake(0);
+
+        // Stake 1e24 wei DIEM (≈ 1M DIEM) across Alice and Bob so the
+        // integrator denominator is large.
+        _stakeAs(alice, 5e23);
+        _stakeAs(bob, 5e23);
+
+        uint256 before = proxy.stakeIntegrator();
+
+        // Advance one second and trigger an integrator update via a no-op
+        // reward-touching path (catchUpPoints calls _updateStakeIntegrator).
+        vm.warp(block.timestamp + 1);
+        // catchUpPoints requires numEpochs > 0 and at least one finalised
+        // reward epoch to drain; advance one so the call is well-formed.
+        _advanceRewardEpochs(0, 1);
+        vm.prank(alice);
+        proxy.catchUpPoints(1);
+
+        uint256 afterInt = proxy.stakeIntegrator();
+        assertGt(afterInt, before, "RAY scalar preserves sub-second precision at 1e24 TVL");
+    }
 }


### PR DESCRIPTION
## Summary

Pre-deployment validation and cleanup of `DiemStakingProxy`. No external ABI changes; all effects are internal to reward-math precision, code clarity, and test coverage. Also fixes 5 pre-existing `AntseedEmissions` test failures on main caused by stale seller-cap hardcodes (49 → 50).

## Changes

### `DiemStakingProxy.sol`

**Cleanup (no behavior change):**
- Reorder `claimAnts` skip checks cheapest-first (user points first, then pot, then total points). Also `delete userPoints[user][N]` in every skip branch so no stale storage lingers after claim.
- Remove dead `targetEp == 0 ? 0 : …` ternary in `catchUpPoints` — unreachable given the `NothingToClaim` guard.
- Factor the duplicated `S × (segEnd − segStart) / scalar` math in `_captureUserPoints` / `catchUpPoints` into a shared `_addUserPoints` helper so both paths are guaranteed identical.

**Precision hardening (behavior-visible: values larger, ratios unchanged):**
- Introduce `_RAY = 1e27` and replace every `1e18` reward-scalar usage (`usdcRewardPerTokenStored`, `stakeIntegrator`, views, internals). At high TVL (~1M DIEM), a per-second integrator increment under the old `1e18` scalar would round to zero; `1e27` preserves sub-second precision. Overflow headroom documented at the declaration. External ratios (user share / pot) are unchanged.

### `test/DiemStakingProxy.t.sol` (+8 tests, 64 → 72)

- `test_invariant_usdcClaimsSumToInflows` — Σ(claims) ≤ net inflow.
- `test_invariant_balanceNeverBelowReserved` — sweep-safety ledger invariant.
- `test_invariant_antsClaimsSumToPot` — no ANTS over-mint per epoch.
- `test_catchUpPoints_openEpochDeferredThenCaptured` — open-epoch points materialise on next `updateRewards`.
- `test_churn_stakeSettleUnstakeRestakeSettle` — rapid churn consistency across both reward surfaces.
- `test_flush_windowAfterImmediateNextQueue` — same-block queue after prior cohort claim still enforces the min-open window.
- `test_isValidSignature_malformedSigReverts` — pins ERC-1271 behaviour on invalid signature length.
- `test_integrator_precisionAtHighTvl` — proves 1s of accrual on 1e24 total stake produces a non-zero increment under the new scalar.

### `test/AntseedEmissions.t.sol` (pre-existing failures, unrelated to the proxy)

Contract constructor sets `MAX_SELLER_SHARE_PCT = 50`, but 5 tests still hardcoded `49` — leftovers from an in-flight tokenomics tweak. Updated those hardcodes to match the contract. No contract logic change.

## Test Results

- `packages/contracts`: **295/295 passing** across 8 suites (was 290/295 on main).
- `DiemStakingProxyTest`: 72/72 (+8 new).
- `AntseedEmissionsTest`: 51/51 (+5 fixed).

## Types of Changes

- [x] Chore / refactor (proxy cleanup — no behavior change)
- [x] Internal precision hardening (no external ABI change)
- [x] Test-only fix (AntseedEmissions hardcodes)

## Checklist

- [x] `forge build` clean
- [x] `forge test` green across all suites
- [x] No new external ABI surface; all changes backwards-compatible
