### PR TITLE
fix(cli): read buyer.state.json for buyer status

### DIFF
--- a/apps/cli/src/status/node-status.ts
+++ b/apps/cli/src/status/node-status.ts
@@ -22,6 +22,12 @@ export interface NodeStatus {
 /** Stale threshold: 30 seconds */
 const STALE_THRESHOLD_MS = 30_000;
 
+/** Seller daemon writes daemon.state.json; buyer proxy writes buyer.state.json. */
+const STATE_FILES: Array<{ name: string; role: 'seller' | 'buyer' }> = [
+  { name: 'daemon.state.json', role: 'seller' },
+  { name: 'buyer.state.json', role: 'buyer' },
+];
+
 /**
  * Check if a process with the given PID is alive.
  * Uses `process.kill(pid, 0)` which checks existence without sending a signal.
@@ -35,59 +41,115 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+interface LoadedStateFile {
+  path: string;
+  data: Record<string, unknown>;
+  role: 'seller' | 'buyer';
+}
+
+async function loadStateFile(dataDir: string): Promise<LoadedStateFile | null> {
+  for (const { name, role } of STATE_FILES) {
+    const path = join(dataDir, name);
+    try {
+      const raw = await readFile(path, 'utf-8');
+      return { path, data: JSON.parse(raw) as Record<string, unknown>, role };
+    } catch {
+      // try the next candidate
+    }
+  }
+  return null;
+}
+
 /**
  * Query the current node status.
- * Reads from the running daemon's state file at <dataDir>/daemon.state.json.
- * Uses PID-based liveness check first, falls back to 30s stale threshold.
- * Returns idle state with zeroed metrics if no daemon is running or the state file is stale.
+ * Reads from the running daemon's state file at <dataDir>/daemon.state.json
+ * (seller) or <dataDir>/buyer.state.json (buyer proxy). Uses PID-based
+ * liveness check first, falls back to 30s stale threshold. Returns idle state
+ * with zeroed metrics if no daemon is running or the state file is stale.
  */
 export async function getNodeStatus(config: AntseedConfig, dataDir: string = DEFAULT_DATA_DIR): Promise<NodeStatus> {
-  const stateFilePath = join(dataDir, 'daemon.state.json');
-
-  try {
-    const raw = await readFile(stateFilePath, 'utf-8');
-    const state = JSON.parse(raw) as Record<string, unknown>;
-
-    // PID-based liveness check
-    const pid = typeof state.pid === 'number' ? state.pid : null;
-    const alive = pid !== null && isProcessAlive(pid);
-
-    // If PID is present and process is dead, return idle immediately
-    if (pid !== null && !alive) {
-      return idleStatus(config, pid);
-    }
-
-    // Fallback: if no PID in state file, use stale threshold
-    if (pid === null) {
-      const fileStat = await stat(stateFilePath);
-      const ageMs = Date.now() - fileStat.mtimeMs;
-      if (ageMs > STALE_THRESHOLD_MS) {
-        return idleStatus(config, null);
-      }
-    }
-
-    const validStates = ['seeding', 'connected', 'idle'] as const;
-    const rawState = typeof state.state === 'string' && validStates.includes(state.state as NodeStatus['state'])
-      ? (state.state as NodeStatus['state'])
-      : 'idle';
-
-    return {
-      state: rawState,
-      peerCount: typeof state.peerCount === 'number' ? state.peerCount : 0,
-      earningsToday: typeof state.earningsToday === 'string' ? state.earningsToday : '0',
-      tokensToday: typeof state.tokensToday === 'number' ? state.tokensToday : 0,
-      activeChannels: typeof state.activeChannels === 'number' ? state.activeChannels : 0,
-      uptime: typeof state.uptime === 'string' ? state.uptime : '0s',
-      walletAddress: typeof state.walletAddress === 'string' ? state.walletAddress : (config.identity.walletAddress ?? null),
-      proxyPort: typeof state.proxyPort === 'number' ? state.proxyPort : null,
-      capacityUsedPercent: typeof state.capacityUsedPercent === 'number' ? state.capacityUsedPercent : 0,
-      daemonPid: pid,
-      daemonAlive: alive,
-    };
-  } catch {
-    // State file doesn't exist or is unreadable — daemon is not running
+  const loaded = await loadStateFile(dataDir);
+  if (!loaded) {
     return idleStatus(config, null);
   }
+
+  const { path: stateFilePath, data: state, role } = loaded;
+
+  // PID-based liveness check
+  const pid = typeof state.pid === 'number' ? state.pid : null;
+  const alive = pid !== null && isProcessAlive(pid);
+
+  // If PID is present and process is dead, return idle immediately
+  if (pid !== null && !alive) {
+    return idleStatus(config, pid);
+  }
+
+  // Fallback: if no PID in state file, use stale threshold
+  if (pid === null) {
+    const fileStat = await stat(stateFilePath);
+    const ageMs = Date.now() - fileStat.mtimeMs;
+    if (ageMs > STALE_THRESHOLD_MS) {
+      return idleStatus(config, null);
+    }
+  }
+
+  return role === 'buyer'
+    ? buyerStatus(state, config, pid, alive)
+    : sellerStatus(state, config, pid, alive);
+}
+
+function sellerStatus(
+  state: Record<string, unknown>,
+  config: AntseedConfig,
+  pid: number | null,
+  alive: boolean,
+): NodeStatus {
+  const validStates = ['seeding', 'connected', 'idle'] as const;
+  const rawState = typeof state.state === 'string' && validStates.includes(state.state as NodeStatus['state'])
+    ? (state.state as NodeStatus['state'])
+    : 'idle';
+
+  return {
+    state: rawState,
+    peerCount: typeof state.peerCount === 'number' ? state.peerCount : 0,
+    earningsToday: typeof state.earningsToday === 'string' ? state.earningsToday : '0',
+    tokensToday: typeof state.tokensToday === 'number' ? state.tokensToday : 0,
+    activeChannels: typeof state.activeChannels === 'number' ? state.activeChannels : 0,
+    uptime: typeof state.uptime === 'string' ? state.uptime : '0s',
+    walletAddress: typeof state.walletAddress === 'string' ? state.walletAddress : (config.identity.walletAddress ?? null),
+    proxyPort: typeof state.proxyPort === 'number' ? state.proxyPort : null,
+    capacityUsedPercent: typeof state.capacityUsedPercent === 'number' ? state.capacityUsedPercent : 0,
+    daemonPid: pid,
+    daemonAlive: alive,
+  };
+}
+
+function buyerStatus(
+  state: Record<string, unknown>,
+  config: AntseedConfig,
+  pid: number | null,
+  alive: boolean,
+): NodeStatus {
+  // buyer.state.json uses different field names than daemon.state.json:
+  //   - `port` is the proxy port
+  //   - `state` is 'connected' | 'stopped' (map 'stopped' to 'idle')
+  //   - peerCount is derived from the persisted discoveredPeers cache
+  const reportedState = state.state === 'connected' ? 'connected' : 'idle';
+  const peers = Array.isArray(state.discoveredPeers) ? state.discoveredPeers : [];
+
+  return {
+    state: reportedState,
+    peerCount: peers.length,
+    earningsToday: '0',
+    tokensToday: 0,
+    activeChannels: 0,
+    uptime: '0s',
+    walletAddress: config.identity.walletAddress ?? null,
+    proxyPort: typeof state.port === 'number' ? state.port : null,
+    capacityUsedPercent: 0,
+    daemonPid: pid,
+    daemonAlive: alive,
+  };
 }
 
 function idleStatus(config: AntseedConfig, pid: number | null): NodeStatus {


### PR DESCRIPTION
## Summary
- `getNodeStatus()` only read `<dataDir>/daemon.state.json`, which is written by the seller daemon. The buyer proxy persists to `<dataDir>/buyer.state.json`, so `antseed buyer status` always fell back to the idle/zeroed defaults even when the proxy was running.
- Try `daemon.state.json` first, then fall back to `buyer.state.json`, mapping the buyer-specific field names (`port` → `proxyPort`, state `'connected' | 'stopped'` → `'connected' | 'idle'`) and deriving `peerCount` from the persisted `discoveredPeers` cache.

Fixes #370.

## Test plan
- [x] `pnpm --filter @antseed/cli typecheck`
- [x] `pnpm --filter @antseed/cli test` (72 passing)
- [ ] Manual: start `antseed buyer start`, run `antseed buyer status` and confirm it reports `connected` and the correct proxy port instead of `idle`.