### PR TITLE
fix(cli): filter buyer metering channels at DB query level

### DIFF
--- a/apps/cli/src/cli/commands/buyer/metering.ts
+++ b/apps/cli/src/cli/commands/buyer/metering.ts
@@ -29,7 +29,7 @@ export function registerBuyerMeteringCommand(buyerCmd: Command): void {
         const store = openChannelStore(globalOpts.dataDir);
 
         try {
-          const activeChannels = store.getActiveChannels('buyer');
+          const activeChannels = store.getActiveChannelsByBuyer('buyer', buyerAddress);
           const channels = options.peer
             ? activeChannels.filter((channel) => channel.peerId === options.peer)
             : activeChannels;


### PR DESCRIPTION
## Summary
- `antseed buyer metering` now calls `store.getActiveChannelsByBuyer('buyer', buyerAddress)` instead of `getActiveChannels('buyer')`, scoping the initial fetch to the current buyer at the DB level.
- Removes unnecessary over-fetching and a latent data leak (same root cause as #371).

Fixes #372.

## Test plan
- [x] `pnpm --filter @antseed/cli typecheck`