### PR TITLE
fix(node): Send freshInputTokens in NeedAuth

### DIFF
--- a/packages/node/src/p2p/payment-codec.ts
+++ b/packages/node/src/p2p/payment-codec.ts
@@ -107,6 +107,7 @@ export function decodeNeedAuth(data: Uint8Array): NeedAuthPayload {
   if (typeof obj.inputTokens === 'string') result.inputTokens = obj.inputTokens;
   if (typeof obj.outputTokens === 'string') result.outputTokens = obj.outputTokens;
   if (typeof obj.cachedInputTokens === 'string') result.cachedInputTokens = obj.cachedInputTokens;
+  if (typeof obj.freshInputTokens === 'string') result.freshInputTokens = obj.freshInputTokens;
   if (typeof obj.service === 'string') result.service = obj.service;
   return result;
 }

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -808,14 +808,21 @@ export class BuyerPaymentManager {
       const sellerIn = BigInt(payload.inputTokens ?? '0');
       const sellerOut = BigInt(payload.outputTokens ?? '0');
       const sellerCached = BigInt(payload.cachedInputTokens ?? '0');
+      // Prefer seller-supplied freshInputTokens to avoid OpenAI-vs-Anthropic
+      // cached-semantics ambiguity (OpenAI: prompt_tokens includes cached;
+      // Anthropic: input_tokens excludes cached). Fall back to OpenAI-style
+      // subtraction for older sellers that don't emit the field.
+      const sellerFreshExplicit = payload.freshInputTokens != null
+        ? BigInt(payload.freshInputTokens)
+        : null;
 
       // Use the buyer's own knowledge of which service it requested, not the seller's claim.
       // A malicious seller could set service to a more expensive model to inflate the ceiling.
       const pricing = this.getSessionPricing(sellerPeerId, buyerService);
       if (pricing && sellerCost > 0n) {
-        const freshIn = sellerCached > 0n
+        const freshIn = sellerFreshExplicit ?? (sellerCached > 0n
           ? BigInt(Math.max(0, Number(sellerIn) - Number(sellerCached)))
-          : sellerIn;
+          : sellerIn);
         const buyerEstimate = computeCostUsdc(Number(freshIn), Number(sellerOut), pricing, Number(sellerCached));
         const maxAcceptable = BigInt(Math.ceil(Number(buyerEstimate) * this._costTolerance));
         if (buyerEstimate > 0n && sellerCost > maxAcceptable) {
@@ -867,21 +874,20 @@ export class BuyerPaymentManager {
     // Update cumulative amount
     this._cumulativeAmount.set(sellerPeerId, effectiveAmount);
 
-    // Update cumulative metadata from reported tokens
-    if (payload.inputTokens || payload.outputTokens) {
-      const prev = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
-      const newMeta: SpendingAuthMetadata = {
-        cumulativeInputTokens: prev.cumulativeInputTokens + BigInt(payload.inputTokens ?? '0'),
-        cumulativeOutputTokens: prev.cumulativeOutputTokens + BigInt(payload.outputTokens ?? '0'),
-        cumulativeRequestCount: prev.cumulativeRequestCount + 1n,
-      };
-      this._metadata.set(sellerPeerId, newMeta);
-    }
+    // Advance cumulative metadata. requestCount always increments so the
+    // on-chain metadata stays consistent even when older sellers omit token
+    // fields; absent token fields contribute 0 to the running totals.
+    const prevMeta = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
+    const newMeta: SpendingAuthMetadata = {
+      cumulativeInputTokens: prevMeta.cumulativeInputTokens + BigInt(payload.inputTokens ?? '0'),
+      cumulativeOutputTokens: prevMeta.cumulativeOutputTokens + BigInt(payload.outputTokens ?? '0'),
+      cumulativeRequestCount: prevMeta.cumulativeRequestCount + 1n,
+    };
+    this._metadata.set(sellerPeerId, newMeta);
 
-    // Sign SpendingAuth with the effective amount and current metadata
-    const currentMeta = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
-    const metadataHashHex = computeMetadataHash(currentMeta);
-    const encodedMetadata = encodeMetadata(currentMeta);
+    // Sign SpendingAuth with the effective amount and updated metadata
+    const metadataHashHex = computeMetadataHash(newMeta);
+    const encodedMetadata = encodeMetadata(newMeta);
 
     const channelsDomain = this._channelsDomain;
     const metadataMsg: SpendingAuthMessage = {

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -375,6 +375,7 @@ export class SellerRequestHandler {
               inputTokens: String(usage.inputTokens),
               outputTokens: String(usage.outputTokens),
               cachedInputTokens: String(usage.cachedInputTokens),
+              freshInputTokens: String(usage.freshInputTokens),
               service: this._extractRequestedService(request) ?? undefined,
             });
           }

--- a/packages/node/src/types/protocol.ts
+++ b/packages/node/src/types/protocol.ts
@@ -119,12 +119,21 @@ export interface NeedAuthPayload {
   requestId?: string;
   /** Seller-computed cost for the last request (USDC base units). */
   lastRequestCost?: string;
-  /** Input tokens consumed by the last request. */
+  /** Total input tokens consumed by the last request (provider-style total — may include cached). */
   inputTokens?: string;
   /** Output tokens consumed by the last request. */
   outputTokens?: string;
   /** Cached input tokens consumed by the last request. */
   cachedInputTokens?: string;
+  /**
+   * Fresh (non-cached) input tokens consumed by the last request.
+   * Sent explicitly by the seller so the buyer doesn't have to guess at
+   * OpenAI-vs-Anthropic cached-token semantics (OpenAI: prompt_tokens
+   * includes cached; Anthropic: input_tokens excludes cached). When absent,
+   * the buyer falls back to `inputTokens - cachedInputTokens` (OpenAI
+   * convention) for backward compat with older sellers.
+   */
+  freshInputTokens?: string;
   /** Service/model name for service-specific pricing validation. */
   service?: string;
 }


### PR DESCRIPTION
## Summary

Fixes #366 and an upstream cause that's been silently rejecting valid seller cost claims when the upstream API uses Anthropic-style cached-token semantics.

## The bug

The buyer's `handleNeedAuth` cost-tolerance check re-derived fresh input tokens as `inputTokens - cachedInputTokens`, which is correct for OpenAI-style usage (`prompt_tokens` includes cached) but wrong for Anthropic-style usage (`input_tokens` already excludes cached). For an Anthropic response where `input=145408, cached=145145, out=92`:

- Seller correctly computes cost = 96230 (using `freshInputTokens=145408` from the disambiguated parser).
- Buyer's `handleNeedAuth` re-derives `freshIn = 145408 - 145145 = 263`, computes a buyer estimate of 9142, and rejects the seller as ~10x over budget.

Symptom in buyer logs:

```
[BuyerNegotiator] Estimated cost ... cost=96230 (in=145408 cached=145145 out=92)
[BuyerPayment] NeedAuth: seller claimed cost 96230 exceeds 1.4x buyer estimate 9142 — rejecting
```

Note that `estimateCostFromResponse` (which uses `usage.freshInputTokens` directly) and `handleNeedAuth` (which re-derived it) disagreed on the same response.

## Why on-chain metadata showed 0/0 (#366)

When `handleNeedAuth` rejects, cumulative auth doesn't advance. Subsequent requests hit a 402 catch-up flow whose `NeedAuth` carries no token fields, so the buyer signed higher cumulative amounts without ever incrementing `cumulativeInputTokens` / `cumulativeOutputTokens`. The on-chain `SpendingAuth` metadata then ends up with USDC > 0 but tokens = 0 — exactly the issue reporter's tx.

## Fix

- Add optional `freshInputTokens` to `NeedAuthPayload` and the codec.
- Seller emits it from `parseResponseUsage` (which already disambiguates OpenAI vs Anthropic correctly via `extractUsage`).
- Buyer prefers it for cost validation; falls back to OpenAI-style subtraction when absent.
- Drop the `if (payload.inputTokens || payload.outputTokens)` gate in `handleNeedAuth` so `cumulativeRequestCount` always advances, even when older sellers omit token fields.

## Compatibility

Wire-protocol only — no contract or schema changes.

- New buyer + old seller: field absent, falls back to prior math (no behavior change for OpenAI-style; Anthropic-style still mis-rejects until seller upgrades).
- Old buyer + new seller: ignores the new field — no break.
- No migration, no contract redeploy.

## Test plan

- `pnpm --filter @antseed/node typecheck` — clean.
- `pnpm --filter @antseed/node build` — clean.
- `pnpm --filter @antseed/node test` — 579/579 pass.

Closes #366.
