### PR TITLE
fix(buyer): keep chat pinned to its peer/service

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -93,6 +93,16 @@ const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504])
  */
 const CARRY_FORWARD_TTL_MS = 2 * 60 * 60_000
 
+/**
+ * A single failed request is not enough to evict a peer: timeouts, transient
+ * upstream slowness, or one flaky stream shouldn't wipe a peer (and its
+ * service metadata) from cache — that just breaks every follow-up request
+ * pinned to the same peer/service. We only drop a peer once it has failed
+ * repeatedly within a short window.
+ */
+const PEER_FAILURE_THRESHOLD = 4
+const PEER_FAILURE_WINDOW_MS = 5 * 60_000
+
 type TransformResult = { request: SerializedHttpRequest; streamRequested: boolean; requestedModel: string | null }
 type AdaptResponseMeta = { streamRequested: boolean; fallbackModel: string | null }
 
@@ -307,6 +317,14 @@ export class BuyerProxy {
   private _peerRefreshPromise: Promise<PeerInfo[]> | null = null
   private _lastStaleCacheLogAtMs = 0
   private _bgRefreshHandle: ReturnType<typeof setInterval> | null = null
+
+  /**
+   * Per-peer rolling failure counters. Entries are created on the first
+   * failure and cleared on the next successful request, or when eviction
+   * actually fires. A stale window (older than PEER_FAILURE_WINDOW_MS) resets
+   * the counter so a peer that recovers isn't penalised forever.
+   */
+  private _peerFailures: Map<string, { count: number; firstFailureAt: number; lastFailureAt: number }> = new Map()
 
   constructor(config: BuyerProxyConfig) {
     this._node = config.node
@@ -568,6 +586,7 @@ export class BuyerProxy {
   private _evictPeer(peerId: string): void {
     const before = this._cachedPeers.length
     this._cachedPeers = this._cachedPeers.filter((p) => p.peerId !== peerId)
+    this._peerFailures.delete(peerId)
     if (this._cachedPeers.length < before) {
       this._cacheLastUpdatedAtMs = Date.now()
       this._cacheMutationEpoch += 1
@@ -577,11 +596,53 @@ export class BuyerProxy {
   }
 
   /**
+   * Record a failure against a peer and evict only once it has accumulated
+   * enough failures inside the rolling window. A single timeout or stream
+   * drop is no longer enough to wipe the peer (and its service metadata)
+   * from cache — this kept breaking pinned chats whose peer went briefly
+   * slow but was otherwise healthy.
+   *
+   * Returns true when the threshold was reached and the peer was evicted.
+   */
+  private _recordPeerFailure(peerId: string, reason: string): boolean {
+    const now = Date.now()
+    const existing = this._peerFailures.get(peerId)
+    let entry: { count: number; firstFailureAt: number; lastFailureAt: number }
+    if (!existing || now - existing.lastFailureAt > PEER_FAILURE_WINDOW_MS) {
+      // First failure, or the previous window lapsed — start fresh.
+      entry = { count: 1, firstFailureAt: now, lastFailureAt: now }
+    } else {
+      entry = {
+        count: existing.count + 1,
+        firstFailureAt: existing.firstFailureAt,
+        lastFailureAt: now,
+      }
+    }
+    this._peerFailures.set(peerId, entry)
+
+    if (entry.count >= PEER_FAILURE_THRESHOLD) {
+      log(
+        `Peer ${peerId.slice(0, 12)}... reached failure threshold `
+        + `(${entry.count}/${PEER_FAILURE_THRESHOLD} within ${PEER_FAILURE_WINDOW_MS}ms, reason=${reason}); evicting.`,
+      )
+      this._evictPeer(peerId)
+      return true
+    }
+
+    log(
+      `Peer ${peerId.slice(0, 12)}... failure ${entry.count}/${PEER_FAILURE_THRESHOLD} within window (reason=${reason}); keeping in cache.`,
+    )
+    return false
+  }
+
+  /**
    * Stamp `lastReachedAt` on a peer after a successful request so the
    * carry-forward heuristic can trust local transport liveness even when the
-   * DHT record grows stale. Persisted so the signal survives restarts.
+   * DHT record grows stale. Persisted so the signal survives restarts. Also
+   * clears any accumulated failure counter so the peer starts fresh.
    */
   private _rememberSuccessfulPeer(peerId: string): void {
+    this._peerFailures.delete(peerId)
     const cached = this._cachedPeers.find((p) => p.peerId === peerId)
     if (cached) {
       cached.lastReachedAt = Date.now()
@@ -1332,20 +1393,23 @@ export class BuyerProxy {
       const normalizedPath = requestForPeer.path.toLowerCase()
       const isControlPlaneServicesRequest = normalizedPath.startsWith('/v1/models')
       if (isControlPlaneServicesRequest) {
-        log(`Skipping peer eviction for control-plane failure on ${requestForPeer.path}`)
+        log(`Skipping peer failure accounting for control-plane failure on ${requestForPeer.path}`)
       } else if (connectionChurnError) {
         const currentState = this._node.getPeerConnectionState(selectedPeer.peerId)
         if (isConnectionHealthy(currentState)) {
           log(
-            `Skipping peer eviction after connection churn: peer ${selectedPeer.peerId.slice(0, 12)}... `
+            `Skipping peer failure accounting after connection churn: peer ${selectedPeer.peerId.slice(0, 12)}... `
             + `has replacement connection state=${currentState}`,
           )
         } else {
-          this._evictPeer(selectedPeer.peerId)
+          // Route churn-without-replacement through the softened counter so
+          // a single transport hiccup doesn't wipe the peer.
+          this._recordPeerFailure(selectedPeer.peerId, 'connection-churn')
         }
       } else {
-        // Evict only the failing peer — others remain usable.
-        this._evictPeer(selectedPeer.peerId)
+        // Soft-evict: only wipe the peer after repeated failures within the
+        // rolling window. A single timeout / 5xx is not enough.
+        this._recordPeerFailure(selectedPeer.peerId, 'request-failed')
       }
 
       if (res.headersSent) {

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -100,7 +100,7 @@ const CARRY_FORWARD_TTL_MS = 2 * 60 * 60_000
  * pinned to the same peer/service. We only drop a peer once it has failed
  * repeatedly within a short window.
  */
-const PEER_FAILURE_THRESHOLD = 4
+const PEER_FAILURE_THRESHOLD = 10
 const PEER_FAILURE_WINDOW_MS = 5 * 60_000
 
 type TransformResult = { request: SerializedHttpRequest; streamRequested: boolean; requestedModel: string | null }

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -958,33 +958,52 @@ export function initChatModule({
     }));
 
     const activeConversationPeerId = activeConversation?.peerId?.trim() ?? '';
+    const hasActiveConversation = Boolean(activeConversation?.id);
+
+    // Resolve the preferred selection. The first-available-option fallback
+    // (`optionCandidates[0]?.value`) is ONLY safe for the new-chat landing
+    // page — silently rebinding an active conversation to whatever happens
+    // to sort first in the catalog has catastrophic consequences:
+    // `chatSelectedPeerId` and `preferredPeerByConversationId` in main stay
+    // pinned to the conversation's original peer, so the outbound request
+    // ends up with pin-peer=<originalPeer> + service=<unrelated peer's
+    // service>, which the buyer proxy rejects with "Service strict-miss" in
+    // a permanent 502 loop. This is the exact flip that turned a kimi-k2.6
+    // chat into a chaotic-pm chat when the original peer's metadata briefly
+    // dropped its service on re-hydration.
+    const firstOptionFallback = hasActiveConversation ? null : (optionCandidates[0]?.value ?? null);
     const preferred =
       findMatchingChatServiceOptionValue(
         optionCandidates,
         currentSelection.id,
         currentSelection.provider,
         currentSelection.peerId,
-      ) ??
-      findMatchingChatServiceOptionValue(
+      )
+      ?? findMatchingChatServiceOptionValue(
         optionCandidates,
         activeConversationModel,
         activeConversationProvider,
         activeConversationPeerId,
-      ) ??
-      optionCandidates[0]?.value ??
-      '';
+      )
+      ?? firstOptionFallback;
 
     const nextSignature = computeServiceOptionsSignature(options);
     if (
-      nextSignature === lastServiceOptionsSignature &&
-      uiState.chatSelectedServiceValue === preferred
+      nextSignature === lastServiceOptionsSignature
+      && (preferred === null || uiState.chatSelectedServiceValue === preferred)
     ) {
       return;
     }
 
     if (options.length === 0) {
       uiState.chatServiceOptions = [];
-      uiState.chatSelectedServiceValue = '';
+      // Preserve the chat's pinned (service, peer) across a transient empty
+      // catalog. Clearing here would otherwise force the next refresh into
+      // the first-option fallback when options reappear, re-opening the
+      // silent-rebind hole above.
+      if (!hasActiveConversation) {
+        uiState.chatSelectedServiceValue = '';
+      }
       lastServiceOptionsSignature = '';
       notifyUiStateChanged();
       return;
@@ -1005,7 +1024,16 @@ export function initChatModule({
       description: entry.description,
     }));
 
-    uiState.chatSelectedServiceValue = preferred;
+    if (preferred !== null) {
+      uiState.chatSelectedServiceValue = preferred;
+    }
+    // When `preferred === null` (active conversation whose (service, peer)
+    // pair is temporarily missing from the catalog), we intentionally leave
+    // `chatSelectedServiceValue` as-is. The dropdown shows the refreshed
+    // option list; the chat stays bound to its original service until the
+    // user explicitly switches via `handleServiceChange`, and any send that
+    // reaches the proxy in the meantime surfaces a real error instead of
+    // silently retargeting a different peer's service.
     lastServiceOptionsSignature = nextSignature;
     notifyUiStateChanged();
   }
@@ -1758,7 +1786,7 @@ export function initChatModule({
         if (!supportsMultimodal) {
           const label = currentOption?.label || 'this service';
           showChatError(
-            `${label} doesn't support images. Remove the image attachment or switch to a multimodal service (look for the “multimodal” tag in Discover).`,
+            `${label} doesn't support images. Remove the image attachment or switch to a multimodal service (look for the “Image Upload” tag in Discover).`,
           );
           setConversationSending(convId, false);
           return;


### PR DESCRIPTION
## Description

A single 300s stream timeout was evicting the failing peer from the buyer proxy cache, which dropped its `providerServiceApiProtocols` metadata. On the next DHT refresh the peer sometimes re-hydrated without the chat's service listed, and the desktop renderer's `applyChatServiceOptions` then silently rebound the active chat to an unrelated peer's service via the first-in-catalog fallback. Outbound requests went out with `pin-peer=<originalPeer>` + `service=<other peer's service>` and stuck in a permanent "Service strict-miss" 502 retry loop.

Two changes, one on each side of the broken flow:

- **Buyer proxy (`apps/cli/src/proxy/buyer-proxy.ts`)** — replace single-failure eviction with a rolling `_peerFailures` counter (threshold 4, window 5 min). Counters clear on success and on actual eviction. The existing short-circuits for `/v1/models` probes and connection-churn-with-healthy-replacement are preserved, now also flowing through the softened counter.
- **Desktop renderer (`apps/desktop/src/renderer/modules/chat.ts`)** — drop the `optionCandidates[0]?.value` first-option fallback in `applyChatServiceOptions` when a conversation is active. If neither the current selection nor the conversation's persisted `(service, provider, peerId)` match the refreshed catalog, leave `chatSelectedServiceValue` unchanged so the chat stays bound to its original peer/service. New-chat start-screen behavior is unchanged.

## Release Notes

- Fixed a case where a slow/stuck chat would cause the desktop to silently switch to a different peer's service, leaving the chat stranded on repeated "No peers support …" errors. The original peer now stays in cache through a single timeout, and active chats stay pinned to their chosen service.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
