### PR TITLE
fix(buyer): speed up discovery with background shard sweep

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -345,11 +345,16 @@ export class BuyerProxy {
       })
     })
 
-    this._node.on('peers:discovered', (peers: PeerInfo[]) => {
-      if (peers.length === 0) return
-      log(`Background discovery found ${peers.length} peer(s)`)
-      this._replacePeers(peers)
-    })
+    const eventNode = this._node as AntseedNode & {
+      on?: (event: 'peers:discovered', listener: (peers: PeerInfo[]) => void) => unknown
+    }
+    if (typeof eventNode.on === 'function') {
+      eventNode.on('peers:discovered', (peers: PeerInfo[]) => {
+        if (peers.length === 0) return
+        log(`Background discovery found ${peers.length} peer(s)`)
+        this._replacePeers(peers)
+      })
+    }
   }
 
   async start(): Promise<void> {

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -344,6 +344,12 @@ export class BuyerProxy {
         res.end(`Proxy error: ${err instanceof Error ? err.message : String(err)}`)
       })
     })
+
+    this._node.on('peers:discovered', (peers: PeerInfo[]) => {
+      if (peers.length === 0) return
+      log(`Background discovery found ${peers.length} peer(s)`)
+      this._replacePeers(peers)
+    })
   }
 
   async start(): Promise<void> {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/renderer/ui/AppShell.tsx
+++ b/apps/desktop/src/renderer/ui/AppShell.tsx
@@ -70,7 +70,7 @@ export function AppShell() {
     return <SetupScreen />;
   }
 
-  if (showOnboarding) {
+  /* if (showOnboarding) {
     return (
       <>
         <TitleBar />
@@ -85,7 +85,7 @@ export function AppShell() {
         <StreamingIndicator />
       </>
     );
-  }
+  } */
 
   return (
     <>

--- a/packages/node/src/discovery/http-metadata-resolver.ts
+++ b/packages/node/src/discovery/http-metadata-resolver.ts
@@ -3,7 +3,7 @@ import type { PeerMetadata } from './peer-metadata.js';
 import { debugWarn } from '../utils/debug.js';
 
 export interface HttpMetadataResolverConfig {
-  /** Timeout in ms for each metadata fetch. Default: 2000 */
+  /** Timeout in ms for each metadata fetch. Default: 750 */
   timeoutMs?: number;
   /** Port offset from the signaling port to the metadata HTTP port. Default: 0 (same port) */
   metadataPortOffset?: number;
@@ -11,6 +11,8 @@ export interface HttpMetadataResolverConfig {
   failureCooldownMs?: number;
   /** Upper bound for failure cooldown backoff. Default: 1800000 (30 minutes) */
   maxFailureCooldownMs?: number;
+  /** Maximum concurrent metadata fetches. Default: 24 */
+  maxConcurrent?: number;
 }
 
 type FailedEndpointState = {
@@ -23,16 +25,20 @@ export class HttpMetadataResolver implements MetadataResolver {
   private readonly metadataPortOffset: number;
   private readonly failureCooldownMs: number;
   private readonly maxFailureCooldownMs: number;
+  private readonly maxConcurrent: number;
   private readonly failedEndpoints: Map<string, FailedEndpointState>;
+  private activeCount = 0;
+  private readonly waiters: Array<() => void> = [];
 
   constructor(config?: HttpMetadataResolverConfig) {
-    this.timeoutMs = config?.timeoutMs ?? 2000;
+    this.timeoutMs = config?.timeoutMs ?? 750;
     this.metadataPortOffset = config?.metadataPortOffset ?? 0;
     this.failureCooldownMs = Math.max(0, config?.failureCooldownMs ?? 30_000);
     this.maxFailureCooldownMs = Math.max(
       this.failureCooldownMs,
       config?.maxFailureCooldownMs ?? 30 * 60_000,
     );
+    this.maxConcurrent = Math.max(1, config?.maxConcurrent ?? 24);
     this.failedEndpoints = new Map<string, FailedEndpointState>();
   }
 
@@ -51,6 +57,7 @@ export class HttpMetadataResolver implements MetadataResolver {
 
     const url = `http://${peer.host}:${metadataPort}/metadata`;
 
+    await this.acquireSlot();
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -75,6 +82,28 @@ export class HttpMetadataResolver implements MetadataResolver {
       return null;
     } finally {
       clearTimeout(timeout);
+      this.releaseSlot();
+    }
+  }
+
+  private async acquireSlot(): Promise<void> {
+    if (this.activeCount < this.maxConcurrent) {
+      this.activeCount += 1;
+      return;
+    }
+    await new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+    this.activeCount += 1;
+  }
+
+  private releaseSlot(): void {
+    if (this.activeCount > 0) {
+      this.activeCount -= 1;
+    }
+    const next = this.waiters.shift();
+    if (next) {
+      next();
     }
   }
 

--- a/packages/node/src/discovery/peer-lookup.ts
+++ b/packages/node/src/discovery/peer-lookup.ts
@@ -11,6 +11,7 @@ import {
 import type { PeerMetadata } from "./peer-metadata.js";
 import { encodeMetadataForSigning } from "./metadata-codec.js";
 import type { MetadataResolver, PeerEndpoint } from "./metadata-resolver.js";
+import { debugLog } from "../utils/debug.js";
 
 function shuffle<T>(arr: T[]): T[] {
   const out = arr.slice();
@@ -28,6 +29,12 @@ export interface LookupConfig {
   allowStaleMetadata: boolean;
   maxAnnouncementAgeMs: number;
   maxResults: number;
+  /**
+   * Optional foreground DHT budget for findAll(). Each individual lookup still
+   * gets the DHT's full operation timeout; the budget only controls how many
+   * subnet shards we attempt before returning the peers already found.
+   */
+  maxFindAllDhtDurationMs?: number;
 }
 
 export const DEFAULT_LOOKUP_CONFIG: Omit<LookupConfig, "dht" | "metadataResolver"> = {
@@ -38,6 +45,10 @@ export const DEFAULT_LOOKUP_CONFIG: Omit<LookupConfig, "dht" | "metadataResolver
   // keep browse/discovery truncation comfortably above current scale while
   // still bounding downstream enrichment/rendering work.
   maxResults: 1000,
+  // Do not make buyer startup wait for every empty shard in the foreground.
+  // A shard we do run still gets the full DHT operation timeout, but the
+  // sweep can resume from the next shard on the next refresh.
+  maxFindAllDhtDurationMs: 20_000,
 };
 
 export interface LookupResult {
@@ -46,8 +57,21 @@ export interface LookupResult {
   port: number;
 }
 
+export interface LookupPartialContext {
+  mode: "foreground" | "background";
+  phase: "wildcard" | "subnet";
+  subnet?: number;
+  endpointCount: number;
+}
+
+export type LookupPartialCallback = (
+  results: LookupResult[],
+  context: LookupPartialContext,
+) => void | Promise<void>;
+
 export class PeerLookup {
   private readonly config: LookupConfig;
+  private nextSubnetStart = 0;
 
   constructor(config: LookupConfig) {
     this.config = config;
@@ -66,37 +90,142 @@ export class PeerLookup {
    *      us well under the K-closest saturation limit that made the single
    *      wildcard topic return inconsistent subsets at scale.
    *
-   * Why sequential: firing all 17 infohashes through `lookupMany` in one
-   * shot starved each iterative lookup of UDP socket bandwidth and shared
-   * a single 25s budget across the batch. Most subnet lookups never
-   * converged before the timeout, and `findAll()` typically returned only
-   * the one or two subnets nearest the local node ID. Sequential gives
-   * each lookup a full operation timeout and the entire UDP socket — every
-   * iterative lookup converges, and we get a complete picture, at the
-   * cost of higher wall-clock on cold starts.
+   * Why sequential: firing all shard lookups together through one UDP socket
+   * gave us lower wall-clock but worse completeness. Buyers need to give a
+   * shard lookup enough time to converge and drain its peer events, so every
+   * shard we do run gets a full lookup slot.
+   *
+   * Startup still should not block on all 16 shards when most of them are
+   * empty. If `maxFindAllDhtDurationMs` is configured, `findAll()` walks
+   * shards in a rotating order and stops after the foreground budget is
+   * exhausted; the next refresh resumes from the next shard. This preserves
+   * per-shard quality without forcing every buyer startup to pay the full
+   * network-wide sweep cost.
    *
    * `resolveLookupResults` deduplicates by `host:port` before resolving
-   * metadata, so the union still has the same cost as before.
+   * metadata, so the union still only incurs one metadata fetch per endpoint.
    */
   async findAll(): Promise<LookupResult[]> {
-    const merged: PeerEndpoint[] = [];
+    return this.findAllWithDhtBudget(this.config.maxFindAllDhtDurationMs, "foreground");
+  }
 
-    // Stage 1: wildcard, on its own. Warms the routing table.
+  /**
+   * Complete a full sequential wildcard+subnet sweep. Intended for background
+   * catch-up after a fast foreground discovery has already populated the UI.
+   *
+   * When `onPartial` is provided, each non-empty DHT batch is metadata-resolved
+   * and emitted immediately instead of making callers wait for every shard to
+   * finish. This keeps the buyer catalog moving while the exhaustive sweep is
+   * still walking later shards.
+   */
+  async findAllExhaustive(onPartial?: LookupPartialCallback): Promise<LookupResult[]> {
+    return this.findAllWithDhtBudget(undefined, "background", onPartial);
+  }
+
+  private async findAllWithDhtBudget(
+    maxDhtDurationMs: number | undefined,
+    mode: "foreground" | "background",
+    onPartial?: LookupPartialCallback,
+  ): Promise<LookupResult[]> {
+    const merged: PeerEndpoint[] = [];
+    const partialResults: LookupResult[] = [];
+    const sweepStartedAt = Date.now();
+
+    // Stage 1: wildcard, on its own. Warm the routing table.
+    const wildcardStartedAt = Date.now();
+    debugLog(`[PeerLookup] ${mode}: wildcard lookup starting`);
     const wildcardEndpoints = await this.config.dht.lookup(
       topicToInfoHash(ANTSEED_WILDCARD_TOPIC),
     );
+    debugLog(
+      `[PeerLookup] ${mode}: wildcard lookup returned ${wildcardEndpoints.length} endpoint(s) `
+      + `in ${Date.now() - wildcardStartedAt}ms`,
+    );
     merged.push(...wildcardEndpoints);
-
-    // Stage 2: per-subnet, sequential. Each lookup gets full UDP bandwidth
-    // and a fresh per-lookup timeout.
-    for (let i = 0; i < SUBNET_COUNT; i++) {
-      const subnetEndpoints = await this.config.dht.lookup(
-        topicToInfoHash(subnetTopic(i)),
-      );
-      merged.push(...subnetEndpoints);
+    if (onPartial && wildcardEndpoints.length > 0) {
+      const resolved = await this.resolveLookupResults(shuffle(wildcardEndpoints));
+      partialResults.push(...resolved);
+      await onPartial(resolved, {
+        mode,
+        phase: "wildcard",
+        endpointCount: wildcardEndpoints.length,
+      });
     }
 
-    return this.resolveLookupResults(shuffle(merged));
+    // Stage 2: per-subnet, sequential. Each lookup gets the full operation
+    // timeout and exclusive use of the UDP socket. Rotate the start shard so
+    // budgeted foreground scans eventually cover the whole shard ring.
+    const startedAt = Date.now();
+    const start = this.nextSubnetStart;
+    let nextStart = start;
+    for (let offset = 0; offset < SUBNET_COUNT; offset++) {
+      if (
+        offset > 0
+        && maxDhtDurationMs !== undefined
+        && Date.now() - startedAt >= maxDhtDurationMs
+      ) {
+        break;
+      }
+
+      const subnet = (start + offset) % SUBNET_COUNT;
+      const subnetStartedAt = Date.now();
+      debugLog(`[PeerLookup] ${mode}: subnet ${subnet}/${SUBNET_COUNT - 1} lookup starting`);
+      const subnetEndpoints = await this.config.dht.lookup(
+        topicToInfoHash(subnetTopic(subnet)),
+      );
+      debugLog(
+        `[PeerLookup] ${mode}: subnet ${subnet}/${SUBNET_COUNT - 1} returned `
+        + `${subnetEndpoints.length} endpoint(s) in ${Date.now() - subnetStartedAt}ms`,
+      );
+      merged.push(...subnetEndpoints);
+      if (onPartial && subnetEndpoints.length > 0) {
+        const partialStartedAt = Date.now();
+        const resolved = await this.resolveLookupResults(shuffle(subnetEndpoints));
+        partialResults.push(...resolved);
+        debugLog(
+          `[PeerLookup] ${mode}: subnet ${subnet}/${SUBNET_COUNT - 1} partial metadata resolved `
+          + `${resolved.length}/${subnetEndpoints.length} in ${Date.now() - partialStartedAt}ms`,
+        );
+        await onPartial(resolved, {
+          mode,
+          phase: "subnet",
+          subnet,
+          endpointCount: subnetEndpoints.length,
+        });
+      }
+      nextStart = (subnet + 1) % SUBNET_COUNT;
+    }
+    this.nextSubnetStart = nextStart;
+
+    if (onPartial) {
+      const deduped = this.deduplicateResultsByPeerId(partialResults);
+      debugLog(
+        `[PeerLookup] ${mode}: emitted ${deduped.length} incremental metadata result(s) from `
+        + `${merged.length} DHT endpoint(s) (total ${Date.now() - sweepStartedAt}ms)`,
+      );
+      return deduped;
+    }
+
+    const metadataStartedAt = Date.now();
+    const resolved = await this.resolveLookupResults(shuffle(merged));
+    debugLog(
+      `[PeerLookup] ${mode}: resolved ${resolved.length} metadata result(s) from `
+      + `${merged.length} DHT endpoint(s) in ${Date.now() - metadataStartedAt}ms `
+      + `(total ${Date.now() - sweepStartedAt}ms)`,
+    );
+    return resolved;
+  }
+
+  private deduplicateResultsByPeerId(results: LookupResult[]): LookupResult[] {
+    const seen = new Set<string>();
+    const deduped: LookupResult[] = [];
+    for (const result of results) {
+      const peerId = result.metadata.peerId.toLowerCase();
+      if (seen.has(peerId)) continue;
+      seen.add(peerId);
+      deduped.push(result);
+    }
+    return deduped;
   }
 
   async findByCapability(capability: string, name?: string): Promise<LookupResult[]> {

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -22,6 +22,7 @@ import { ConnectionState } from "./types/connection.js";
 import {
   DHTNode,
   DEFAULT_DHT_CONFIG,
+  SUBNET_COUNT,
   type DHTNodeConfig,
 } from "./discovery/dht-node.js";
 import { toBootstrapConfig, OFFICIAL_BOOTSTRAP_NODES, mergeBootstrapNodes } from "./discovery/bootstrap.js";
@@ -236,6 +237,8 @@ export class AntseedNode extends EventEmitter {
   private _closeRequestedFromBlock: number = 0;
   /** Seller session lifecycle tracking (metering, settlement). */
   private _sessionTracker: SellerSessionTracker | null = null;
+  /** Buyer-side background full discovery sweep, if one is running. */
+  private _backgroundPeerDiscoveryPromise: Promise<PeerInfo[]> | null = null;
 
   constructor(config: NodeConfig) {
     super();
@@ -442,6 +445,7 @@ export class AntseedNode extends EventEmitter {
     this._buyerPaymentManager = null;
     this._buyerNegotiator = null;
     this._buyerHandler = null;
+    this._backgroundPeerDiscoveryPromise = null;
     this._sellerPaymentManager = null;
     this._sessionTracker = null;
     this._started = false;
@@ -454,6 +458,7 @@ export class AntseedNode extends EventEmitter {
     }
 
     debugLog(`[Node] Discovering peers (service: "${service ?? "*"}")...`);
+    debugLog(`[Node] Discovery plan: wildcard warmup + budgeted sequential subnet shard lookups (${SUBNET_COUNT} total) + parallel metadata resolve; exhaustive sweep continues in background`);
 
     // Always enumerate via subnet+wildcard. Service filtering is metadata
     // driven — announcing per-service DHT topics did O(services) work per
@@ -463,8 +468,12 @@ export class AntseedNode extends EventEmitter {
     // metadata-side anyway). The signed metadata document carries the full
     // service catalog, so we filter against that after enumeration.
     const results = await this._peerLookup.findAll();
-    debugLog(`[Node] DHT returned ${results.length} result(s)`);
+    debugLog(`[Node] DHT returned ${results.length} foreground result(s)`);
+    this._startBackgroundPeerDiscoverySweep();
+    return this._lookupResultsToPeerInfos(results, service);
+  }
 
+  private async _lookupResultsToPeerInfos(results: LookupResult[], service?: string): Promise<PeerInfo[]> {
     // Deduplicate by peerId (DHT can return the same peer from multiple topic lookups)
     const seen = new Set<string>();
     const peers: PeerInfo[] = [];
@@ -486,6 +495,35 @@ export class AntseedNode extends EventEmitter {
       debugLog(`[Node]   peer ${p.peerId.slice(0, 12)}... providers=[${p.providers.join(",")}] addr=${p.publicAddress ?? "?"}`);
     }
     return filtered;
+  }
+
+  private _startBackgroundPeerDiscoverySweep(): void {
+    if (!this._peerLookup || this._backgroundPeerDiscoveryPromise) {
+      return;
+    }
+    const peerLookup = this._peerLookup;
+    debugLog(`[Node] Starting background exhaustive peer discovery sweep`);
+    this._backgroundPeerDiscoveryPromise = (async () => {
+      const results = await peerLookup.findAllExhaustive(async (partialResults, context) => {
+        if (partialResults.length === 0) return;
+        const peers = await this._lookupResultsToPeerInfos(partialResults);
+        debugLog(
+          `[Node] Background DHT partial ${context.phase}`
+          + `${context.subnet !== undefined ? ` ${context.subnet}/${SUBNET_COUNT - 1}` : ""}`
+          + ` emitted ${peers.length} peer(s) from ${context.endpointCount} endpoint(s)`,
+        );
+        this.emit("peers:discovered", peers);
+      });
+      debugLog(`[Node] Background DHT sweep returned ${results.length} result(s)`);
+      const peers = await this._lookupResultsToPeerInfos(results);
+      this.emit("peers:discovered", peers);
+      return peers;
+    })().catch((err) => {
+      debugWarn(`[Node] Background DHT sweep failed: ${err instanceof Error ? err.message : err}`);
+      return [];
+    }).finally(() => {
+      this._backgroundPeerDiscoveryPromise = null;
+    });
   }
 
   /**
@@ -1107,7 +1145,10 @@ export class AntseedNode extends EventEmitter {
     });
 
     // Create PeerLookup with HttpMetadataResolver
-    const metadataResolver = new HttpMetadataResolver();
+    const metadataResolver = new HttpMetadataResolver({
+      timeoutMs: 750,
+      maxConcurrent: 24,
+    });
     const lookupConfig: LookupConfig = {
       dht: this._dht,
       metadataResolver,
@@ -1115,6 +1156,7 @@ export class AntseedNode extends EventEmitter {
       allowStaleMetadata: DEFAULT_LOOKUP_CONFIG.allowStaleMetadata,
       maxAnnouncementAgeMs: DEFAULT_LOOKUP_CONFIG.maxAnnouncementAgeMs,
       maxResults: DEFAULT_LOOKUP_CONFIG.maxResults,
+      maxFindAllDhtDurationMs: DEFAULT_LOOKUP_CONFIG.maxFindAllDhtDurationMs,
     };
     this._peerLookup = new PeerLookup(lookupConfig);
 

--- a/packages/node/tests/http-metadata-resolver.test.ts
+++ b/packages/node/tests/http-metadata-resolver.test.ts
@@ -32,6 +32,53 @@ afterEach(() => {
 });
 
 describe('HttpMetadataResolver', () => {
+  it('limits concurrent metadata fetches', async () => {
+    let active = 0;
+    let peak = 0;
+    const releaseQueue: Array<() => void> = [];
+    const fetchMock = vi.fn(async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise<void>((resolve) => {
+        releaseQueue.push(() => {
+          active -= 1;
+          resolve();
+        });
+      });
+      return new Response(JSON.stringify(buildMetadata()), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resolver = new HttpMetadataResolver({
+      timeoutMs: 100,
+      maxConcurrent: 2,
+      failureCooldownMs: 0,
+    });
+
+    const pending = [
+      resolver.resolve({ host: '1.1.1.1', port: 6882 }),
+      resolver.resolve({ host: '1.1.1.2', port: 6882 }),
+      resolver.resolve({ host: '1.1.1.3', port: 6882 }),
+    ];
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(peak).toBe(2);
+
+    releaseQueue.shift()?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    while (releaseQueue.length > 0) {
+      releaseQueue.shift()?.();
+    }
+    const results = await Promise.all(pending);
+    expect(results.every((result) => result !== null)).toBe(true);
+  });
   it('caches failed endpoints for the configured cooldown', async () => {
     const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/node/tests/peer-lookup.test.ts
+++ b/packages/node/tests/peer-lookup.test.ts
@@ -50,9 +50,6 @@ describe('PeerLookup', () => {
     const wildcardEndpoint: PeerEndpoint = { host: '10.99.99.1', port: 6882 };
     const wildcardHashHex = topicToInfoHash(ANTSEED_WILDCARD_TOPIC).toString('hex');
 
-    // findAll now calls dht.lookup(infoHash) (single-hash) sequentially
-    // — once for the wildcard, then once per subnet. Each call goes
-    // through lookupMany under the hood (which `lookup` delegates to).
     const lookupMany = vi.fn(async (hashes: Buffer[]) => {
       const merged: PeerEndpoint[] = [];
       for (const hash of hashes) {
@@ -78,7 +75,6 @@ describe('PeerLookup', () => {
     });
 
     const results = await peerLookup.findAll();
-    // Sequential fan-out: 1 wildcard + 16 subnets = 17 calls total.
     expect(lookup).toHaveBeenCalledTimes(SUBNET_COUNT + 1);
     expect(results).toHaveLength(SUBNET_COUNT + 1);
     const hosts = results.map((r) => r.host).sort();
@@ -104,6 +100,7 @@ describe('PeerLookup', () => {
       allowStaleMetadata: true,
       maxAnnouncementAgeMs: 60_000,
       maxResults: 1000,
+      maxFindAllDhtDurationMs: Number.POSITIVE_INFINITY,
     });
     await peerLookup.findAll();
 
@@ -115,7 +112,78 @@ describe('PeerLookup', () => {
     }
   });
 
-  it('findAll queries the exact set of subnet + wildcard topics announcer-side advertises', async () => {
+  it('findAll honors the foreground DHT budget and resumes from the next subnet', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const capturedHashes: Buffer[] = [];
+    const lookup = vi.fn(async (hash: Buffer) => {
+      capturedHashes.push(hash);
+      vi.setSystemTime(Date.now() + 10_000);
+      return [] as PeerEndpoint[];
+    });
+    const dht = { lookup } as unknown as DHTNode;
+    const peerLookup = new PeerLookup({
+      dht,
+      metadataResolver: { resolve: vi.fn() },
+      requireValidSignature: false,
+      allowStaleMetadata: true,
+      maxAnnouncementAgeMs: 60_000,
+      maxResults: 1000,
+      maxFindAllDhtDurationMs: 20_000,
+    });
+
+    await peerLookup.findAll();
+    await peerLookup.findAll();
+
+    const calls = capturedHashes.map((h) => h.toString('hex'));
+    expect(calls).toEqual([
+      topicToInfoHash(ANTSEED_WILDCARD_TOPIC).toString('hex'),
+      topicToInfoHash(subnetTopic(0)).toString('hex'),
+      topicToInfoHash(subnetTopic(1)).toString('hex'),
+      topicToInfoHash(ANTSEED_WILDCARD_TOPIC).toString('hex'),
+      topicToInfoHash(subnetTopic(2)).toString('hex'),
+      topicToInfoHash(subnetTopic(3)).toString('hex'),
+    ]);
+  });
+
+  it('findAllExhaustive emits metadata partials for non-empty batches', async () => {
+    const wildcardPeer: PeerEndpoint = { host: '10.99.99.1', port: 6882 };
+    const subnetPeer: PeerEndpoint = { host: '10.0.7.1', port: 6882 };
+    const wildcardHashHex = topicToInfoHash(ANTSEED_WILDCARD_TOPIC).toString('hex');
+    const subnet7HashHex = topicToInfoHash(subnetTopic(7)).toString('hex');
+    const lookup = vi.fn(async (hash: Buffer) => {
+      const hex = hash.toString('hex');
+      if (hex === wildcardHashHex) return [wildcardPeer];
+      if (hex === subnet7HashHex) return [subnetPeer];
+      return [] as PeerEndpoint[];
+    });
+    const dht = { lookup } as unknown as DHTNode;
+    const resolve = vi.fn(async (peer: PeerEndpoint) => buildMetadata({
+      peerId: peer.host === wildcardPeer.host ? 'a'.repeat(40) as any : 'b'.repeat(40) as any,
+    }));
+    const peerLookup = new PeerLookup({
+      dht,
+      metadataResolver: { resolve },
+      requireValidSignature: false,
+      allowStaleMetadata: true,
+      maxAnnouncementAgeMs: 60_000,
+      maxResults: 1000,
+    });
+
+    const partials: Array<{ count: number; phase: string; subnet?: number }> = [];
+    const results = await peerLookup.findAllExhaustive((batch, context) => {
+      partials.push({ count: batch.length, phase: context.phase, subnet: context.subnet });
+    });
+
+    expect(partials).toEqual([
+      { count: 1, phase: 'wildcard' },
+      { count: 1, phase: 'subnet', subnet: 7 },
+    ]);
+    expect(results).toHaveLength(2);
+  });
+
+  it('findAllExhaustive queries the exact set of subnet + wildcard topics announcer-side advertises', async () => {
     // Symmetry guard: the announcer chooses `subnetTopic(subnetOf(peerId))`
     // and the wildcard; the buyer must query every subnet topic plus the
     // wildcard, with no extras and no missing entries. If a future change
@@ -136,7 +204,7 @@ describe('PeerLookup', () => {
       maxAnnouncementAgeMs: 60_000,
       maxResults: 1000,
     });
-    await peerLookup.findAll();
+    await peerLookup.findAllExhaustive();
 
     const expectedHashes = new Set<string>([
       topicToInfoHash(ANTSEED_WILDCARD_TOPIC).toString('hex'),
@@ -149,12 +217,12 @@ describe('PeerLookup', () => {
     expect(capturedHashes).toHaveLength(SUBNET_COUNT + 1);
   });
 
-  it('findAll covers every subnetOf(peerId) the announcer might pick, across the full byte space', async () => {
+  it('findAllExhaustive covers every subnetOf(peerId) the announcer might pick, across the full byte space', async () => {
     // Property-style: for any peerId, the subnet the announcer would publish
     // under (subnetTopic(subnetOf(peerId))) must be in the set of topics
-    // findAll asks the DHT about. Combined with the symmetry test above, this
-    // pins down the contract: announcer + lookup agree for every possible
-    // peerId.
+    // exhaustive discovery asks the DHT about. Combined with the symmetry test
+    // above, this pins down the contract: announcer + lookup agree for every
+    // possible peerId.
     const capturedHashes: Buffer[] = [];
     const lookup = vi.fn(async (hash: Buffer) => {
       capturedHashes.push(hash);
@@ -169,7 +237,7 @@ describe('PeerLookup', () => {
       maxAnnouncementAgeMs: 60_000,
       maxResults: 1000,
     });
-    await peerLookup.findAll();
+    await peerLookup.findAllExhaustive();
 
     const queriedHashes = new Set(capturedHashes.map((h) => h.toString('hex')));
     for (let byte = 0; byte < 256; byte++) {


### PR DESCRIPTION
## Summary
- keep buyer DHT shard lookup sequential for completeness, but cap the foreground startup sweep
- start an exhaustive background shard sweep immediately and emit incremental peer batches as metadata resolves
- reduce metadata fetch timeout and cap metadata fetch concurrency to avoid long stalls on dead endpoints
- update buyer proxy cache when background discovery emits new peers

## Validation
- pnpm vitest run packages/node/tests/peer-lookup.test.ts packages/node/tests/http-metadata-resolver.test.ts