### PR TITLE
feat(desktop): add Show Thinking toggle in settings

### DIFF
--- a/apps/desktop/src/renderer/core/state.ts
+++ b/apps/desktop/src/renderer/core/state.ts
@@ -47,6 +47,7 @@ export type ConfigFormData = {
   minRep: number;
   paymentMethod: string;
   devMode: boolean;
+  showThinking: boolean;
   cryptoChainId: string;
 };
 
@@ -174,6 +175,7 @@ export type RendererUiState = {
   configFormData: ConfigFormData | null;
   configSaving: boolean;
   devMode: boolean;
+  showThinking: boolean;
 
   // --- Plugin setup ---
   installedPlugins: Set<string>;
@@ -324,6 +326,7 @@ export function createInitialUiState(): RendererUiState {
     configFormData: null,
     configSaving: false,
     devMode: false,
+    showThinking: true,
 
     // Plugin setup
     installedPlugins: new Set<string>(),

--- a/apps/desktop/src/renderer/modules/settings.ts
+++ b/apps/desktop/src/renderer/modules/settings.ts
@@ -19,6 +19,7 @@ function asRecord(value: unknown): Record<string, unknown> {
 }
 
 const DESKTOP_DEV_MODE_KEY = 'antseed.desktop.devMode';
+const DESKTOP_SHOW_THINKING_KEY = 'antseed.desktop.showThinking';
 
 function loadDesktopDevMode(): boolean {
   try {
@@ -36,6 +37,23 @@ function persistDesktopDevMode(value: boolean): void {
   }
 }
 
+function loadDesktopShowThinking(): boolean {
+  try {
+    // Default to true when unset so existing users keep seeing thinking.
+    return window.localStorage.getItem(DESKTOP_SHOW_THINKING_KEY) !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+function persistDesktopShowThinking(value: boolean): void {
+  try {
+    window.localStorage.setItem(DESKTOP_SHOW_THINKING_KEY, value ? 'true' : 'false');
+  } catch {
+    // Ignore storage errors and continue with in-memory state.
+  }
+}
+
 export function initSettingsModule({
   uiState,
   getDashboardData,
@@ -44,10 +62,12 @@ export function initSettingsModule({
 }: SettingsModuleOptions) {
   let configFormPopulated = false;
   uiState.devMode = loadDesktopDevMode();
+  uiState.showThinking = loadDesktopShowThinking();
   void setDebugLogs(uiState.devMode);
 
   function applyConfigFormData(formData: ConfigFormData): void {
     uiState.devMode = formData.devMode;
+    uiState.showThinking = formData.showThinking;
     uiState.configFormData = { ...formData };
   }
 
@@ -70,6 +90,7 @@ export function initSettingsModule({
       minRep: safeNumber(buyer.minPeerReputation, 0),
       paymentMethod: safeString(payments.preferredMethod, 'crypto'),
       devMode: uiState.devMode,
+      showThinking: uiState.showThinking,
       cryptoChainId: safeString(crypto.chainId, 'base-mainnet'),
     });
     notifyUiStateChanged();
@@ -78,6 +99,7 @@ export function initSettingsModule({
   async function saveConfig(formData: ConfigFormData): Promise<void> {
     uiState.configSaving = true;
     persistDesktopDevMode(formData.devMode);
+    persistDesktopShowThinking(formData.showThinking);
     void setDebugLogs(formData.devMode);
     applyConfigFormData(formData);
     notifyUiStateChanged();

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -7,6 +7,7 @@ import type { ReactNode } from 'react';
 import { MarkdownContent } from './chat-utils.js';
 import styles from './ChatBubble.module.scss';
 import { AttachmentViewer, type ViewerAttachment } from './AttachmentViewer';
+import { useUiSnapshot } from '../../hooks/useUiSnapshot';
 import type { ChatMessage, ContentBlock } from './chat-shared';
 import {
   buildChatMetaParts,
@@ -165,9 +166,11 @@ function StreamingMarkdown({ text }: { text: string }) {
 }
 
 function ThinkingBlockView({ block }: { block: ContentBlock }) {
+  const showThinking = useUiSnapshot().showThinking;
   const [manualToggle, setManualToggle] = useState<boolean | null>(null);
   const isOpen = manualToggle ?? true;
 
+  if (!showThinking) return null;
   if (!block.thinking?.trim()) return null;
 
   const thinkingText = String(block.thinking || '');

--- a/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
@@ -7,7 +7,7 @@ type ConfigViewProps = {
 };
 
 export function ConfigView({ active }: ConfigViewProps) {
-  const { configFormData, configSaving, devMode, configMessage } = useUiSnapshot();
+  const { configFormData, configSaving, devMode, showThinking, configMessage } = useUiSnapshot();
   const actions = useActions();
 
   // Local form state — initialized from config, edited locally, saved on button click
@@ -37,6 +37,11 @@ export function ConfigView({ active }: ConfigViewProps) {
   function toggleDevMode() {
     if (!configFormData) return;
     void actions.saveConfig({ ...configFormData, devMode: !devMode });
+  }
+
+  function toggleShowThinking() {
+    if (!configFormData) return;
+    void actions.saveConfig({ ...configFormData, showThinking: !showThinking });
   }
 
   // Save all config and restart the buyer runtime
@@ -183,6 +188,24 @@ export function ConfigView({ active }: ConfigViewProps) {
                   <span className="settings-switch-thumb" />
                 </span>
                 <span className="settings-switch-label">{devMode ? 'On' : 'Off'}</span>
+              </button>
+            </div>
+            <div className="settings-item">
+              <div className="settings-copy">
+                <h4>Show Thinking</h4>
+                <p>Show the model&apos;s internal thoughts in chat responses.</p>
+              </div>
+              <button
+                type="button"
+                className={`settings-switch${showThinking ? ' is-on' : ''}`}
+                aria-pressed={showThinking}
+                onClick={toggleShowThinking}
+                disabled={configSaving}
+              >
+                <span className="settings-switch-track">
+                  <span className="settings-switch-thumb" />
+                </span>
+                <span className="settings-switch-label">{showThinking ? 'On' : 'Off'}</span>
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Adds a "Show Thinking" toggle in Settings → Desktop Preferences (default on) that hides the model's internal thinking blocks in chat.
- Persisted in localStorage alongside the existing `devMode` preference; takes effect immediately, no restart.

## Test plan
- [ ] Toggle off in Settings → chat responses no longer render the "Internal Thoughts" disclosure.
- [ ] Toggle on → thinking blocks reappear.
- [ ] Preference survives app restart.

Fixes #353