### PR TITLE
docs(cli): document 'antseed network peer' for full peer details

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -33,7 +33,8 @@ Command-line interface and web dashboard for the AntSeed Network — a P2P netwo
 | `antseed buyer status` | Show buyer status |
 | `antseed config` | Manage configuration |
 | `antseed profile` | Manage your peer profile |
-| `antseed peer <peerId>` | Show a peer profile |
+| `antseed peer <peerId>` | Show a peer's profile (lightweight) |
+| `antseed network peer <peerId>` | Show full peer details (providers, services, on-chain stats) |
 | `antseed dashboard` | Start the web dashboard |
 | `antseed buyer channels` | List payment channels |
 | `antseed seller emissions info` | View ANTS emissions and epoch info |


### PR DESCRIPTION
The commands table only listed `antseed peer <peerId>` (lightweight profile view). The richer `antseed network peer <peerId>` — which shows providers, services, and on-chain stats — wasn't documented in the CLI README, even though it's the one users actually need when picking a seller from `antseed network browse`.

Adds a row for it next to the existing one, and clarifies that `antseed peer` is the lightweight version.

Discovered while writing the [`pi-antseed`](https://github.com/AntSeed/pi-antseed) buyer-side README.