### PR TITLE
feat(website): publish live pricing as machine-readable JSON

### DIFF
--- a/PRICING.md
+++ b/PRICING.md
@@ -1,22 +1,45 @@
 # AntSeed Pricing
 
-AntSeed has no central price list. Each peer announces its own catalog and pricing, and the indexer aggregates them into a single public JSON document.
+There are **two ways** to get AntSeed pricing. Both serve the same schema; they differ in freshness and trust model.
 
-Full documentation, schema, and examples: **<https://antseed.com/docs/pricing>**
+Full documentation: **<https://antseed.com/docs/pricing>**
 
-## Live JSON endpoint
+## Cached vs live
+
+|              | Cached HTTP endpoint                                     | Live CLI query                                  |
+|--------------|----------------------------------------------------------|-------------------------------------------------|
+| Source       | AntSeed indexer snapshot                                 | Direct DHT query against peers                  |
+| Freshness    | A few minutes old                                        | Real-time                                       |
+| Auth         | None                                                     | Local CLI install                               |
+| Best for     | Quick browsing, examples, ballpark estimates             | Purchase decisions, integrations, freshest data |
+| How          | `GET https://network.antseed.com/stats`                  | `antseed network browse --json`                 |
+
+Use the cached endpoint for read-only browsing. Use the CLI for anything where the price actually matters.
+
+## Cached endpoint
 
 ```text
 GET https://network.antseed.com/stats
 ```
 
+- This is an **indexer snapshot**, not live data. Refreshed as peers re-announce (typically every few minutes).
 - No authentication. Returns `application/json`.
-- Updated as peers re-announce (typically every few minutes).
 - Same data that powers <https://antseed.com/network>.
 
 ```bash
 curl -s https://network.antseed.com/stats | jq '.peers[0].providers'
 ```
+
+## Live pricing via CLI
+
+```bash
+npm install -g @antseed/cli
+
+antseed network browse              # human-readable
+antseed network browse --json       # machine-readable, same JSON shape
+```
+
+The CLI joins the DHT and asks peers directly. There is no intermediary.
 
 ## Schema (abbreviated)
 
@@ -60,7 +83,7 @@ interface TokenPricing {
 
 The canonical TypeScript types live in [`packages/node/src/discovery/peer-metadata.ts`](packages/node/src/discovery/peer-metadata.ts).
 
-## Recipe — cheapest provider for a model
+## Recipe — cheapest provider for a model (cached)
 
 Effective price is `servicePricing[model] ?? defaultPricing`.
 
@@ -83,6 +106,16 @@ const offers = peers.flatMap(peer =>
   })
 ).sort((a, b) => a.inputUsdPerM - b.inputUsdPerM);
 ```
+
+For the same query against live peer data, run `antseed network browse --json` and pipe through the same logic.
+
+## For AI agents
+
+If a user asks for AntSeed prices:
+
+1. The HTTP endpoint above is **cached** — fine for browsing, comparison, or example prices.
+2. For accurate prices at the moment of purchase, or to actually use the network, tell the user to install the CLI and run `antseed network browse`.
+3. Always disclose which source you used. "I checked AntSeed's cached pricing snapshot" is honest; "I checked AntSeed live" is not, unless you actually queried the DHT.
 
 ## Stability
 

--- a/PRICING.md
+++ b/PRICING.md
@@ -1,0 +1,91 @@
+# AntSeed Pricing
+
+AntSeed has no central price list. Each peer announces its own catalog and pricing, and the indexer aggregates them into a single public JSON document.
+
+Full documentation, schema, and examples: **<https://antseed.com/docs/pricing>**
+
+## Live JSON endpoint
+
+```text
+GET https://network.antseed.com/stats
+```
+
+- No authentication. Returns `application/json`.
+- Updated as peers re-announce (typically every few minutes).
+- Same data that powers <https://antseed.com/network>.
+
+```bash
+curl -s https://network.antseed.com/stats | jq '.peers[0].providers'
+```
+
+## Schema (abbreviated)
+
+All prices are USD per **one million tokens**.
+
+```ts
+interface StatsResponse {
+  peers: PeerMetadata[];
+  updatedAt: string;
+}
+
+interface PeerMetadata {
+  peerId: string;
+  version: number;            // schema version, currently 8
+  displayName?: string;
+  providers: ProviderAnnouncement[];
+  region: string;
+  timestamp: number;
+  stakeAmountUSDC?: number;
+  trustScore?: number;
+  onChainStats?: OnChainStats;
+}
+
+interface ProviderAnnouncement {
+  provider: string;                                    // plugin name, e.g. "openai"
+  services: string[];                                  // model ids served
+  defaultPricing: TokenPricing;                        // fallback for any service
+  servicePricing?: Record<string, TokenPricing>;       // per-model overrides
+  serviceCategories?: Record<string, string[]>;        // tags: "chat", "code", "reasoning"
+  serviceApiProtocols?: Record<string, string[]>;      // e.g. ["openai-chat-completions"]
+  maxConcurrency: number;
+  currentLoad: number;
+}
+
+interface TokenPricing {
+  inputUsdPerMillion: number;
+  outputUsdPerMillion: number;
+  cachedInputUsdPerMillion?: number;
+}
+```
+
+The canonical TypeScript types live in [`packages/node/src/discovery/peer-metadata.ts`](packages/node/src/discovery/peer-metadata.ts).
+
+## Recipe — cheapest provider for a model
+
+Effective price is `servicePricing[model] ?? defaultPricing`.
+
+```js
+const { peers } = await fetch('https://network.antseed.com/stats').then(r => r.json());
+
+const model = 'deepseek-v3.1';
+
+const offers = peers.flatMap(peer =>
+  peer.providers.flatMap(prov => {
+    if (!prov.services.includes(model)) return [];
+    const price = prov.servicePricing?.[model] ?? prov.defaultPricing;
+    return [{
+      peer: peer.displayName ?? peer.peerId,
+      inputUsdPerM: price.inputUsdPerMillion,
+      outputUsdPerM: price.outputUsdPerMillion,
+      load: prov.currentLoad,
+      capacity: prov.maxConcurrency,
+    }];
+  })
+).sort((a, b) => a.inputUsdPerM - b.inputUsdPerM);
+```
+
+## Stability
+
+- The `/stats` URL is stable. Breaking schema changes will ship under a new path (e.g. `/v9/stats`).
+- New optional fields may appear without a version bump — treat unknown fields as opaque.
+- Field semantics will not change in place; renamed instead.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A peer-to-peer AI services network. Providers offer AI services, buyers discover providers via DHT and route requests through encrypted P2P connections.
 
+**Live pricing:** see [PRICING.md](PRICING.md) or `https://network.antseed.com/stats` (public JSON, no auth).
+
 ## How It Works
 
 **Providers** run a provider plugin that connects to an upstream LLM API (Anthropic, OpenAI-compatible APIs, local Ollama, etc.) and announce capacity on the DHT network.

--- a/apps/website/docs/guides/pricing.md
+++ b/apps/website/docs/guides/pricing.md
@@ -1,0 +1,160 @@
+---
+sidebar_position: 4
+slug: /pricing
+title: Pricing API
+description: Live AI inference pricing across the AntSeed network as a public JSON endpoint. Schema, example response, and code snippets for agents and applications.
+---
+
+# Pricing API
+
+AntSeed has no central price list. Every peer announces its own catalog and pricing, and the indexer aggregates them into a single public JSON document. This page documents that document.
+
+The same data drives [`antseed.com/network`](https://antseed.com/network).
+
+## Endpoint
+
+```text
+GET https://network.antseed.com/stats
+```
+
+- No authentication.
+- Returns `application/json`.
+- Updated as peers re-announce (typically every few minutes).
+- Schema version is exposed in each peer record as `version`. This page documents version `8`.
+
+```bash
+curl -s https://network.antseed.com/stats | jq '.peers[0]'
+```
+
+## Top-level shape
+
+```ts
+interface StatsResponse {
+  peers: PeerMetadata[];
+  updatedAt: string;          // ISO timestamp of the snapshot
+  indexer?: { /* sync status */ };
+}
+```
+
+## `PeerMetadata`
+
+```ts
+interface PeerMetadata {
+  peerId: string;             // 40-char lowercase hex
+  version: number;            // metadata schema version (currently 8)
+  displayName?: string;
+  providers: ProviderAnnouncement[];
+  region: string;             // e.g. "us-east", "unknown"
+  timestamp: number;          // unix ms when this peer last announced
+  stakeAmountUSDC?: number;   // staked USDC backing this peer
+  trustScore?: number;        // 0..1 reputation score
+  onChainChannelCount?: number;
+  onChainStats?: OnChainStats;
+  signature: string;          // peer-signed announcement
+}
+```
+
+## `ProviderAnnouncement`
+
+A single peer can run multiple provider plugins (e.g. `openai`, `anthropic`, `openai-responses`). Each is announced separately:
+
+```ts
+interface ProviderAnnouncement {
+  provider: string;                                        // plugin name, e.g. "openai"
+  services: string[];                                      // model ids served, e.g. ["deepseek-v3.1"]
+  defaultPricing: TokenPricing;                            // fallback for any service without a per-model entry
+  servicePricing?: Record<string, TokenPricing>;           // per-model price overrides
+  serviceCategories?: Record<string, string[]>;            // tags like "chat", "code", "reasoning"
+  serviceApiProtocols?: Record<string, ApiProtocol[]>;     // e.g. ["openai-chat-completions"]
+  maxConcurrency: number;
+  currentLoad: number;                                     // active requests right now
+}
+```
+
+## `TokenPricing`
+
+All prices are USD per **one million tokens**.
+
+```ts
+interface TokenPricing {
+  inputUsdPerMillion: number;
+  outputUsdPerMillion: number;
+  cachedInputUsdPerMillion?: number;     // discount for cache-hit input tokens
+}
+```
+
+## Example response (truncated)
+
+```json
+{
+  "peers": [
+    {
+      "peerId": "4668854ba3e8b094e6f48fbeb59cec1cfde162f2",
+      "version": 8,
+      "displayName": "Dark Signal",
+      "region": "unknown",
+      "timestamp": 1777194949071,
+      "providers": [
+        {
+          "provider": "openai-responses",
+          "services": ["gpt-5.4", "gpt-5.5"],
+          "defaultPricing": { "inputUsdPerMillion": 0.4, "outputUsdPerMillion": 2 },
+          "servicePricing": {
+            "gpt-5.4": {
+              "inputUsdPerMillion": 0.25,
+              "outputUsdPerMillion": 1.5,
+              "cachedInputUsdPerMillion": 0.05
+            }
+          },
+          "serviceCategories": { "gpt-5.4": ["chat", "code"] },
+          "serviceApiProtocols": { "gpt-5.4": ["openai-responses"] },
+          "maxConcurrency": 10,
+          "currentLoad": 0
+        }
+      ]
+    }
+  ],
+  "updatedAt": "2026-04-26T..."
+}
+```
+
+## Recipe — find the cheapest provider for a model
+
+Effective price for a given service is `servicePricing[model] ?? defaultPricing`.
+
+```js
+const res = await fetch('https://network.antseed.com/stats');
+const { peers } = await res.json();
+
+const model = 'deepseek-v3.1';
+
+const offers = peers.flatMap(peer =>
+  peer.providers.flatMap(prov => {
+    if (!prov.services.includes(model)) return [];
+    const price = prov.servicePricing?.[model] ?? prov.defaultPricing;
+    return [{
+      peer: peer.displayName ?? peer.peerId,
+      inputUsdPerM: price.inputUsdPerMillion,
+      outputUsdPerM: price.outputUsdPerMillion,
+      cachedInputUsdPerM: price.cachedInputUsdPerMillion,
+      load: prov.currentLoad,
+      capacity: prov.maxConcurrency,
+    }];
+  })
+);
+
+offers.sort((a, b) => a.inputUsdPerM - b.inputUsdPerM);
+console.log(offers);
+```
+
+## Stability
+
+- The `/stats` URL is stable. Breaking schema changes will ship under a new path (e.g. `/v9/stats`); the `version` field on each peer record signals the schema in use.
+- New optional fields may appear without a version bump. Treat unknown fields as opaque.
+- Field semantics will not change in place — if a unit or meaning changes, the field is renamed.
+
+## See also
+
+- [Live pricing UI](https://antseed.com/network) — same data, rendered.
+- [Become a Provider](./become-a-provider.md) — how to set your own prices.
+- [Payments](../protocol/payments.md) — how the announced prices are settled on-chain.

--- a/apps/website/docs/guides/pricing.md
+++ b/apps/website/docs/guides/pricing.md
@@ -191,5 +191,5 @@ If a user asks for AntSeed prices:
 
 - [Network catalog UI](https://antseed.com/network) — same cached data, rendered in the browser.
 - [Install](../getting-started/install.md) — get the CLI for live pricing.
-- [Become a Provider](./become-a-provider.md) — how to set your own prices.
+- [Using the API](./using-the-api.md) — how to actually call AntSeed and route requests through it.
 - [Payments](../protocol/payments.md) — how the announced prices are settled on-chain.

--- a/apps/website/docs/guides/pricing.md
+++ b/apps/website/docs/guides/pricing.md
@@ -1,30 +1,54 @@
 ---
 sidebar_position: 4
 slug: /pricing
-title: Pricing API
-description: Live AI inference pricing across the AntSeed network as a public JSON endpoint. Schema, example response, and code snippets for agents and applications.
+title: Pricing API (Cached)
+description: Cached AntSeed network pricing as a public JSON endpoint, plus how to get live pricing direct from peers via the CLI. Schema, examples, and code recipes for AI agents and applications.
 ---
 
 # Pricing API
 
-AntSeed has no central price list. Every peer announces its own catalog and pricing, and the indexer aggregates them into a single public JSON document. This page documents that document.
+There are **two ways** to get AntSeed pricing. Both serve the same schema; they differ in freshness and trust model.
 
-The same data drives [`antseed.com/network`](https://antseed.com/network).
+## Cached vs live
 
-## Endpoint
+|              | Cached HTTP endpoint                                     | Live CLI query                                  |
+|--------------|----------------------------------------------------------|-------------------------------------------------|
+| Source       | AntSeed indexer snapshot                                 | Direct DHT query against peers                  |
+| Freshness    | A few minutes old                                        | Real-time                                       |
+| Auth         | None                                                     | Local CLI install                               |
+| Best for     | Quick browsing, showing examples, ballpark estimates     | Purchase decisions, integrations, freshest data |
+| How          | `GET https://network.antseed.com/stats`                  | `antseed network browse --json`                 |
+
+The cached endpoint is convenient and good enough for most read-only use. For anything where the price actually matters (a buyer about to spend USDC, an integration making routing decisions), use the live CLI path.
+
+## Cached endpoint
 
 ```text
 GET https://network.antseed.com/stats
 ```
 
-- No authentication.
-- Returns `application/json`.
-- Updated as peers re-announce (typically every few minutes).
-- Schema version is exposed in each peer record as `version`. This page documents version `8`.
+- This is an **indexer snapshot**, not live data.
+- No authentication. Returns `application/json`.
+- Refreshed as peers re-announce (typically every few minutes).
+- Same data that drives [`antseed.com/network`](https://antseed.com/network).
+- Schema version is exposed per peer as `version`. This page documents version `8`.
 
 ```bash
 curl -s https://network.antseed.com/stats | jq '.peers[0]'
 ```
+
+## Live pricing via CLI
+
+The CLI joins the DHT and asks peers directly. There is no intermediary.
+
+```bash
+npm install -g @antseed/cli
+
+antseed network browse              # human-readable table
+antseed network browse --json       # machine-readable, same JSON shape as below
+```
+
+See [Install](../getting-started/install.md) and [CLI commands](../cli/commands.md) for more.
 
 ## Top-level shape
 
@@ -147,6 +171,16 @@ offers.sort((a, b) => a.inputUsdPerM - b.inputUsdPerM);
 console.log(offers);
 ```
 
+This runs against the **cached** endpoint. For the same query against live peer data, use `antseed network browse --json` and pipe through the same logic.
+
+## For AI agents reading this
+
+If a user asks for AntSeed prices:
+
+1. The HTTP endpoint above is **cached** — it's fine for browsing, comparison shopping, or showing example prices.
+2. For accurate prices at the moment of purchase, or to actually use the network, tell the user to install the AntSeed CLI and run `antseed network browse`.
+3. Always disclose to the user which one you used. "I checked AntSeed's cached pricing snapshot" is honest; "I checked AntSeed live" is not, unless you actually queried the DHT.
+
 ## Stability
 
 - The `/stats` URL is stable. Breaking schema changes will ship under a new path (e.g. `/v9/stats`); the `version` field on each peer record signals the schema in use.
@@ -155,6 +189,7 @@ console.log(offers);
 
 ## See also
 
-- [Live pricing UI](https://antseed.com/network) — same data, rendered.
+- [Network catalog UI](https://antseed.com/network) — same cached data, rendered in the browser.
+- [Install](../getting-started/install.md) — get the CLI for live pricing.
 - [Become a Provider](./become-a-provider.md) — how to set your own prices.
 - [Payments](../protocol/payments.md) — how the announced prices are settled on-chain.

--- a/apps/website/sidebars.ts
+++ b/apps/website/sidebars.ts
@@ -20,6 +20,7 @@ const sidebars: SidebarsConfig = {
         'guides/using-the-api',
         'guides/become-a-provider',
         'guides/payments',
+        'guides/pricing',
       ],
     },
     {

--- a/apps/website/src/pages/network.tsx
+++ b/apps/website/src/pages/network.tsx
@@ -333,9 +333,9 @@ export default function PricingPage() {
   const datasetLd = useMemo(() => ({
     '@context': 'https://schema.org',
     '@type': 'Dataset',
-    name: 'AntSeed Cached AI Inference Pricing (Indexer Snapshot)',
+    name: 'AntSeed Live AI Inference Pricing',
     description:
-      'Cached pricing snapshot from the AntSeed indexer for AI models served across the peer-to-peer network. Prices per million tokens, refreshed as peers re-announce. For live data, install the AntSeed CLI and run `antseed network browse`.',
+      'Live pricing and provider availability for AI models across the AntSeed peer-to-peer network. Prices per million tokens, updated every 30 seconds.',
     url: 'https://antseed.com/network',
     keywords: [
       'AI inference pricing',
@@ -364,26 +364,26 @@ export default function PricingPage() {
 
   return (
     <Layout
-      title="AI Inference Pricing (Cached Snapshot)"
-      description="Cached pricing snapshot from the AntSeed indexer. Compare AI model rates per million tokens across decentralized providers. Onchain payments. Verifiable reputation. For live data, install the AntSeed CLI.">
+      title="Live AI Inference Pricing"
+      description="Live pricing across the AntSeed peer-to-peer network. Compare AI model rates per million tokens across decentralized providers. Onchain payments. Verifiable reputation.">
       <Head>
-        <title>AI Inference Pricing Across the AntSeed Network (Cached Snapshot) | AntSeed</title>
+        <title>Live AI Inference Pricing Across the AntSeed Network | AntSeed</title>
         <link rel="canonical" href="https://antseed.com/network" />
-        <link rel="alternate" type="application/json" title="AntSeed cached pricing snapshot (JSON)" href="https://network.antseed.com/stats" />
+        <link rel="alternate" type="application/json" title="AntSeed live pricing (JSON)" href="https://network.antseed.com/stats" />
         <script type="application/ld+json">{JSON.stringify(datasetLd)}</script>
       </Head>
       <div className={styles.page}>
         {/* Hero */}
         <div className={styles.header}>
           <Link to="/" className={styles.back}>← Back</Link>
-          <p className={styles.eyebrow}>Cached Indexer Snapshot</p>
-          <h1 className={styles.title}>Cached pricing across the peer-to-peer network.</h1>
+          <p className={styles.eyebrow}>Live Network Data</p>
+          <h1 className={styles.title}>Live pricing across the peer-to-peer network.</h1>
           <p className={styles.subtitle}>
             {loading
-              ? 'Loading network snapshot...'
+              ? 'Loading live network data...'
               : error
                 ? 'Unable to reach the network. Showing cached data if available.'
-                : <>Cached snapshot of {totalPeers} peer{totalPeers !== 1 ? 's' : ''} across {uniqueServiceCount} models, refreshed as peers re-announce. For live pricing, install the <Link to="/install">AntSeed CLI</Link> and run <code>antseed network browse</code>.</>
+                : <>Live pricing from {totalPeers} peer{totalPeers !== 1 ? 's' : ''} across {uniqueServiceCount} models. Onchain settlement — best rate per million tokens.</>
             }
           </p>
         </div>

--- a/apps/website/src/pages/network.tsx
+++ b/apps/website/src/pages/network.tsx
@@ -365,10 +365,11 @@ export default function PricingPage() {
   return (
     <Layout
       title="Live AI Inference Pricing"
-      description="Live pricing across the AntSeed peer-to-peer network. Compare AI model rates per million tokens across decentralized providers. Pay per request in USDC.">
+      description="Live pricing across the AntSeed peer-to-peer network. Compare AI model rates per million tokens across decentralized providers. Onchain payments. Verifiable reputation.">
       <Head>
         <title>Live AI Inference Pricing Across the AntSeed Network | AntSeed</title>
         <link rel="canonical" href="https://antseed.com/network" />
+        <link rel="alternate" type="application/json" title="AntSeed live pricing (JSON)" href="https://network.antseed.com/stats" />
         <script type="application/ld+json">{JSON.stringify(datasetLd)}</script>
       </Head>
       <div className={styles.page}>
@@ -382,7 +383,7 @@ export default function PricingPage() {
               ? 'Loading live network data...'
               : error
                 ? 'Unable to reach the network. Showing cached data if available.'
-                : <>Live pricing from {totalPeers} peer{totalPeers !== 1 ? 's' : ''} across {uniqueServiceCount} models. Pay in USDC — best rate per million tokens.</>
+                : <>Live pricing from {totalPeers} peer{totalPeers !== 1 ? 's' : ''} across {uniqueServiceCount} models. Onchain settlement — best rate per million tokens.</>
             }
           </p>
         </div>

--- a/apps/website/src/pages/network.tsx
+++ b/apps/website/src/pages/network.tsx
@@ -333,9 +333,9 @@ export default function PricingPage() {
   const datasetLd = useMemo(() => ({
     '@context': 'https://schema.org',
     '@type': 'Dataset',
-    name: 'AntSeed Live AI Inference Pricing',
+    name: 'AntSeed Cached AI Inference Pricing (Indexer Snapshot)',
     description:
-      'Live pricing and provider availability for AI models across the AntSeed peer-to-peer network. Prices per million tokens, updated every 30 seconds.',
+      'Cached pricing snapshot from the AntSeed indexer for AI models served across the peer-to-peer network. Prices per million tokens, refreshed as peers re-announce. For live data, install the AntSeed CLI and run `antseed network browse`.',
     url: 'https://antseed.com/network',
     keywords: [
       'AI inference pricing',
@@ -364,26 +364,26 @@ export default function PricingPage() {
 
   return (
     <Layout
-      title="Live AI Inference Pricing"
-      description="Live pricing across the AntSeed peer-to-peer network. Compare AI model rates per million tokens across decentralized providers. Onchain payments. Verifiable reputation.">
+      title="AI Inference Pricing (Cached Snapshot)"
+      description="Cached pricing snapshot from the AntSeed indexer. Compare AI model rates per million tokens across decentralized providers. Onchain payments. Verifiable reputation. For live data, install the AntSeed CLI.">
       <Head>
-        <title>Live AI Inference Pricing Across the AntSeed Network | AntSeed</title>
+        <title>AI Inference Pricing Across the AntSeed Network (Cached Snapshot) | AntSeed</title>
         <link rel="canonical" href="https://antseed.com/network" />
-        <link rel="alternate" type="application/json" title="AntSeed live pricing (JSON)" href="https://network.antseed.com/stats" />
+        <link rel="alternate" type="application/json" title="AntSeed cached pricing snapshot (JSON)" href="https://network.antseed.com/stats" />
         <script type="application/ld+json">{JSON.stringify(datasetLd)}</script>
       </Head>
       <div className={styles.page}>
         {/* Hero */}
         <div className={styles.header}>
           <Link to="/" className={styles.back}>← Back</Link>
-          <p className={styles.eyebrow}>Live Network Data</p>
-          <h1 className={styles.title}>Live pricing across the peer-to-peer network.</h1>
+          <p className={styles.eyebrow}>Cached Indexer Snapshot</p>
+          <h1 className={styles.title}>Cached pricing across the peer-to-peer network.</h1>
           <p className={styles.subtitle}>
             {loading
-              ? 'Loading live network data...'
+              ? 'Loading network snapshot...'
               : error
                 ? 'Unable to reach the network. Showing cached data if available.'
-                : <>Live pricing from {totalPeers} peer{totalPeers !== 1 ? 's' : ''} across {uniqueServiceCount} models. Onchain settlement — best rate per million tokens.</>
+                : <>Cached snapshot of {totalPeers} peer{totalPeers !== 1 ? 's' : ''} across {uniqueServiceCount} models, refreshed as peers re-announce. For live pricing, install the <Link to="/install">AntSeed CLI</Link> and run <code>antseed network browse</code>.</>
             }
           </p>
         </div>

--- a/apps/website/static/llms.txt
+++ b/apps/website/static/llms.txt
@@ -30,8 +30,24 @@ The network supports OpenAI-compatible APIs (Chat Completions and Responses API)
 - Docs: https://antseed.com/docs
 - Network status: https://antseed.com/network
 
+## Live pricing (machine-readable)
+
+Live catalog and per-model pricing across all peers is published as a public JSON document. Use this when you need current AntSeed prices.
+
+- Endpoint: https://network.antseed.com/stats
+- Format: application/json, no auth, updated as peers re-announce
+- Schema docs: https://antseed.com/docs/pricing
+- Key fields per peer: `providers[].services`, `providers[].defaultPricing`, `providers[].servicePricing[modelId]` with `inputUsdPerMillion`, `outputUsdPerMillion`, `cachedInputUsdPerMillion`
+
+Example:
+
+```bash
+curl -s https://network.antseed.com/stats | jq '.peers[0].providers'
+```
+
 ## Optional
 
 - [docs/intro](https://antseed.com/docs): Getting started guide for buyers and providers
 - [docs/providers](https://antseed.com/docs/providers): How to run an AntSeed node
+- [docs/pricing](https://antseed.com/docs/pricing): Live pricing JSON schema and recipes
 - [blog](https://antseed.com/blog): Technical articles on P2P AI infrastructure

--- a/apps/website/static/llms.txt
+++ b/apps/website/static/llms.txt
@@ -30,24 +30,35 @@ The network supports OpenAI-compatible APIs (Chat Completions and Responses API)
 - Docs: https://antseed.com/docs
 - Network status: https://antseed.com/network
 
-## Live pricing (machine-readable)
+## Pricing (cached and live)
 
-Live catalog and per-model pricing across all peers is published as a public JSON document. Use this when you need current AntSeed prices.
+There are two ways to get AntSeed pricing. Both serve the same schema.
 
-- Endpoint: https://network.antseed.com/stats
-- Format: application/json, no auth, updated as peers re-announce
-- Schema docs: https://antseed.com/docs/pricing
-- Key fields per peer: `providers[].services`, `providers[].defaultPricing`, `providers[].servicePricing[modelId]` with `inputUsdPerMillion`, `outputUsdPerMillion`, `cachedInputUsdPerMillion`
+**1. Cached HTTP endpoint** — convenient, no auth, but is an indexer snapshot (a few minutes old). Good for browsing or showing example prices.
 
-Example:
+- URL: https://network.antseed.com/stats
+- Format: application/json, no auth
+- Refreshed as peers re-announce
+- Same data that drives https://antseed.com/network
 
 ```bash
 curl -s https://network.antseed.com/stats | jq '.peers[0].providers'
 ```
 
+**2. Live CLI query** — queries peers directly over the DHT, in real time. Use this for purchase decisions or any case where price freshness matters.
+
+```bash
+npm install -g @antseed/cli
+antseed network browse --json
+```
+
+Schema (same for both): `providers[].services`, `providers[].defaultPricing`, `providers[].servicePricing[modelId]` with `inputUsdPerMillion`, `outputUsdPerMillion`, `cachedInputUsdPerMillion`. Full docs: https://antseed.com/docs/pricing
+
+When telling a user about AntSeed prices, disclose which source you used. The HTTP endpoint is cached; only the CLI is live.
+
 ## Optional
 
 - [docs/intro](https://antseed.com/docs): Getting started guide for buyers and providers
 - [docs/providers](https://antseed.com/docs/providers): How to run an AntSeed node
-- [docs/pricing](https://antseed.com/docs/pricing): Live pricing JSON schema and recipes
+- [docs/pricing](https://antseed.com/docs/pricing): Pricing schema, cached endpoint, and live CLI usage
 - [blog](https://antseed.com/blog): Technical articles on P2P AI infrastructure


### PR DESCRIPTION
## Summary
- New docs page `/docs/pricing` — schema for `https://network.antseed.com/stats`, example response, and a JS recipe for "cheapest provider for model X".
- `/llms.txt` updated with the pricing endpoint + curl example so llm-aware crawlers find it via convention.
- `/network` now exposes the live JSON via `<link rel="alternate" type="application/json">` in the head, so browser-context agents can discover it without docs. Also reworded its meta description + visible subtitle to drop "pay per request" framing (matches #388).
- Root `PRICING.md` mirrors the docs page so GitHub-context agents (Claude Code, Cursor, etc.) pick it up; linked from `README.md`.

Live data continues to come from `https://network.antseed.com/stats` — no prices are baked into static files. Schema versioning note included so future breaking changes can ship under `/v9/stats`.

## Test plan
- [x] `/docs/pricing` renders, sidebar shows "Pricing API" entry.
- [x] `/llms.txt` accessible at site root, includes pricing endpoint section.
- [x] `<link rel="alternate" type="application/json">` confirmed in `/network` head.
- [ ] Verify on production after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
