### PR TITLE
chore(node): log peer metadata resolution decisions

### DIFF
--- a/packages/node/src/discovery/http-metadata-resolver.ts
+++ b/packages/node/src/discovery/http-metadata-resolver.ts
@@ -1,6 +1,6 @@
 import type { PeerEndpoint, MetadataResolver } from './metadata-resolver.js';
 import type { PeerMetadata } from './peer-metadata.js';
-import { debugWarn } from '../utils/debug.js';
+import { debugLog, debugWarn } from '../utils/debug.js';
 
 export interface HttpMetadataResolverConfig {
   /** Timeout in ms for each metadata fetch. Default: 1500 */
@@ -51,6 +51,11 @@ export class HttpMetadataResolver implements MetadataResolver {
     const failedState = this.failedEndpoints.get(endpointKey);
     if (failedState !== undefined) {
       if (failedState.nextRetryAt > now) {
+        debugLog(
+          `[MetadataResolver] Skipping ${endpointKey}: failure cooldown `
+          + `${failedState.nextRetryAt - now}ms remaining after `
+          + `${failedState.consecutiveFailures} failure(s)`,
+        );
         return null;
       }
     }
@@ -65,11 +70,18 @@ export class HttpMetadataResolver implements MetadataResolver {
 
       if (!response.ok) {
         this.markEndpointFailure(endpointKey);
+        debugWarn(`[MetadataResolver] Failed to resolve ${url}: HTTP ${response.status}`);
         return null;
       }
 
       const metadata = (await response.json()) as PeerMetadata;
       this.failedEndpoints.delete(endpointKey);
+      debugLog(
+        `[MetadataResolver] Resolved ${url}: peerId=${metadata.peerId?.slice(0, 12) ?? 'unknown'}... `
+        + `displayName=${JSON.stringify(metadata.displayName ?? null)} `
+        + `providers=${metadata.providers?.length ?? 0} `
+        + `ageMs=${typeof metadata.timestamp === 'number' ? Date.now() - metadata.timestamp : 'unknown'}`,
+      );
       return metadata;
     } catch (err) {
       this.markEndpointFailure(endpointKey);

--- a/packages/node/src/discovery/peer-lookup.ts
+++ b/packages/node/src/discovery/peer-lookup.ts
@@ -11,7 +11,7 @@ import {
 import type { PeerMetadata } from "./peer-metadata.js";
 import { encodeMetadataForSigning } from "./metadata-codec.js";
 import type { MetadataResolver, PeerEndpoint } from "./metadata-resolver.js";
-import { debugLog } from "../utils/debug.js";
+import { debugLog, debugWarn } from "../utils/debug.js";
 
 function shuffle<T>(arr: T[]): T[] {
   const out = arr.slice();
@@ -271,6 +271,15 @@ export class PeerLookup {
       }
     }
 
+    debugLog(
+      `[PeerLookup] Resolving metadata for ${uniquePeers.length}/${peers.length} unique endpoint(s)`,
+    );
+    if (uniquePeers.length > 0) {
+      debugLog(
+        `[PeerLookup] Metadata endpoints: ${uniquePeers.map((p) => `${p.host}:${p.port}`).join(', ')}`,
+      );
+    }
+
     // Resolve all peers in parallel — bad-port timeouts no longer block good peers
     const settled = await Promise.allSettled(
       uniquePeers.map((peer) => this._resolveSinglePeer(peer)),
@@ -290,6 +299,7 @@ export class PeerLookup {
   }
 
   private async _resolveSinglePeer(peer: PeerEndpoint): Promise<LookupResult | null> {
+    const endpoint = `${peer.host}:${peer.port}`;
     const metadata = await this.config.metadataResolver.resolve(peer);
     if (metadata === null) {
       return null;
@@ -298,14 +308,28 @@ export class PeerLookup {
     if (this.config.requireValidSignature) {
       const valid = await this.verifyMetadataSignature(metadata);
       if (!valid) {
+        debugWarn(
+          `[PeerLookup] Dropping metadata from ${endpoint}: invalid signature `
+          + `peerId=${metadata.peerId?.slice(0, 12) ?? 'unknown'}...`,
+        );
         return null;
       }
     }
 
     if (!this.config.allowStaleMetadata && this.isStale(metadata)) {
+      debugWarn(
+        `[PeerLookup] Dropping metadata from ${endpoint}: stale `
+        + `ageMs=${Date.now() - metadata.timestamp} maxAgeMs=${this.config.maxAnnouncementAgeMs} `
+        + `peerId=${metadata.peerId?.slice(0, 12) ?? 'unknown'}...`,
+      );
       return null;
     }
 
+    debugLog(
+      `[PeerLookup] Accepted metadata from ${endpoint}: peerId=${metadata.peerId.slice(0, 12)}... `
+      + `displayName=${JSON.stringify(metadata.displayName ?? null)} `
+      + `providers=${metadata.providers.length}`,
+    );
     return { metadata, host: peer.host, port: peer.port };
   }
 


### PR DESCRIPTION
## Summary\n- log successful metadata fetches, including peer id, display name, provider count, and metadata age\n- log endpoints skipped due to metadata resolver failure cooldown\n- log metadata endpoint sets and validation drops for invalid signatures or stale announcements\n\n## Why\nThis makes DHT discovery failures diagnosable by distinguishing:\n- DHT did not return the live endpoint\n- metadata HTTP fetch succeeded but was later dropped\n- metadata was stale or signature-invalid\n- resolver skipped an endpoint due to cooldown\n\n## Test\n- pnpm --filter=@antseed/node run typecheck