### PR TITLE
fix(node): sequential peer discovery with wildcard-first warm-up

### DIFF
--- a/packages/node/src/discovery/peer-lookup.ts
+++ b/packages/node/src/discovery/peer-lookup.ts
@@ -56,27 +56,46 @@ export class PeerLookup {
   /**
    * Enumerate every peer on the network.
    *
-   * Each subnet topic only holds ~total/SUBNET_COUNT announcers, which keeps
-   * us well under the K-closest saturation limit that made the single
-   * wildcard topic return inconsistent subsets. The wildcard lookup is kept
-   * in parallel as a transition fallback so buyers running this build still
-   * see peers on older sellers that haven't started announcing on a subnet
-   * topic yet. `resolveLookupResults` deduplicates by `host:port` before
-   * resolving metadata, so the union has no extra cost beyond the parallel
-   * lookups themselves.
+   * The lookup runs in two stages, sequentially:
    *
-   * `DHTNode.lookupMany` shares a single temporary "peer" listener across
-   * the fan-out so subnet enumeration does not trip EventEmitter's default
-   * listener limit. Failures inside `lookupMany` (per-infohash callback
-   * errors) are absorbed and contribute zero endpoints, so a misbehaving
-   * subnet doesn't black-hole the whole enumeration.
+   *   1. Wildcard topic, alone. Its broad reach pulls many peers and warms
+   *      the local DHT routing table with nodes that already know about
+   *      AntSeed traffic.
+   *   2. Each subnet topic, one at a time, against that hot routing table.
+   *      Each subnet only holds ~total/SUBNET_COUNT announcers, which keeps
+   *      us well under the K-closest saturation limit that made the single
+   *      wildcard topic return inconsistent subsets at scale.
+   *
+   * Why sequential: firing all 17 infohashes through `lookupMany` in one
+   * shot starved each iterative lookup of UDP socket bandwidth and shared
+   * a single 25s budget across the batch. Most subnet lookups never
+   * converged before the timeout, and `findAll()` typically returned only
+   * the one or two subnets nearest the local node ID. Sequential gives
+   * each lookup a full operation timeout and the entire UDP socket — every
+   * iterative lookup converges, and we get a complete picture, at the
+   * cost of higher wall-clock on cold starts.
+   *
+   * `resolveLookupResults` deduplicates by `host:port` before resolving
+   * metadata, so the union still has the same cost as before.
    */
   async findAll(): Promise<LookupResult[]> {
-    const hashes = [
-      ...Array.from({ length: SUBNET_COUNT }, (_, i) => topicToInfoHash(subnetTopic(i))),
+    const merged: PeerEndpoint[] = [];
+
+    // Stage 1: wildcard, on its own. Warms the routing table.
+    const wildcardEndpoints = await this.config.dht.lookup(
       topicToInfoHash(ANTSEED_WILDCARD_TOPIC),
-    ];
-    const merged = await this.config.dht.lookupMany(hashes);
+    );
+    merged.push(...wildcardEndpoints);
+
+    // Stage 2: per-subnet, sequential. Each lookup gets full UDP bandwidth
+    // and a fresh per-lookup timeout.
+    for (let i = 0; i < SUBNET_COUNT; i++) {
+      const subnetEndpoints = await this.config.dht.lookup(
+        topicToInfoHash(subnetTopic(i)),
+      );
+      merged.push(...subnetEndpoints);
+    }
+
     return this.resolveLookupResults(shuffle(merged));
   }
 

--- a/packages/node/tests/peer-lookup.test.ts
+++ b/packages/node/tests/peer-lookup.test.ts
@@ -39,8 +39,7 @@ describe('PeerLookup', () => {
   it('findAll fans out across every subnet (and the wildcard) and unions the results', async () => {
     // Build a synthetic network where each subnet topic returns one unique
     // endpoint, plus the wildcard topic returns one legacy endpoint that
-    // wasn't sharded yet. The wall-clock cost of each lookup is identical;
-    // we just need to verify the union and fan-out shape.
+    // wasn't sharded yet. We verify the union and fan-out shape.
     const subnetEndpoints: Record<string, PeerEndpoint> = {};
     for (let i = 0; i < SUBNET_COUNT; i++) {
       subnetEndpoints[topicToInfoHash(subnetTopic(i)).toString('hex')] = {
@@ -51,6 +50,9 @@ describe('PeerLookup', () => {
     const wildcardEndpoint: PeerEndpoint = { host: '10.99.99.1', port: 6882 };
     const wildcardHashHex = topicToInfoHash(ANTSEED_WILDCARD_TOPIC).toString('hex');
 
+    // findAll now calls dht.lookup(infoHash) (single-hash) sequentially
+    // — once for the wildcard, then once per subnet. Each call goes
+    // through lookupMany under the hood (which `lookup` delegates to).
     const lookupMany = vi.fn(async (hashes: Buffer[]) => {
       const merged: PeerEndpoint[] = [];
       for (const hash of hashes) {
@@ -61,7 +63,8 @@ describe('PeerLookup', () => {
       }
       return merged;
     });
-    const dht = { lookupMany } as unknown as DHTNode;
+    const lookup = vi.fn(async (hash: Buffer) => lookupMany([hash]));
+    const dht = { lookup, lookupMany } as unknown as DHTNode;
 
     const resolve = vi.fn(async () => buildMetadata());
     const metadataResolver: MetadataResolver = { resolve };
@@ -75,8 +78,8 @@ describe('PeerLookup', () => {
     });
 
     const results = await peerLookup.findAll();
-    expect(lookupMany).toHaveBeenCalledTimes(1);
-    expect(lookupMany.mock.calls[0]?.[0]).toHaveLength(SUBNET_COUNT + 1);
+    // Sequential fan-out: 1 wildcard + 16 subnets = 17 calls total.
+    expect(lookup).toHaveBeenCalledTimes(SUBNET_COUNT + 1);
     expect(results).toHaveLength(SUBNET_COUNT + 1);
     const hosts = results.map((r) => r.host).sort();
     const expectedHosts = [
@@ -86,18 +89,44 @@ describe('PeerLookup', () => {
     expect(hosts).toEqual(expectedHosts);
   });
 
+  it('findAll queries the wildcard first, then subnet topics in order', async () => {
+    // The wildcard runs alone first to warm the local DHT routing table
+    // with nodes that already know about AntSeed traffic; subsequent
+    // per-subnet lookups converge much faster against that hot cache.
+    // If this ordering regresses, sequential subnet lookups go back to
+    // converging slowly on a cold routing table.
+    const lookup = vi.fn(async (_hash: Buffer): Promise<PeerEndpoint[]> => []);
+    const dht = { lookup } as unknown as DHTNode;
+    const peerLookup = new PeerLookup({
+      dht,
+      metadataResolver: { resolve: vi.fn() },
+      requireValidSignature: false,
+      allowStaleMetadata: true,
+      maxAnnouncementAgeMs: 60_000,
+      maxResults: 1000,
+    });
+    await peerLookup.findAll();
+
+    expect(lookup).toHaveBeenCalledTimes(SUBNET_COUNT + 1);
+    const calls = lookup.mock.calls.map(([h]) => (h as Buffer).toString('hex'));
+    expect(calls[0]).toBe(topicToInfoHash(ANTSEED_WILDCARD_TOPIC).toString('hex'));
+    for (let i = 0; i < SUBNET_COUNT; i++) {
+      expect(calls[i + 1]).toBe(topicToInfoHash(subnetTopic(i)).toString('hex'));
+    }
+  });
+
   it('findAll queries the exact set of subnet + wildcard topics announcer-side advertises', async () => {
     // Symmetry guard: the announcer chooses `subnetTopic(subnetOf(peerId))`
     // and the wildcard; the buyer must query every subnet topic plus the
     // wildcard, with no extras and no missing entries. If a future change
     // diverges the two sides (e.g. announcer adopts a new SUBNET_COUNT but
     // lookup is left behind), this test fails immediately.
-    let capturedHashes: Buffer[] = [];
-    const lookupMany = vi.fn(async (hashes: Buffer[]) => {
-      capturedHashes = hashes;
+    const capturedHashes: Buffer[] = [];
+    const lookup = vi.fn(async (hash: Buffer) => {
+      capturedHashes.push(hash);
       return [] as PeerEndpoint[];
     });
-    const dht = { lookupMany } as unknown as DHTNode;
+    const dht = { lookup } as unknown as DHTNode;
 
     const peerLookup = new PeerLookup({
       dht,
@@ -126,12 +155,12 @@ describe('PeerLookup', () => {
     // findAll asks the DHT about. Combined with the symmetry test above, this
     // pins down the contract: announcer + lookup agree for every possible
     // peerId.
-    let capturedHashes: Buffer[] = [];
-    const lookupMany = vi.fn(async (hashes: Buffer[]) => {
-      capturedHashes = hashes;
+    const capturedHashes: Buffer[] = [];
+    const lookup = vi.fn(async (hash: Buffer) => {
+      capturedHashes.push(hash);
       return [] as PeerEndpoint[];
     });
-    const dht = { lookupMany } as unknown as DHTNode;
+    const dht = { lookup } as unknown as DHTNode;
     const peerLookup = new PeerLookup({
       dht,
       metadataResolver: { resolve: vi.fn() },
@@ -152,12 +181,12 @@ describe('PeerLookup', () => {
 
   it('findAll deduplicates a peer that appears on multiple topics (subnet + wildcard)', async () => {
     // Sellers running this build announce on both a subnet AND the wildcard
-    // during the transition. `lookupMany` returns the duplicate raw endpoint
-    // pair to the resolver, which must collapse it via the host:port dedup
-    // before issuing metadata fetches.
+    // during the transition. The sequential `lookup` returns the same
+    // endpoint from each topic, and the resolver must collapse it via the
+    // host:port dedup before issuing metadata fetches.
     const shared: PeerEndpoint = { host: '10.0.7.1', port: 6882 };
-    const lookupMany = vi.fn(async (hashes: Buffer[]) => hashes.map(() => shared));
-    const dht = { lookupMany } as unknown as DHTNode;
+    const lookup = vi.fn(async () => [shared]);
+    const dht = { lookup } as unknown as DHTNode;
 
     const resolve = vi.fn(async () => buildMetadata());
     const metadataResolver: MetadataResolver = { resolve };
@@ -171,7 +200,7 @@ describe('PeerLookup', () => {
     });
 
     const results = await peerLookup.findAll();
-    expect(lookupMany).toHaveBeenCalledTimes(1);
+    expect(lookup).toHaveBeenCalledTimes(SUBNET_COUNT + 1);
     expect(resolve).toHaveBeenCalledTimes(1);
     expect(results).toHaveLength(1);
     expect(results[0]?.host).toBe(shared.host);
@@ -269,8 +298,8 @@ describe('PeerLookup', () => {
 
   it('preserves metadata publicAddress so callers can prefer it over the DHT source host', async () => {
     const peers: PeerEndpoint[] = [{ host: '34.134.97.133', port: 6882 }];
-    const lookupMany = vi.fn(async () => peers);
-    const dht = { lookupMany } as unknown as DHTNode;
+    const lookup = vi.fn(async () => peers);
+    const dht = { lookup } as unknown as DHTNode;
 
     const resolve = vi.fn(async () => buildMetadata({ publicAddress: '34.27.100.162:6882' }));
     const metadataResolver: MetadataResolver = { resolve };


### PR DESCRIPTION
## Summary
`PeerLookup.findAll()` previously fanned out all 17 lookups (16 subnet topics + wildcard) through `DHTNode.lookupMany` sharing one UDP socket and a single 25 s budget. Each iterative `bittorrent-dht` lookup needs ~5–15 s of UDP traffic to converge; 17 of them contending for the same socket inside one shared timeout meant most subnet lookups never finished — `findAll()` typically returned only the subnet(s) nearest the local DHT node ID.

This PR splits `findAll()` into two sequential stages:
1. **Wildcard topic, alone.** Broad reach, warms the local routing table with nodes that already speak AntSeed.
2. **Each subnet topic, one at a time**, against that hot routing table. Full UDP socket and a fresh per-lookup timeout per subnet → every iterative lookup converges.

Trade-off: cold-start wall-clock can grow to ≈ N × per-lookup-timeout (worst case 17 × 25 s, typically much less). Steady-state / warm discovery is unchanged because the routing table is already populated.

## Observed in the wild
Subscriptions buyer cold-start log:
```
[proxy] Hydrated 6 peer(s) from buyer.state.json
[proxy] Discovering peers via DHT...
[Node] DHT returned 1 result(s)
[Node]   peer 4668854ba3e8... (Dark Signal)
```
Direct standalone DHT probes (one infohash at a time, see `/tmp/probe-mine.mjs` script run during diagnosis) returned **all three** of the user's peers (Dark Signal, Open Forge, The Seeder) on their respective subnet topics and on the wildcard. The parallel batch lost the other two to UDP contention.

## Tests
- New ordering test asserts wildcard first, then subnets 0..N in order — guards against regressing the routing-table-warm-up property.
- Existing fan-out / symmetry / dedup tests rewritten against the single-hash `dht.lookup` mock (`PeerLookup` no longer calls `lookupMany` for subnet enumeration; it calls `lookup(infoHash)` 17 times sequentially).

## Test plan
- [x] `pnpm test` in `@antseed/node` — 588 passed
- [x] Full `pnpm run typecheck` — clean
- [ ] After publish + roll: cold-start a buyer, confirm `[Node] DHT returned >1 result(s)` with all peers in the network surfaced.