### PR TITLE
fix(desktop): Fix title bar on RTL macOS locales

### DIFF
--- a/apps/desktop/src/renderer/app.ts
+++ b/apps/desktop/src/renderer/app.ts
@@ -38,6 +38,26 @@ function detectApplePlatform(): boolean {
 const isMacPlatform = detectApplePlatform();
 document.body.classList.toggle('platform-macos', isMacPlatform);
 
+// On macOS, when the system UI language is RTL (Hebrew, Arabic, Persian, Urdu),
+// the window traffic-light buttons are mirrored to the top-right. We need to
+// flip the title-bar padding so the right-side controls are not covered.
+function detectRtlSystemLocale(): boolean {
+  const rtlPrefixes = ['he', 'iw', 'ar', 'fa', 'ur', 'yi', 'ji'];
+  const candidates = [
+    ...(Array.isArray(navigator.languages) ? navigator.languages : []),
+    navigator.language,
+  ].filter(Boolean);
+  return candidates.some((lang) => {
+    const primary = String(lang).toLowerCase().split(/[-_]/)[0];
+    return rtlPrefixes.includes(primary);
+  });
+}
+
+document.body.classList.toggle(
+  'platform-macos-rtl',
+  isMacPlatform && detectRtlSystemLocale(),
+);
+
 const bridge = window.antseedDesktop as DesktopBridge | undefined;
 const uiState = createInitialUiState();
 initStore(uiState);

--- a/apps/desktop/src/renderer/ui/components/TitleBar.module.scss
+++ b/apps/desktop/src/renderer/ui/components/TitleBar.module.scss
@@ -15,8 +15,17 @@
     padding-left: 80px;
   }
 
+  // macOS mirrors the traffic-light buttons to the right side when the
+  // system UI language is RTL (e.g. Hebrew, Arabic). Flip the padding so
+  // the right-side controls are not covered by the window buttons.
+  :global(body.platform-macos-rtl) & {
+    padding-left: 16px;
+    padding-right: 80px;
+  }
+
   :global(body.platform-fullscreen) & {
     padding-left: 16px;
+    padding-right: 16px;
   }
 }
 


### PR DESCRIPTION
## Description

On macOS, when the system UI language is RTL (Hebrew, Arabic, Persian, Urdu), the window traffic-light buttons are mirrored to the top-right and cover the theme toggle and credits balance buttons in the custom title bar.

Detect an RTL system locale from `navigator.language` / `navigator.languages` in the renderer and toggle a `platform-macos-rtl` class on `<body>`. The title-bar SCSS swaps the 80px padding from the left to the right in this mode so the controls clear the traffic lights.

## Release Notes

- Desktop: Fix theme and balance buttons being hidden behind the window controls on macOS when the system language is Hebrew, Arabic, or another RTL locale.