### PR TITLE
fix(node): handle Codex Responses usage shape and /v1/models query string

### DIFF
--- a/packages/api-adapter/src/utils.ts
+++ b/packages/api-adapter/src/utils.ts
@@ -60,18 +60,34 @@ export interface TokenUsage {
 }
 
 export function extractUsage(parsed: Record<string, unknown>): TokenUsage {
-  const usage = parsed.usage && typeof parsed.usage === 'object'
-    ? (parsed.usage as Record<string, unknown>)
-    : {};
+  // Direct shape: { usage: {...} } (OpenAI Chat, Anthropic Messages, etc.)
+  // Nested shape: { response: { usage: {...} } } (OpenAI Responses SSE
+  // `response.completed` events from the Codex backend bury usage under
+  // `response`).
+  let usage: Record<string, unknown> = {};
+  if (parsed.usage && typeof parsed.usage === 'object') {
+    usage = parsed.usage as Record<string, unknown>;
+  } else if (parsed.response && typeof parsed.response === 'object') {
+    const inner = parsed.response as Record<string, unknown>;
+    if (inner.usage && typeof inner.usage === 'object') {
+      usage = inner.usage as Record<string, unknown>;
+    }
+  }
 
   const totalInput = toNonNegativeInt(usage.prompt_tokens ?? usage.input_tokens);
   const outputTokens = toNonNegativeInt(usage.completion_tokens ?? usage.output_tokens);
 
-  // OpenAI/Together: prompt_tokens_details.cached_tokens (subset of prompt_tokens)
-  const details = usage.prompt_tokens_details && typeof usage.prompt_tokens_details === 'object'
+  // Cache hits — supports both shapes:
+  //   - OpenAI Chat:      usage.prompt_tokens_details.cached_tokens
+  //   - OpenAI Responses: usage.input_tokens_details.cached_tokens
+  // Both express the cached portion as a *subset* of the total input count.
+  const promptDetails = usage.prompt_tokens_details && typeof usage.prompt_tokens_details === 'object'
     ? (usage.prompt_tokens_details as Record<string, unknown>)
     : {};
-  const openaiCached = toNonNegativeInt(details.cached_tokens);
+  const inputDetails = usage.input_tokens_details && typeof usage.input_tokens_details === 'object'
+    ? (usage.input_tokens_details as Record<string, unknown>)
+    : {};
+  const openaiCached = toNonNegativeInt(promptDetails.cached_tokens ?? inputDetails.cached_tokens);
 
   // Anthropic: cache_read_input_tokens is separate from input_tokens (which is fresh-only)
   const anthropicCached = toNonNegativeInt(usage.cache_read_input_tokens ?? usage.prompt_cache_hit_tokens);

--- a/packages/api-adapter/tests/extract-usage.test.ts
+++ b/packages/api-adapter/tests/extract-usage.test.ts
@@ -82,6 +82,51 @@ describe('extractUsage', () => {
     expect(result.cachedInputTokens).toBe(100);
   });
 
+  it('unwraps OpenAI Responses SSE shape (response.completed event)', () => {
+    // The Codex backend's `response.completed` event nests usage under
+    // `response`, not at the top level. Without unwrapping, every Responses
+    // request was metered as zero tokens.
+    const result = extractUsage({
+      type: 'response.completed',
+      response: {
+        id: 'resp_abc',
+        model: 'gpt-5.5',
+        usage: {
+          input_tokens: 22,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens: 20,
+          output_tokens_details: { reasoning_tokens: 12 },
+          total_tokens: 42,
+        },
+      },
+    });
+    expect(result).toEqual({
+      inputTokens: 22,
+      outputTokens: 20,
+      freshInputTokens: 22,
+      cachedInputTokens: 0,
+    });
+  });
+
+  it('reads input_tokens_details.cached_tokens (OpenAI Responses cached subset)', () => {
+    const result = extractUsage({
+      type: 'response.completed',
+      response: {
+        usage: {
+          input_tokens: 1000,
+          input_tokens_details: { cached_tokens: 750 },
+          output_tokens: 100,
+        },
+      },
+    });
+    expect(result).toEqual({
+      inputTokens: 1000,
+      outputTokens: 100,
+      freshInputTokens: 250,    // 1000 - 750
+      cachedInputTokens: 750,
+    });
+  });
+
   it('prefers Anthropic cache field over OpenAI when both present', () => {
     // Anthropic cache_read_input_tokens takes priority since it's checked first
     const result = extractUsage({

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -60,7 +60,10 @@ export class SellerRequestHandler {
       debugLog(`[SellerHandler] Received request: ${request.method} ${request.path} (reqId=${request.requestId.slice(0, 8)})`);
 
       // Handle /v1/models locally — free metadata endpoint, no payment required.
-      if (request.method === 'GET' && (request.path === '/v1/models' || request.path.startsWith('/v1/models/'))) {
+      // Compare against the path without its query string so callers like
+      // Codex CLI (which appends `?client_version=…`) hit the local fast path.
+      const pathOnly = request.path.split('?')[0] ?? request.path;
+      if (request.method === 'GET' && (pathOnly === '/v1/models' || pathOnly.startsWith('/v1/models/'))) {
         const modelsResponse = this._handleModelsRequest(request);
         mux.sendProxyResponse(modelsResponse);
         return;
@@ -395,7 +398,9 @@ export class SellerRequestHandler {
     const now = Math.floor(Date.now() / 1000);
 
     // GET /v1/models/:id — single model lookup
-    const singleModelMatch = request.path.match(/^\/v1\/models\/(.+)$/);
+    // Strip query string so `/v1/models/gpt-5.5?client_version=…` resolves to "gpt-5.5".
+    const pathOnly = request.path.split('?')[0] ?? request.path;
+    const singleModelMatch = pathOnly.match(/^\/v1\/models\/(.+)$/);
     if (singleModelMatch) {
       const modelId = decodeURIComponent(singleModelMatch[1]!);
       if (allServices.includes(modelId)) {

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -34,6 +34,99 @@ function makeProvider(inputUsdPerMillion: number, outputUsdPerMillion: number, o
 }
 
 describe('SellerRequestHandler payment pricing selection', () => {
+  it('routes GET /v1/models to the local handler even when a query string is appended', async () => {
+    // Codex CLI calls `GET /v1/models?client_version=…` at startup. The
+    // local-models fast path used to compare `request.path === "/v1/models"`,
+    // which fails once a query string is present, so the request fell through
+    // to the model-matching branch and 400'd.
+    const provider = makeProvider(1, 1, {
+      name: 'openai',
+      services: ['gpt-5.4', 'gpt-5.5'],
+    });
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: null,
+      sessionTracker: null,
+      channelsClient: null,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = {
+      send(frame: Uint8Array) {
+        sentFrames.push(frame);
+      },
+    } as any;
+    const paymentMux = {
+      sendNeedAuth: vi.fn(),
+      sendPaymentRequired: vi.fn(),
+    } as any;
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({
+      type: MessageType.HttpRequest,
+      messageId: 1,
+      payload: encodeHttpRequest({
+        requestId: 'req-models-list',
+        method: 'GET',
+        path: '/v1/models?client_version=0.125.0',
+        headers: {},
+        body: new Uint8Array(0),
+      }),
+    });
+
+    const decoded = decodeFrame(sentFrames[0]!);
+    expect(decoded?.message.type).toBe(MessageType.HttpResponse);
+    const response = decodeHttpResponse(decoded!.message.payload);
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(new TextDecoder().decode(response.body));
+    expect(body.object).toBe('list');
+    expect(body.data.map((m: { id: string }) => m.id).sort()).toEqual(['gpt-5.4', 'gpt-5.5']);
+  });
+
+  it('routes GET /v1/models/:id to the local handler even when a query string is appended', async () => {
+    const provider = makeProvider(1, 1, {
+      name: 'openai',
+      services: ['gpt-5.5'],
+    });
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: null,
+      sessionTracker: null,
+      channelsClient: null,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = {
+      send(frame: Uint8Array) {
+        sentFrames.push(frame);
+      },
+    } as any;
+    const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired: vi.fn() } as any;
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({
+      type: MessageType.HttpRequest,
+      messageId: 1,
+      payload: encodeHttpRequest({
+        requestId: 'req-models-single',
+        method: 'GET',
+        path: '/v1/models/gpt-5.5?client_version=0.125.0',
+        headers: {},
+        body: new Uint8Array(0),
+      }),
+    });
+
+    const decoded = decodeFrame(sentFrames[0]!);
+    const response = decodeHttpResponse(decoded!.message.payload);
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(new TextDecoder().decode(response.body));
+    expect(body.id).toBe('gpt-5.5');
+  });
+
   it('matches the requested provider and service pricing instead of using the first provider defaults', () => {
     const anthropic = makeProvider(3, 15, {
       name: 'anthropic',

--- a/packages/node/tests/response-usage.test.ts
+++ b/packages/node/tests/response-usage.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { parseResponseUsage } from '../src/utils/response-usage.js';
+
+const enc = new TextEncoder();
+
+describe('parseResponseUsage', () => {
+  it('extracts usage from a multi-event Responses SSE stream', () => {
+    // Mirrors the shape of a real Codex `response.completed` event:
+    // usage is nested under `response`, and cached tokens live under
+    // `input_tokens_details.cached_tokens`.
+    const stream = [
+      'event: response.created',
+      'data: {"type":"response.created","response":{"id":"r1","model":"gpt-5.5"}}',
+      '',
+      'event: response.in_progress',
+      'data: {"type":"response.in_progress","response":{"id":"r1","model":"gpt-5.5"}}',
+      '',
+      'event: response.output_text.delta',
+      'data: {"type":"response.output_text.delta","delta":"Hi"}',
+      '',
+      'event: response.completed',
+      'data: {"type":"response.completed","response":{"id":"r1","model":"gpt-5.5","usage":{"input_tokens":42,"input_tokens_details":{"cached_tokens":10},"output_tokens":7}}}',
+      '',
+    ].join('\n');
+    const usage = parseResponseUsage(enc.encode(stream));
+    expect(usage.inputTokens).toBe(42);
+    expect(usage.outputTokens).toBe(7);
+    expect(usage.cachedInputTokens).toBe(10);
+    expect(usage.freshInputTokens).toBe(32);
+  });
+
+  it('returns zeros when the body has no usage field', () => {
+    const usage = parseResponseUsage(enc.encode(JSON.stringify({ model: 'foo' })));
+    expect(usage).toEqual({ inputTokens: 0, outputTokens: 0, freshInputTokens: 0, cachedInputTokens: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

Two Codex-CLI compat fixes for sellers serving the new `gpt-5.4` / `gpt-5.5` services that use the OpenAI Responses backend.

### 1. Usage extraction (`@antseed/api-adapter`)
The Codex `response.completed` SSE event nests usage under `response`, and reports cache hits via `input_tokens_details.cached_tokens` (not the OpenAI-Chat `prompt_tokens_details.cached_tokens`). `extractUsage` recognized neither, so every Codex request through an AntSeed seller logged `cost=0 cumulative=0 (in=0 cached=0 out=0)` — buyers weren't charged and sellers had no metering signal.

Fix: fall back to `parsed.response.usage` when top-level `usage` is missing; read `input_tokens_details.cached_tokens` alongside the existing prompt-details path.

### 2. `/v1/models` query string (`@antseed/node` seller-request-handler)
Codex CLI calls `GET /v1/models?client_version=0.125.0` at startup. The local fast path compared `request.path === "/v1/models"` — fails once a query string is present, so the request fell through to model-matching and 400'd with `"must include a service or model field"`. The `/v1/models/:id` single-model regex had the same bug.

Fix: strip the query string before path matching in both branches.

## Tests
- 2 new cases in `extract-usage.test.ts` for the unwrapped shape and `input_tokens_details.cached_tokens` math.
- New `response-usage.test.ts` driving a multi-event Responses SSE stream through `parseResponseUsage` and asserting non-zero counts.
- 2 new `SellerRequestHandler` tests covering `GET /v1/models` and `GET /v1/models/:id` with a query string.

## Test plan
- [x] `pnpm test` in `@antseed/api-adapter` — passed
- [x] `pnpm test` in `@antseed/node` — 583 passed
- [x] Full `pnpm run typecheck` — clean
- [ ] After publish + roll: confirm `[SellerHandler] Cost recorded` shows non-zero in/out for new Codex traffic, and Codex CLI `--profile antseed` enumerates models successfully.