### PR TITLE
fix(payments): Withdraw via connected wallet, not server signer

### DIFF
--- a/apps/payments/src/routes.ts
+++ b/apps/payments/src/routes.ts
@@ -5,7 +5,6 @@ import {
   EmissionsClient,
   ANTSTokenClient,
   formatUsdc,
-  parseUsdc,
   signSetOperator,
   makeDepositsDomain,
   type ChainConfig,
@@ -31,7 +30,6 @@ interface RouteContext {
 
 // Use shared utilities from @antseed/node
 const formatUsdc6 = formatUsdc;
-const parseUsdc6 = parseUsdc;
 
 // Retry helper for on-chain view calls. Base RPC occasionally returns an
 // unparseable response (ethers surfaces it as CALL_EXCEPTION with null
@@ -146,26 +144,10 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
     return { transactions: [] };
   });
 
-  fastify.post('/api/withdraw', async (request, reply) => {
-    if (!ctx.cryptoCtx) {
-      return reply.status(503).send({ ok: false, error: 'Identity not configured — set ANTSEED_IDENTITY_HEX or run antseed seller setup' });
-    }
-
-    const body = request.body as { amount?: string } | null;
-    const amount = body?.amount;
-    if (!amount || isNaN(parseFloat(amount)) || parseFloat(amount) <= 0) {
-      return reply.status(400).send({ ok: false, error: 'Invalid amount' });
-    }
-
-    try {
-      const baseUnits = parseUsdc6(amount);
-      const client = getClient()!;
-      const txHash = await client.withdraw(ctx.cryptoCtx.wallet, ctx.cryptoCtx.evmAddress, baseUnits);
-      return { ok: true, txHash };
-    } catch (err) {
-      return reply.status(500).send({ ok: false, error: err instanceof Error ? err.message : String(err) });
-    }
-  });
+  // Withdrawals are now submitted directly from the connected wallet
+  // (see apps/payments/web/src/hooks/useWithdraw.ts). The contract requires
+  // msg.sender == operator and sends funds to msg.sender, so the server-side
+  // signer cannot execute withdraw once a separate wallet is authorized.
 
   fastify.get('/api/channels', async () => {
     if (!ctx.cryptoCtx) return { channels: [] };

--- a/apps/payments/web/src/App.tsx
+++ b/apps/payments/web/src/App.tsx
@@ -246,7 +246,7 @@ function AppShell({
         title="Withdraw USDC"
         subtitle="Send funds to your authorized wallet."
       >
-        <WithdrawView balance={balance} onAction={refreshBalance} />
+        <WithdrawView config={config} balance={balance} onAction={refreshBalance} />
       </ActionModal>
     </>
   );

--- a/apps/payments/web/src/api.ts
+++ b/apps/payments/web/src/api.ts
@@ -39,13 +39,6 @@ export async function getConfig(): Promise<PaymentConfig> {
   return fetchJson('/api/config');
 }
 
-export async function withdraw(amount: string): Promise<{ ok: boolean; txHash?: string; error?: string }> {
-  return fetchJson('/api/withdraw', {
-    method: 'POST',
-    body: JSON.stringify({ amount }),
-  });
-}
-
 /** Raw channel row from the buyer proxy's local ChannelStore — no on-chain enrichment. */
 export interface RawChannel {
   channelId: string;

--- a/apps/payments/web/src/components/WithdrawView.tsx
+++ b/apps/payments/web/src/components/WithdrawView.tsx
@@ -1,19 +1,33 @@
 import { useState } from 'react';
-import type { BalanceData } from '../types';
-import { withdraw } from '../api';
+import { useAccount } from 'wagmi';
+import { ConnectButton } from '@rainbow-me/rainbowkit';
+import type { BalanceData, PaymentConfig } from '../types';
 import { useAuthorizedWallet } from '../context/AuthorizedWalletContext';
+import { useWithdraw } from '../hooks/useWithdraw';
+import { usePaymentNetwork } from '../payment-network';
 import './WithdrawView.scss';
 
 interface WithdrawViewProps {
+  config: PaymentConfig | null;
   balance: BalanceData | null;
   onAction: () => void;
 }
 
-export function WithdrawView({ balance, onAction }: WithdrawViewProps) {
+const ZERO_ADDR = '0x0000000000000000000000000000000000000000';
+
+function shortAddr(addr: string): string {
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+}
+
+export function WithdrawView({ config, balance, onAction }: WithdrawViewProps) {
   const [amount, setAmount] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [status, setStatus] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
-  const { requireAuthorization } = useAuthorizedWallet();
+  const { address, isConnected } = useAccount();
+  const { requireAuthorization, operator } = useAuthorizedWallet();
+  const { targetChainName, walletChainId, wrongChain, isSwitchingChain } = usePaymentNetwork(config);
+
+  const { run, running, success, error, reset, txHash } = useWithdraw(config, () => {
+    onAction();
+  });
 
   if (!balance) {
     return (
@@ -25,27 +39,27 @@ export function WithdrawView({ balance, onAction }: WithdrawViewProps) {
   }
 
   const availableAmount = parseFloat(balance.available);
+  const buyer = config?.evmAddress ?? balance.evmAddress;
 
-  function handleWithdraw() {
-    if (!amount || parseFloat(amount) <= 0) return;
+  const operatorSet = !!operator && operator !== ZERO_ADDR;
+  const wrongWallet = Boolean(
+    isConnected && operatorSet && address && address.toLowerCase() !== operator!.toLowerCase(),
+  );
+
+  const amountNum = amount ? parseFloat(amount) : 0;
+  const validAmount = Number.isFinite(amountNum) && amountNum > 0 && amountNum <= availableAmount;
+
+  function handleClick() {
+    if (!buyer) return;
     requireAuthorization(async () => {
-      setLoading(true);
-      setStatus(null);
-      try {
-        const result = await withdraw(amount);
-        if (result.ok) {
-          setStatus({ type: 'success', message: `Withdrawal complete. TX: ${result.txHash ?? 'confirmed'}` });
-          setAmount('');
-          onAction();
-        } else {
-          setStatus({ type: 'error', message: result.error || 'Withdrawal failed' });
-        }
-      } catch (err) {
-        setStatus({ type: 'error', message: err instanceof Error ? err.message : String(err) });
-      } finally {
-        setLoading(false);
-      }
+      reset();
+      await run(buyer, amount);
     });
+  }
+
+  function resetForm() {
+    setAmount('');
+    reset();
   }
 
   return (
@@ -57,35 +71,93 @@ export function WithdrawView({ balance, onAction }: WithdrawViewProps) {
           authorize one if you haven't already.
         </div>
 
-        <div className="withdraw-request">
-          <div className="input-group">
-            <label className="input-label">Amount (USDC)</label>
-            <input
-              className="input-field"
-              type="number"
-              min="0"
-              step="0.01"
-              placeholder="0.00"
-              value={amount}
-              onChange={(e) => setAmount(e.target.value)}
-              disabled={loading}
-            />
-            <span className="hint">Available: ${availableAmount.toFixed(2)} USDC</span>
+        {success ? (
+          <div className="deposit-success">
+            <div className="deposit-success-icon">&#10003;</div>
+            <div className="deposit-success-title">Withdrawal confirmed!</div>
+            {txHash && <div className="deposit-success-hash">{txHash.slice(0, 18)}...</div>}
+            <div className="deposit-success-note">
+              Funds were sent to {address ? shortAddr(address) : 'your authorized wallet'}.
+            </div>
+            <button className="btn-outline" onClick={resetForm} style={{ marginTop: 12 }}>
+              Withdraw more
+            </button>
           </div>
-
-          <button
-            className="btn-primary"
-            onClick={handleWithdraw}
-            disabled={loading || !amount || parseFloat(amount) <= 0 || parseFloat(amount) > availableAmount}
-          >
-            {loading ? 'Processing...' : 'Withdraw'}
-          </button>
-        </div>
-
-        {status && (
-          <div className={`status-msg ${status.type === 'success' ? 'status-success' : 'status-error'}`}>
-            {status.message}
+        ) : !isConnected ? (
+          <div className="deposit-connect-wrapper">
+            <ConnectButton.Custom>
+              {({ openConnectModal, mounted }) => (
+                <button
+                  type="button"
+                  className="btn-primary"
+                  onClick={openConnectModal}
+                  disabled={!mounted}
+                >
+                  Connect Wallet
+                </button>
+              )}
+            </ConnectButton.Custom>
           </div>
+        ) : (
+          <>
+            <div className="deposit-connected">
+              <div className="deposit-connected-dot" />
+              <span className="deposit-connected-addr">{address ? shortAddr(address) : ''}</span>
+              <span className="deposit-connected-label">Connected</span>
+            </div>
+
+            {wrongChain && (
+              <div className="status-msg" style={{ marginTop: 0, marginBottom: 16 }}>
+                Wallet is on chain {walletChainId ?? 'unknown'}. Switch to {targetChainName} before withdrawing.
+              </div>
+            )}
+
+            {wrongWallet && operator && (
+              <div className="status-msg status-error" role="alert" style={{ marginBottom: 16 }}>
+                This account is authorized to <strong>{shortAddr(operator)}</strong>. Connect that wallet
+                to withdraw, or transfer authorization to the connected wallet first.
+              </div>
+            )}
+
+            <div className="withdraw-request">
+              <div className="input-group">
+                <label className="input-label">Amount (USDC)</label>
+                <input
+                  className="input-field"
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  placeholder="0.00"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  disabled={running}
+                />
+                <span className="hint">Available: ${availableAmount.toFixed(2)} USDC</span>
+              </div>
+
+              <button
+                className="btn-primary"
+                onClick={handleClick}
+                disabled={
+                  running ||
+                  isSwitchingChain ||
+                  !validAmount ||
+                  !buyer ||
+                  wrongWallet ||
+                  !config
+                }
+              >
+                {isSwitchingChain ? `Switching to ${targetChainName}...` :
+                 wrongChain ? `Switch to ${targetChainName}` :
+                 running ? 'Processing...' :
+                 'Withdraw'}
+              </button>
+            </div>
+          </>
+        )}
+
+        {error && (
+          <div className="status-msg status-error">{error}</div>
         )}
       </div>
     </div>

--- a/apps/payments/web/src/hooks/useWithdraw.ts
+++ b/apps/payments/web/src/hooks/useWithdraw.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useWriteContract, useWaitForTransactionReceipt } from 'wagmi';
+import { parseAbi, parseUnits } from 'viem';
+import type { PaymentConfig } from '../types';
+import { getErrorMessage, usePaymentNetwork } from '../payment-network';
+
+const DEPOSITS_WITHDRAW_ABI = parseAbi([
+  'function withdraw(address buyer, uint256 amount) external',
+]);
+
+export interface UseWithdrawResult {
+  /** Sends `withdraw(buyer, parseUnits(amount, 6))` from the connected wallet. */
+  run: (buyer: string, amount: string) => Promise<void>;
+  running: boolean;
+  success: boolean;
+  error: string | null;
+  reset: () => void;
+  txHash: string | undefined;
+}
+
+/**
+ * Submits AntseedDeposits.withdraw() through the connected wallet (wagmi).
+ *
+ * The deposits contract requires `msg.sender == buyers[buyer].operator` and
+ * sends the withdrawn USDC to `msg.sender`. So the connected wallet must be
+ * the authorized operator for the buyer — typically that's the wallet the
+ * user authorized via setOperator.
+ */
+export function useWithdraw(config: PaymentConfig | null, onSuccess?: () => void): UseWithdrawResult {
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { expectedChainId, ensureCorrectNetwork } = usePaymentNetwork(config);
+
+  const { writeContract, data: txHash, reset: resetWrite } = useWriteContract();
+  const { isSuccess } = useWaitForTransactionReceipt({ hash: txHash, chainId: expectedChainId });
+
+  useEffect(() => {
+    if (isSuccess && running) {
+      setRunning(false);
+      onSuccess?.();
+    }
+  }, [isSuccess, running, onSuccess]);
+
+  const run = useCallback(async (buyer: string, amount: string) => {
+    if (!config?.depositsContractAddress) {
+      setError('Payments contract is not configured.');
+      return;
+    }
+    if (!/^0x[0-9a-fA-F]{40}$/.test(buyer)) {
+      setError('Invalid buyer address.');
+      return;
+    }
+    const parsed = Number(amount);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      setError('Enter a valid amount.');
+      return;
+    }
+
+    let units: bigint;
+    try {
+      units = parseUnits(amount, 6);
+    } catch {
+      setError('Invalid amount.');
+      return;
+    }
+    if (units <= 0n) {
+      setError('Enter a valid amount.');
+      return;
+    }
+
+    setError(null);
+    setRunning(true);
+    resetWrite();
+
+    try {
+      await ensureCorrectNetwork();
+      writeContract({
+        address: config.depositsContractAddress as `0x${string}`,
+        abi: DEPOSITS_WITHDRAW_ABI,
+        functionName: 'withdraw',
+        chainId: expectedChainId,
+        args: [buyer as `0x${string}`, units],
+      }, {
+        onError: (err) => {
+          setRunning(false);
+          setError(getErrorMessage(err));
+        },
+      });
+    } catch (err) {
+      setRunning(false);
+      setError(getErrorMessage(err, 'Failed to withdraw'));
+    }
+  }, [config, ensureCorrectNetwork, expectedChainId, writeContract, resetWrite]);
+
+  const reset = useCallback(() => {
+    setError(null);
+    setRunning(false);
+    resetWrite();
+  }, [resetWrite]);
+
+  return { run, running, success: isSuccess, error, reset, txHash };
+}


### PR DESCRIPTION
## Description

The Withdraw button in the payments portal posted to `/api/withdraw`, which signed the tx with the desktop's local identity key. Once a separate MetaMask wallet has been authorized via `setOperator`, that key is no longer the operator and `AntseedDeposits.withdraw` reverts with `NotAuthorized()` (selector `0xea8e4eb5`). The contract requires `msg.sender == buyers[buyer].operator` and sends funds to `msg.sender`, so withdrawals must originate from the authorized wallet itself.

## Changes

- New `useWithdraw` hook (wagmi) modeled on `useTransferOperator`.
- Rewrote `WithdrawView` to submit through the connected wallet, with `ConnectButton`, chain-switch handling, and a clear inline error when the connected wallet isn't the on-chain operator.
- Passed `config` to `WithdrawView` from `App`.
- Removed the now-unused `withdraw()` client helper and `/api/withdraw` server route.

## Release Notes

- Fix: payments withdrawals now go through the connected (authorized) wallet, resolving `NotAuthorized` reverts when a wallet other than the desktop signer is the on-chain operator.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Chore