### PR TITLE
fix(node): Catch up buyer SpendingAuth on budget-exhausted 402

### DIFF
--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -299,7 +299,13 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
             ? String(Math.round(parseFloat(cryptoOverrides.defaultLockAmountUSDC) * 1_000_000))
             : '1000000',
           platformFeeRate: config.payments?.platformFeeRate,
-          maxPerRequestUsdc: config.payments?.maxPerRequestUsdc ?? '100000',
+          // $0.30 overdraft window per channel — large enough that a single
+          // typical long-context request (~$0.05–$0.15 on the priciest
+          // published models) fits within verifiedCost + maxPerRequest, so the
+          // budget-exhausted 402 catch-up closes in a single signature. Set
+          // conservatively to bound the worst-case exposure a malicious
+          // seller can extract via an inflated 402 target (per 402 round trip).
+          maxPerRequestUsdc: config.payments?.maxPerRequestUsdc ?? '300000',
           maxReserveAmountUsdc: config.payments?.maxReserveAmountUsdc ?? '1000000',
         }
       }
@@ -313,7 +319,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
       }
       console.log(chalk.bold('Effective buyer settings:'))
       console.log(chalk.dim(`  max pricing defaults (USD/1M): input=${effectiveBuyerConfig.maxPricing.defaults.inputUsdPerMillion}, output=${effectiveBuyerConfig.maxPricing.defaults.outputUsdPerMillion}`))
-      const maxPerRequestUsdc = config.payments?.maxPerRequestUsdc ?? '100000'
+      const maxPerRequestUsdc = config.payments?.maxPerRequestUsdc ?? '300000'
       const maxReserveAmountUsdc = config.payments?.maxReserveAmountUsdc ?? '1000000'
       console.log(chalk.dim(`  max per-request USDC: ${(Number(maxPerRequestUsdc) / 1_000_000).toFixed(6)}`))
       console.log(chalk.dim(`  max reserve USDC: ${(Number(maxReserveAmountUsdc) / 1_000_000).toFixed(6)}`))

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -119,7 +119,13 @@ export interface PaymentsCLIConfig {
    * amount. Default: "2000" (~$0.002).
    */
   minSettleDelta?: string;
-  /** Maximum USDC the buyer authorizes per single request in base units. Default: "100000" ($0.10). */
+  /**
+   * Maximum USDC the buyer authorizes per single request in base units — the
+   * per-request overdraft window beyond the buyer's independently-verified
+   * cumulative cost. Caps how much a misreporting or malicious seller can
+   * extract in one catch-up round trip. Default: "300000" ($0.30), sized to
+   * fit a single long-context request on the priciest published models.
+   */
   maxPerRequestUsdc?: string;
   /** Maximum total USDC the buyer will reserve in a single SpendingAuth in base units. Default: "1000000" ($1.00). */
   maxReserveAmountUsdc?: string;

--- a/packages/node/src/p2p/payment-codec.ts
+++ b/packages/node/src/p2p/payment-codec.ts
@@ -83,6 +83,11 @@ export function decodePaymentRequired(data: Uint8Array): PaymentRequiredPayload 
   };
   if (typeof obj.inputUsdPerMillion === 'number') result.inputUsdPerMillion = obj.inputUsdPerMillion;
   if (typeof obj.outputUsdPerMillion === 'number') result.outputUsdPerMillion = obj.outputUsdPerMillion;
+  if (typeof obj.cachedInputUsdPerMillion === 'number') result.cachedInputUsdPerMillion = obj.cachedInputUsdPerMillion;
+  if (typeof obj.requiredCumulativeAmount === 'string') result.requiredCumulativeAmount = obj.requiredCumulativeAmount;
+  if (typeof obj.currentSpent === 'string') result.currentSpent = obj.currentSpent;
+  if (typeof obj.currentAcceptedCumulative === 'string') result.currentAcceptedCumulative = obj.currentAcceptedCumulative;
+  if (typeof obj.channelId === 'string') result.channelId = obj.channelId;
   return result;
 }
 

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -264,6 +264,17 @@ export class BuyerPaymentManager {
     // verifiedCost to N is safe because the buyer can either pay N or watch the seller
     // close() on its existing signed auth — the exposure is bounded by whatever the seller
     // can actually prove on-chain, which it can already claim up to `accepted`.
+    //
+    // SECURITY: a malicious seller can inflate `targetCumulative` up to the on-chain
+    // `reserveMaxAmount` (our `_currentReserveCeiling`) in a single 402, bypassing the
+    // usual per-request overdraft pacing. The upper bound is still bounded by that
+    // ceiling — `nextCumulative = min(requestedAmount, maxSignable)` and `maxSignable`
+    // is capped at the ceiling — so the seller can never push the buyer past what the
+    // buyer explicitly reserved. The effect is that an abusive seller could drain the
+    // reserve in one catch-up instead of over many well-metered requests, but cannot
+    // charge beyond the reserve. Accepting this tradeoff: the attacker could already
+    // settle up to `accepted` on-chain today with the signatures we've already issued,
+    // and losing the pacing doesn't expose new funds.
     const floor = targetCumulative != null && targetCumulative > currentCumulative
       ? targetCumulative
       : currentCumulative;

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -242,6 +242,7 @@ export class BuyerPaymentManager {
     sellerPeerId: string,
     minBudgetPerRequest: bigint,
     paymentMux: PaymentMux,
+    targetCumulative?: bigint,
   ): Promise<string> {
     const session = this.getActiveSession(sellerPeerId);
     if (!session) {
@@ -257,20 +258,35 @@ export class BuyerPaymentManager {
     // the signed SpendingAuth, so advancing verified to match reclaims the overdraft headroom
     // without adding new exposure. Per-request cost claims are still tolerance-checked at
     // NeedAuth time, so this is not a new attack surface.
-    if (maxSignable <= currentCumulative) {
+    //
+    // The same reasoning extends to catch-up against a seller-reported target: if the seller
+    // says it has already *spent* N (currentSpent in the PaymentRequired body), advancing
+    // verifiedCost to N is safe because the buyer can either pay N or watch the seller
+    // close() on its existing signed auth — the exposure is bounded by whatever the seller
+    // can actually prove on-chain, which it can already claim up to `accepted`.
+    const floor = targetCumulative != null && targetCumulative > currentCumulative
+      ? targetCumulative
+      : currentCumulative;
+    if (maxSignable <= floor) {
       const previousVerified = this._verifiedCost.get(sellerPeerId) ?? 0n;
-      if (currentCumulative > previousVerified) {
-        this._verifiedCost.set(sellerPeerId, currentCumulative);
+      if (floor > previousVerified) {
+        this._verifiedCost.set(sellerPeerId, floor);
         maxSignable = this._maxSignable(sellerPeerId);
         debugLog(
-          `[BuyerPayment] extendCurrentSpendingAuth: advanced verifiedCost ${previousVerified} → ${currentCumulative} ` +
+          `[BuyerPayment] extendCurrentSpendingAuth: advanced verifiedCost ${previousVerified} → ${floor} ` +
           `to unblock overdraft window for ${sellerPeerId.slice(0, 12)}...`,
         );
       }
     }
 
     const ceiling = this._getCeiling(sellerPeerId);
-    const requestedAmount = currentCumulative + minBudgetPerRequest;
+    // Prefer the seller-supplied target when present — a raw
+    // `currentCumulative + minBudgetPerRequest` advance may still fall short
+    // of what the seller has already spent, producing an infinite 402 loop.
+    const minAdvance = currentCumulative + minBudgetPerRequest;
+    const requestedAmount = targetCumulative != null && targetCumulative > minAdvance
+      ? targetCumulative
+      : minAdvance;
 
     if (requestedAmount > maxSignable && maxSignable >= ceiling) {
       await this.topUpReserve(sellerPeerId, paymentMux);
@@ -281,7 +297,7 @@ export class BuyerPaymentManager {
     if (nextCumulative <= currentCumulative) {
       debugWarn(
         `[BuyerPayment] Cannot extend active session for ${sellerPeerId.slice(0, 12)}... ` +
-        `(current=${currentCumulative} maxSignable=${maxSignable})`,
+        `(current=${currentCumulative} maxSignable=${maxSignable} target=${targetCumulative ?? 'n/a'})`,
       );
       return session.sessionId;
     }

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -252,39 +252,32 @@ export class BuyerPaymentManager {
     const currentCumulative = this._cumulativeAmount.get(sellerPeerId) ?? BigInt(session.authMax);
     let maxSignable = this._maxSignable(sellerPeerId);
 
-    // If the overdraft window has collapsed to the current cumulative, the buyer has already
-    // signed up to verified + maxPerRequest and the seller returned 402 because spent caught up
-    // to the accepted cumulative. The buyer has already committed to pay currentCumulative via
-    // the signed SpendingAuth, so advancing verified to match reclaims the overdraft headroom
-    // without adding new exposure. Per-request cost claims are still tolerance-checked at
-    // NeedAuth time, so this is not a new attack surface.
+    // Overdraft-window unblock: when the buyer has already signed up to
+    // `verified + maxPerRequest` and the seller returned 402 because `spent`
+    // caught up, advance `verifiedCost` to the current signed cumulative so
+    // the window reopens. The buyer has already committed to pay
+    // `currentCumulative` via the signed SpendingAuth, so the seller can
+    // already claim that much on-chain — advancing verified to match doesn't
+    // expose new funds, it just reclaims overdraft headroom.
     //
-    // The same reasoning extends to catch-up against a seller-reported target: if the seller
-    // says it has already *spent* N (currentSpent in the PaymentRequired body), advancing
-    // verifiedCost to N is safe because the buyer can either pay N or watch the seller
-    // close() on its existing signed auth — the exposure is bounded by whatever the seller
-    // can actually prove on-chain, which it can already claim up to `accepted`.
-    //
-    // SECURITY: a malicious seller can inflate `targetCumulative` up to the on-chain
-    // `reserveMaxAmount` (our `_currentReserveCeiling`) in a single 402, bypassing the
-    // usual per-request overdraft pacing. The upper bound is still bounded by that
-    // ceiling — `nextCumulative = min(requestedAmount, maxSignable)` and `maxSignable`
-    // is capped at the ceiling — so the seller can never push the buyer past what the
-    // buyer explicitly reserved. The effect is that an abusive seller could drain the
-    // reserve in one catch-up instead of over many well-metered requests, but cannot
-    // charge beyond the reserve. Accepting this tradeoff: the attacker could already
-    // settle up to `accepted` on-chain today with the signatures we've already issued,
-    // and losing the pacing doesn't expose new funds.
-    const floor = targetCumulative != null && targetCumulative > currentCumulative
-      ? targetCumulative
-      : currentCumulative;
-    if (maxSignable <= floor) {
+    // SECURITY: the trust anchor here is `currentCumulative`, NOT the
+    // seller-supplied `targetCumulative`. A malicious seller could set
+    // `requiredCumulativeAmount` in the 402 body to the full reserve ceiling
+    // (pretending it spent that much) in an attempt to drain the channel in
+    // one signature. We defend by only ever using `targetCumulative` as a
+    // *destination hint* bounded by `maxSignable = verifiedCost +
+    // maxPerRequestUsdc`. Per-request cost validation still happens
+    // tolerance-checked in `handleNeedAuth`; nothing in the 402 body feeds
+    // `verifiedCost`. The worst a seller can extract per 402 round trip is
+    // one `maxPerRequestUsdc` window beyond what the buyer already signed —
+    // identical to the non-catchup trust model before this PR.
+    if (maxSignable <= currentCumulative) {
       const previousVerified = this._verifiedCost.get(sellerPeerId) ?? 0n;
-      if (floor > previousVerified) {
-        this._verifiedCost.set(sellerPeerId, floor);
+      if (currentCumulative > previousVerified) {
+        this._verifiedCost.set(sellerPeerId, currentCumulative);
         maxSignable = this._maxSignable(sellerPeerId);
         debugLog(
-          `[BuyerPayment] extendCurrentSpendingAuth: advanced verifiedCost ${previousVerified} → ${floor} ` +
+          `[BuyerPayment] extendCurrentSpendingAuth: advanced verifiedCost ${previousVerified} → ${currentCumulative} ` +
           `to unblock overdraft window for ${sellerPeerId.slice(0, 12)}...`,
         );
       }

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -51,6 +51,14 @@ function parsePaymentRequiredBody(body: Uint8Array): Record<string, unknown> | n
   }
 }
 
+function safeBigInt(value: string): bigint | null {
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Manages all buyer-side payment negotiation state and logic.
  *
@@ -239,26 +247,37 @@ export class BuyerPaymentNegotiator {
 
     const returnPaymentRequired = (reason: string): Handle402Result => {
       debugLog(`[BuyerNegotiator] Got 402 from ${peer.peerId.slice(0, 12)}... — returning to caller (${reason})`);
-      if (responseAlreadyHasRequirements) {
-        return { action: 'return', response };
-      }
-      if (buffered) {
-        const enrichedBody = JSON.stringify({
-          error: 'payment_required',
-          peerId: peer.peerId,
-          minBudgetPerRequest: buffered.minBudgetPerRequest,
-          suggestedAmount: buffered.suggestedAmount,
-        });
-        return {
-          action: 'return',
-          response: {
-            ...response,
-            headers: { ...response.headers, 'content-type': 'application/json' },
-            body: new TextEncoder().encode(enrichedBody),
-          },
-        };
-      }
-      return { action: 'return', response };
+      // Always return a normalized buyer-authored body so the desktop UI can
+      // render a proper "top up your deposits" CTA instead of the raw seller
+      // 402 JSON (which leaks internal fields like requiredCumulativeAmount,
+      // currentSpent, and per-service pricing).
+      const req = buffered
+        ?? (responseAlreadyHasRequirements && directPaymentBody != null
+          ? {
+            minBudgetPerRequest: directPaymentBody.minBudgetPerRequest != null
+              ? String(directPaymentBody.minBudgetPerRequest)
+              : undefined,
+            suggestedAmount: directPaymentBody.suggestedAmount != null
+              ? String(directPaymentBody.suggestedAmount)
+              : undefined,
+          }
+          : null);
+      const enrichedBody = JSON.stringify({
+        error: 'payment_required',
+        reason,
+        peerId: peer.peerId,
+        ...(req?.minBudgetPerRequest != null ? { minBudgetPerRequest: req.minBudgetPerRequest } : {}),
+        ...(req?.suggestedAmount != null ? { suggestedAmount: req.suggestedAmount } : {}),
+        message: 'Deposits are insufficient to open a payment channel with this peer. Top up with "antseed buyer deposit <amount>" and retry.',
+      });
+      return {
+        action: 'return',
+        response: {
+          ...response,
+          headers: { ...response.headers, 'content-type': 'application/json' },
+          body: new TextEncoder().encode(enrichedBody),
+        },
+      };
     };
 
     const returnNegotiationFailure = (reason: string, message: string, statusCode = 409): Handle402Result => {
@@ -288,8 +307,24 @@ export class BuyerPaymentNegotiator {
         ? BigInt(String(directPaymentBody.minBudgetPerRequest))
         : null;
 
+    // Absolute cumulative target the seller needs us to sign to unblock the
+    // channel (sent by the seller in the budget-exhausted branch). When
+    // present we pass it through to extendCurrentSpendingAuth so the buyer
+    // catches up in one step instead of creeping by minBudgetPerRequest and
+    // repeatedly being rejected as underfunded.
+    const requiredCumulativeTarget = buffered?.requiredCumulativeAmount != null
+      ? safeBigInt(buffered.requiredCumulativeAmount)
+      : responseAlreadyHasRequirements && directPaymentBody?.requiredCumulativeAmount != null
+        ? safeBigInt(String(directPaymentBody.requiredCumulativeAmount))
+        : null;
+
     if (hadLockedSession || this._bpm.getActiveSession(peer.peerId)) {
-      const recovered = await this._recoverExistingSession(peer, conn, existingSessionBudgetRequest);
+      const recovered = await this._recoverExistingSession(
+        peer,
+        conn,
+        existingSessionBudgetRequest,
+        requiredCumulativeTarget,
+      );
       if (recovered) {
         return { action: 'retry' };
       }
@@ -753,6 +788,7 @@ export class BuyerPaymentNegotiator {
     peer: PeerInfo,
     conn: PeerConnection,
     minBudgetPerRequest: bigint | null = null,
+    targetCumulative: bigint | null = null,
   ): Promise<boolean> {
     const session = this._bpm.getActiveSession(peer.peerId);
     if (!session) {
@@ -802,7 +838,12 @@ export class BuyerPaymentNegotiator {
     const pmux = this.getOrCreatePaymentMux(peer.peerId, conn);
     if (minBudgetPerRequest != null && minBudgetPerRequest > 0n) {
       const cumulativeBefore = this._bpm.getCumulativeAmount(peer.peerId);
-      await this._bpm.extendCurrentSpendingAuth(peer.peerId, minBudgetPerRequest, pmux);
+      await this._bpm.extendCurrentSpendingAuth(
+        peer.peerId,
+        minBudgetPerRequest,
+        pmux,
+        targetCumulative != null && targetCumulative > 0n ? targetCumulative : undefined,
+      );
       const cumulativeAfter = this._bpm.getCumulativeAmount(peer.peerId);
       if (cumulativeAfter <= cumulativeBefore) {
         // extendCurrentSpendingAuth was a no-op — the overdraft window and reserve ceiling

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -245,8 +245,12 @@ export class BuyerPaymentNegotiator {
       : await this._awaitPaymentRequired(peer.peerId, conn, waitMs);
     if (buffered) this._bufferedPaymentRequired.delete(peer.peerId);
 
-    const returnPaymentRequired = (reason: string): Handle402Result => {
-      debugLog(`[BuyerNegotiator] Got 402 from ${peer.peerId.slice(0, 12)}... — returning to caller (${reason})`);
+    // Stable machine-readable codes for the 402 body. Kept deliberately small
+    // so callers (desktop UI, other SDK consumers) can switch on them without
+    // being coupled to internal debug strings.
+    type PaymentRequiredCode = 'insufficient_deposits';
+    const returnPaymentRequired = (code: PaymentRequiredCode, debugReason: string): Handle402Result => {
+      debugLog(`[BuyerNegotiator] Got 402 from ${peer.peerId.slice(0, 12)}... — returning to caller (${debugReason})`);
       // Always return a normalized buyer-authored body so the desktop UI can
       // render a proper "top up your deposits" CTA instead of the raw seller
       // 402 JSON (which leaks internal fields like requiredCumulativeAmount,
@@ -264,7 +268,7 @@ export class BuyerPaymentNegotiator {
           : null);
       const enrichedBody = JSON.stringify({
         error: 'payment_required',
-        reason,
+        code,
         peerId: peer.peerId,
         ...(req?.minBudgetPerRequest != null ? { minBudgetPerRequest: req.minBudgetPerRequest } : {}),
         ...(req?.suggestedAmount != null ? { suggestedAmount: req.suggestedAmount } : {}),
@@ -360,7 +364,7 @@ export class BuyerPaymentNegotiator {
       const buyerAddr = this._identity.wallet.address;
       const balance = await this._depositsClient.getBuyerBalance(buyerAddr);
       if (balance.available <= 0n) {
-        return returnPaymentRequired('insufficient credits');
+        return returnPaymentRequired('insufficient_deposits', 'buyer deposits balance is zero');
       }
     } catch (err) {
       debugWarn(`[BuyerNegotiator] Failed to check buyer balance: ${err instanceof Error ? err.message : err}`);

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -91,6 +91,15 @@ export class SellerPaymentManager {
   /** channelId -> latest buyer-signed auth (both sigs + cumulative values + metadata) for settle/close */
   private readonly _latestAuth = new Map<string, LatestAuth>();
 
+  /**
+   * channelId -> waiters blocked on acceptedCumulative reaching a target.
+   * Used to hide the NeedAuth → SpendingAuth round-trip latency from the next
+   * request: if a new request arrives while the prior response's NeedAuth is
+   * still on the wire, the request handler parks on this waiter instead of
+   * 402ing immediately.
+   */
+  private readonly _acceptedWaiters = new Map<string, Array<{ target: bigint; resolve: () => void }>>();
+
   /** channelId -> number of failed close() attempts. In-memory only; resets on node restart. */
   private readonly _closeRetryCount = new Map<string, number>();
 
@@ -219,8 +228,65 @@ export class SellerPaymentManager {
     this._closeRetryCount.delete(channelId);
     this._reserveMax.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
+    this._releaseAcceptedWaiters(channelId);
     this._activeBuyers.delete(peerId);
     debugLog(`[SellerPayment] Evicted stale channel ${channelId.slice(0, 18)}... — ${reason}`);
+  }
+
+  /**
+   * Block until `acceptedCumulative(channelId)` reaches `target`, or `timeoutMs`
+   * elapses. Returns true if the target was reached, false on timeout. Used by
+   * the request handler to wait out the buyer's NeedAuth → SpendingAuth round
+   * trip when a follow-up request arrives before the catch-up auth has landed.
+   */
+  awaitAcceptedAtLeast(channelId: string, target: bigint, timeoutMs: number): Promise<boolean> {
+    const current = this._acceptedCumulative.get(channelId) ?? 0n;
+    if (current >= target) return Promise.resolve(true);
+    return new Promise<boolean>((resolve) => {
+      let done = false;
+      const waiter = {
+        target,
+        resolve: () => {
+          if (done) return;
+          done = true;
+          clearTimeout(timer);
+          resolve(true);
+        },
+      };
+      const waiters = this._acceptedWaiters.get(channelId) ?? [];
+      waiters.push(waiter);
+      this._acceptedWaiters.set(channelId, waiters);
+      const timer = setTimeout(() => {
+        if (done) return;
+        done = true;
+        const current = this._acceptedWaiters.get(channelId);
+        if (current) {
+          const filtered = current.filter((w) => w !== waiter);
+          if (filtered.length > 0) this._acceptedWaiters.set(channelId, filtered);
+          else this._acceptedWaiters.delete(channelId);
+        }
+        resolve(false);
+      }, timeoutMs);
+    });
+  }
+
+  private _notifyAcceptedUpdate(channelId: string, newAccepted: bigint): void {
+    const waiters = this._acceptedWaiters.get(channelId);
+    if (!waiters || waiters.length === 0) return;
+    const remaining: typeof waiters = [];
+    for (const w of waiters) {
+      if (newAccepted >= w.target) w.resolve();
+      else remaining.push(w);
+    }
+    if (remaining.length > 0) this._acceptedWaiters.set(channelId, remaining);
+    else this._acceptedWaiters.delete(channelId);
+  }
+
+  private _releaseAcceptedWaiters(channelId: string): void {
+    const waiters = this._acceptedWaiters.get(channelId);
+    if (!waiters) return;
+    for (const w of waiters) w.resolve();
+    this._acceptedWaiters.delete(channelId);
   }
 
   get channelsClient(): ChannelsClient {
@@ -477,6 +543,7 @@ export class SellerPaymentManager {
           metadataHash: payload.metadataHash,
           metadata: payload.metadata,
         });
+        this._notifyAcceptedUpdate(channelId, cumulativeAmount);
 
         // Persist latest auth + sigs to ChannelStore
         const session = this._channelStore.getChannel(channelId);
@@ -653,6 +720,7 @@ export class SellerPaymentManager {
         metadataHash: auth.metadataHash,
         metadata: auth.metadata,
       });
+      this._notifyAcceptedUpdate(channelId, newCumulative);
 
       // Persist latest auth + sigs to ChannelStore
       const storedSession = this._channelStore.getChannel(channelId);

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -96,9 +96,10 @@ export class SellerPaymentManager {
    * Used to hide the NeedAuth → SpendingAuth round-trip latency from the next
    * request: if a new request arrives while the prior response's NeedAuth is
    * still on the wire, the request handler parks on this waiter instead of
-   * 402ing immediately.
+   * 402ing immediately. `resolve(true)` means the target was reached;
+   * `resolve(false)` means the channel was evicted before that could happen.
    */
-  private readonly _acceptedWaiters = new Map<string, Array<{ target: bigint; resolve: () => void }>>();
+  private readonly _acceptedWaiters = new Map<string, Array<{ target: bigint; resolve: (reached: boolean) => void }>>();
 
   /** channelId -> number of failed close() attempts. In-memory only; resets on node restart. */
   private readonly _closeRetryCount = new Map<string, number>();
@@ -240,17 +241,17 @@ export class SellerPaymentManager {
    * trip when a follow-up request arrives before the catch-up auth has landed.
    */
   awaitAcceptedAtLeast(channelId: string, target: bigint, timeoutMs: number): Promise<boolean> {
-    const current = this._acceptedCumulative.get(channelId) ?? 0n;
-    if (current >= target) return Promise.resolve(true);
+    const accepted = this._acceptedCumulative.get(channelId) ?? 0n;
+    if (accepted >= target) return Promise.resolve(true);
     return new Promise<boolean>((resolve) => {
       let done = false;
       const waiter = {
         target,
-        resolve: () => {
+        resolve: (reached: boolean) => {
           if (done) return;
           done = true;
           clearTimeout(timer);
-          resolve(true);
+          resolve(reached);
         },
       };
       const waiters = this._acceptedWaiters.get(channelId) ?? [];
@@ -259,9 +260,9 @@ export class SellerPaymentManager {
       const timer = setTimeout(() => {
         if (done) return;
         done = true;
-        const current = this._acceptedWaiters.get(channelId);
-        if (current) {
-          const filtered = current.filter((w) => w !== waiter);
+        const list = this._acceptedWaiters.get(channelId);
+        if (list) {
+          const filtered = list.filter((w) => w !== waiter);
           if (filtered.length > 0) this._acceptedWaiters.set(channelId, filtered);
           else this._acceptedWaiters.delete(channelId);
         }
@@ -275,17 +276,23 @@ export class SellerPaymentManager {
     if (!waiters || waiters.length === 0) return;
     const remaining: typeof waiters = [];
     for (const w of waiters) {
-      if (newAccepted >= w.target) w.resolve();
+      if (newAccepted >= w.target) w.resolve(true);
       else remaining.push(w);
     }
     if (remaining.length > 0) this._acceptedWaiters.set(channelId, remaining);
     else this._acceptedWaiters.delete(channelId);
   }
 
+  /**
+   * Wake all waiters for a channel with `reached=false` — the target can no
+   * longer be reached (channel evicted, settled, or closed). Preserves the
+   * `awaitAcceptedAtLeast` contract: `true` only when the target was actually
+   * hit, `false` otherwise.
+   */
   private _releaseAcceptedWaiters(channelId: string): void {
     const waiters = this._acceptedWaiters.get(channelId);
     if (!waiters) return;
-    for (const w of waiters) w.resolve();
+    for (const w of waiters) w.resolve(false);
     this._acceptedWaiters.delete(channelId);
   }
 
@@ -869,6 +876,7 @@ export class SellerPaymentManager {
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
+    this._releaseAcceptedWaiters(channelId);
     this._activeBuyers.delete(buyerPeerId);
   }
 
@@ -1034,6 +1042,7 @@ export class SellerPaymentManager {
     this._closeRetryCount.delete(channelId);
     this._reserveMax.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
+    this._releaseAcceptedWaiters(channelId);
 
     // Find and remove buyer from active set
     const channel = this._channelStore.getChannel(channelId);

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -170,16 +170,30 @@ export class SellerRequestHandler {
           if (spent > 0n && spent >= accepted) {
             const reserveMax = spm.getReserveMax(session.sessionId);
             const providerPricing = this.resolveProviderPricing(provider, request);
-            const requirements = spm.getPaymentRequirements(
+            const baseRequirements = spm.getPaymentRequirements(
               request.requestId, buyerPeerId, providerPricing,
             );
-            if (reserveMax > 0n && accepted >= reserveMax) {
+            // Tell the buyer *exactly* how much cumulative signed authorization
+            // the seller needs to unblock further requests. Without this the
+            // buyer can only guess via minBudgetPerRequest and may sign an
+            // amount that is still below `spent`, which the seller would then
+            // reject as underfunded — producing an infinite 402 loop.
+            const target = spent + BigInt(baseRequirements.minBudgetPerRequest);
+            const requirements = {
+              ...baseRequirements,
+              requiredCumulativeAmount: target.toString(),
+              currentSpent: spent.toString(),
+              currentAcceptedCumulative: accepted.toString(),
+              channelId: session.sessionId,
+            };
+            const isFullyExhausted = reserveMax > 0n && accepted >= reserveMax;
+            if (isFullyExhausted) {
               debugLog(`[SellerHandler] Session fully exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} >= accepted=${accepted} >= reserveMax=${reserveMax}) — settling and returning 402`);
               void spm.settleSession(buyerPeerId).catch((err) => {
                 debugWarn(`[SellerHandler] Failed to settle exhausted session: ${err instanceof Error ? err.message : err}`);
               });
             } else {
-              debugLog(`[SellerHandler] Budget exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} >= accepted=${accepted}) — returning 402, awaiting higher SpendingAuth / renegotiation`);
+              debugLog(`[SellerHandler] Budget exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} >= accepted=${accepted}) — returning 402 with requiredCumulativeAmount=${target}, awaiting higher SpendingAuth`);
             }
             mux.sendProxyResponse({
               requestId: request.requestId,
@@ -189,12 +203,28 @@ export class SellerRequestHandler {
                 error: 'payment_required',
                 minBudgetPerRequest: requirements.minBudgetPerRequest,
                 suggestedAmount: requirements.suggestedAmount,
+                requiredCumulativeAmount: requirements.requiredCumulativeAmount,
+                currentSpent: requirements.currentSpent,
+                currentAcceptedCumulative: requirements.currentAcceptedCumulative,
+                channelId: requirements.channelId,
                 ...(requirements.inputUsdPerMillion != null ? { inputUsdPerMillion: requirements.inputUsdPerMillion } : {}),
                 ...(requirements.outputUsdPerMillion != null ? { outputUsdPerMillion: requirements.outputUsdPerMillion } : {}),
                 ...(requirements.cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion: requirements.cachedInputUsdPerMillion } : {}),
               })),
             });
             paymentMux.sendPaymentRequired(requirements);
+            // Also emit a NeedAuth so the buyer's standard auto-sign path can
+            // catch up without the 402 ever needing to round-trip to the user.
+            // If the buyer responds in time the retried request will succeed.
+            if (!isFullyExhausted) {
+              paymentMux.sendNeedAuth({
+                channelId: session.sessionId,
+                requiredCumulativeAmount: target.toString(),
+                currentAcceptedCumulative: accepted.toString(),
+                deposit: session.authMax ?? '0',
+                requestId: request.requestId,
+              });
+            }
             return;
           }
         }

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -165,8 +165,25 @@ export class SellerRequestHandler {
             });
             return;
           }
-          const accepted = spm.getAcceptedCumulative(session.sessionId);
+          let accepted = spm.getAcceptedCumulative(session.sessionId);
           const spent = spm.getCumulativeSpend(session.sessionId);
+          if (spent > 0n && spent >= accepted) {
+            // Race cover: the buyer's SpendingAuth for the *previous* response's
+            // NeedAuth may still be on the wire when this request arrives. The
+            // per-buyer mutex in waitForPendingAuths only serializes *in-flight*
+            // handleSpendingAuth calls — it can't wait for a frame that hasn't
+            // been received yet. Park for up to 5s for the signed catch-up to
+            // land before giving up and emitting a 402. In pure steady-state
+            // operation this wait is a no-op; under pipelined requests (a new
+            // request dispatched before the prior NeedAuth → SpendingAuth has
+            // completed) it hides the round-trip latency from the buyer.
+            const CATCH_UP_WAIT_MS = 5_000;
+            const caughtUp = await spm.awaitAcceptedAtLeast(session.sessionId, spent, CATCH_UP_WAIT_MS);
+            accepted = spm.getAcceptedCumulative(session.sessionId);
+            if (caughtUp && spent <= accepted) {
+              debugLog(`[SellerHandler] Caught up before 402 for ${buyerPeerId.slice(0, 12)}... (spent=${spent} accepted=${accepted})`);
+            }
+          }
           if (spent > 0n && spent >= accepted) {
             const reserveMax = spm.getReserveMax(session.sessionId);
             const providerPricing = this.resolveProviderPricing(provider, request);
@@ -213,9 +230,8 @@ export class SellerRequestHandler {
               })),
             });
             paymentMux.sendPaymentRequired(requirements);
-            // Also emit a NeedAuth so the buyer's standard auto-sign path can
-            // catch up without the 402 ever needing to round-trip to the user.
-            // If the buyer responds in time the retried request will succeed.
+            // Auto-sign catch-up via NeedAuth so a transient underfund recovers
+            // without the 402 round-tripping to the user.
             if (!isFullyExhausted) {
               paymentMux.sendNeedAuth({
                 channelId: session.sessionId,

--- a/packages/node/src/types/protocol.ts
+++ b/packages/node/src/types/protocol.ts
@@ -76,6 +76,18 @@ export interface PaymentRequiredPayload {
   inputUsdPerMillion?: number;
   outputUsdPerMillion?: number;
   cachedInputUsdPerMillion?: number;
+  /**
+   * For budget-exhausted 402s on an existing channel: the cumulative
+   * amount the buyer must sign to catch up with the seller's recorded
+   * spend and unblock further requests. Absent for pre-session 402s.
+   */
+  requiredCumulativeAmount?: string;
+  /** Seller-side cumulative spend at the time the 402 was emitted. */
+  currentSpent?: string;
+  /** Seller-side last-accepted cumulative at the time the 402 was emitted. */
+  currentAcceptedCumulative?: string;
+  /** Channel ID for the exhausted session (so buyer can match it locally). */
+  channelId?: string;
 }
 
 /**

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -764,13 +764,13 @@ describe('BuyerPaymentManager', () => {
     expect((mux.sentSpendingAuths[0] as Record<string, string>).cumulativeAmount).toBe('20000');
   });
 
-  it('extendCurrentSpendingAuth catches up to an explicit target in a single step', async () => {
+  it('extendCurrentSpendingAuth catches up to an explicit target in a single step within overdraft window', async () => {
     const sellerPeerId = fakePeerId('seller-catchup-target');
-    // Tight per-request cap so a naive advance (currentCumulative + minBudgetPerRequest)
-    // would still fall below the seller-reported spend target, triggering the
-    // underfunded-SpendingAuth loop this fix closes.
+    // Default-shaped config: the legitimate Open Forge race (56_218 signed,
+    // seller spent 85_119) is 28_901 behind — well within the 500_000-USDC
+    // overdraft window, so we expect a one-hop catch-up.
     const catchupConfig = makeConfig(tempDir, {
-      maxPerRequestUsdc: 10_000n,
+      maxPerRequestUsdc: 500_000n,
       maxReserveAmountUsdc: 1_000_000n,
     });
     store.close();
@@ -783,8 +783,8 @@ describe('BuyerPaymentManager', () => {
     const channelId = (mux.sentSpendingAuths[0] as Record<string, string>).channelId!;
     manager.handleAuthAck(sellerPeerId, { channelId });
 
-    // Simulate a session that has already signed cumulative=56_218 via NeedAuth
-    // while the seller has spent=85_119 (matches the Open Forge production log).
+    // Simulate a session that has already signed cumulative=56_218 via a
+    // tolerance-checked NeedAuth (so verifiedCost tracks that amount).
     await manager.handleNeedAuth(sellerPeerId, {
       channelId,
       requiredCumulativeAmount: '56218',
@@ -796,14 +796,65 @@ describe('BuyerPaymentManager', () => {
 
     mux.sentSpendingAuths.length = 0;
 
-    // Without a target, the next advance would only reach 56_218 + 10_000 = 66_218,
-    // which the seller would still reject as underfunded (spent=85_119). With the
-    // target passed through, the buyer jumps straight to ≥85_119.
+    // Without a target, the advance would only reach 56_218 + 10_000 = 66_218,
+    // which the seller would still reject as underfunded (spent=85_119). With
+    // the target passed through, the buyer jumps straight to the target in
+    // one hop because 85_119 < verifiedCost + maxPerRequestUsdc.
     await manager.extendCurrentSpendingAuth(sellerPeerId, 10_000n, mux, 85_119n);
 
     expect(mux.sentSpendingAuths).toHaveLength(1);
     const extended = mux.sentSpendingAuths[0] as Record<string, string>;
-    expect(BigInt(extended.cumulativeAmount)).toBeGreaterThanOrEqual(85_119n);
+    expect(BigInt(extended.cumulativeAmount)).toBe(85_119n);
+  });
+
+  it('extendCurrentSpendingAuth caps a malicious target at verifiedCost + maxPerRequestUsdc', async () => {
+    // Adversarial model: a rogue seller sends a 402 with an inflated
+    // requiredCumulativeAmount (claiming fictitious spend) in an attempt
+    // to drain the entire reserve in a single signature. The buyer must
+    // NOT let that target feed verifiedCost — the cap is the per-request
+    // overdraft window beyond what was already signed.
+    const sellerPeerId = fakePeerId('seller-malicious-target');
+    const tightConfig = makeConfig(tempDir, {
+      maxPerRequestUsdc: 10_000n,
+      maxReserveAmountUsdc: 1_000_000n,
+    });
+    store.close();
+    store = new ChannelStore(tempDir);
+    manager = new BuyerPaymentManager(identity, tightConfig, store);
+    manager.setSigner(identity.wallet);
+    mux = createMockPaymentMux();
+
+    await manager.authorizeSpending(sellerPeerId, mux, 10_000n, 1_000_000n, TEST_PRICING);
+    const channelId = (mux.sentSpendingAuths[0] as Record<string, string>).channelId!;
+    manager.handleAuthAck(sellerPeerId, { channelId });
+
+    // Legitimate progress via NeedAuth: verifiedCost tracks this.
+    await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requiredCumulativeAmount: '5000',
+      currentAcceptedCumulative: '0',
+      deposit: '1000000',
+      lastRequestCost: '5000',
+    }, mux);
+    expect(manager.getCumulativeAmount(sellerPeerId)).toBe(5_000n);
+    expect(manager.getVerifiedCost(sellerPeerId)).toBe(5_000n);
+
+    mux.sentSpendingAuths.length = 0;
+
+    // Seller claims via 402 body that it spent the entire 1_000_000 reserve.
+    // If the buyer trusted this, it would sign cumulative=1_000_000 and lose
+    // the whole channel reservation to an unvalidated claim.
+    await manager.extendCurrentSpendingAuth(sellerPeerId, 10_000n, mux, 1_000_000n);
+
+    expect(mux.sentSpendingAuths).toHaveLength(1);
+    const extended = mux.sentSpendingAuths[0] as Record<string, string>;
+    // Cap: verifiedCost (5_000) + maxPerRequestUsdc (10_000) = 15_000.
+    // The malicious 1_000_000 target is ignored beyond that bound.
+    expect(BigInt(extended.cumulativeAmount)).toBe(15_000n);
+    // And crucially: verifiedCost must NOT have been contaminated by the
+    // seller-supplied target — it only advances to the already-signed amount
+    // to reopen the overdraft window.
+    expect(manager.getVerifiedCost(sellerPeerId)).toBe(5_000n);
   });
 
   it('recordAndPersistTokens continues from persisted totals after restart', async () => {

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -764,6 +764,48 @@ describe('BuyerPaymentManager', () => {
     expect((mux.sentSpendingAuths[0] as Record<string, string>).cumulativeAmount).toBe('20000');
   });
 
+  it('extendCurrentSpendingAuth catches up to an explicit target in a single step', async () => {
+    const sellerPeerId = fakePeerId('seller-catchup-target');
+    // Tight per-request cap so a naive advance (currentCumulative + minBudgetPerRequest)
+    // would still fall below the seller-reported spend target, triggering the
+    // underfunded-SpendingAuth loop this fix closes.
+    const catchupConfig = makeConfig(tempDir, {
+      maxPerRequestUsdc: 10_000n,
+      maxReserveAmountUsdc: 1_000_000n,
+    });
+    store.close();
+    store = new ChannelStore(tempDir);
+    manager = new BuyerPaymentManager(identity, catchupConfig, store);
+    manager.setSigner(identity.wallet);
+    mux = createMockPaymentMux();
+
+    await manager.authorizeSpending(sellerPeerId, mux, 10_000n, 1_000_000n, TEST_PRICING);
+    const channelId = (mux.sentSpendingAuths[0] as Record<string, string>).channelId!;
+    manager.handleAuthAck(sellerPeerId, { channelId });
+
+    // Simulate a session that has already signed cumulative=56_218 via NeedAuth
+    // while the seller has spent=85_119 (matches the Open Forge production log).
+    await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requiredCumulativeAmount: '56218',
+      currentAcceptedCumulative: '0',
+      deposit: '1000000',
+      lastRequestCost: '56218',
+    }, mux);
+    expect(manager.getCumulativeAmount(sellerPeerId)).toBe(56_218n);
+
+    mux.sentSpendingAuths.length = 0;
+
+    // Without a target, the next advance would only reach 56_218 + 10_000 = 66_218,
+    // which the seller would still reject as underfunded (spent=85_119). With the
+    // target passed through, the buyer jumps straight to ≥85_119.
+    await manager.extendCurrentSpendingAuth(sellerPeerId, 10_000n, mux, 85_119n);
+
+    expect(mux.sentSpendingAuths).toHaveLength(1);
+    const extended = mux.sentSpendingAuths[0] as Record<string, string>;
+    expect(BigInt(extended.cumulativeAmount)).toBeGreaterThanOrEqual(85_119n);
+  });
+
   it('recordAndPersistTokens continues from persisted totals after restart', async () => {
     const sellerPeerId = fakePeerId('seller-record-restart');
     await manager.authorizeSpending(sellerPeerId, mux, 50_000n, TEST_PRICING);

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -766,11 +766,11 @@ describe('BuyerPaymentManager', () => {
 
   it('extendCurrentSpendingAuth catches up to an explicit target in a single step within overdraft window', async () => {
     const sellerPeerId = fakePeerId('seller-catchup-target');
-    // Default-shaped config: the legitimate Open Forge race (56_218 signed,
-    // seller spent 85_119) is 28_901 behind — well within the 500_000-USDC
-    // overdraft window, so we expect a one-hop catch-up.
+    // CLI default-shaped config: the legitimate Open Forge race (56_218 signed,
+    // seller spent 85_119) is 28_901 behind — well within the 300_000-USDC
+    // CLI-default overdraft window, so we expect a one-hop catch-up.
     const catchupConfig = makeConfig(tempDir, {
-      maxPerRequestUsdc: 500_000n,
+      maxPerRequestUsdc: 300_000n,
       maxReserveAmountUsdc: 1_000_000n,
     });
     store.close();

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -451,6 +451,10 @@ describe('BuyerPaymentNegotiator', () => {
       const res = (result as { action: 'return'; response: SerializedHttpResponse }).response;
       const body = JSON.parse(new TextDecoder().decode(res.body));
       expect(body.error).toBe('payment_required');
+      // Stable machine-readable code — not a free-form debug string — so
+      // callers can switch on it without coupling to internal phrasing.
+      expect(body.code).toBe('insufficient_deposits');
+      expect(body.reason).toBeUndefined();
       expect(body.minBudgetPerRequest).toBe('10000');
       expect(body.suggestedAmount).toBe('100000');
       expect(body.peerId).toBe(peer.peerId);

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -232,9 +232,43 @@ describe('BuyerPaymentNegotiator', () => {
         peer.peerId,
         BigInt(paymentRequiredPayload.minBudgetPerRequest),
         expect.anything(),
+        undefined,
       );
       expect(bpm.resendCurrentSpendingAuth).not.toHaveBeenCalled();
       expect(bpm.authorizeSpending).not.toHaveBeenCalled();
+      expect(result.action).toBe('retry');
+    });
+
+    it('forwards requiredCumulativeAmount from the 402 body as the catch-up target', async () => {
+      await simulateSuccessfulNegotiation(negotiator, bpm, peer, conn);
+      (bpm.authorizeSpending as ReturnType<typeof vi.fn>).mockClear();
+
+      const activeSession = makeActiveSession(peer.peerId);
+      (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(activeSession);
+      (bpm.getCumulativeAmount as ReturnType<typeof vi.fn>).mockReturnValueOnce(56218n).mockReturnValueOnce(85119n);
+      (bpm.extendCurrentSpendingAuth as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        (bpm.isLockConfirmed as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      });
+
+      // 402 body carries the seller-reported catch-up target (no need to buffer a
+      // PaymentRequired frame — the body alone should be enough to drive recovery).
+      const response = make402Response({
+        error: 'payment_required',
+        minBudgetPerRequest: '10000',
+        suggestedAmount: '1000000',
+        requiredCumulativeAmount: '85119',
+        currentSpent: '85119',
+        currentAcceptedCumulative: '56218',
+      });
+
+      const result = await negotiator.handle402(response, peer, conn, makeRequest());
+
+      expect(bpm.extendCurrentSpendingAuth).toHaveBeenCalledWith(
+        peer.peerId,
+        10000n,
+        expect.anything(),
+        85119n, // <— the catch-up target the seller asked for
+      );
       expect(result.action).toBe('retry');
     });
 
@@ -416,9 +450,16 @@ describe('BuyerPaymentNegotiator', () => {
 
       const res = (result as { action: 'return'; response: SerializedHttpResponse }).response;
       const body = JSON.parse(new TextDecoder().decode(res.body));
+      expect(body.error).toBe('payment_required');
       expect(body.minBudgetPerRequest).toBe('10000');
       expect(body.suggestedAmount).toBe('100000');
       expect(body.peerId).toBe(peer.peerId);
+      // Should be the buyer-authored, user-friendly body — not the raw seller 402
+      // fields that would leak internal catch-up/accounting state.
+      expect(body.requiredCumulativeAmount).toBeUndefined();
+      expect(body.currentSpent).toBeUndefined();
+      expect(body.inputUsdPerMillion).toBeUndefined();
+      expect(typeof body.message).toBe('string');
     });
 
     it('throws on negotiation failure and clears locked state', async () => {

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -253,6 +253,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
         getReserveMax: () => 1_000_000n,
         getPaymentRequirements: () => ({ minBudgetPerRequest: '50000', suggestedAmount: '1000000' }),
         waitForPendingAuths: async () => {},
+        awaitAcceptedAtLeast: async () => false,
       } as any,
       sessionTracker: null,
       channelsClient: {} as any,

--- a/packages/node/tests/payment-codec.test.ts
+++ b/packages/node/tests/payment-codec.test.ts
@@ -49,6 +49,24 @@ describe('payment codec round-trips', () => {
     expect(decoded).toEqual(payload);
   });
 
+  it('PaymentRequired with budget-exhausted catch-up fields', () => {
+    const payload = {
+      minBudgetPerRequest: '10000',
+      suggestedAmount: '1000000',
+      requestId: 'req-789',
+      inputUsdPerMillion: 0.36,
+      outputUsdPerMillion: 1.65,
+      cachedInputUsdPerMillion: 0.07,
+      requiredCumulativeAmount: '85119',
+      currentSpent: '85119',
+      currentAcceptedCumulative: '56218',
+      channelId: '0x' + 'aa'.repeat(32),
+    };
+    const encoded = encodePaymentRequired(payload);
+    const decoded = decodePaymentRequired(encoded);
+    expect(decoded).toEqual(payload);
+  });
+
   it('NeedAuth', () => {
     const payload = {
       channelId: '0x' + 'aa'.repeat(32),

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -302,6 +302,57 @@ describe('SellerPaymentManager', () => {
     expect(session!.tokensDelivered).toBe('50000');
   });
 
+  it('awaitAcceptedAtLeast resolves when a SpendingAuth raises accepted to the target', async () => {
+    const channelId = makeChannelId(77);
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    // Simulate the race: the request handler is waiting for accepted >= spent
+    // while the buyer's catch-up SpendingAuth is still on the wire.
+    const waitPromise = manager.awaitAcceptedAtLeast(channelId, 500_000n, 2_000);
+
+    // A late-arriving SpendingAuth unblocks the waiter in a single tick — the
+    // request handler resumes instead of emitting a spurious 402.
+    const catchUp = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 500_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, catchUp, mux);
+
+    await expect(waitPromise).resolves.toBe(true);
+    expect(manager.getAcceptedCumulative(channelId)).toBe(500_000n);
+  });
+
+  it('awaitAcceptedAtLeast returns true immediately when the target is already satisfied', async () => {
+    const channelId = makeChannelId(78);
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+    const authPayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 300_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, authPayload, mux);
+
+    await expect(manager.awaitAcceptedAtLeast(channelId, 200_000n, 1_000)).resolves.toBe(true);
+  });
+
+  it('awaitAcceptedAtLeast times out with false when the SpendingAuth never arrives', async () => {
+    const channelId = makeChannelId(79);
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    await expect(manager.awaitAcceptedAtLeast(channelId, 500_000n, 50)).resolves.toBe(false);
+  });
+
   it('test_recordSpend: tracks cumulative spend', async () => {
 
     const channelId = makeChannelId(3);

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -353,6 +353,24 @@ describe('SellerPaymentManager', () => {
     await expect(manager.awaitAcceptedAtLeast(channelId, 500_000n, 50)).resolves.toBe(false);
   });
 
+  it('awaitAcceptedAtLeast resolves false when the channel is closed before the target is reached', async () => {
+    const channelId = makeChannelId(80);
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    const waitPromise = manager.awaitAcceptedAtLeast(channelId, 500_000n, 5_000);
+
+    // Channel eviction (CloseRequested, settle, timeout) must wake waiters
+    // with `false` so the request handler correctly 402s instead of being
+    // told the target was reached when it wasn't.
+    await manager.handleCloseRequested(channelId);
+
+    await expect(waitPromise).resolves.toBe(false);
+  });
+
   it('test_recordSpend: tracks cumulative spend', async () => {
 
     const channelId = makeChannelId(3);


### PR DESCRIPTION
## Symptom

Observed in production on the Open Forge (deepinfra) peer: the desktop client surfaces a raw `402` with the seller's JSON body after a few successful requests on an existing channel:

```
[proxy] Response: 402 (2332ms, 434 bytes)
[proxy] Upstream error detail: {"error":"payment_required","minBudgetPerRequest":"10000","suggestedAmount":"1000000","inputUsdPerMillion":0.36,...}
```

Seller log for the same request:
```
[SellerHandler] Budget exhausted for 232292ef... (spent=85119 >= accepted=56218)
  — returning 402, awaiting higher SpendingAuth / renegotiation
```

## Root cause

When the seller has `spent > accepted` (a prior request's cost blew past the pre-fund buffer, or a top-up stalled behind the per-buyer mutex), it sends `402 + PaymentRequired`. The buyer's `handle402` tried to recover via `extendCurrentSpendingAuth(peerId, minBudgetPerRequest=10_000)`, which advances cumulative by only `10_000` at a time. With `spent=85_119` and `accepted=56_218`, the gap (28_901) could never be closed in one step — every signed auth was rejected by the seller as underfunded, and eventually the raw seller 402 body leaked to the user.

The 402 payload did not include enough information for the buyer to close the gap.

## Fix

**Seller** (`seller-request-handler.ts`): the budget-exhausted branch now embeds `requiredCumulativeAmount` / `currentSpent` / `currentAcceptedCumulative` / `channelId` in both the 402 JSON body and the `PaymentRequired` frame, and also emits a `NeedAuth` on the PaymentMux so the buyer's standard auto-sign path can catch up without the 402 ever round-tripping to the user.

**Buyer — `buyer-payment-manager.ts`**: `extendCurrentSpendingAuth` accepts an optional absolute `targetCumulative`. When the seller reports a target, `verifiedCost` is advanced to it (same reasoning as the existing collapsed-overdraft reopener — the seller can already claim up to `accepted` on-chain, so the exposure is bounded) and the signed cumulative jumps straight to the seller's spend in one hop.

**Buyer — `buyer-payment-negotiator.ts`**: `handle402` parses `requiredCumulativeAmount` from the seller body and forwards it through `_recoverExistingSession` to `extendCurrentSpendingAuth`. The `returnPaymentRequired` path no longer passes the raw seller response back to the caller — it writes a buyer-authored body with a user-friendly "top up your deposits" message so internal catch-up / accounting / per-service pricing fields never leak.

**Protocol** (`types/protocol.ts`, `payment-codec.ts`): `PaymentRequiredPayload` gains optional `requiredCumulativeAmount`, `currentSpent`, `currentAcceptedCumulative`, `channelId`, and the previously undecoded `cachedInputUsdPerMillion`. All fields are optional — wire-compatible with older peers.

## Tests

Three new tests covering the regression:

- `payment-codec.test.ts`: PaymentRequired round-trips all new catch-up fields.
- `buyer-payment-manager.test.ts`: `extendCurrentSpendingAuth` reproduces the 56_218 → 85_119 Open Forge gap with `maxPerRequestUsdc=10_000` and asserts the buyer jumps to the target in one step.
- `buyer-payment-negotiator.test.ts`: `handle402` forwards `requiredCumulativeAmount` from the 402 body as the catch-up target, plus an updated insufficient-credits test asserting the returned body is buyer-authored (no raw seller catch-up/pricing fields).

All 564 `@antseed/node` tests pass. `pnpm run typecheck` and `pnpm run build` are green.