### PR TITLE
feat(payments): Allow depositing USDC to a different address

### DIFF
--- a/apps/payments/web/src/components/DepositView.scss
+++ b/apps/payments/web/src/components/DepositView.scss
@@ -211,6 +211,90 @@
   margin-bottom: 5px;
 }
 
+.deposit-advanced {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: -4px;
+}
+
+.deposit-advanced-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  border: none;
+  background: none;
+  padding: 2px 0;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.14s;
+
+  &:hover { color: var(--text-secondary); }
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+}
+
+.deposit-advanced-chevron {
+  display: inline-block;
+  font-size: 14px;
+  line-height: 1;
+  transition: transform 0.15s;
+  transform: rotate(0deg);
+
+  &--open { transform: rotate(90deg); }
+}
+
+.deposit-advanced-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  background: var(--input-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+}
+
+.deposit-advanced-desc {
+  margin: 0 0 4px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+.deposit-advanced-warn {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  background: var(--danger-dim, rgba(220, 80, 80, 0.08));
+  border: 1px solid var(--danger-border, rgba(220, 80, 80, 0.35));
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.deposit-advanced-warn-icon {
+  flex-shrink: 0;
+  line-height: 1.4;
+  color: var(--danger);
+}
+
+.input-field--mono {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 12px;
+}
+
+.hint--error { color: var(--danger); }
+.hint--warn { color: var(--accent-text); }
+
 .deposit-amount-max {
   border: none;
   background: none;

--- a/apps/payments/web/src/components/DepositView.tsx
+++ b/apps/payments/web/src/components/DepositView.tsx
@@ -126,6 +126,9 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
   const [amount, setAmount] = useState('');
   const [step, setStep] = useState<'idle' | 'approving' | 'depositing' | 'done'>('idle');
   const [error, setError] = useState<string | null>(null);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [customTarget, setCustomTarget] = useState('');
+  const [customTargetEdited, setCustomTargetEdited] = useState(false);
 
   const currentTotal = balance ? parseFloat(balance.total) : 0;
   const creditLimit = balance ? parseFloat(balance.creditLimit) : 0;
@@ -166,7 +169,29 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
     isSwitchingChain,
     ensureCorrectNetwork,
   } = usePaymentNetwork(config);
-  const depositTarget = buyerAddress ?? address;
+  const defaultTarget = buyerAddress ?? address;
+
+  // Pre-fill the override input with the signer address once available,
+  // until the user manually edits it. This lets people see what the deposit
+  // will credit to, and gives them a concrete address to replace.
+  useEffect(() => {
+    if (customTargetEdited) return;
+    if (!address) return;
+    setCustomTarget(address);
+  }, [address, customTargetEdited]);
+
+  const customTargetTrimmed = customTarget.trim();
+  const customTargetIsValid = /^0x[a-fA-F0-9]{40}$/.test(customTargetTrimmed);
+  const customTargetInvalid = showAdvanced && customTargetTrimmed !== '' && !customTargetIsValid;
+  const depositTarget =
+    showAdvanced && customTargetIsValid
+      ? (customTargetTrimmed as `0x${string}`)
+      : defaultTarget;
+  const isOverridingTarget =
+    showAdvanced &&
+    customTargetIsValid &&
+    defaultTarget !== undefined &&
+    customTargetTrimmed.toLowerCase() !== (defaultTarget as string).toLowerCase();
 
   // Read on-chain allowance (always, when connected)
   const { data: allowance, refetch: refetchAllowance } = useReadContract({
@@ -391,10 +416,66 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
             </div>
           )}
 
+          <div className="deposit-advanced">
+            <button
+              type="button"
+              className="deposit-advanced-toggle"
+              onClick={() => setShowAdvanced((v) => !v)}
+              aria-expanded={showAdvanced}
+              aria-controls="deposit-advanced-panel"
+            >
+              <span className={`deposit-advanced-chevron ${showAdvanced ? 'deposit-advanced-chevron--open' : ''}`} aria-hidden="true">›</span>
+              Advanced — deposit to a different address
+            </button>
+            {showAdvanced && (
+              <div id="deposit-advanced-panel" className="deposit-advanced-body">
+                <p className="deposit-advanced-desc">
+                  Deposits credit the AntSeed account whose address you enter below.
+                  Anyone can fund any AntSeed account — the balance is still spendable
+                  only by that account's signer. Override only if you mean to top up
+                  someone else's AntSeed account (e.g. a teammate). This does not change
+                  which account spends the credits.
+                </p>
+                <label className="input-label" htmlFor="deposit-custom-target">Signer address</label>
+                <input
+                  id="deposit-custom-target"
+                  className="input-field input-field--mono"
+                  type="text"
+                  spellCheck={false}
+                  autoComplete="off"
+                  placeholder={defaultTarget ?? '0x…'}
+                  value={customTarget}
+                  onChange={(e) => {
+                    setCustomTargetEdited(true);
+                    setCustomTarget(e.target.value);
+                  }}
+                  disabled={step !== 'idle'}
+                />
+                <div className="deposit-advanced-warn" role="note">
+                  <span className="deposit-advanced-warn-icon" aria-hidden="true">⚠</span>
+                  <span>
+                    Do not send USDC directly to this address — it will not be credited.
+                    Use the Deposit button below; funds must go through the AntSeed
+                    Deposits contract.
+                  </span>
+                </div>
+                {customTargetInvalid && (
+                  <span className="hint hint--error">Enter a valid 0x… address (42 chars).</span>
+                )}
+                {isOverridingTarget && (
+                  <span className="hint hint--warn">
+                    Credits will go to {customTargetTrimmed.slice(0, 6)}…{customTargetTrimmed.slice(-4)},
+                    not your connected wallet.
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+
           <button
             className="btn-primary"
             onClick={handleDeposit}
-            disabled={step !== 'idle' || !isValidAmount || !config || isSwitchingChain}
+            disabled={step !== 'idle' || !isValidAmount || !config || isSwitchingChain || customTargetInvalid || !depositTarget}
           >
             {isSwitchingChain ? `Switching to ${targetChainName}...` :
              wrongChain ? `Switch to ${targetChainName}` :


### PR DESCRIPTION
## Description

Adds a collapsible "Advanced — deposit to a different address" panel to the payments portal deposit modal. Lets a connected wallet credit an AntSeed deposit balance belonging to a different address (e.g. funding a teammate's account). The on-chain `AntseedDeposits.deposit(address buyer, uint256)` already supports this — only the UI was gated to the connected wallet's own address.

The override is hidden by default. When opened, the signer-address input is pre-filled with the connected wallet's address and the panel shows an inline warning that sending USDC directly to that address will not credit the AntSeed balance — the Deposit button must be used so funds flow through the Deposits contract.

## Release Notes

- Payments portal: added an "Advanced" section in the deposit modal that lets you deposit USDC to a different AntSeed account's address.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes