### PR TITLE
fix(node): Reliable peer lookup via per-peer DHT topic

### DIFF
--- a/apps/cli/src/cli/commands/network/bootstrap.ts
+++ b/apps/cli/src/cli/commands/network/bootstrap.ts
@@ -2,7 +2,7 @@ import type { Command } from 'commander'
 import chalk from 'chalk'
 import { getGlobalOptions } from '../types.js'
 import { loadOrCreateIdentity } from '@antseed/node'
-import { DHTNode, parseBootstrapList } from '@antseed/node/discovery'
+import { DEFAULT_DHT_CONFIG, DHTNode, parseBootstrapList } from '@antseed/node/discovery'
 import { setupShutdownHandler } from '../../shutdown.js'
 
 export function registerNetworkBootstrapCommand(networkCmd: Command): void {
@@ -40,8 +40,8 @@ export function registerNetworkBootstrapCommand(networkCmd: Command): void {
         peerId: identity.peerId,
         port,
         bootstrapNodes,
-        reannounceIntervalMs: 15 * 60 * 1000,
-        operationTimeoutMs: 10_000,
+        reannounceIntervalMs: DEFAULT_DHT_CONFIG.reannounceIntervalMs,
+        operationTimeoutMs: DEFAULT_DHT_CONFIG.operationTimeoutMs,
       })
 
       await dht.start()

--- a/apps/cli/src/cli/commands/network/peer.ts
+++ b/apps/cli/src/cli/commands/network/peer.ts
@@ -308,21 +308,10 @@ export function registerNetworkPeerCommand(networkCmd: Command): void {
           await node.start();
           match = await node.findPeer(normalized);
           if (match) {
-            spinner.succeed(chalk.green('Found via per-peer DHT topic'));
-            sourceLabel = 'live DHT (per-peer topic)';
+            spinner.succeed(chalk.green('Found via live DHT lookup'));
+            sourceLabel = 'live DHT lookup';
           } else {
-            // Per-peer topic missed — fall back to a wildcard scan in case
-            // this peer is running an older build that doesn't announce
-            // the per-peer topic yet.
-            spinner.text = `Per-peer topic empty, scanning wildcard for ${normalized.slice(0, 12)}...`;
-            const all = await node.discoverPeers();
-            match = all.find((p) => p.peerId.toLowerCase() === normalized) ?? null;
-            if (match) {
-              spinner.succeed(chalk.green('Found via wildcard scan'));
-              sourceLabel = 'live DHT (wildcard scan)';
-            } else {
-              spinner.fail(chalk.red(`Peer ${normalized} not announcing right now`));
-            }
+            spinner.fail(chalk.red(`Peer ${normalized} not announcing right now`));
           }
         } catch (err) {
           spinner.fail(chalk.red(`Discovery failed: ${(err as Error).message}`));

--- a/apps/cli/src/cli/commands/network/peer.ts
+++ b/apps/cli/src/cli/commands/network/peer.ts
@@ -283,15 +283,21 @@ export function registerNetworkPeerCommand(networkCmd: Command): void {
       const globalOpts = getGlobalOptions(networkCmd);
       const config = await loadConfig(globalOpts.config);
 
-      let peers = await loadPeersFromBuyerDaemon(globalOpts.dataDir);
-      let sourceLabel = 'buyer daemon cache';
+      const cachedPeers = await loadPeersFromBuyerDaemon(globalOpts.dataDir);
+      let match: PeerInfo | null =
+        cachedPeers?.find((p) => p.peerId.toLowerCase() === normalized) ?? null;
+      let sourceLabel = match ? 'buyer daemon cache' : '';
 
-      if (!peers) {
+      // Fall back to a live DHT lookup when the cache misses or the daemon
+      // isn't running. Prefer the per-peer topic (deterministic, one infohash)
+      // over scanning the wildcard — the wildcard is saturated on a busy
+      // network and routinely omits individual peers.
+      if (!match) {
         const bootstrapNodes = config.network.bootstrapNodes.length > 0
           ? toBootstrapConfig(parseBootstrapList(config.network.bootstrapNodes))
           : undefined;
         const paymentsConfig = buildPaymentsConfig(config.payments?.crypto);
-        const spinner = ora(`Discovering peer ${normalized.slice(0, 12)}...`).start();
+        const spinner = ora(`Looking up peer ${normalized.slice(0, 12)}...`).start();
         const node = new AntseedNode({
           role: 'buyer',
           ...(bootstrapNodes ? { bootstrapNodes } : {}),
@@ -300,9 +306,24 @@ export function registerNetworkPeerCommand(networkCmd: Command): void {
         });
         try {
           await node.start();
-          peers = await node.discoverPeers();
-          spinner.succeed(chalk.green(`Found ${peers.length} peer(s)`));
-          sourceLabel = 'live DHT discovery';
+          match = await node.findPeer(normalized);
+          if (match) {
+            spinner.succeed(chalk.green('Found via per-peer DHT topic'));
+            sourceLabel = 'live DHT (per-peer topic)';
+          } else {
+            // Per-peer topic missed — fall back to a wildcard scan in case
+            // this peer is running an older build that doesn't announce
+            // the per-peer topic yet.
+            spinner.text = `Per-peer topic empty, scanning wildcard for ${normalized.slice(0, 12)}...`;
+            const all = await node.discoverPeers();
+            match = all.find((p) => p.peerId.toLowerCase() === normalized) ?? null;
+            if (match) {
+              spinner.succeed(chalk.green('Found via wildcard scan'));
+              sourceLabel = 'live DHT (wildcard scan)';
+            } else {
+              spinner.fail(chalk.red(`Peer ${normalized} not announcing right now`));
+            }
+          }
         } catch (err) {
           spinner.fail(chalk.red(`Discovery failed: ${(err as Error).message}`));
           try { await node.stop(); } catch { /* ignore */ }
@@ -311,9 +332,12 @@ export function registerNetworkPeerCommand(networkCmd: Command): void {
         try { await node.stop(); } catch { /* ignore */ }
       }
 
-      const match = peers!.find((p) => p.peerId.toLowerCase() === normalized) ?? null;
       if (!match) {
-        console.error(chalk.red(`Peer ${normalized} not found (source: ${sourceLabel}).`));
+        console.error(
+          chalk.red(
+            `Peer ${normalized} not found${sourceLabel ? ` (source: ${sourceLabel})` : ''}.`,
+          ),
+        );
         console.error(chalk.dim('Run `antseed network browse` to see all peers currently visible on the network.'));
         process.exit(1);
       }

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -6,6 +6,7 @@ import {
   serviceTopic,
   serviceSearchTopic,
   capabilityTopic,
+  peerTopic,
   topicToInfoHash,
   normalizeServiceTopicKey,
   normalizeServiceSearchTopicKey,
@@ -302,6 +303,13 @@ export class PeerAnnouncer {
     }
 
     if (!(await this._tryAnnounceTopic(ANTSEED_WILDCARD_TOPIC))) failures += 1;
+
+    // Per-peer topic: lets buyers do a deterministic lookup-by-peerId without
+    // scanning the (saturated) wildcard. Cheap to publish — one extra announce
+    // per cycle — and dramatically improves "find this exact peer" queries.
+    if (!(await this._tryAnnounceTopic(peerTopic(this.config.identity.peerId)))) {
+      failures += 1;
+    }
 
     if (this.config.offerings) {
       const announcedCapabilities = new Set<string>();

--- a/packages/node/src/discovery/dht-node.ts
+++ b/packages/node/src/discovery/dht-node.ts
@@ -17,8 +17,14 @@ export interface DHTNodeConfig {
 export const DEFAULT_DHT_CONFIG: Omit<DHTNodeConfig, "peerId"> = {
   port: 6881,
   bootstrapNodes: toBootstrapConfig(OFFICIAL_BOOTSTRAP_NODES),
-  reannounceIntervalMs: 15 * 60 * 1000,
-  operationTimeoutMs: 10_000,
+  // 5 min — short enough that a missed reannounce is recovered well before
+  // most BEP-5 storage nodes expire the value (~30 min). Used to be 15 min,
+  // which sat right at the edge and caused intermittent visibility gaps.
+  reannounceIntervalMs: 5 * 60 * 1000,
+  // 25s — long enough for a cold routing table to fan out and for the DHT
+  // to drain its 'peer' events. With 10s we frequently observed lookups
+  // returning a small subset of announcers right after bootstrap.
+  operationTimeoutMs: 25_000,
 };
 
 function isPublicIP(host: string): boolean {
@@ -45,6 +51,17 @@ function normalizeTopicSegment(value: string): string {
 
 /** Wildcard topic that all peers announce on — used for general discovery. */
 export const ANTSEED_WILDCARD_TOPIC = "antseed:*";
+
+/**
+ * Per-peer topic that the announcer registers under so callers can look
+ * up a single peer by its peerId without scanning the wildcard. Buyers do
+ * `dht.lookup(topicToInfoHash(peerTopic(peerId)))` to get the peer's
+ * signaling endpoint(s) directly. The peerId is normalized to lowercase
+ * hex (no `0x`); validation is the caller's responsibility.
+ */
+export function peerTopic(peerId: string): string {
+  return "antseed:peer:" + peerId.trim().toLowerCase().replace(/^0x/, "");
+}
 
 export function normalizeServiceTopicKey(serviceName: string): string {
   return normalizeTopicSegment(serviceName);

--- a/packages/node/src/discovery/index.ts
+++ b/packages/node/src/discovery/index.ts
@@ -6,6 +6,7 @@ export {
   serviceTopic,
   serviceSearchTopic,
   capabilityTopic,
+  peerTopic,
   normalizeServiceTopicKey,
   normalizeServiceSearchTopicKey,
   type DHTNodeConfig,

--- a/packages/node/src/discovery/peer-lookup.ts
+++ b/packages/node/src/discovery/peer-lookup.ts
@@ -5,6 +5,7 @@ import {
   serviceTopic,
   serviceSearchTopic,
   capabilityTopic,
+  peerTopic,
   topicToInfoHash,
   normalizeServiceTopicKey,
   normalizeServiceSearchTopicKey,
@@ -35,7 +36,10 @@ export const DEFAULT_LOOKUP_CONFIG: Omit<LookupConfig, "dht" | "metadataResolver
   requireValidSignature: true,
   allowStaleMetadata: false,
   maxAnnouncementAgeMs: 30 * 60 * 1000,
-  maxResults: 50,
+  // Old cap was 50; with the network growing past that, browse views were
+  // silently truncated. 200 keeps the parallel metadata fan-out reasonable
+  // while no longer hiding peers from ‘network browse’.
+  maxResults: 200,
 };
 
 export interface LookupResult {
@@ -82,6 +86,25 @@ export class PeerLookup {
     const infoHash = topicToInfoHash(topic);
     const peers = await this.config.dht.lookup(infoHash);
     return this.resolveLookupResults(shuffle(peers));
+  }
+
+  /**
+   * Look up a single peer by its peerId via the per-peer DHT topic
+   * (`antseed:peer:<peerId>`). Returns every endpoint whose served metadata
+   * actually matches the requested peerId — a remote endpoint announcing
+   * the topic but serving a different peer's metadata is filtered out, so
+   * a hostile peer cannot squat another peer's identity.
+   *
+   * The peerId is normalized to lowercase hex; passing an empty / invalid
+   * id returns an empty list.
+   */
+  async findByPeerId(peerId: string): Promise<LookupResult[]> {
+    const normalized = peerId.trim().toLowerCase().replace(/^0x/, "");
+    if (normalized.length === 0) return [];
+    const infoHash = topicToInfoHash(peerTopic(normalized));
+    const peers = await this.config.dht.lookup(infoHash);
+    const all = await this.resolveLookupResults(shuffle(peers));
+    return all.filter((r) => r.metadata.peerId.toLowerCase() === normalized);
   }
 
   private async resolveLookupResults(peers: PeerEndpoint[]): Promise<LookupResult[]> {

--- a/packages/node/src/discovery/peer-lookup.ts
+++ b/packages/node/src/discovery/peer-lookup.ts
@@ -100,14 +100,19 @@ export class PeerLookup {
    */
   async findByPeerId(peerId: string): Promise<LookupResult[]> {
     const normalized = peerId.trim().toLowerCase().replace(/^0x/, "");
-    if (normalized.length === 0) return [];
+    if (!/^[0-9a-f]{40}$/.test(normalized)) return [];
     const infoHash = topicToInfoHash(peerTopic(normalized));
     const peers = await this.config.dht.lookup(infoHash);
-    const all = await this.resolveLookupResults(shuffle(peers));
-    return all.filter((r) => r.metadata.peerId.toLowerCase() === normalized);
+    return this.resolveLookupResults(shuffle(peers), { metadataPeerId: normalized });
   }
 
-  private async resolveLookupResults(peers: PeerEndpoint[]): Promise<LookupResult[]> {
+  private async resolveLookupResults(
+    peers: PeerEndpoint[],
+    options?: { metadataPeerId?: string; maxResults?: number },
+  ): Promise<LookupResult[]> {
+    const maxResults = options?.maxResults ?? this.config.maxResults;
+    const metadataPeerId = options?.metadataPeerId;
+
     // Deduplicate endpoints before firing parallel requests
     const seenEndpoints = new Set<string>();
     const uniquePeers: PeerEndpoint[] = [];
@@ -127,8 +132,11 @@ export class PeerLookup {
     const results: LookupResult[] = [];
     for (const r of settled) {
       if (r.status === "fulfilled" && r.value !== null) {
+        if (metadataPeerId && r.value.metadata.peerId.toLowerCase() !== metadataPeerId) {
+          continue;
+        }
         results.push(r.value);
-        if (results.length >= this.config.maxResults) break;
+        if (results.length >= maxResults) break;
       }
     }
     return results;

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -151,7 +151,7 @@ export interface NodeConfig {
   /** Use only the provided bootstrapNodes and skip the official public DHT nodes. Default: false.
    *  Set true for isolated local testing where official nodes must not be contacted. */
   noOfficialBootstrap?: boolean;
-  /** Override the DHT operation timeout in ms. Defaults to DEFAULT_DHT_CONFIG.operationTimeoutMs (10 000). */
+  /** Override the DHT operation timeout in ms. Defaults to DEFAULT_DHT_CONFIG.operationTimeoutMs. */
   dhtOperationTimeoutMs?: number;
   /** Optional seller-side payment runtime wiring. */
   payments?: NodePaymentsConfig;

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -490,7 +490,9 @@ export class AntseedNode extends EventEmitter {
    * Look up a single peer by its peerId via the per-peer DHT topic.
    * Much cheaper and more deterministic than walking the wildcard topic:
    * one infohash lookup, return the first endpoint that serves matching
-   * signed metadata. Returns `null` if the peer is not currently announcing
+   * signed metadata. Falls back to wildcard discovery for compatibility with
+   * old sellers that do not announce per-peer topics yet.
+   * Returns `null` if the peer is not currently announcing
    * (or if its metadata is stale / signature-invalid).
    *
    * The returned `PeerInfo` is on-chain-enriched the same way `discoverPeers`
@@ -507,10 +509,16 @@ export class AntseedNode extends EventEmitter {
     }
 
     debugLog(`[Node] findPeer(${normalized.slice(0, 12)}...) via per-peer DHT topic`);
-    const results = await this._peerLookup.findByPeerId(normalized);
+    let results = await this._peerLookup.findByPeerId(normalized);
     if (results.length === 0) {
-      debugLog(`[Node]   per-peer topic empty; not found`);
-      return null;
+      debugLog(`[Node]   per-peer topic empty; falling back to wildcard scan`);
+      results = (await this._peerLookup.findAll()).filter(
+        (r) => r.metadata.peerId.toLowerCase() === normalized,
+      );
+      if (results.length === 0) {
+        debugLog(`[Node]   wildcard fallback empty; not found`);
+        return null;
+      }
     }
 
     // Multiple endpoints can legitimately announce for the same peerId

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -478,69 +478,117 @@ export class AntseedNode extends EventEmitter {
       }
     }
 
-    // Verify claimed on-chain stats against actual contract data, and
-    // populate volume/last-settled which are never announced by sellers.
-    //
-    // Concurrency is capped so a wildcard DHT lookup returning hundreds of
-    // peers doesn't fan out into hundreds of simultaneous eth_calls (resolver
-    // isOperator + getAgentId + getAgentStats per peer). Most RPC endpoints
-    // will rate-limit past ~10-20 concurrent calls; we stay well under that.
-    if (this._channelsClient && this._stakingClient) {
-      const channelsClient = this._channelsClient;
-      const stakingClient = this._stakingClient;
-      const resolver = this._sellerAddressResolver;
-      const DISCOVERY_RPC_CONCURRENCY = 8;
-      const queue = peers.slice();
-      const workers: Array<Promise<void>> = [];
-      // Throttle on-chain reads across rapid discovery cycles. 60s is short
-      // enough that freshness feels real-time in the UI, and long enough that
-      // back-to-back `discoverPeers()` calls don't hammer the RPC endpoint.
-      const ON_CHAIN_STATS_TTL_MS = 60_000;
-      const nowMs = Date.now();
-      const verifyOne = async (p: PeerInfo): Promise<void> => {
-        if (
-          typeof p.onChainStatsFetchedAt === 'number'
-          && nowMs - p.onChainStatsFetchedAt < ON_CHAIN_STATS_TTL_MS
-        ) {
-          return;
-        }
-        try {
-          const evmAddress = resolver
-            ? await resolver.resolveSellerAddress(p.peerId, p.metadata)
-            : peerIdToAddress(p.peerId);
-          const agentId = await stakingClient.getAgentId(evmAddress);
-          const stats = await channelsClient.getAgentStats(agentId);
-          p.onChainChannelCount = stats.channelCount;
-          p.onChainGhostCount = stats.ghostCount;
-          // totalVolumeUsdc is base-6 USDC. Clamp to safe-int range before
-          // narrowing to Number — ~9M USDC fits Number.MAX_SAFE_INTEGER.
-          const volumeMicros = stats.totalVolumeUsdc;
-          p.onChainTotalVolumeUsdcMicros = volumeMicros <= BigInt(Number.MAX_SAFE_INTEGER)
-            ? Number(volumeMicros)
-            : Number.MAX_SAFE_INTEGER;
-          p.onChainLastSettledAtSec = stats.lastSettledAt;
-          p.onChainStatsFetchedAt = Date.now();
-        } catch {
-          // Per-peer verification failure — keep whatever seller metadata claimed
-          // (channelCount/ghostCount); volume/lastSettled remain undefined.
-        }
-      };
-      for (let i = 0; i < Math.min(DISCOVERY_RPC_CONCURRENCY, queue.length); i++) {
-        workers.push((async () => {
-          for (;;) {
-            const next = queue.shift();
-            if (!next) return;
-            await verifyOne(next);
-          }
-        })());
-      }
-      await Promise.all(workers);
-    }
+    await this._enrichPeersWithOnChainStats(peers);
 
     for (const p of peers) {
       debugLog(`[Node]   peer ${p.peerId.slice(0, 12)}... providers=[${p.providers.join(",")}] addr=${p.publicAddress ?? "?"}`);
     }
     return peers;
+  }
+
+  /**
+   * Look up a single peer by its peerId via the per-peer DHT topic.
+   * Much cheaper and more deterministic than walking the wildcard topic:
+   * one infohash lookup, return the first endpoint that serves matching
+   * signed metadata. Returns `null` if the peer is not currently announcing
+   * (or if its metadata is stale / signature-invalid).
+   *
+   * The returned `PeerInfo` is on-chain-enriched the same way `discoverPeers`
+   * enriches its results, so volume / last-settled / ghost counts are
+   * available when chain RPC is configured.
+   */
+  async findPeer(peerId: string): Promise<PeerInfo | null> {
+    if (!this._peerLookup) {
+      throw new Error("Node not started or not in buyer mode");
+    }
+    const normalized = peerId.trim().toLowerCase().replace(/^0x/, "");
+    if (!/^[0-9a-f]{40}$/.test(normalized)) {
+      return null;
+    }
+
+    debugLog(`[Node] findPeer(${normalized.slice(0, 12)}...) via per-peer DHT topic`);
+    const results = await this._peerLookup.findByPeerId(normalized);
+    if (results.length === 0) {
+      debugLog(`[Node]   per-peer topic empty; not found`);
+      return null;
+    }
+
+    // Multiple endpoints can legitimately announce for the same peerId
+    // (multi-homed seller). The lookup already filtered to those whose
+    // served metadata matches the id; pick the freshest by timestamp.
+    const best = results.reduce((acc, r) =>
+      r.metadata.timestamp > acc.metadata.timestamp ? r : acc,
+    );
+    const peer = this._lookupResultToPeerInfo(best);
+    await this._enrichPeersWithOnChainStats([peer]);
+    return peer;
+  }
+
+  /**
+   * Verify claimed on-chain stats against actual contract data, and
+   * populate volume / last-settled which are never announced by sellers.
+   *
+   * Concurrency is capped so a wildcard DHT lookup returning hundreds of
+   * peers doesn't fan out into hundreds of simultaneous eth_calls (resolver
+   * isOperator + getAgentId + getAgentStats per peer). Most RPC endpoints
+   * will rate-limit past ~10-20 concurrent calls; we stay well under that.
+   *
+   * Mutates the supplied peers in place. No-op when chain clients aren't
+   * configured — callers can safely invoke this regardless.
+   */
+  private async _enrichPeersWithOnChainStats(peers: PeerInfo[]): Promise<void> {
+    if (!this._channelsClient || !this._stakingClient || peers.length === 0) {
+      return;
+    }
+    const channelsClient = this._channelsClient;
+    const stakingClient = this._stakingClient;
+    const resolver = this._sellerAddressResolver;
+    const DISCOVERY_RPC_CONCURRENCY = 8;
+    // Throttle on-chain reads across rapid discovery cycles. 60s is short
+    // enough that freshness feels real-time in the UI, and long enough that
+    // back-to-back `discoverPeers()` calls don't hammer the RPC endpoint.
+    const ON_CHAIN_STATS_TTL_MS = 60_000;
+    const nowMs = Date.now();
+    const queue = peers.slice();
+    const verifyOne = async (p: PeerInfo): Promise<void> => {
+      if (
+        typeof p.onChainStatsFetchedAt === 'number'
+        && nowMs - p.onChainStatsFetchedAt < ON_CHAIN_STATS_TTL_MS
+      ) {
+        return;
+      }
+      try {
+        const evmAddress = resolver
+          ? await resolver.resolveSellerAddress(p.peerId, p.metadata)
+          : peerIdToAddress(p.peerId);
+        const agentId = await stakingClient.getAgentId(evmAddress);
+        const stats = await channelsClient.getAgentStats(agentId);
+        p.onChainChannelCount = stats.channelCount;
+        p.onChainGhostCount = stats.ghostCount;
+        // totalVolumeUsdc is base-6 USDC. Clamp to safe-int range before
+        // narrowing to Number — ~9M USDC fits Number.MAX_SAFE_INTEGER.
+        const volumeMicros = stats.totalVolumeUsdc;
+        p.onChainTotalVolumeUsdcMicros = volumeMicros <= BigInt(Number.MAX_SAFE_INTEGER)
+          ? Number(volumeMicros)
+          : Number.MAX_SAFE_INTEGER;
+        p.onChainLastSettledAtSec = stats.lastSettledAt;
+        p.onChainStatsFetchedAt = Date.now();
+      } catch {
+        // Per-peer verification failure — keep whatever seller metadata claimed
+        // (channelCount/ghostCount); volume/lastSettled remain undefined.
+      }
+    };
+    const workers: Array<Promise<void>> = [];
+    for (let i = 0; i < Math.min(DISCOVERY_RPC_CONCURRENCY, queue.length); i++) {
+      workers.push((async () => {
+        for (;;) {
+          const next = queue.shift();
+          if (!next) return;
+          await verifyOne(next);
+        }
+      })());
+    }
+    await Promise.all(workers);
   }
 
   /**

--- a/packages/node/tests/announcer-load.test.ts
+++ b/packages/node/tests/announcer-load.test.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'node:crypto';
 import { Wallet } from 'ethers';
 import { PeerAnnouncer, type AnnouncerConfig } from '../src/discovery/announcer.js';
 import { encodeMetadataForSigning } from '../src/discovery/metadata-codec.js';
-import { ANTSEED_WILDCARD_TOPIC, serviceSearchTopic, serviceTopic, topicToInfoHash } from '../src/discovery/dht-node.js';
+import { ANTSEED_WILDCARD_TOPIC, peerTopic, serviceSearchTopic, serviceTopic, topicToInfoHash } from '../src/discovery/dht-node.js';
 import { verifySignature, bytesToHex, hexToBytes } from '../src/p2p/identity.js';
 import { toPeerId } from '../src/types/peer.js';
 
@@ -100,7 +100,7 @@ describe('PeerAnnouncer live load metadata', () => {
     });
   });
 
-  it('announces deduped lowercase service topics and wildcard', async () => {
+  it('announces deduped lowercase service topics, wildcard, and per-peer topic', async () => {
     const { config, dht } = makeConfig();
     config.providers = [
       {
@@ -116,9 +116,11 @@ describe('PeerAnnouncer live load metadata', () => {
     const announcer = new PeerAnnouncer(config);
     await announcer.announce();
 
-    expect(dht.announce).toHaveBeenCalledTimes(2);
+    // canonical service topic + wildcard + per-peer topic = 3
+    expect(dht.announce).toHaveBeenCalledTimes(3);
     expect(dht.announce).toHaveBeenCalledWith(topicToInfoHash(serviceTopic('kimi2.5')), 6882);
     expect(dht.announce).toHaveBeenCalledWith(topicToInfoHash(ANTSEED_WILDCARD_TOPIC), 6882);
+    expect(dht.announce).toHaveBeenCalledWith(topicToInfoHash(peerTopic(config.identity.peerId)), 6882);
   });
 
   it('announces compact service-search topic when canonical service key differs', async () => {
@@ -142,5 +144,6 @@ describe('PeerAnnouncer live load metadata', () => {
     expect(dht.announce).toHaveBeenCalledWith(topicToInfoHash(serviceTopic('kimi 2.5')), 6882);
     expect(dht.announce).toHaveBeenCalledWith(topicToInfoHash(serviceSearchTopic('kimi2.5')), 6882);
     expect(dht.announce).toHaveBeenCalledWith(topicToInfoHash(ANTSEED_WILDCARD_TOPIC), 6882);
+    expect(dht.announce).toHaveBeenCalledWith(topicToInfoHash(peerTopic(config.identity.peerId)), 6882);
   });
 });

--- a/packages/node/tests/dht-topic.test.ts
+++ b/packages/node/tests/dht-topic.test.ts
@@ -4,6 +4,7 @@ import {
   serviceTopic,
   serviceSearchTopic,
   capabilityTopic,
+  peerTopic,
   normalizeServiceTopicKey,
   normalizeServiceSearchTopicKey,
 } from '../src/discovery/dht-node.js';
@@ -27,5 +28,14 @@ describe('DHT topic helpers', () => {
 
   it('normalizes capability topics to lowercase', () => {
     expect(capabilityTopic('  TASK  ', '  My-Worker  ')).toBe('antseed:task:my-worker');
+  });
+
+  it('builds per-peer topics with the peerId normalized to lowercase hex (no 0x)', () => {
+    expect(peerTopic('0E49122E76BD8B9CCB2FE10C0088C41CEB608927')).toBe(
+      'antseed:peer:0e49122e76bd8b9ccb2fe10c0088c41ceb608927',
+    );
+    expect(peerTopic('  0x0E49122E76BD8B9CCB2FE10C0088C41CEB608927  ')).toBe(
+      'antseed:peer:0e49122e76bd8b9ccb2fe10c0088c41ceb608927',
+    );
   });
 });

--- a/packages/node/tests/find-peer-compat.test.ts
+++ b/packages/node/tests/find-peer-compat.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AntseedNode } from '../src/node.js';
+import { METADATA_VERSION, type PeerMetadata } from '../src/discovery/peer-metadata.js';
+
+function buildMetadata(peerId: string, timestamp = Date.now()): PeerMetadata {
+  return {
+    peerId: peerId as any,
+    version: METADATA_VERSION,
+    providers: [
+      {
+        provider: 'anthropic',
+        services: ['claude-3-opus'],
+        defaultPricing: {
+          inputUsdPerMillion: 15,
+          outputUsdPerMillion: 75,
+        },
+        maxConcurrency: 10,
+        currentLoad: 1,
+      },
+    ],
+    region: 'test',
+    timestamp,
+    signature: 'b'.repeat(128),
+  };
+}
+
+describe('AntseedNode.findPeer compatibility', () => {
+  it('falls back to wildcard discovery for old sellers without per-peer topics', async () => {
+    const targetId = 'a'.repeat(40);
+    const otherId = 'b'.repeat(40);
+    const node = new AntseedNode({ role: 'buyer' });
+
+    (node as any)._peerLookup = {
+      findByPeerId: vi.fn().mockResolvedValue([]),
+      findAll: vi.fn().mockResolvedValue([
+        {
+          metadata: buildMetadata(otherId),
+          host: '5.5.5.5',
+          port: 6882,
+        },
+        {
+          metadata: buildMetadata(targetId),
+          host: '34.10.10.10',
+          port: 6882,
+        },
+      ]),
+    };
+
+    const peer = await node.findPeer(targetId);
+
+    expect(peer?.peerId).toBe(targetId);
+    expect(peer?.publicAddress).toBe('34.10.10.10:6882');
+    expect((node as any)._peerLookup.findByPeerId).toHaveBeenCalledWith(targetId);
+    expect((node as any)._peerLookup.findAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not scan wildcard when the per-peer topic returns a match', async () => {
+    const targetId = 'a'.repeat(40);
+    const node = new AntseedNode({ role: 'buyer' });
+
+    (node as any)._peerLookup = {
+      findByPeerId: vi.fn().mockResolvedValue([
+        {
+          metadata: buildMetadata(targetId),
+          host: '34.10.10.10',
+          port: 6882,
+        },
+      ]),
+      findAll: vi.fn(),
+    };
+
+    const peer = await node.findPeer(targetId);
+
+    expect(peer?.peerId).toBe(targetId);
+    expect((node as any)._peerLookup.findAll).not.toHaveBeenCalled();
+  });
+});

--- a/packages/node/tests/peer-lookup.test.ts
+++ b/packages/node/tests/peer-lookup.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { PeerLookup, type LookupConfig } from '../src/discovery/peer-lookup.js';
-import { serviceSearchTopic, serviceTopic, topicToInfoHash } from '../src/discovery/dht-node.js';
+import { peerTopic, serviceSearchTopic, serviceTopic, topicToInfoHash } from '../src/discovery/dht-node.js';
 import type { DHTNode } from '../src/discovery/dht-node.js';
 import type { MetadataResolver, PeerEndpoint } from '../src/discovery/metadata-resolver.js';
 import { METADATA_VERSION, type PeerMetadata } from '../src/discovery/peer-metadata.js';
@@ -119,6 +119,64 @@ describe('PeerLookup', () => {
     const results = await peerLookup.findByService('kimi2.5');
     expect(lookup).toHaveBeenCalledTimes(1);
     expect(results).toHaveLength(1);
+  });
+
+  it('findByPeerId looks up the per-peer topic and filters out spoofed metadata', async () => {
+    const targetId = 'a'.repeat(40);
+    const otherId = 'b'.repeat(40);
+
+    const honest: PeerEndpoint = { host: '34.10.10.10', port: 6882 };
+    const liar: PeerEndpoint = { host: '5.5.5.5', port: 6882 };
+    const expectedHashHex = topicToInfoHash(peerTopic(targetId)).toString('hex');
+
+    const lookup = vi.fn(async (hash: Buffer) => {
+      if (hash.toString('hex') === expectedHashHex) return [honest, liar];
+      return [];
+    });
+    const dht = { lookup } as unknown as DHTNode;
+
+    const resolve = vi.fn(async (peer: PeerEndpoint) => {
+      // Honest peer serves metadata that matches the requested id; the
+      // liar announces under the same per-peer topic but serves a
+      // different identity — PeerLookup must drop it.
+      if (peer.host === honest.host) return buildMetadata({ peerId: targetId as any });
+      if (peer.host === liar.host) return buildMetadata({ peerId: otherId as any });
+      return null;
+    });
+    const metadataResolver: MetadataResolver = { resolve };
+    const config: LookupConfig = {
+      dht,
+      metadataResolver,
+      requireValidSignature: false,
+      allowStaleMetadata: true,
+      maxAnnouncementAgeMs: 60_000,
+      maxResults: 50,
+    };
+    const peerLookup = new PeerLookup(config);
+
+    const results = await peerLookup.findByPeerId(targetId);
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.host).toBe(honest.host);
+    expect(results[0]?.metadata.peerId).toBe(targetId);
+  });
+
+  it('findByPeerId returns empty for invalid input without hitting the DHT', async () => {
+    const lookup = vi.fn();
+    const dht = { lookup } as unknown as DHTNode;
+    const metadataResolver: MetadataResolver = { resolve: vi.fn() };
+    const peerLookup = new PeerLookup({
+      dht,
+      metadataResolver,
+      requireValidSignature: false,
+      allowStaleMetadata: true,
+      maxAnnouncementAgeMs: 60_000,
+      maxResults: 50,
+    });
+
+    expect(await peerLookup.findByPeerId('')).toEqual([]);
+    expect(await peerLookup.findByPeerId('   ')).toEqual([]);
+    expect(lookup).not.toHaveBeenCalled();
   });
 
   it('preserves metadata publicAddress so callers can prefer it over the DHT source host', async () => {

--- a/packages/node/tests/peer-lookup.test.ts
+++ b/packages/node/tests/peer-lookup.test.ts
@@ -161,6 +161,35 @@ describe('PeerLookup', () => {
     expect(results[0]?.metadata.peerId).toBe(targetId);
   });
 
+  it('findByPeerId applies maxResults after filtering matching metadata', async () => {
+    const targetId = 'a'.repeat(40);
+    const otherId = 'b'.repeat(40);
+
+    const liar: PeerEndpoint = { host: '5.5.5.5', port: 6882 };
+    const honest: PeerEndpoint = { host: '34.10.10.10', port: 6882 };
+    const lookup = vi.fn(async () => [liar, honest]);
+    const dht = { lookup } as unknown as DHTNode;
+
+    const resolve = vi.fn(async (peer: PeerEndpoint) => {
+      if (peer.host === liar.host) return buildMetadata({ peerId: otherId as any });
+      if (peer.host === honest.host) return buildMetadata({ peerId: targetId as any });
+      return null;
+    });
+    const metadataResolver: MetadataResolver = { resolve };
+    const peerLookup = new PeerLookup({
+      dht,
+      metadataResolver,
+      requireValidSignature: false,
+      allowStaleMetadata: true,
+      maxAnnouncementAgeMs: 60_000,
+      maxResults: 1,
+    });
+
+    const results = await peerLookup.findByPeerId(targetId);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.host).toBe(honest.host);
+  });
+
   it('findByPeerId returns empty for invalid input without hitting the DHT', async () => {
     const lookup = vi.fn();
     const dht = { lookup } as unknown as DHTNode;
@@ -176,6 +205,9 @@ describe('PeerLookup', () => {
 
     expect(await peerLookup.findByPeerId('')).toEqual([]);
     expect(await peerLookup.findByPeerId('   ')).toEqual([]);
+    expect(await peerLookup.findByPeerId('not-a-peer')).toEqual([]);
+    expect(await peerLookup.findByPeerId('a'.repeat(39))).toEqual([]);
+    expect(await peerLookup.findByPeerId('g'.repeat(40))).toEqual([]);
     expect(lookup).not.toHaveBeenCalled();
   });
 

--- a/scripts/find-peer.mjs
+++ b/scripts/find-peer.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 // Fresh DHT lookup for a specific peerId, independent of any running buyer
-// daemon's cache. Bootstraps a brand-new DHT node, performs a wildcard-topic
-// lookup, fetches metadata over HTTP for every endpoint, and prints whichever
-// announcement matches the requested peerId.
+// daemon's cache. Bootstraps a brand-new DHT node, performs a per-peer-topic
+// lookup first, then falls back to the wildcard topic to characterize the old
+// discovery path. For each endpoint it fetches metadata over HTTP and prints
+// announcements that match the requested peerId.
 //
 // Usage:
 //   node scripts/find-peer.mjs <peerId>
@@ -13,13 +14,19 @@ import {
   DHTNode,
   DEFAULT_DHT_CONFIG,
   ANTSEED_WILDCARD_TOPIC,
+  peerTopic,
   topicToInfoHash,
 } from "../packages/node/dist/discovery/dht-node.js";
 import { HttpMetadataResolver } from "../packages/node/dist/discovery/http-metadata-resolver.js";
 
-const TARGET = (process.argv[2] ?? "").toLowerCase();
+function normalizePeerId(raw) {
+  const cleaned = raw.trim().toLowerCase().replace(/^0x/, "");
+  return /^[0-9a-f]{40}$/.test(cleaned) ? cleaned : null;
+}
+
+const TARGET = normalizePeerId(process.argv[2] ?? "");
 if (!TARGET) {
-  console.error("usage: node scripts/find-peer.mjs <peerId>");
+  console.error("usage: node scripts/find-peer.mjs <40-char-peerId>");
   process.exit(1);
 }
 
@@ -48,28 +55,7 @@ function summarizeMetadata(md) {
   return { peerId, name, services };
 }
 
-async function main() {
-  console.log(`[*] target peerId: ${TARGET}`);
-  console.log(`[*] starting fresh DHT node on port ${LOOKUP_PORT}...`);
-
-  const dht = new DHTNode({
-    ...DEFAULT_DHT_CONFIG,
-    peerId: "00".repeat(20), // dummy — we only do lookups, never announce
-    port: LOOKUP_PORT,
-    operationTimeoutMs: OPERATION_TIMEOUT_MS,
-  });
-
-  await dht.start();
-  console.log(`[*] DHT ready; routing-table nodes: ${dht.getNodeCount()}`);
-
-  const infoHash = topicToInfoHash(ANTSEED_WILDCARD_TOPIC);
-  console.log(
-    `[*] looking up wildcard topic '${ANTSEED_WILDCARD_TOPIC}' (${infoHash.toString("hex")})`,
-  );
-
-  const rawEndpoints = await dht.lookup(infoHash);
-  console.log(`[*] DHT returned ${rawEndpoints.length} endpoint(s)`);
-
+function dedupeEndpoints(rawEndpoints) {
   const seen = new Set();
   const endpoints = [];
   for (const ep of rawEndpoints) {
@@ -78,9 +64,18 @@ async function main() {
     seen.add(key);
     endpoints.push(ep);
   }
-  console.log(`[*] ${endpoints.length} unique endpoint(s); resolving metadata...`);
+  return endpoints;
+}
 
-  const resolver = new HttpMetadataResolver({ timeoutMs: METADATA_TIMEOUT_MS });
+async function lookupTopic({ dht, resolver, label, topic, target }) {
+  const infoHash = topicToInfoHash(topic);
+  console.log(`[*] looking up ${label} topic '${topic}' (${infoHash.toString("hex")})`);
+
+  const rawEndpoints = await dht.lookup(infoHash);
+  console.log(`[*] ${label} DHT returned ${rawEndpoints.length} endpoint(s)`);
+
+  const endpoints = dedupeEndpoints(rawEndpoints);
+  console.log(`[*] ${endpoints.length} unique endpoint(s); resolving metadata...`);
 
   let found = null;
   let resolved = 0;
@@ -94,8 +89,8 @@ async function main() {
       }
       resolved += 1;
       const { peerId, name, services } = summarizeMetadata(md);
-      const isMatch = peerId === TARGET;
-      const tag = isMatch ? "  <-- MATCH" : "";
+      const isMatch = peerId === target;
+      const tag = isMatch ? "  <-- MATCH" : "  <-- different peerId";
       const svcSummary =
         services.length === 0
           ? "no services"
@@ -111,35 +106,93 @@ async function main() {
     }),
   );
 
-  console.log("");
-  if (found) {
-    const ageSec = Math.round((Date.now() - (found.md.timestamp ?? Date.now())) / 1000);
-    console.log(`[✓] FOUND ${TARGET}`);
-    console.log(`    endpoint:  ${found.peer.host}:${found.peer.port}`);
-    console.log(`    name:      ${found.name}`);
-    if (found.md.timestamp) {
-      console.log(
-        `    timestamp: ${new Date(found.md.timestamp).toISOString()} (age ${ageSec}s)`,
-      );
-    }
-    console.log(`    services:  ${found.services.length} total`);
-    if (found.services.length > 0) {
-      const preview = found.services.slice(0, 10).join(", ");
-      const more = found.services.length > 10 ? ` +${found.services.length - 10} more` : "";
-      console.log(`               ${preview}${more}`);
-    }
-  } else {
-    console.log(`[✗] peer ${TARGET} NOT FOUND on the wildcard topic`);
+  return { found, resolved, endpointCount: endpoints.length };
+}
+
+function printFound(target, found, label) {
+  const ageSec = Math.round((Date.now() - (found.md.timestamp ?? Date.now())) / 1000);
+  console.log(`[✓] FOUND ${target} via ${label}`);
+  console.log(`    endpoint:  ${found.peer.host}:${found.peer.port}`);
+  console.log(`    name:      ${found.name}`);
+  if (found.md.timestamp) {
     console.log(
-      `    (resolved metadata for ${resolved}/${endpoints.length} endpoints)`,
+      `    timestamp: ${new Date(found.md.timestamp).toISOString()} (age ${ageSec}s)`,
     );
   }
+  console.log(`    services:  ${found.services.length} total`);
+  if (found.services.length > 0) {
+    const preview = found.services.slice(0, 10).join(", ");
+    const more = found.services.length > 10 ? ` +${found.services.length - 10} more` : "";
+    console.log(`               ${preview}${more}`);
+  }
+}
 
-  await dht.stop();
-  process.exit(found ? 0 : 1);
+async function main() {
+  console.log(`[*] target peerId: ${TARGET}`);
+  console.log(`[*] starting fresh DHT node on port ${LOOKUP_PORT}...`);
+
+  const dht = new DHTNode({
+    ...DEFAULT_DHT_CONFIG,
+    peerId: "00".repeat(20), // dummy — we only do lookups, never announce
+    port: LOOKUP_PORT,
+    operationTimeoutMs: OPERATION_TIMEOUT_MS,
+  });
+
+  try {
+    await dht.start();
+    console.log(`[*] DHT ready; routing-table nodes: ${dht.getNodeCount()}`);
+
+    const resolver = new HttpMetadataResolver({ timeoutMs: METADATA_TIMEOUT_MS });
+
+    const perPeer = await lookupTopic({
+      dht,
+      resolver,
+      label: "per-peer",
+      topic: peerTopic(TARGET),
+      target: TARGET,
+    });
+
+    console.log("");
+    if (perPeer.found) {
+      printFound(TARGET, perPeer.found, "per-peer topic");
+      return true;
+    }
+
+    console.log(
+      `[!] peer ${TARGET} not found on per-peer topic; scanning wildcard fallback`,
+    );
+    console.log("");
+
+    const wildcard = await lookupTopic({
+      dht,
+      resolver,
+      label: "wildcard",
+      topic: ANTSEED_WILDCARD_TOPIC,
+      target: TARGET,
+    });
+
+    console.log("");
+    if (wildcard.found) {
+      printFound(TARGET, wildcard.found, "wildcard topic");
+      return true;
+    }
+
+    console.log(`[✗] peer ${TARGET} NOT FOUND`);
+    console.log(
+      `    (resolved metadata for ${perPeer.resolved}/${perPeer.endpointCount} per-peer endpoints, `
+        + `${wildcard.resolved}/${wildcard.endpointCount} wildcard endpoints)`,
+    );
+    return false;
+  } finally {
+    await dht.stop();
+  }
 }
 
 main().catch((err) => {
   console.error(`[!] fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
   process.exit(2);
+}).then((found) => {
+  if (typeof found === "boolean") {
+    process.exit(found ? 0 : 1);
+  }
 });

--- a/scripts/find-peer.mjs
+++ b/scripts/find-peer.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+// Fresh DHT lookup for a specific peerId, independent of any running buyer
+// daemon's cache. Bootstraps a brand-new DHT node, performs a wildcard-topic
+// lookup, fetches metadata over HTTP for every endpoint, and prints whichever
+// announcement matches the requested peerId.
+//
+// Usage:
+//   node scripts/find-peer.mjs <peerId>
+//
+// Requires `pnpm run build` to have produced packages/node/dist.
+
+import {
+  DHTNode,
+  DEFAULT_DHT_CONFIG,
+  ANTSEED_WILDCARD_TOPIC,
+  topicToInfoHash,
+} from "../packages/node/dist/discovery/dht-node.js";
+import { HttpMetadataResolver } from "../packages/node/dist/discovery/http-metadata-resolver.js";
+
+const TARGET = (process.argv[2] ?? "").toLowerCase();
+if (!TARGET) {
+  console.error("usage: node scripts/find-peer.mjs <peerId>");
+  process.exit(1);
+}
+
+// Use a non-default port to avoid colliding with a buyer/seller daemon on 6881.
+const LOOKUP_PORT = 16881;
+const OPERATION_TIMEOUT_MS = 25_000;
+const METADATA_TIMEOUT_MS = 4_000;
+
+/** Compose a one-line summary of a metadata document for the listing. */
+function summarizeMetadata(md) {
+  const peerId = (md.peerId ?? "").toLowerCase();
+  const name = md.displayName ?? md.name ?? "-";
+
+  const providerServices = Array.isArray(md.providers)
+    ? md.providers.flatMap((p) =>
+        Array.isArray(p?.services)
+          ? p.services.map((s) => (typeof s === "string" ? s : s?.name)).filter(Boolean)
+          : [],
+      )
+    : [];
+  const flatServices = Array.isArray(md.services)
+    ? md.services.map((s) => (typeof s === "string" ? s : s?.name)).filter(Boolean)
+    : [];
+  const services = providerServices.length > 0 ? providerServices : flatServices;
+
+  return { peerId, name, services };
+}
+
+async function main() {
+  console.log(`[*] target peerId: ${TARGET}`);
+  console.log(`[*] starting fresh DHT node on port ${LOOKUP_PORT}...`);
+
+  const dht = new DHTNode({
+    ...DEFAULT_DHT_CONFIG,
+    peerId: "00".repeat(20), // dummy — we only do lookups, never announce
+    port: LOOKUP_PORT,
+    operationTimeoutMs: OPERATION_TIMEOUT_MS,
+  });
+
+  await dht.start();
+  console.log(`[*] DHT ready; routing-table nodes: ${dht.getNodeCount()}`);
+
+  const infoHash = topicToInfoHash(ANTSEED_WILDCARD_TOPIC);
+  console.log(
+    `[*] looking up wildcard topic '${ANTSEED_WILDCARD_TOPIC}' (${infoHash.toString("hex")})`,
+  );
+
+  const rawEndpoints = await dht.lookup(infoHash);
+  console.log(`[*] DHT returned ${rawEndpoints.length} endpoint(s)`);
+
+  const seen = new Set();
+  const endpoints = [];
+  for (const ep of rawEndpoints) {
+    const key = `${ep.host}:${ep.port}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    endpoints.push(ep);
+  }
+  console.log(`[*] ${endpoints.length} unique endpoint(s); resolving metadata...`);
+
+  const resolver = new HttpMetadataResolver({ timeoutMs: METADATA_TIMEOUT_MS });
+
+  let found = null;
+  let resolved = 0;
+
+  await Promise.allSettled(
+    endpoints.map(async (peer) => {
+      const md = await resolver.resolve(peer);
+      if (!md) {
+        console.log(`    ${peer.host}:${peer.port}  -> no metadata`);
+        return;
+      }
+      resolved += 1;
+      const { peerId, name, services } = summarizeMetadata(md);
+      const isMatch = peerId === TARGET;
+      const tag = isMatch ? "  <-- MATCH" : "";
+      const svcSummary =
+        services.length === 0
+          ? "no services"
+          : services.length <= 3
+            ? services.join(", ")
+            : `${services.slice(0, 3).join(", ")} +${services.length - 3}`;
+      console.log(
+        `    ${peer.host}:${peer.port}  peerId=${peerId.slice(0, 16)}…  name=${name}  [${svcSummary}]${tag}`,
+      );
+      if (isMatch) {
+        found = { peer, md, name, services };
+      }
+    }),
+  );
+
+  console.log("");
+  if (found) {
+    const ageSec = Math.round((Date.now() - (found.md.timestamp ?? Date.now())) / 1000);
+    console.log(`[✓] FOUND ${TARGET}`);
+    console.log(`    endpoint:  ${found.peer.host}:${found.peer.port}`);
+    console.log(`    name:      ${found.name}`);
+    if (found.md.timestamp) {
+      console.log(
+        `    timestamp: ${new Date(found.md.timestamp).toISOString()} (age ${ageSec}s)`,
+      );
+    }
+    console.log(`    services:  ${found.services.length} total`);
+    if (found.services.length > 0) {
+      const preview = found.services.slice(0, 10).join(", ");
+      const more = found.services.length > 10 ? ` +${found.services.length - 10} more` : "";
+      console.log(`               ${preview}${more}`);
+    }
+  } else {
+    console.log(`[✗] peer ${TARGET} NOT FOUND on the wildcard topic`);
+    console.log(
+      `    (resolved metadata for ${resolved}/${endpoints.length} endpoints)`,
+    );
+  }
+
+  await dht.stop();
+  process.exit(found ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(`[!] fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
+  process.exit(2);
+});


### PR DESCRIPTION
## Description

A single wildcard DHT topic (`antseed:*`) doesn't scale: as the network grew past the K closest storage nodes' capacity, individual peers became intermittently invisible — back-to-back lookups returned 15 / 61 / 60 endpoints with the same target dropping in and out. Stats pods, buyer daemons, and `antseed network peer <id>` all suffered.

This PR makes peer lookups deterministic and recoverable:

- **Per-peer DHT topic.** Each peer now also announces under `antseed:peer:<peerId>`, and `PeerLookup.findByPeerId(peerId)` / `AntseedNode.findPeer(peerId)` use it for a single-infohash lookup. Spoofing protection: only endpoints whose served metadata's `peerId` actually matches the request are returned, and the result cap is applied after that identity filter.
- **Tighter reannounce cadence.** Default 15 min → 5 min (well under the ~30 min BEP-5 storage TTL that caused the visibility gaps).
- **Longer DHT operation timeout.** 10 s → 25 s so cold routing tables finish fanning out before lookups resolve.
- **Higher lookup result cap.** `maxResults` 50 → 200 so `network browse` stops silently truncating on a busy network.
- **CLI** `network peer <id>`: cache miss now tries the per-peer topic first (deterministic), then falls back to a wildcard scan only for peers still on older builds. This also fixes the cache-present/cache-miss case where the old command skipped live DHT discovery.
- **`scripts/find-peer.mjs`**: standalone fresh-DHT diagnostic script that bypasses local caches, tries the per-peer topic first, and uses wildcard only as a fallback/old-path comparison.

## Review Follow-up

- Hardened `PeerLookup.findByPeerId()` to reject malformed peer IDs before touching the DHT.
- Moved exact-peer metadata filtering ahead of the `maxResults` cap so topic-squatting endpoints cannot fill the cap before the honest endpoint is considered.
- Updated the diagnostic script to exercise the new per-peer lookup path first.

## Release Notes

- `antseed network peer <peerId>` now uses a deterministic per-peer DHT topic for lookup, so peers are reliably found by id even when the wildcard topic is saturated.
- Sellers reannounce every 5 minutes (down from 15) so brief DHT hiccups no longer make a peer disappear from buyers' views.
- `antseed network browse` no longer silently truncates results at 50 peers.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
