### PR TITLE
feat(website): drop 'pay per request' from homepage tagline

### DIFF
--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -298,7 +298,7 @@ export default function Home(): JSX.Element {
   return (
     <Layout
       title={siteConfig.tagline}
-      description="The open market for AI inference. Serve or consume AI peer-to-peer. Pay per request in USDC. Anonymous. Private. No gatekeepers."
+      description="The open market for AI inference. Serve or consume AI peer-to-peer. Onchain payments. Verifiable reputation. Anonymous. Private. No gatekeepers."
       wrapperClassName="homepage-wrapper">
       <Head>
         <script type="application/ld+json">{JSON.stringify(faqLd)}</script>
@@ -307,7 +307,7 @@ export default function Home(): JSX.Element {
       {/* Hero */}
       <section className={styles.hero}>
         <h1 className={styles.heroTitle}>The open market for AI inference.</h1>
-        <p className={styles.heroSub}>Permissionless peer-to-peer. Pay per request in USDC.</p>
+        <p className={styles.heroSub}>Permissionless peer-to-peer. Onchain payments. Verifiable reputation.</p>
       </section>
 
       {/* Liveness */}


### PR DESCRIPTION
## Summary
- Replace the homepage hero subline and meta description: **"Permissionless peer-to-peer. Pay per request in USDC."** → **"Permissionless peer-to-peer. Onchain payments. Verifiable reputation."**
- Per-request framing locked us into one billing model; subscription/other settlement modes remain open. "Onchain payments" covers all of them, and the reputation layer is load-bearing enough to call out in the tagline.

## Test plan
- [x] Verified live in dev preview: hero shows new copy, meta description updated.
- [ ] Visual check on production after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)