### PR TITLE
Harden Diem staking proxy

### DIFF
--- a/packages/contracts/AntseedSellerDelegation.sol
+++ b/packages/contracts/AntseedSellerDelegation.sol
@@ -3,9 +3,27 @@ pragma solidity ^0.8.24;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import {IAntseedRegistry} from "./interfaces/IAntseedRegistry.sol";
-import {IAntseedChannels} from "./interfaces/IAntseedChannels.sol";
+import { IAntseedRegistry } from "./interfaces/IAntseedRegistry.sol";
+import { IAntseedChannels } from "./interfaces/IAntseedChannels.sol";
+
+interface IAntseedEmissionsClaim {
+    function claimSellerEmissions(uint256[] calldata epochs) external;
+    function pendingEmissions(address account, uint256[] calldata epochs)
+        external
+        view
+        returns (uint256 totalSeller, uint256 totalBuyer);
+}
+
+interface IAntseedEmissionsClock {
+    function currentEpoch() external view returns (uint256);
+}
+
+interface IAntseedDepositsToken {
+    function usdc() external view returns (address);
+}
 
 /**
  * @title AntseedSellerDelegation
@@ -27,16 +45,27 @@ import {IAntseedChannels} from "./interfaces/IAntseedChannels.sol";
  *         reward streams, pool accounting).
  */
 abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    uint256 public constant MAX_OPERATOR_FEE_BPS = 500;
+    uint256 internal constant _BPS = 10_000;
+
     /// @notice Central AntSeed address book. Resolves channels / deposits / etc.
     IAntseedRegistry public immutable registry;
 
     /// @notice Authorized operators for this contract.
     mapping(address => bool) public isOperator;
 
+    uint256 public operatorFeeBps;
+    address public operatorFeeRecipient;
+
     event OperatorSet(address indexed operator, bool enabled);
+    event OperatorFeeSet(uint256 feeBps, address indexed recipient);
+    event OperatorFeePaid(address indexed token, address indexed recipient, uint256 amount);
 
     error InvalidAddress();
     error NotOperator();
+    error OperatorFeeTooLarge();
 
     modifier onlyOperator() {
         if (!isOperator[msg.sender]) revert NotOperator();
@@ -60,6 +89,16 @@ abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
         emit OperatorSet(op, enabled);
     }
 
+    /// @notice Set the operator fee taken from delegated seller revenue streams.
+    /// @dev `feeBps` may be zero. A non-zero fee requires a non-zero recipient.
+    function setOperatorFee(uint256 feeBps, address recipient) external onlyOwner {
+        if (feeBps > MAX_OPERATOR_FEE_BPS) revert OperatorFeeTooLarge();
+        if (feeBps > 0 && recipient == address(0)) revert InvalidAddress();
+        operatorFeeBps = feeBps;
+        operatorFeeRecipient = recipient;
+        emit OperatorFeeSet(feeBps, recipient);
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     //                        CHANNEL LIFECYCLE FAÇADE
     // ═══════════════════════════════════════════════════════════════════
@@ -74,13 +113,11 @@ abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
     // the same lock as the super forward, with no gap in between.
 
     /// @notice Forwarded `AntseedChannels.reserve`.
-    function reserve(
-        address buyer,
-        bytes32 salt,
-        uint128 maxAmount,
-        uint256 deadline,
-        bytes calldata buyerSig
-    ) public virtual onlyOperator {
+    function reserve(address buyer, bytes32 salt, uint128 maxAmount, uint256 deadline, bytes calldata buyerSig)
+        public
+        virtual
+        onlyOperator
+    {
         _channels().reserve(buyer, salt, maxAmount, deadline, buyerSig);
     }
 
@@ -93,33 +130,78 @@ abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
         uint128 newMaxAmount,
         uint256 deadline,
         bytes calldata reserveSig
-    ) public virtual onlyOperator {
+    ) public virtual onlyOperator returns (uint256 netPayout) {
+        IERC20 payoutToken = _sellerPayoutToken();
+        uint256 beforeBal = payoutToken.balanceOf(address(this));
         _channels().topUp(channelId, cumulativeAmount, metadata, spendingSig, newMaxAmount, deadline, reserveSig);
+        netPayout = _takeOperatorFee(payoutToken, payoutToken.balanceOf(address(this)) - beforeBal);
     }
 
     /// @notice Forwarded `AntseedChannels.settle`.
-    function settle(
-        bytes32 channelId,
-        uint128 cumulativeAmount,
-        bytes calldata metadata,
-        bytes calldata buyerSig
-    ) public virtual onlyOperator {
+    function settle(bytes32 channelId, uint128 cumulativeAmount, bytes calldata metadata, bytes calldata buyerSig)
+        public
+        virtual
+        onlyOperator
+        returns (uint256 netPayout)
+    {
+        IERC20 payoutToken = _sellerPayoutToken();
+        uint256 beforeBal = payoutToken.balanceOf(address(this));
         _channels().settle(channelId, cumulativeAmount, metadata, buyerSig);
+        netPayout = _takeOperatorFee(payoutToken, payoutToken.balanceOf(address(this)) - beforeBal);
     }
 
     /// @notice Forwarded `AntseedChannels.close`.
-    function close(
-        bytes32 channelId,
-        uint128 finalAmount,
-        bytes calldata metadata,
-        bytes calldata buyerSig
-    ) public virtual onlyOperator {
+    function close(bytes32 channelId, uint128 finalAmount, bytes calldata metadata, bytes calldata buyerSig)
+        public
+        virtual
+        onlyOperator
+        returns (uint256 netPayout)
+    {
+        IERC20 payoutToken = _sellerPayoutToken();
+        uint256 beforeBal = payoutToken.balanceOf(address(this));
         _channels().close(channelId, finalAmount, metadata, buyerSig);
+        netPayout = _takeOperatorFee(payoutToken, payoutToken.balanceOf(address(this)) - beforeBal);
     }
 
     /// @dev Resolve the current channels contract via the registry.
     function _channels() internal view returns (IAntseedChannels) {
         return IAntseedChannels(registry.channels());
+    }
+
+    function _sellerPayoutToken() internal view returns (IERC20) {
+        return IERC20(IAntseedDepositsToken(registry.deposits()).usdc());
+    }
+
+    function _currentEmissionsEpoch() internal view returns (uint256) {
+        return IAntseedEmissionsClock(registry.emissions()).currentEpoch();
+    }
+
+    function _claimSellerEmissions(uint256[] memory epochs) internal {
+        IAntseedEmissionsClaim(registry.emissions()).claimSellerEmissions(epochs);
+    }
+
+    function _pendingSellerEmissions(address account, uint256[] memory epochs)
+        internal
+        view
+        returns (uint256 pendingSeller)
+    {
+        (pendingSeller,) = IAntseedEmissionsClaim(registry.emissions()).pendingEmissions(account, epochs);
+    }
+
+    function _operatorFeeNetAmount(uint256 grossAmount) internal view returns (uint256 netAmount) {
+        uint256 feeBps = operatorFeeBps;
+        if (grossAmount == 0 || feeBps == 0) return grossAmount;
+        uint256 fee = (grossAmount * feeBps) / _BPS;
+        return grossAmount - fee;
+    }
+
+    function _takeOperatorFee(IERC20 token, uint256 grossAmount) internal returns (uint256 netAmount) {
+        netAmount = _operatorFeeNetAmount(grossAmount);
+        uint256 fee = grossAmount - netAmount;
+        if (fee == 0) return grossAmount;
+        address recipient = operatorFeeRecipient;
+        token.safeTransfer(recipient, fee);
+        emit OperatorFeePaid(address(token), recipient, fee);
     }
 
     /// @notice The underlying AntseedChannels contract. Client SDKs treat this

--- a/packages/contracts/AntseedSellerDelegation.sol
+++ b/packages/contracts/AntseedSellerDelegation.sol
@@ -8,22 +8,8 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import { IAntseedRegistry } from "./interfaces/IAntseedRegistry.sol";
 import { IAntseedChannels } from "./interfaces/IAntseedChannels.sol";
-
-interface IAntseedEmissionsClaim {
-    function claimSellerEmissions(uint256[] calldata epochs) external;
-    function pendingEmissions(address account, uint256[] calldata epochs)
-        external
-        view
-        returns (uint256 totalSeller, uint256 totalBuyer);
-}
-
-interface IAntseedEmissionsClock {
-    function currentEpoch() external view returns (uint256);
-}
-
-interface IAntseedDepositsToken {
-    function usdc() external view returns (address);
-}
+import { IAntseedDeposits } from "./interfaces/IAntseedDeposits.sol";
+import { IAntseedEmissions } from "./interfaces/IAntseedEmissions.sol";
 
 /**
  * @title AntseedSellerDelegation
@@ -47,7 +33,8 @@ interface IAntseedDepositsToken {
 abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
-    uint256 public constant MAX_OPERATOR_FEE_BPS = 500;
+    uint256 public constant DEFAULT_OPERATOR_FEE_BPS = 1000;
+    uint256 public constant MAX_OPERATOR_FEE_BPS = 2000;
     uint256 internal constant _BPS = 10_000;
 
     /// @notice Central AntSeed address book. Resolves channels / deposits / etc.
@@ -78,6 +65,9 @@ abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
         if (_registry == address(0)) revert InvalidAddress();
         if (initialOperator == address(0)) revert InvalidAddress();
         registry = IAntseedRegistry(_registry);
+        operatorFeeBps = DEFAULT_OPERATOR_FEE_BPS;
+        operatorFeeRecipient = initialOperator;
+        emit OperatorFeeSet(DEFAULT_OPERATOR_FEE_BPS, initialOperator);
         isOperator[initialOperator] = true;
         emit OperatorSet(initialOperator, true);
     }
@@ -169,18 +159,18 @@ abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
     }
 
     function _sellerPayoutToken() internal view returns (IERC20) {
-        return IERC20(IAntseedDepositsToken(registry.deposits()).usdc());
+        return IERC20(IAntseedDeposits(registry.deposits()).usdc());
     }
 
     function _currentEmissionsEpoch() internal view returns (uint256) {
-        return IAntseedEmissionsClock(registry.emissions()).currentEpoch();
+        return IAntseedEmissions(registry.emissions()).currentEpoch();
     }
 
     function _claimSellerEmissions(uint256[] memory epochs) internal returns (uint256 netPayout) {
-        IERC20 payoutToken = IERC20(registry.antsToken());
-        uint256 beforeBal = payoutToken.balanceOf(address(this));
-        IAntseedEmissionsClaim(registry.emissions()).claimSellerEmissions(epochs);
-        netPayout = _takeOperatorFee(payoutToken, payoutToken.balanceOf(address(this)) - beforeBal);
+        IERC20 antsToken = IERC20(registry.antsToken());
+        uint256 beforeBal = antsToken.balanceOf(address(this));
+        IAntseedEmissions(registry.emissions()).claimSellerEmissions(epochs);
+        netPayout = _takeOperatorFee(antsToken, antsToken.balanceOf(address(this)) - beforeBal);
     }
 
     function _pendingSellerEmissions(address account, uint256[] memory epochs)
@@ -188,7 +178,7 @@ abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
         view
         returns (uint256 pendingSeller)
     {
-        (pendingSeller,) = IAntseedEmissionsClaim(registry.emissions()).pendingEmissions(account, epochs);
+        (pendingSeller,) = IAntseedEmissions(registry.emissions()).pendingEmissions(account, epochs);
     }
 
     function _operatorFeeNetAmount(uint256 grossAmount) internal view returns (uint256 netAmount) {
@@ -201,7 +191,7 @@ abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
     function _takeOperatorFee(IERC20 token, uint256 grossAmount) internal returns (uint256 netAmount) {
         netAmount = _operatorFeeNetAmount(grossAmount);
         uint256 fee = grossAmount - netAmount;
-        if (fee == 0) return grossAmount;
+        if (fee == 0) return netAmount;
         address recipient = operatorFeeRecipient;
         token.safeTransfer(recipient, fee);
         emit OperatorFeePaid(address(token), recipient, fee);

--- a/packages/contracts/AntseedSellerDelegation.sol
+++ b/packages/contracts/AntseedSellerDelegation.sol
@@ -176,8 +176,11 @@ abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
         return IAntseedEmissionsClock(registry.emissions()).currentEpoch();
     }
 
-    function _claimSellerEmissions(uint256[] memory epochs) internal {
+    function _claimSellerEmissions(uint256[] memory epochs) internal returns (uint256 netPayout) {
+        IERC20 payoutToken = IERC20(registry.antsToken());
+        uint256 beforeBal = payoutToken.balanceOf(address(this));
         IAntseedEmissionsClaim(registry.emissions()).claimSellerEmissions(epochs);
+        netPayout = _takeOperatorFee(payoutToken, payoutToken.balanceOf(address(this)) - beforeBal);
     }
 
     function _pendingSellerEmissions(address account, uint256[] memory epochs)

--- a/packages/contracts/AntseedSellerDelegation.sol
+++ b/packages/contracts/AntseedSellerDelegation.sol
@@ -176,9 +176,10 @@ abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
     function _pendingSellerEmissions(address account, uint256[] memory epochs)
         internal
         view
-        returns (uint256 pendingSeller)
+        returns (uint256 netPendingSeller)
     {
-        (pendingSeller,) = IAntseedEmissions(registry.emissions()).pendingEmissions(account, epochs);
+        (uint256 grossPendingSeller,) = IAntseedEmissions(registry.emissions()).pendingEmissions(account, epochs);
+        netPendingSeller = _operatorFeeNetAmount(grossPendingSeller);
     }
 
     function _operatorFeeAmount(uint256 grossAmount) internal view returns (uint256) {

--- a/packages/contracts/AntseedSellerDelegation.sol
+++ b/packages/contracts/AntseedSellerDelegation.sol
@@ -48,7 +48,6 @@ abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
 
     event OperatorSet(address indexed operator, bool enabled);
     event OperatorFeeSet(uint256 feeBps, address indexed recipient);
-    event OperatorFeePaid(address indexed token, address indexed recipient, uint256 amount);
 
     error InvalidAddress();
     error NotOperator();
@@ -193,9 +192,7 @@ abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
     function _takeOperatorFee(IERC20 token, uint256 grossAmount) internal returns (uint256) {
         uint256 fee = _operatorFeeAmount(grossAmount);
         if (fee == 0) return grossAmount;
-        address recipient = operatorFeeRecipient;
-        token.safeTransfer(recipient, fee);
-        emit OperatorFeePaid(address(token), recipient, fee);
+        token.safeTransfer(operatorFeeRecipient, fee);
         return grossAmount - fee;
     }
 

--- a/packages/contracts/AntseedSellerDelegation.sol
+++ b/packages/contracts/AntseedSellerDelegation.sol
@@ -181,20 +181,21 @@ abstract contract AntseedSellerDelegation is Ownable, ReentrancyGuard {
         (pendingSeller,) = IAntseedEmissions(registry.emissions()).pendingEmissions(account, epochs);
     }
 
-    function _operatorFeeNetAmount(uint256 grossAmount) internal view returns (uint256 netAmount) {
-        uint256 feeBps = operatorFeeBps;
-        if (grossAmount == 0 || feeBps == 0) return grossAmount;
-        uint256 fee = (grossAmount * feeBps) / _BPS;
-        return grossAmount - fee;
+    function _operatorFeeAmount(uint256 grossAmount) internal view returns (uint256) {
+        return (grossAmount * operatorFeeBps) / _BPS;
     }
 
-    function _takeOperatorFee(IERC20 token, uint256 grossAmount) internal returns (uint256 netAmount) {
-        netAmount = _operatorFeeNetAmount(grossAmount);
-        uint256 fee = grossAmount - netAmount;
-        if (fee == 0) return netAmount;
+    function _operatorFeeNetAmount(uint256 grossAmount) internal view returns (uint256) {
+        return grossAmount - _operatorFeeAmount(grossAmount);
+    }
+
+    function _takeOperatorFee(IERC20 token, uint256 grossAmount) internal returns (uint256) {
+        uint256 fee = _operatorFeeAmount(grossAmount);
+        if (fee == 0) return grossAmount;
         address recipient = operatorFeeRecipient;
         token.safeTransfer(recipient, fee);
         emit OperatorFeePaid(address(token), recipient, fee);
+        return grossAmount - fee;
     }
 
     /// @notice The underlying AntseedChannels contract. Client SDKs treat this

--- a/packages/contracts/DiemStakingProxy.sol
+++ b/packages/contracts/DiemStakingProxy.sol
@@ -506,7 +506,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         if (userEpochClaimed[account][rewardEpoch]) return 0;
         if (rewardEpoch >= syncedRewardEpoch) return 0;
         RewardEpoch memory re = rewardEpochs[rewardEpoch];
-        uint256 antsPot = re.funded ? re.antsPot : _operatorFeeNetAmount(_grossPendingRewardEpochEmissions(rewardEpoch));
+        uint256 antsPot = re.funded ? re.antsPot : _pendingRewardEpochEmissions(rewardEpoch);
         if (antsPot == 0) return 0;
         uint256 totalPoints = re.totalPoints;
         if (totalPoints == 0) return 0;
@@ -620,7 +620,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         emit RewardEpochFunded(rewardEpoch, antsPot);
     }
 
-    function _grossPendingRewardEpochEmissions(uint32 rewardEpoch) internal view returns (uint256 pendingSeller) {
+    function _pendingRewardEpochEmissions(uint32 rewardEpoch) internal view returns (uint256 pendingSeller) {
         uint256[] memory ids = new uint256[](1);
         ids[0] = rewardEpoch;
         pendingSeller = _pendingSellerEmissions(address(this), ids);

--- a/packages/contracts/DiemStakingProxy.sol
+++ b/packages/contracts/DiemStakingProxy.sol
@@ -435,6 +435,18 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         if (_syncFinalizedRewardEpochsBounded(maxEpochs) == 0) revert NothingToSync();
     }
 
+    function syncBacklog() external view returns (uint32 finalized, uint32 synced, uint32 remaining) {
+        finalized = _finalizedRewardEpoch();
+        synced = syncedRewardEpoch;
+        if (finalized > synced) remaining = finalized - synced;
+    }
+
+    function userPointsBacklog(address account) external view returns (uint32 userEpoch, uint32 synced, uint32 remaining) {
+        userEpoch = userCurrentEpoch[account];
+        synced = syncedRewardEpoch;
+        if (synced > userEpoch) remaining = synced - userEpoch;
+    }
+
     // ═══════════════════════════════════════════════════════════════════
     //                        ADMIN
     // ═══════════════════════════════════════════════════════════════════
@@ -569,7 +581,8 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
 
     function _syncFinalizedRewardEpochsForUpdate() internal {
         uint32 finalized = _finalizedRewardEpoch();
-        if (finalized > syncedRewardEpoch && finalized - syncedRewardEpoch > MAX_EPOCHS_PER_CAPTURE) {
+        uint32 synced = syncedRewardEpoch;
+        if (finalized > synced && finalized - synced > MAX_EPOCHS_PER_CAPTURE) {
             revert BacklogTooLarge();
         }
         _syncRewardEpochsUntil(finalized);

--- a/packages/contracts/DiemStakingProxy.sol
+++ b/packages/contracts/DiemStakingProxy.sol
@@ -4,12 +4,12 @@ pragma solidity ^0.8.24;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
-import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
 
-import {AntseedSellerDelegation} from "./AntseedSellerDelegation.sol";
-import {IAntseedRegistry} from "./interfaces/IAntseedRegistry.sol";
+import { AntseedSellerDelegation } from "./AntseedSellerDelegation.sol";
+import { IAntseedRegistry } from "./interfaces/IAntseedRegistry.sol";
 
 interface IDiemStake {
     function stake(uint256 amount) external;
@@ -20,18 +20,6 @@ interface IDiemStake {
 
 interface IAntseedStakingSeller {
     function unstake() external;
-}
-
-interface IAntseedEmissionsClaim {
-    function claimSellerEmissions(uint256[] calldata epochs) external;
-    function pendingEmissions(address account, uint256[] calldata epochs)
-        external
-        view
-        returns (uint256 totalSeller, uint256 totalBuyer);
-}
-
-interface IAntseedEmissionsClock {
-    function currentEpoch() external view returns (uint256);
 }
 
 contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
@@ -173,7 +161,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         currentUnstakeBatch = 1;
         oldestUnclaimedUnstakeBatch = 1;
 
-        uint32 _firstRewardEpoch = IAntseedEmissionsClock(_emissions).currentEpoch().toUint32();
+        uint32 _firstRewardEpoch = _currentEmissionsEpoch().toUint32();
         firstRewardEpoch = _firstRewardEpoch;
         syncedRewardEpoch = _firstRewardEpoch;
 
@@ -248,7 +236,10 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         if (e.total == 0) revert NothingToFlush();
 
         uint64 openedAt = currentUnstakeBatchOpenedAt;
-        if (e.userCount < MAX_PER_UNSTAKE_BATCH && block.timestamp < uint256(openedAt) + uint256(minUnstakeBatchOpenSecs)) {
+        if (
+            e.userCount < MAX_PER_UNSTAKE_BATCH
+                && block.timestamp < uint256(openedAt) + uint256(minUnstakeBatchOpenSecs)
+        ) {
             revert UnstakeBatchTooYoung();
         }
 
@@ -397,10 +388,9 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         uint128 newMaxAmount,
         uint256 deadline,
         bytes calldata reserveSig
-    ) public override nonReentrant whenNotPaused {
-        uint256 beforeBal = usdc.balanceOf(address(this));
-        super.topUp(channelId, cumulativeAmount, metadata, spendingSig, newMaxAmount, deadline, reserveSig);
-        _distributeUsdcInstant(usdc.balanceOf(address(this)) - beforeBal);
+    ) public override nonReentrant whenNotPaused returns (uint256 netPayout) {
+        netPayout = super.topUp(channelId, cumulativeAmount, metadata, spendingSig, newMaxAmount, deadline, reserveSig);
+        _distributeUsdcInstant(netPayout);
     }
 
     function settle(bytes32 channelId, uint128 cumulativeAmount, bytes calldata metadata, bytes calldata buyerSig)
@@ -408,10 +398,10 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         override
         nonReentrant
         whenNotPaused
+        returns (uint256 netPayout)
     {
-        uint256 beforeBal = usdc.balanceOf(address(this));
-        super.settle(channelId, cumulativeAmount, metadata, buyerSig);
-        _distributeUsdcInstant(usdc.balanceOf(address(this)) - beforeBal);
+        netPayout = super.settle(channelId, cumulativeAmount, metadata, buyerSig);
+        _distributeUsdcInstant(netPayout);
     }
 
     function close(bytes32 channelId, uint128 finalAmount, bytes calldata metadata, bytes calldata buyerSig)
@@ -419,10 +409,10 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         override
         nonReentrant
         whenNotPaused
+        returns (uint256 netPayout)
     {
-        uint256 beforeBal = usdc.balanceOf(address(this));
-        super.close(channelId, finalAmount, metadata, buyerSig);
-        _distributeUsdcInstant(usdc.balanceOf(address(this)) - beforeBal);
+        netPayout = super.close(channelId, finalAmount, metadata, buyerSig);
+        _distributeUsdcInstant(netPayout);
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -441,7 +431,11 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         if (finalized > synced) remaining = finalized - synced;
     }
 
-    function userPointsBacklog(address account) external view returns (uint32 userEpoch, uint32 synced, uint32 remaining) {
+    function userPointsBacklog(address account)
+        external
+        view
+        returns (uint32 userEpoch, uint32 synced, uint32 remaining)
+    {
         userEpoch = userCurrentEpoch[account];
         synced = syncedRewardEpoch;
         if (synced > userEpoch) remaining = synced - userEpoch;
@@ -512,7 +506,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         if (userEpochClaimed[account][rewardEpoch]) return 0;
         if (rewardEpoch >= syncedRewardEpoch) return 0;
         RewardEpoch memory re = rewardEpochs[rewardEpoch];
-        uint256 antsPot = re.funded ? re.antsPot : _pendingRewardEpochPot(rewardEpoch);
+        uint256 antsPot = re.funded ? re.antsPot : _operatorFeeNetAmount(_pendingRewardEpochPot(rewardEpoch));
         if (antsPot == 0) return 0;
         uint256 totalPoints = re.totalPoints;
         if (totalPoints == 0) return 0;
@@ -576,7 +570,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
     }
 
     function _finalizedRewardEpoch() internal view returns (uint32) {
-        return IAntseedEmissionsClock(emissions).currentEpoch().toUint32();
+        return _currentEmissionsEpoch().toUint32();
     }
 
     function _syncFinalizedRewardEpochsForUpdate() internal {
@@ -619,8 +613,8 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         uint256[] memory ids = new uint256[](1);
         ids[0] = rewardEpoch;
         uint256 beforeBal = ants.balanceOf(address(this));
-        IAntseedEmissionsClaim(emissions).claimSellerEmissions(ids);
-        antsPot = ants.balanceOf(address(this)) - beforeBal;
+        _claimSellerEmissions(ids);
+        antsPot = _takeOperatorFee(ants, ants.balanceOf(address(this)) - beforeBal);
 
         rewardEpochs[rewardEpoch].antsPot = antsPot;
         rewardEpochs[rewardEpoch].funded = true;
@@ -631,7 +625,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
     function _pendingRewardEpochPot(uint32 rewardEpoch) internal view returns (uint256 pendingSeller) {
         uint256[] memory ids = new uint256[](1);
         ids[0] = rewardEpoch;
-        (pendingSeller,) = IAntseedEmissionsClaim(emissions).pendingEmissions(address(this), ids);
+        pendingSeller = _pendingSellerEmissions(address(this), ids);
     }
 
     function _advanceUserClaimCursor(address account) internal {

--- a/packages/contracts/DiemStakingProxy.sol
+++ b/packages/contracts/DiemStakingProxy.sol
@@ -255,7 +255,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         emit UnstakeBatchFlushed(batchId, e.total, unlockAt);
     }
 
-    function claimUnstakeBatch(uint32 batchId) external nonReentrant whenNotPaused {
+    function claimUnstakeBatch(uint32 batchId) external nonReentrant {
         UnstakeBatch storage e = unstakeBatches[batchId];
         if (e.unlockAt == 0 || block.timestamp < e.unlockAt) revert UnstakeBatchNotReady();
         if (e.claimed) revert UnstakeBatchAlreadyClaimed();
@@ -419,7 +419,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
     //                        REWARD EPOCHS
     // ═══════════════════════════════════════════════════════════════════
 
-    function syncRewardEpochs(uint32 maxEpochs) external nonReentrant whenNotPaused {
+    function syncRewardEpochs(uint32 maxEpochs) external nonReentrant {
         if (maxEpochs == 0) revert InvalidAmount();
 
         if (_syncFinalizedRewardEpochsBounded(maxEpochs) == 0) revert NothingToSync();
@@ -506,7 +506,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         if (userEpochClaimed[account][rewardEpoch]) return 0;
         if (rewardEpoch >= syncedRewardEpoch) return 0;
         RewardEpoch memory re = rewardEpochs[rewardEpoch];
-        uint256 antsPot = re.funded ? re.antsPot : _operatorFeeNetAmount(_pendingRewardEpochPot(rewardEpoch));
+        uint256 antsPot = re.funded ? re.antsPot : _operatorFeeNetAmount(_grossPendingRewardEpochEmissions(rewardEpoch));
         if (antsPot == 0) return 0;
         uint256 totalPoints = re.totalPoints;
         if (totalPoints == 0) return 0;
@@ -620,7 +620,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         emit RewardEpochFunded(rewardEpoch, antsPot);
     }
 
-    function _pendingRewardEpochPot(uint32 rewardEpoch) internal view returns (uint256 pendingSeller) {
+    function _grossPendingRewardEpochEmissions(uint32 rewardEpoch) internal view returns (uint256 pendingSeller) {
         uint256[] memory ids = new uint256[](1);
         ids[0] = rewardEpoch;
         pendingSeller = _pendingSellerEmissions(address(this), ids);

--- a/packages/contracts/DiemStakingProxy.sol
+++ b/packages/contracts/DiemStakingProxy.sol
@@ -248,7 +248,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
         if (e.total == 0) revert NothingToFlush();
 
         uint64 openedAt = currentUnstakeBatchOpenedAt;
-        if (block.timestamp < uint256(openedAt) + uint256(minUnstakeBatchOpenSecs)) {
+        if (e.userCount < MAX_PER_UNSTAKE_BATCH && block.timestamp < uint256(openedAt) + uint256(minUnstakeBatchOpenSecs)) {
             revert UnstakeBatchTooYoung();
         }
 

--- a/packages/contracts/DiemStakingProxy.sol
+++ b/packages/contracts/DiemStakingProxy.sol
@@ -612,9 +612,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
     function _fundRewardEpoch(uint32 rewardEpoch) internal returns (uint256 antsPot) {
         uint256[] memory ids = new uint256[](1);
         ids[0] = rewardEpoch;
-        uint256 beforeBal = ants.balanceOf(address(this));
-        _claimSellerEmissions(ids);
-        antsPot = _takeOperatorFee(ants, ants.balanceOf(address(this)) - beforeBal);
+        antsPot = _claimSellerEmissions(ids);
 
         rewardEpochs[rewardEpoch].antsPot = antsPot;
         rewardEpochs[rewardEpoch].funded = true;

--- a/packages/contracts/DiemStakingProxy.sol
+++ b/packages/contracts/DiemStakingProxy.sol
@@ -531,7 +531,8 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
     // ═══════════════════════════════════════════════════════════════════
 
     function isValidSignature(bytes32 hash, bytes calldata signature) external view override returns (bytes4) {
-        address recovered = ECDSA.recover(hash, signature);
+        (address recovered, ECDSA.RecoverError err,) = ECDSA.tryRecover(hash, signature);
+        if (err != ECDSA.RecoverError.NoError) return bytes4(0xffffffff);
         return recovered == owner() ? ERC1271_MAGIC_VALUE : bytes4(0xffffffff);
     }
 

--- a/packages/contracts/DiemStakingProxy.sol
+++ b/packages/contracts/DiemStakingProxy.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import {IERC1271} from "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 
 import {AntseedSellerDelegation} from "./AntseedSellerDelegation.sol";
 import {IAntseedRegistry} from "./interfaces/IAntseedRegistry.sol";
@@ -33,7 +34,7 @@ interface IAntseedEmissionsClock {
     function currentEpoch() external view returns (uint256);
 }
 
-contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
+contract DiemStakingProxy is AntseedSellerDelegation, IERC1271, Pausable {
     using SafeERC20 for IERC20;
     using SafeCast for uint256;
 
@@ -195,7 +196,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
     //                        STAKING
     // ═══════════════════════════════════════════════════════════════════
 
-    function stake(uint256 amount) external nonReentrant updateRewards(msg.sender) {
+    function stake(uint256 amount) external nonReentrant whenNotPaused updateRewards(msg.sender) {
         if (amount == 0) revert InvalidAmount();
         uint256 cap = maxTotalStake;
         if (cap != 0 && totalStaked + amount > cap) revert MaxStakeExceeded();
@@ -211,7 +212,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
         emit Staked(msg.sender, amount);
     }
 
-    function initiateUnstake(uint256 amount) external nonReentrant updateRewards(msg.sender) {
+    function initiateUnstake(uint256 amount) external nonReentrant whenNotPaused updateRewards(msg.sender) {
         if (amount == 0) revert InvalidAmount();
         if (amount > staked[msg.sender]) revert InsufficientStake();
 
@@ -239,7 +240,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
         emit UnstakeQueued(msg.sender, batchId, amount);
     }
 
-    function flush() external nonReentrant {
+    function flush() external nonReentrant whenNotPaused {
         if (currentUnstakeBatch != oldestUnclaimedUnstakeBatch) revert PriorUnstakeBatchUnclaimed();
 
         uint32 batchId = currentUnstakeBatch;
@@ -263,7 +264,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
         emit UnstakeBatchFlushed(batchId, e.total, unlockAt);
     }
 
-    function claimUnstakeBatch(uint32 batchId) external nonReentrant {
+    function claimUnstakeBatch(uint32 batchId) external nonReentrant whenNotPaused {
         UnstakeBatch storage e = unstakeBatches[batchId];
         if (e.unlockAt == 0 || block.timestamp < e.unlockAt) revert UnstakeBatchNotReady();
         if (e.claimed) revert UnstakeBatchAlreadyClaimed();
@@ -290,7 +291,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
     //                        REWARD CLAIMS
     // ═══════════════════════════════════════════════════════════════════
 
-    function claimUsdc() external nonReentrant updateRewards(msg.sender) {
+    function claimUsdc() external nonReentrant whenNotPaused updateRewards(msg.sender) {
         uint256 owed = usdcRewards[msg.sender];
         if (owed == 0) revert NothingToClaim();
         usdcRewards[msg.sender] = 0;
@@ -299,7 +300,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
         emit UsdcPaid(msg.sender, owed);
     }
 
-    function claimAnts(uint32[] calldata rewardEpochIds) external nonReentrant {
+    function claimAnts(uint32[] calldata rewardEpochIds) external nonReentrant whenNotPaused {
         uint256 len = rewardEpochIds.length;
         if (len == 0 || len > MAX_EPOCHS_PER_CAPTURE) revert InvalidAmount();
 
@@ -358,7 +359,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
         emit AntsClaimed(msg.sender, rewardEpochIds, totalAnts);
     }
 
-    function catchUpPoints(uint32 numEpochs) external nonReentrant {
+    function catchUpPoints(uint32 numEpochs) external nonReentrant whenNotPaused {
         if (numEpochs == 0) revert InvalidAmount();
         _updateUsdcForUser(msg.sender);
         _syncFinalizedRewardEpochsBounded(numEpochs);
@@ -396,7 +397,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
         uint128 newMaxAmount,
         uint256 deadline,
         bytes calldata reserveSig
-    ) public override nonReentrant {
+    ) public override nonReentrant whenNotPaused {
         uint256 beforeBal = usdc.balanceOf(address(this));
         super.topUp(channelId, cumulativeAmount, metadata, spendingSig, newMaxAmount, deadline, reserveSig);
         _distributeUsdcInstant(usdc.balanceOf(address(this)) - beforeBal);
@@ -406,6 +407,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
         public
         override
         nonReentrant
+        whenNotPaused
     {
         uint256 beforeBal = usdc.balanceOf(address(this));
         super.settle(channelId, cumulativeAmount, metadata, buyerSig);
@@ -416,6 +418,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
         public
         override
         nonReentrant
+        whenNotPaused
     {
         uint256 beforeBal = usdc.balanceOf(address(this));
         super.close(channelId, finalAmount, metadata, buyerSig);
@@ -426,7 +429,7 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
     //                        REWARD EPOCHS
     // ═══════════════════════════════════════════════════════════════════
 
-    function syncRewardEpochs(uint32 maxEpochs) external nonReentrant {
+    function syncRewardEpochs(uint32 maxEpochs) external nonReentrant whenNotPaused {
         if (maxEpochs == 0) revert InvalidAmount();
 
         if (_syncFinalizedRewardEpochsBounded(maxEpochs) == 0) revert NothingToSync();
@@ -435,6 +438,14 @@ contract DiemStakingProxy is AntseedSellerDelegation, IERC1271 {
     // ═══════════════════════════════════════════════════════════════════
     //                        ADMIN
     // ═══════════════════════════════════════════════════════════════════
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
 
     function withdrawAntseedStake(address recipient) external onlyOwner nonReentrant {
         if (recipient == address(0)) revert InvalidAddress();

--- a/packages/contracts/interfaces/IAntseedDeposits.sol
+++ b/packages/contracts/interfaces/IAntseedDeposits.sol
@@ -2,11 +2,9 @@
 pragma solidity ^0.8.24;
 
 interface IAntseedDeposits {
+    function usdc() external view returns (address);
     function lockForChannel(address buyer, uint256 amount) external;
-    function chargeAndCreditPayouts(
-        address buyer, address seller, uint256 amount,
-        uint256 platformFee
-    ) external;
+    function chargeAndCreditPayouts(address buyer, address seller, uint256 amount, uint256 platformFee) external;
     function releaseLock(address buyer, uint256 amount) external;
     function getOperator(address buyer) external view returns (address);
     function getOperatorNonce(address buyer) external view returns (uint256);

--- a/packages/contracts/interfaces/IAntseedEmissions.sol
+++ b/packages/contracts/interfaces/IAntseedEmissions.sol
@@ -4,4 +4,10 @@ pragma solidity ^0.8.24;
 interface IAntseedEmissions {
     function accrueSellerPoints(address seller, uint256 pointsDelta) external;
     function accrueBuyerPoints(address buyer, uint256 pointsDelta) external;
+    function claimSellerEmissions(uint256[] calldata epochs) external;
+    function pendingEmissions(address account, uint256[] calldata epochs)
+        external
+        view
+        returns (uint256 totalSeller, uint256 totalBuyer);
+    function currentEpoch() external view returns (uint256);
 }

--- a/packages/contracts/test/DiemStakingProxy.t.sol
+++ b/packages/contracts/test/DiemStakingProxy.t.sol
@@ -324,6 +324,22 @@ contract DiemStakingProxyTest is Test {
         proxy.flush();
     }
 
+    function test_flush_succeedsImmediatelyWhenBatchFull() public {
+        vm.prank(owner);
+        proxy.setMinUnstakeBatchOpenSecs(6 hours);
+
+        for (uint256 i = 0; i < proxy.MAX_PER_UNSTAKE_BATCH(); i++) {
+            address user = address(uint160(0x1000 + i));
+            _stakeAs(user, 1e18);
+            vm.prank(user);
+            proxy.initiateUnstake(1e18);
+        }
+
+        (,, uint32 userCount,) = proxy.unstakeBatches(proxy.currentUnstakeBatch());
+        assertEq(userCount, proxy.MAX_PER_UNSTAKE_BATCH());
+        proxy.flush();
+    }
+
     function test_flush_windowMeasuredFromFirstQueuer() public {
         vm.prank(owner);
         proxy.setMinUnstakeBatchOpenSecs(6 hours);
@@ -403,6 +419,89 @@ contract DiemStakingProxyTest is Test {
         vm.prank(owner);
         proxy.setMinUnstakeBatchOpenSecs(7 days);
         assertEq(proxy.minUnstakeBatchOpenSecs(), 7 days);
+    }
+
+    function test_pause_onlyOwnerAndUnpauseRestoresStake() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.pause();
+
+        vm.prank(owner);
+        proxy.pause();
+
+        diem.mint(alice, 10e18);
+        vm.startPrank(alice);
+        diem.approve(address(proxy), 10e18);
+        vm.expectRevert();
+        proxy.stake(10e18);
+        vm.stopPrank();
+
+        vm.prank(owner);
+        proxy.unpause();
+
+        vm.prank(alice);
+        proxy.stake(10e18);
+        assertEq(proxy.staked(alice), 10e18);
+    }
+
+    function test_pause_blocksUserFacingFlowsButAllowsExitAndSync() public {
+        _stakeAs(alice, 100e18);
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.prank(alice);
+        proxy.initiateUnstake(50e18);
+        uint32 batchId = proxy.currentUnstakeBatch();
+        proxy.flush();
+
+        vm.prank(owner);
+        proxy.pause();
+
+        diem.mint(bob, 1e18);
+        vm.startPrank(bob);
+        diem.approve(address(proxy), 1e18);
+        vm.expectRevert();
+        proxy.stake(1e18);
+        vm.stopPrank();
+
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.initiateUnstake(1e18);
+
+        vm.expectRevert();
+        proxy.flush();
+
+        bytes memory pausedMetadata = _encodeMetadata(600e6, 0);
+        bytes memory pausedSig = _signSpendingAuth(channelId, 600e6, pausedMetadata);
+
+        vm.prank(operator);
+        vm.expectRevert();
+        proxy.settle(channelId, 600e6, pausedMetadata, pausedSig);
+
+        vm.prank(operator);
+        vm.expectRevert();
+        proxy.close(channelId, 600e6, pausedMetadata, pausedSig);
+
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.claimUsdc();
+
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.claimAnts(_rewardEpochs(0, 1));
+
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.catchUpPoints(1);
+
+        vm.warp(block.timestamp + EPOCH_DURATION + 1);
+        proxy.syncRewardEpochs(1);
+        assertEq(proxy.syncedRewardEpoch(), 1, "sync remains available while paused");
+
+        vm.warp(block.timestamp + DIEM_COOLDOWN + 1);
+        uint256 before = diem.balanceOf(alice);
+        proxy.claimUnstakeBatch(batchId);
+        assertEq(diem.balanceOf(alice) - before, 50e18, "exits remain available while paused");
     }
 
     function _advanceRewardEpochs(uint256 count) internal {
@@ -594,7 +693,7 @@ contract DiemStakingProxyTest is Test {
         _settleViaProxy(channelId, 500e6);
         uint256 inflow = usdc.balanceOf(address(proxy)) - usdcBefore;
 
-        assertEq(inflow, 500e6 - (500e6 * 200) / 10000);
+        assertEq(inflow, 500e6 - (500e6 * 200) / 10000 - ((500e6 - (500e6 * 200) / 10000) * 1000) / 10000);
 
         uint256 storedAfter = proxy.usdcRewardPerTokenStored();
         assertGt(storedAfter, storedBefore);
@@ -610,29 +709,28 @@ contract DiemStakingProxyTest is Test {
         _closeViaProxy(channelId, 400e6);
         uint256 inflow = usdc.balanceOf(address(proxy)) - usdcBefore;
 
-        assertEq(inflow, 400e6 - (400e6 * 200) / 10000);
+        assertEq(inflow, 400e6 - (400e6 * 200) / 10000 - ((400e6 - (400e6 * 200) / 10000) * 1000) / 10000);
         assertEq(proxy.earnedUsdc(alice), inflow);
 
         assertEq(channels.activeChannelCount(address(proxy)), 0);
     }
 
-    function test_operatorFee_takesUsdcCutFromSettlement() public {
+    function test_operatorFee_takesDefaultUsdcCutFromSettlement() public {
         _stakeAs(alice, 100e18);
-
-        vm.prank(owner);
-        proxy.setOperatorFee(500, bob);
 
         bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
 
-        uint256 recipientBefore = usdc.balanceOf(bob);
+        uint256 recipientBefore = usdc.balanceOf(operator);
         uint256 proxyBefore = usdc.balanceOf(address(proxy));
         _settleViaProxy(channelId, 500e6);
 
         uint256 protocolNetInflow = 500e6 - (500e6 * 200) / 10000;
-        uint256 operatorFee = (protocolNetInflow * 500) / 10000;
+        uint256 operatorFee = (protocolNetInflow * proxy.DEFAULT_OPERATOR_FEE_BPS()) / 10000;
         uint256 stakerNet = protocolNetInflow - operatorFee;
 
-        assertEq(usdc.balanceOf(bob) - recipientBefore, operatorFee);
+        assertEq(proxy.operatorFeeBps(), 1000);
+        assertEq(proxy.operatorFeeRecipient(), operator);
+        assertEq(usdc.balanceOf(operator) - recipientBefore, operatorFee);
         assertEq(usdc.balanceOf(address(proxy)) - proxyBefore, stakerNet);
         assertEq(proxy.earnedUsdc(alice), stakerNet);
         assertEq(proxy.totalUsdcReservedForStakers(), stakerNet);
@@ -650,14 +748,15 @@ contract DiemStakingProxyTest is Test {
 
         vm.prank(owner);
         vm.expectRevert(AntseedSellerDelegation.OperatorFeeTooLarge.selector);
-        proxy.setOperatorFee(501, bob);
+        proxy.setOperatorFee(2001, bob);
+
+        vm.prank(owner);
+        proxy.setOperatorFee(2000, bob);
+        assertEq(proxy.operatorFeeBps(), 2000);
     }
 
     function test_operatorFee_takesAntsCutFromEpochPot() public {
         _stakeAs(alice, 100e18);
-
-        vm.prank(owner);
-        proxy.setOperatorFee(500, bob);
 
         bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
         _settleViaProxy(channelId, 500e6);
@@ -667,15 +766,15 @@ contract DiemStakingProxyTest is Test {
         uint256[] memory ids = new uint256[](1);
         ids[0] = 0;
         (uint256 pendingSeller,) = emissions.pendingEmissions(address(proxy), ids);
-        uint256 operatorFee = (pendingSeller * 500) / 10000;
+        uint256 operatorFee = (pendingSeller * proxy.DEFAULT_OPERATOR_FEE_BPS()) / 10000;
         uint256 stakerPot = pendingSeller - operatorFee;
 
         uint256 aliceBefore = ants.balanceOf(alice);
-        uint256 recipientBefore = ants.balanceOf(bob);
+        uint256 recipientBefore = ants.balanceOf(operator);
         vm.prank(alice);
         proxy.claimAnts(_rewardEpochs(0, 1));
 
-        assertEq(ants.balanceOf(bob) - recipientBefore, operatorFee);
+        assertEq(ants.balanceOf(operator) - recipientBefore, operatorFee);
         assertEq(ants.balanceOf(alice) - aliceBefore, stakerPot);
         (,, uint256 antsPot,) = proxy.rewardEpochs(0);
         assertEq(antsPot, stakerPot);

--- a/packages/contracts/test/DiemStakingProxy.t.sol
+++ b/packages/contracts/test/DiemStakingProxy.t.sol
@@ -1393,11 +1393,10 @@ contract DiemStakingProxyTest is Test {
     }
 
 
-    function test_isValidSignature_malformedSigReverts() public {
+    function test_isValidSignature_malformedSigReturnsInvalid() public {
         bytes32 hash = keccak256("venice-api-key-challenge");
         bytes memory bad = hex"deadbeef"; // 4 bytes, not 65
-        vm.expectRevert();
-        proxy.isValidSignature(hash, bad);
+        assertEq(proxy.isValidSignature(hash, bad), bytes4(0xffffffff));
     }
 
 

--- a/packages/contracts/test/DiemStakingProxy.t.sol
+++ b/packages/contracts/test/DiemStakingProxy.t.sol
@@ -3,18 +3,18 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 
-import {MockUSDC} from "../MockUSDC.sol";
-import {MockERC8004Registry} from "../MockERC8004Registry.sol";
-import {ANTSToken} from "../ANTSToken.sol";
-import {AntseedRegistry} from "../AntseedRegistry.sol";
-import {AntseedDeposits} from "../AntseedDeposits.sol";
-import {AntseedStaking} from "../AntseedStaking.sol";
-import {AntseedChannels} from "../AntseedChannels.sol";
-import {AntseedEmissions} from "../AntseedEmissions.sol";
-import {DiemStakingProxy} from "../DiemStakingProxy.sol";
-import {AntseedSellerDelegation} from "../AntseedSellerDelegation.sol";
+import { MockUSDC } from "../MockUSDC.sol";
+import { MockERC8004Registry } from "../MockERC8004Registry.sol";
+import { ANTSToken } from "../ANTSToken.sol";
+import { AntseedRegistry } from "../AntseedRegistry.sol";
+import { AntseedDeposits } from "../AntseedDeposits.sol";
+import { AntseedStaking } from "../AntseedStaking.sol";
+import { AntseedChannels } from "../AntseedChannels.sol";
+import { AntseedEmissions } from "../AntseedEmissions.sol";
+import { DiemStakingProxy } from "../DiemStakingProxy.sol";
+import { AntseedSellerDelegation } from "../AntseedSellerDelegation.sol";
 
-import {MockDiem} from "./mocks/MockDiem.sol";
+import { MockDiem } from "./mocks/MockDiem.sol";
 
 contract DiemStakingProxyTest is Test {
     uint256 constant OWNER_PK = 0x0A;
@@ -110,7 +110,6 @@ contract DiemStakingProxyTest is Test {
         proxy.setMinUnstakeBatchOpenSecs(0);
     }
 
-
     function _stakeAs(address user, uint256 amount) internal {
         diem.mint(user, amount);
         vm.startPrank(user);
@@ -118,7 +117,6 @@ contract DiemStakingProxyTest is Test {
         proxy.stake(amount);
         vm.stopPrank();
     }
-
 
     function _setupBuyer(uint256 depositAmount) internal {
         vm.prank(buyer);
@@ -199,7 +197,6 @@ contract DiemStakingProxyTest is Test {
         vm.prank(operator);
         proxy.close(channelId, finalAmount, metadata, sig);
     }
-
 
     function test_stake_success() public {
         _stakeAs(alice, 100e18);
@@ -308,7 +305,6 @@ contract DiemStakingProxyTest is Test {
         proxy.flush();
     }
 
-
     function test_flush_revertsBeforeMinUnstakeBatchOpenSecs() public {
         vm.prank(owner);
         proxy.setMinUnstakeBatchOpenSecs(6 hours);
@@ -408,7 +404,6 @@ contract DiemStakingProxyTest is Test {
         proxy.setMinUnstakeBatchOpenSecs(7 days);
         assertEq(proxy.minUnstakeBatchOpenSecs(), 7 days);
     }
-
 
     function _advanceRewardEpochs(uint256 count) internal {
         for (uint256 i = 0; i < count; i++) {
@@ -571,7 +566,6 @@ contract DiemStakingProxyTest is Test {
         assertEq(diem.balanceOf(address(proxy)), 100e18);
     }
 
-
     function test_reserve_forwardsToChannels() public {
         _setupBuyer(200e6);
 
@@ -622,6 +616,71 @@ contract DiemStakingProxyTest is Test {
         assertEq(channels.activeChannelCount(address(proxy)), 0);
     }
 
+    function test_operatorFee_takesUsdcCutFromSettlement() public {
+        _stakeAs(alice, 100e18);
+
+        vm.prank(owner);
+        proxy.setOperatorFee(500, bob);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+
+        uint256 recipientBefore = usdc.balanceOf(bob);
+        uint256 proxyBefore = usdc.balanceOf(address(proxy));
+        _settleViaProxy(channelId, 500e6);
+
+        uint256 protocolNetInflow = 500e6 - (500e6 * 200) / 10000;
+        uint256 operatorFee = (protocolNetInflow * 500) / 10000;
+        uint256 stakerNet = protocolNetInflow - operatorFee;
+
+        assertEq(usdc.balanceOf(bob) - recipientBefore, operatorFee);
+        assertEq(usdc.balanceOf(address(proxy)) - proxyBefore, stakerNet);
+        assertEq(proxy.earnedUsdc(alice), stakerNet);
+        assertEq(proxy.totalUsdcReservedForStakers(), stakerNet);
+    }
+
+    function test_setOperatorFee_enforcesMaxAndRecipient() public {
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit AntseedSellerDelegation.OperatorFeeSet(0, address(0));
+        proxy.setOperatorFee(0, address(0));
+
+        vm.prank(owner);
+        vm.expectRevert(AntseedSellerDelegation.InvalidAddress.selector);
+        proxy.setOperatorFee(1, address(0));
+
+        vm.prank(owner);
+        vm.expectRevert(AntseedSellerDelegation.OperatorFeeTooLarge.selector);
+        proxy.setOperatorFee(501, bob);
+    }
+
+    function test_operatorFee_takesAntsCutFromEpochPot() public {
+        _stakeAs(alice, 100e18);
+
+        vm.prank(owner);
+        proxy.setOperatorFee(500, bob);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.warp(block.timestamp + EPOCH_DURATION + 1);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 0;
+        (uint256 pendingSeller,) = emissions.pendingEmissions(address(proxy), ids);
+        uint256 operatorFee = (pendingSeller * 500) / 10000;
+        uint256 stakerPot = pendingSeller - operatorFee;
+
+        uint256 aliceBefore = ants.balanceOf(alice);
+        uint256 recipientBefore = ants.balanceOf(bob);
+        vm.prank(alice);
+        proxy.claimAnts(_rewardEpochs(0, 1));
+
+        assertEq(ants.balanceOf(bob) - recipientBefore, operatorFee);
+        assertEq(ants.balanceOf(alice) - aliceBefore, stakerPot);
+        (,, uint256 antsPot,) = proxy.rewardEpochs(0);
+        assertEq(antsPot, stakerPot);
+    }
+
     function test_topUp_noInflow_noNotify() public {
         _stakeAs(alice, 100e18);
 
@@ -644,7 +703,6 @@ contract DiemStakingProxyTest is Test {
         uint256 storedAfter = proxy.usdcRewardPerTokenStored();
         assertEq(storedAfter, storedBefore, "rewardPerTokenStored must not change");
     }
-
 
     function test_claimAnts_opensAndFundsRewardEpoch() public {
         _stakeAs(alice, 100e18);
@@ -692,7 +750,6 @@ contract DiemStakingProxyTest is Test {
         assertEq(ants.balanceOf(address(proxy)), 0, "no ANTS minted into proxy");
         assertTrue(proxy.userEpochClaimed(alice, 0), "user can advance past empty epoch");
     }
-
 
     function test_claimUsdcAndClaimAnts_paysBothRewards() public {
         _stakeAs(alice, 100e18);
@@ -881,7 +938,6 @@ contract DiemStakingProxyTest is Test {
         assertGt(proxy.pendingAntsForEpoch(alice, 0), 0, "unstaked user retains points");
     }
 
-
     function test_setOperator_onlyOwner_revertsForNonOwner() public {
         vm.prank(alice);
         vm.expectRevert();
@@ -955,7 +1011,6 @@ contract DiemStakingProxyTest is Test {
         assertEq(storedAfter, storedBefore, "stake recovery must not be routed to stakers as a reward");
     }
 
-
     function test_isValidSignature_validOwner() public view {
         bytes32 hash = keccak256("venice-api-key-challenge");
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(OWNER_PK, hash);
@@ -991,7 +1046,6 @@ contract DiemStakingProxyTest is Test {
         bytes memory newSig = abi.encodePacked(r2, s2, v2);
         assertEq(proxy.isValidSignature(hash, newSig), bytes4(0x1626ba7e));
     }
-
 
     function test_sweepOrphanUsdc_recoversInflowWithNoStakers() public {
         bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 500e6, 500e6);
@@ -1077,7 +1131,6 @@ contract DiemStakingProxyTest is Test {
         proxy.sweepOrphanUsdc(address(0));
     }
 
-
     function test_maxTotalStake_defaultsToAlphaCap_onFreshDeploy() public {
         vm.prank(owner);
         DiemStakingProxy fresh = new DiemStakingProxy(address(diem), address(usdc), address(antseedRegistry), operator);
@@ -1161,7 +1214,6 @@ contract DiemStakingProxyTest is Test {
         assertEq(proxy.totalStaked(), 1_000_000e18);
     }
 
-
     function test_stakerCount_startsAtZero() public view {
         assertEq(proxy.stakerCount(), 0);
     }
@@ -1207,7 +1259,6 @@ contract DiemStakingProxyTest is Test {
         assertEq(proxy.stakerCount(), 1, "re-entry counts again");
     }
 
-
     function test_totalUsdcDistributedEver_accumulatesAcrossSettles() public {
         _stakeAs(alice, 100e18);
 
@@ -1238,7 +1289,6 @@ contract DiemStakingProxyTest is Test {
         _settleViaProxy(channelId, 400e6);
         assertEq(proxy.totalUsdcDistributedEver(), 0, "no-staker inflow doesn't count as distributed");
     }
-
 
     function test_invariant_usdcClaimsSumToInflows() public {
         _stakeAs(alice, 40e18);
@@ -1315,7 +1365,6 @@ contract DiemStakingProxyTest is Test {
         assertApproxEqAbs(paidOut, antsPot, 2, "rounding dust bounded by #claimants");
     }
 
-
     function test_catchUpPoints_openEpochDeferredThenCaptured() public {
         _stakeAs(alice, 100e18);
 
@@ -1338,7 +1387,6 @@ contract DiemStakingProxyTest is Test {
         proxy.initiateUnstake(1e18);
         assertGt(proxy.userPoints(alice, openEp), 0, "open-epoch points captured on next interaction");
     }
-
 
     function test_churn_stakeSettleUnstakeRestakeSettle() public {
         _stakeAs(alice, 100e18);
@@ -1366,7 +1414,6 @@ contract DiemStakingProxyTest is Test {
         assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
     }
 
-
     function test_flush_windowAfterImmediateNextQueue() public {
         vm.prank(owner);
         proxy.setMinUnstakeBatchOpenSecs(6 hours);
@@ -1392,13 +1439,11 @@ contract DiemStakingProxyTest is Test {
         proxy.flush();
     }
 
-
     function test_isValidSignature_malformedSigReturnsInvalid() public {
         bytes32 hash = keccak256("venice-api-key-challenge");
         bytes memory bad = hex"deadbeef"; // 4 bytes, not 65
         assertEq(proxy.isValidSignature(hash, bad), bytes4(0xffffffff));
     }
-
 
     function test_rewardPerToken_precisionAtHighTvl() public {
         vm.prank(owner);


### PR DESCRIPTION
## Summary
- add emergency pause controls to DiemStakingProxy user-facing flows
- allow full unstake batches to flush immediately to reduce dust griefing impact
- make ERC-1271 malformed signatures return the invalid selector instead of reverting
- expose reward and user-point backlog view helpers for keeper/frontend monitoring
- add configurable seller-delegation operator fees: default 10%, capped at 20%, applied to channel USDC payouts and seller ANTS emissions

## Notes
- operator fee recipient defaults to the initial operator and is owner-configurable; any operator can execute channel lifecycle calls, but fees always go to the configured recipient
- fee logic lives in AntseedSellerDelegation:
  - delegated topUp/settle/close return the net seller payout after fees
  - seller emission claims return the net ANTS payout after fees
  - pending seller emissions are reported net of fees, so DiemStakingProxy does not apply fee math itself
- DiemStakingProxy uses the net values directly for USDC distribution and reward epoch pots
- omitted the per-payment OperatorFeePaid event; only fee configuration changes emit OperatorFeeSet
- addressed review feedback: exits and reward sync stay available while paused; added full-batch flush and pause coverage; moved local interfaces into interfaces/; cleaned operator fee math

## Commits
- feat: add pause controls to Diem staking proxy
- fix: allow full unstake batches to flush immediately
- fix: return invalid for malformed ERC1271 signatures
- feat: expose reward backlog views
- feat: add seller delegation operator fees
- refactor: return net seller emissions from delegation
- fix: address staking proxy review feedback
- refactor: simplify operator fee math
- refactor: net pending seller emissions in delegation
- refactor: omit operator fee paid event

## Tests
- cd packages/contracts && forge test
