### PR TITLE
fix(node): detect channel exhaustion on 402 and renegotiate

### DIFF
--- a/packages/node/src/p2p/payment-codec.ts
+++ b/packages/node/src/p2p/payment-codec.ts
@@ -1,8 +1,9 @@
-import type {
-  SpendingAuthPayload,
-  AuthAckPayload,
-  PaymentRequiredPayload,
-  NeedAuthPayload,
+import {
+  PAYMENT_CODE_CHANNEL_EXHAUSTED,
+  type SpendingAuthPayload,
+  type AuthAckPayload,
+  type PaymentRequiredPayload,
+  type NeedAuthPayload,
 } from '../types/protocol.js';
 
 const encoder = new TextEncoder();
@@ -88,6 +89,8 @@ export function decodePaymentRequired(data: Uint8Array): PaymentRequiredPayload 
   if (typeof obj.currentSpent === 'string') result.currentSpent = obj.currentSpent;
   if (typeof obj.currentAcceptedCumulative === 'string') result.currentAcceptedCumulative = obj.currentAcceptedCumulative;
   if (typeof obj.channelId === 'string') result.channelId = obj.channelId;
+  if (typeof obj.reserveMaxAmount === 'string') result.reserveMaxAmount = obj.reserveMaxAmount;
+  if (obj.code === PAYMENT_CODE_CHANNEL_EXHAUSTED) result.code = obj.code;
   return result;
 }
 

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -3,7 +3,7 @@ import type { PeerConnection } from '../p2p/connection-manager.js';
 import { PaymentMux } from '../p2p/payment-mux.js';
 import type { PeerInfo, PeerId } from '../types/peer.js';
 import type { SerializedHttpRequest, SerializedHttpResponse } from '../types/http.js';
-import type { PaymentRequiredPayload } from '../types/protocol.js';
+import { PAYMENT_CODE_CHANNEL_EXHAUSTED, type PaymentRequiredPayload } from '../types/protocol.js';
 import type { BuyerPaymentManager } from './buyer-payment-manager.js';
 import type { DepositsClient } from './evm/deposits-client.js';
 import type { ChannelsClient } from './evm/channels-client.js';
@@ -322,7 +322,32 @@ export class BuyerPaymentNegotiator {
         ? safeBigInt(String(directPaymentBody.requiredCumulativeAmount))
         : null;
 
-    if (hadLockedSession || this._bpm.getActiveSession(peer.peerId)) {
+    // On-chain reserve ceiling the seller is willing to accept. Used to detect
+    // permanently exhausted channels (where requiredCumulativeAmount > reserveMaxAmount)
+    // so the buyer doesn't loop signing higher cumulatives the seller will reject.
+    const sellerReserveMax = buffered?.reserveMaxAmount != null
+      ? safeBigInt(buffered.reserveMaxAmount)
+      : responseAlreadyHasRequirements && directPaymentBody?.reserveMaxAmount != null
+        ? safeBigInt(String(directPaymentBody.reserveMaxAmount))
+        : null;
+    const channelExhausted = buffered?.code === PAYMENT_CODE_CHANNEL_EXHAUSTED
+      || (responseAlreadyHasRequirements && directPaymentBody?.code === PAYMENT_CODE_CHANNEL_EXHAUSTED)
+      || (requiredCumulativeTarget != null && sellerReserveMax != null && requiredCumulativeTarget > sellerReserveMax);
+
+    const hasActiveSession = hadLockedSession || this._bpm.getActiveSession(peer.peerId) != null;
+
+    if (channelExhausted && hasActiveSession) {
+      debugLog(
+        `[BuyerNegotiator] Channel exhausted for ${peer.peerId.slice(0, 12)}... ` +
+        `(required=${requiredCumulativeTarget ?? 'n/a'} > reserveMax=${sellerReserveMax ?? 'n/a'}) — ` +
+        `retiring session and renegotiating a fresh reserve`,
+      );
+      // 'ghost' rather than 'settled' — buyer hasn't observed the on-chain
+      // settle land. Matches the other buyer-side give-up-locally callsites.
+      this._bpm.retireSession(peer.peerId, 'ghost');
+      this._lockedPeers.delete(peer.peerId);
+      this._firstRequestSent.delete(peer.peerId);
+    } else if (hasActiveSession) {
       const recovered = await this._recoverExistingSession(
         peer,
         conn,

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -16,6 +16,7 @@ import type {
 import { parseResponseUsage } from './utils/response-usage.js';
 import { computeCostUsdc } from './payments/pricing.js';
 import { debugLog, debugWarn } from './utils/debug.js';
+import { PAYMENT_CODE_CHANNEL_EXHAUSTED } from './types/protocol.js';
 
 export interface SellerRequestHandlerDeps {
   providers: Provider[];
@@ -196,14 +197,16 @@ export class SellerRequestHandler {
             // amount that is still below `spent`, which the seller would then
             // reject as underfunded — producing an infinite 402 loop.
             const target = spent + BigInt(baseRequirements.minBudgetPerRequest);
+            const isFullyExhausted = reserveMax > 0n && accepted >= reserveMax;
             const requirements = {
               ...baseRequirements,
               requiredCumulativeAmount: target.toString(),
               currentSpent: spent.toString(),
               currentAcceptedCumulative: accepted.toString(),
               channelId: session.sessionId,
+              ...(reserveMax > 0n ? { reserveMaxAmount: reserveMax.toString() } : {}),
+              ...(isFullyExhausted ? { code: PAYMENT_CODE_CHANNEL_EXHAUSTED } : {}),
             };
-            const isFullyExhausted = reserveMax > 0n && accepted >= reserveMax;
             if (isFullyExhausted) {
               debugLog(`[SellerHandler] Session fully exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} >= accepted=${accepted} >= reserveMax=${reserveMax}) — settling and returning 402`);
               void spm.settleSession(buyerPeerId).catch((err) => {
@@ -224,6 +227,8 @@ export class SellerRequestHandler {
                 currentSpent: requirements.currentSpent,
                 currentAcceptedCumulative: requirements.currentAcceptedCumulative,
                 channelId: requirements.channelId,
+                ...(requirements.reserveMaxAmount != null ? { reserveMaxAmount: requirements.reserveMaxAmount } : {}),
+                ...(requirements.code != null ? { code: requirements.code } : {}),
                 ...(requirements.inputUsdPerMillion != null ? { inputUsdPerMillion: requirements.inputUsdPerMillion } : {}),
                 ...(requirements.outputUsdPerMillion != null ? { outputUsdPerMillion: requirements.outputUsdPerMillion } : {}),
                 ...(requirements.cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion: requirements.cachedInputUsdPerMillion } : {}),

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -197,7 +197,7 @@ export class SellerRequestHandler {
             // amount that is still below `spent`, which the seller would then
             // reject as underfunded — producing an infinite 402 loop.
             const target = spent + BigInt(baseRequirements.minBudgetPerRequest);
-            const isFullyExhausted = reserveMax > 0n && accepted >= reserveMax;
+            const isFullyExhausted = reserveMax > 0n && (accepted >= reserveMax || target > reserveMax);
             const requirements = {
               ...baseRequirements,
               requiredCumulativeAmount: target.toString(),
@@ -208,9 +208,12 @@ export class SellerRequestHandler {
               ...(isFullyExhausted ? { code: PAYMENT_CODE_CHANNEL_EXHAUSTED } : {}),
             };
             if (isFullyExhausted) {
-              debugLog(`[SellerHandler] Session fully exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} >= accepted=${accepted} >= reserveMax=${reserveMax}) — settling and returning 402`);
+              debugLog(`[SellerHandler] Session fully exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} accepted=${accepted} target=${target} reserveMax=${reserveMax}) — closing and returning 402`);
+              // Default settleSession() performs final close(); do not use
+              // settleOnly here because exhausted channels must release the
+              // buyer's unused reserve before the buyer opens a replacement.
               void spm.settleSession(buyerPeerId).catch((err) => {
-                debugWarn(`[SellerHandler] Failed to settle exhausted session: ${err instanceof Error ? err.message : err}`);
+                debugWarn(`[SellerHandler] Failed to close exhausted session: ${err instanceof Error ? err.message : err}`);
               });
             } else {
               debugLog(`[SellerHandler] Budget exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} >= accepted=${accepted}) — returning 402 with requiredCumulativeAmount=${target}, awaiting higher SpendingAuth`);

--- a/packages/node/src/types/protocol.ts
+++ b/packages/node/src/types/protocol.ts
@@ -88,7 +88,22 @@ export interface PaymentRequiredPayload {
   currentAcceptedCumulative?: string;
   /** Channel ID for the exhausted session (so buyer can match it locally). */
   channelId?: string;
+  /**
+   * On-chain reserve ceiling for this channel. When present and the seller's
+   * `requiredCumulativeAmount` exceeds it, the channel is permanently
+   * exhausted and the buyer must retire it and open a new one — no amount
+   * of additional signing on the same channel will be accepted.
+   */
+  reserveMaxAmount?: string;
+  /**
+   * Stable machine-readable code so callers can switch on it without coupling
+   * to internal phrasing. Only set on irrecoverable 402s today.
+   */
+  code?: PaymentRequiredCode;
 }
+
+export const PAYMENT_CODE_CHANNEL_EXHAUSTED = 'channel_exhausted' as const;
+export type PaymentRequiredCode = typeof PAYMENT_CODE_CHANNEL_EXHAUSTED;
 
 /**
  * Seller tells buyer that the current cumulative authorization is insufficient.

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -272,6 +272,78 @@ describe('BuyerPaymentNegotiator', () => {
       expect(result.action).toBe('retry');
     });
 
+    it('retires session as settled and renegotiates without retrying extend when seller flags channel_exhausted', async () => {
+      await simulateSuccessfulNegotiation(negotiator, bpm, peer, conn);
+      (bpm.authorizeSpending as ReturnType<typeof vi.fn>).mockClear();
+      (bpm.extendCurrentSpendingAuth as ReturnType<typeof vi.fn>).mockClear();
+
+      const activeSession = makeActiveSession(peer.peerId);
+      (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(activeSession);
+      (bpm.retireSession as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(null);
+      });
+      (bpm.authorizeSpending as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        (bpm.isLockConfirmed as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      });
+
+      // Seller signals the channel is permanently exhausted: requiredCumulativeAmount
+      // exceeds the on-chain reserveMaxAmount, so no signing on this channel can succeed.
+      const response = make402Response({
+        error: 'payment_required',
+        code: 'channel_exhausted',
+        minBudgetPerRequest: '10000',
+        suggestedAmount: '1000000',
+        requiredCumulativeAmount: '11019626',
+        currentSpent: '11009626',
+        currentAcceptedCumulative: '10998222',
+        reserveMaxAmount: '11000000',
+        channelId: '0x' + 'cd'.repeat(32),
+      });
+
+      const result = await negotiator.handle402(response, peer, conn, makeRequest());
+
+      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, 'ghost');
+      // Critical: no futile signing on the dead channel.
+      expect(bpm.extendCurrentSpendingAuth).not.toHaveBeenCalled();
+      expect(bpm.resendCurrentSpendingAuth).not.toHaveBeenCalled();
+      // Fresh negotiation opens a new channel.
+      expect(bpm.authorizeSpending).toHaveBeenCalled();
+      expect(result.action).toBe('retry');
+    });
+
+    it('detects exhaustion via reserveMaxAmount even when seller omits the explicit code', async () => {
+      await simulateSuccessfulNegotiation(negotiator, bpm, peer, conn);
+      (bpm.authorizeSpending as ReturnType<typeof vi.fn>).mockClear();
+      (bpm.extendCurrentSpendingAuth as ReturnType<typeof vi.fn>).mockClear();
+
+      const activeSession = makeActiveSession(peer.peerId);
+      (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(activeSession);
+      (bpm.retireSession as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(null);
+      });
+      (bpm.authorizeSpending as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        (bpm.isLockConfirmed as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      });
+
+      // Older sellers might emit reserveMaxAmount without the explicit code field —
+      // the buyer should still detect exhaustion when required > reserveMax.
+      const response = make402Response({
+        error: 'payment_required',
+        minBudgetPerRequest: '10000',
+        suggestedAmount: '1000000',
+        requiredCumulativeAmount: '11019626',
+        reserveMaxAmount: '11000000',
+        channelId: '0x' + 'cd'.repeat(32),
+      });
+
+      const result = await negotiator.handle402(response, peer, conn, makeRequest());
+
+      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, 'ghost');
+      expect(bpm.extendCurrentSpendingAuth).not.toHaveBeenCalled();
+      expect(bpm.authorizeSpending).toHaveBeenCalled();
+      expect(result.action).toBe('retry');
+    });
+
     it('retires session as ghost and negotiates fresh reserve when extendCurrentSpendingAuth makes no progress', async () => {
       await simulateSuccessfulNegotiation(negotiator, bpm, peer, conn);
       (bpm.authorizeSpending as ReturnType<typeof vi.fn>).mockClear();

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -4,7 +4,7 @@ import type { SerializedHttpRequest } from '../src/types/http.js';
 import type { Provider } from '../src/interfaces/seller-provider.js';
 import { decodeHttpResponse, encodeHttpRequest } from '../src/proxy/request-codec.js';
 import { decodeFrame } from '../src/p2p/message-protocol.js';
-import { MessageType } from '../src/types/protocol.js';
+import { MessageType, PAYMENT_CODE_CHANNEL_EXHAUSTED } from '../src/types/protocol.js';
 
 function makeProvider(inputUsdPerMillion: number, outputUsdPerMillion: number, opts: {
   name: string;
@@ -296,5 +296,91 @@ describe('SellerRequestHandler payment pricing selection', () => {
     expect(decoded?.message.type).toBe(MessageType.HttpResponse);
     const response = decodeHttpResponse(decoded!.message.payload);
     expect(response.statusCode).toBe(402);
+  });
+
+  it('closes and flags the channel when the next required cumulative exceeds the reserve ceiling', async () => {
+    const provider = makeProvider(1, 1, {
+      name: 'paid-tier',
+      services: ['local-test'],
+    });
+    provider.handleRequest = vi.fn(async (req) => ({
+      requestId: req.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ ok: true })),
+    }));
+
+    const sendPaymentRequired = vi.fn();
+    const sendNeedAuth = vi.fn();
+    const settleSession = vi.fn(async () => {});
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: {
+        hasSession: () => true,
+        getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '950001' }),
+        recordSpend: vi.fn(),
+        getCumulativeSpend: () => 950_001n,
+        getAcceptedCumulative: () => 950_001n,
+        getReserveMax: () => 1_000_000n,
+        getPaymentRequirements: () => ({ minBudgetPerRequest: '50000', suggestedAmount: '1000000' }),
+        waitForPendingAuths: async () => {},
+        awaitAcceptedAtLeast: async () => false,
+        settleSession,
+      } as any,
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = {
+      send(frame: Uint8Array) {
+        sentFrames.push(frame);
+      },
+    } as any;
+    const paymentMux = {
+      sendNeedAuth,
+      sendPaymentRequired,
+    } as any;
+
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    const request: SerializedHttpRequest = {
+      requestId: 'req-near-ceiling',
+      method: 'POST',
+      path: '/v1/chat/completions',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })),
+    };
+
+    await mux.handleFrame({
+      type: MessageType.HttpRequest,
+      messageId: 1,
+      payload: encodeHttpRequest(request),
+    });
+
+    expect(provider.handleRequest).not.toHaveBeenCalled();
+    expect(sendNeedAuth).not.toHaveBeenCalled();
+    expect(settleSession).toHaveBeenCalledOnce();
+    expect(settleSession.mock.calls[0]?.[0]).toBe('b'.repeat(40));
+    expect(settleSession.mock.calls[0]?.[1]?.settleOnly).not.toBe(true);
+
+    expect(sendPaymentRequired).toHaveBeenCalledWith(expect.objectContaining({
+      code: PAYMENT_CODE_CHANNEL_EXHAUSTED,
+      requiredCumulativeAmount: '1000001',
+      reserveMaxAmount: '1000000',
+    }));
+
+    const decoded = decodeFrame(sentFrames[0]!);
+    expect(decoded?.message.type).toBe(MessageType.HttpResponse);
+    const response = decodeHttpResponse(decoded!.message.payload);
+    expect(response.statusCode).toBe(402);
+    const body = JSON.parse(new TextDecoder().decode(response.body));
+    expect(body).toMatchObject({
+      code: PAYMENT_CODE_CHANNEL_EXHAUSTED,
+      requiredCumulativeAmount: '1000001',
+      reserveMaxAmount: '1000000',
+    });
   });
 });

--- a/packages/node/tests/payment-codec.test.ts
+++ b/packages/node/tests/payment-codec.test.ts
@@ -67,6 +67,23 @@ describe('payment codec round-trips', () => {
     expect(decoded).toEqual(payload);
   });
 
+  it('PaymentRequired with channel_exhausted code and reserveMaxAmount', () => {
+    const payload = {
+      minBudgetPerRequest: '10000',
+      suggestedAmount: '1000000',
+      requestId: 'req-exhausted',
+      requiredCumulativeAmount: '11019626',
+      currentSpent: '11009626',
+      currentAcceptedCumulative: '10998222',
+      channelId: '0x' + 'cd'.repeat(32),
+      reserveMaxAmount: '11000000',
+      code: 'channel_exhausted' as const,
+    };
+    const encoded = encodePaymentRequired(payload);
+    const decoded = decodePaymentRequired(encoded);
+    expect(decoded).toEqual(payload);
+  });
+
   it('NeedAuth', () => {
     const payload = {
       channelId: '0x' + 'aa'.repeat(32),


### PR DESCRIPTION
## Summary
- When a payment channel's `accepted` cumulative reaches `reserveMax`, the seller's 402 asks for a `requiredCumulativeAmount` above `reserveMax` — a target the buyer can never satisfy on that channel. Without a signal to escalate, the buyer loops signing higher cumulatives the seller silently rejects (`exceeds deposit ceiling`), driving the local reserve ceiling far above the on-chain cap.
- Seller now emits `code: 'channel_exhausted'` and `reserveMaxAmount` in the PaymentRequired body when `accepted >= reserveMax`.
- Buyer's `handle402` detects this (or computes it from `requiredCumulativeAmount > reserveMaxAmount` for older sellers), retires the session as `'ghost'`, and falls through to fresh negotiation instead of extending the dead channel.

## Observed in the wild
The Hermes buyer (EC2 52.210.48.107, `@antseed/cli` v0.1.98) was stuck in this loop against the GKE `subscriptions-antseed-peer` pod for hours; seller logs showed cumulatives climbing from `15.2M` to `15.4M+` micro-USDC against an on-chain `reserveMax = 11_000_000`, all rejected, while the buyer's local reserve ceiling kept growing via optimistic `topUpReserve` calls.

## Files
- `packages/node/src/types/protocol.ts` — added `reserveMaxAmount?: string` and `code?: PaymentRequiredCode` to `PaymentRequiredPayload`; new `PAYMENT_CODE_CHANNEL_EXHAUSTED` constant.
- `packages/node/src/p2p/payment-codec.ts` — round-trips the two new fields.
- `packages/node/src/seller-request-handler.ts` — emits the fields when the existing `isFullyExhausted` branch fires.
- `packages/node/src/payments/buyer-payment-negotiator.ts` — `handle402` short-circuits to `retireSession('ghost')` + fresh negotiation when exhausted.
- `packages/node/tests/payment-codec.test.ts` — codec round-trip for the new fields.
- `packages/node/tests/buyer-payment-negotiator.test.ts` — two new cases (explicit `code`; implicit `required > reserveMax`).

## Test plan
- [x] `pnpm exec vitest run tests/payment-codec.test.ts tests/buyer-payment-negotiator.test.ts tests/seller-payment-manager.test.ts` — 70 passed
- [x] `pnpm test` in `packages/node` — 578 passed
- [x] `pnpm run typecheck` (full monorepo) — clean
- [x] `pnpm run build` (full monorepo) — clean
- [ ] After merge + publish, verify Hermes buyer recovers automatically once the new CLI is deployed (the stuck channel still needs operator-side close to fully unwind).