### PR TITLE
fix(desktop): Trigger real DHT peer scans

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -125,6 +125,23 @@ test('selectCandidatePeersForRouting keeps all peers when no protocol or provide
   assert.equal(result.routePlanByPeerId.size, 0)
 })
 
+test('peer refresh control endpoint triggers immediate refresh', async () => {
+  const refreshedPeer = makePeer('a', ['anthropic'])
+  const proxy = makeBuyerProxyWithPeers([], [refreshedPeer])
+  let refreshCalled = false
+  ;(proxy as any)._refreshPeersNow = async () => {
+    refreshCalled = true
+    return [refreshedPeer]
+  }
+
+  const res = await invokeProxy(proxy, makeProxyRequest({ path: '/_antseed/peers/refresh' }))
+  const body = JSON.parse(res.body) as { ok: boolean; total: number }
+
+  assert.equal(refreshCalled, true)
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(body, { ok: true, total: 1 })
+})
+
 test('selectCandidatePeersForRouting excludes peers when requested service is not in provider metadata', () => {
   const openAiPeer = makePeer('a', ['openai'])
   openAiPeer.providerServiceApiProtocols = {

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -756,6 +756,21 @@ export class BuyerProxy {
       res.end()
       return
     }
+
+    if (path === '/_antseed/peers/refresh' && method === 'POST') {
+      try {
+        const peers = await this._refreshPeersNow()
+        await this._stateWriteChain
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: true, total: peers.length }))
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        res.writeHead(502, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: message }))
+      }
+      return
+    }
+
     if (path === '/_antseed/peers' && method === 'GET') {
       const peers = await this._getPeers()
       const payload = peers.map((p) => ({

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -69,6 +69,7 @@ const rendererUrl = process.env['VITE_DEV_SERVER_URL'] ?? `file://${path.join(__
 const APP_NAME = 'AntStation Desktop';
 const DESKTOP_DEBUG_ENV = 'ANTSEED_DESKTOP_DEBUG';
 const DESKTOP_DEBUG_FLAGS = new Set(['--debug-runtime', '--desktop-debug']);
+const DEFAULT_BUYER_PROXY_PORT = 8377;
 
 function isTruthyEnv(value: string | undefined): boolean {
   if (!value) {
@@ -192,6 +193,55 @@ function isPublicMetadataHost(rawHost: string): boolean {
   }
 
   return true;
+}
+
+async function resolveBuyerProxyPort(): Promise<number> {
+  try {
+    const config = await readConfig(ACTIVE_CONFIG_PATH);
+    const buyer = asRecord(config['buyer']);
+    const port = Number(buyer['proxyPort']);
+    if (Number.isInteger(port) && port > 0 && port <= 65535) {
+      return port;
+    }
+  } catch {
+    // Fall back to the default proxy port when config is unavailable.
+  }
+  return DEFAULT_BUYER_PROXY_PORT;
+}
+
+async function requestBuyerPeerRefresh(): Promise<void> {
+  const port = await resolveBuyerProxyPort();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 60_000);
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/_antseed/peers/refresh`, {
+      method: 'POST',
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let payload: Record<string, unknown> = {};
+    try {
+      payload = text ? JSON.parse(text) as Record<string, unknown> : {};
+    } catch {
+      payload = {};
+    }
+
+    if (!response.ok || payload['ok'] !== true) {
+      const error = typeof payload['error'] === 'string' && payload['error'].trim().length > 0
+        ? payload['error']
+        : `Buyer proxy returned HTTP ${response.status}`;
+      throw new Error(error);
+    }
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new Error(`Timed out refreshing peers via buyer proxy on port ${port}`);
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Unable to refresh peers via buyer proxy on port ${port}: ${message}`);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 // ── Runtime Activity & Log Wiring ──
@@ -899,10 +949,21 @@ registerPiChatHandlers({
 });
 
 ipcMain.handle('runtime:scan-network', async () => {
-  // The buyer runtime handles peer discovery; just return the current state.
-  await refreshPeerCache();
-  const snapshot = getNetworkSnapshot();
-  return { ok: snapshot.ok, data: snapshot, error: snapshot.error, status: 200 };
+  try {
+    await requestBuyerPeerRefresh();
+    await refreshPeerCache();
+    const snapshot = getNetworkSnapshot();
+    return { ok: snapshot.ok, data: snapshot, error: snapshot.error, status: 200 };
+  } catch (err) {
+    await refreshPeerCache();
+    const snapshot = getNetworkSnapshot();
+    return {
+      ok: false,
+      data: snapshot,
+      error: err instanceof Error ? err.message : String(err),
+      status: null,
+    };
+  }
 });
 
 app.whenReady().then(async () => {


### PR DESCRIPTION
## Description

Adds a buyer proxy control endpoint that forces an immediate peer refresh through the existing DHT discovery path. Updates the desktop Scan DHT action to call that endpoint before reloading the peer cache.

## Release Notes

- Fixed the desktop Scan DHT button so it performs a real peer discovery refresh instead of only rereading cached peer state.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
