### PR TITLE
fix(desktop): replace native title with styled tooltip on Discover +N pill

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
@@ -352,6 +352,47 @@
   color: var(--text-secondary);
 }
 
+/* Overflow “+N” pill with styled hover/focus tooltip */
+.tag-more {
+  position: relative;
+  cursor: default;
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+}
+
+.tag-more-tooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  width: max-content;
+  max-width: 220px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.4;
+  white-space: normal;
+  text-transform: none;
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.12s ease;
+
+  .tag-more:hover &,
+  .tag-more:focus-within & {
+    opacity: 1;
+  }
+}
+
 /* ── Card content ───────────────────────────────────────────────────── */
 
 .card-name {

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -503,12 +503,17 @@ function Card({
           ))}
           {item.tags.length > MAX_VISIBLE_CARD_TAGS && (
             <span
-              className={styles.tag}
-              title={item.tags.slice(MAX_VISIBLE_CARD_TAGS).map(formatCategoryLabel).join(', ')}
+              className={`${styles.tag} ${styles.tagMore}`}
+              tabIndex={0}
               aria-label={`${item.tags.length - MAX_VISIBLE_CARD_TAGS} more categories: `
                 + item.tags.slice(MAX_VISIBLE_CARD_TAGS).map(formatCategoryLabel).join(', ')}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') e.stopPropagation(); }}
             >
               +{item.tags.length - MAX_VISIBLE_CARD_TAGS}
+              <span className={styles.tagMoreTooltip} role="tooltip">
+                {item.tags.slice(MAX_VISIBLE_CARD_TAGS).map(formatCategoryLabel).join(', ')}
+              </span>
             </span>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Adds a CSS-driven `.tagMore` / `.tagMoreTooltip` pair to `DiscoverWelcome.module.scss`, themed via existing `--bg-card` / `--border-subtle` variables and shown on `:hover` / `:focus-within`.
- Drops the native `title` attribute on the Discover `+N` overflow pill, nests the tooltip inside the pill (`role="tooltip"`), and adds `tabIndex={0}` so keyboard users can focus it. `aria-label` is preserved for screen readers.
- Stops Enter/Space and click from bubbling to the parent card, so focusing the pill no longer launches a chat.

Fixes #346

## Test plan
- [ ] Hover the `+N` pill on a Discover card with 5+ categories — styled tooltip fades in, no native browser tooltip alongside.
- [ ] Tab to the pill — same tooltip appears via `:focus-within`; pressing Enter does not start a chat.
- [ ] Verify in both light and dark themes.