### PR TITLE
fix(cli): align buyer channel status output

### DIFF
--- a/apps/cli/src/cli/commands/buyer/channels.ts
+++ b/apps/cli/src/cli/commands/buyer/channels.ts
@@ -2,7 +2,7 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import { loadOrCreateIdentity } from '@antseed/node';
 import { getGlobalOptions } from '../types.js';
-import { openChannelStore } from '../../payment-utils.js';
+import { formatUsdc, openChannelStore } from '../../payment-utils.js';
 
 function short(id: string, len = 10): string {
   return id.length > len ? id.slice(0, len) + '...' : id;
@@ -16,6 +16,15 @@ function statusColor(status: string): string {
     case 'ghost': return chalk.red(status);
     default: return status;
   }
+}
+
+function usdc(baseUnits: string | null | undefined): string {
+  return `${formatUsdc(BigInt(baseUnits ?? '0'))} USDC`;
+}
+
+function subtractBigintFloor(left: string | null | undefined, right: string | null | undefined): string {
+  const result = BigInt(left ?? '0') - BigInt(right ?? '0');
+  return result > 0n ? result.toString() : '0';
 }
 
 export function registerBuyerChannelsCommand(buyerCmd: Command): void {
@@ -64,10 +73,12 @@ export function registerBuyerChannelsCommand(buyerCmd: Command): void {
         console.log(chalk.bold(`Payment Channels (${limited.length} of ${filtered.length}):\n`));
         for (const session of limited) {
           console.log(`  ${chalk.bold(short(session.sessionId, 16))}  ${statusColor(session.status)}  ${chalk.dim(session.role)}`);
+          const unsettled = subtractBigintFloor(session.authMax, session.settledAmount);
           console.log(`    Peer: ${chalk.dim(short(session.peerId, 16))}  Requests: ${session.requestCount}  Tokens: ${session.tokensDelivered}`);
+          console.log(`    Deposit: ${chalk.green(usdc(session.authMax))}  Settled: ${chalk.cyan(usdc(session.settledAmount))}  Unsettled: ${chalk.yellow(usdc(unsettled))}`);
           console.log(`    Created: ${chalk.dim(new Date(session.createdAt).toISOString())}`);
           if (session.settledAt) {
-            console.log(`    Settled: ${chalk.dim(new Date(session.settledAt).toISOString())}  Amount: ${session.settledAmount ?? 'N/A'}`);
+            console.log(`    Settled: ${chalk.dim(new Date(session.settledAt).toISOString())}`);
           }
           console.log('');
         }

--- a/apps/cli/src/cli/commands/buyer/status.ts
+++ b/apps/cli/src/cli/commands/buyer/status.ts
@@ -4,7 +4,7 @@ import Table from 'cli-table3';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { getGlobalOptions } from '../types.js';
-import { createDepositsClient, loadCryptoContext, formatUsdc } from '../../payment-utils.js';
+import { createDepositsClient, loadCryptoContext, formatUsdc, openChannelStore } from '../../payment-utils.js';
 import { loadConfig } from '../../../config/loader.js';
 import { getNodeStatus } from '../../../status/node-status.js';
 
@@ -49,6 +49,19 @@ export function registerBuyerStatusCommand(buyerCmd: Command): void {
           // Non-fatal: show the status view even if chain access is unavailable.
         }
 
+        let activeChannels = nodeStatus.activeChannels;
+        try {
+          const store = openChannelStore(globalOpts.dataDir);
+          try {
+            activeChannels = store.getActiveChannelsByBuyer('buyer', identity.address).length;
+          } finally {
+            store.close();
+          }
+        } catch {
+          // Non-fatal: if the local channel DB does not exist yet, keep the
+          // daemon-reported value (or zero for a buyer proxy with no channels).
+        }
+
         if (options.json) {
           console.log(JSON.stringify({
             connectionState: nodeStatus.state,
@@ -57,7 +70,7 @@ export function registerBuyerStatusCommand(buyerCmd: Command): void {
             pinnedPeerId: buyerState?.pinnedPeerId ?? null,
             depositsAvailable,
             depositsReserved,
-            activeChannels: nodeStatus.activeChannels,
+            activeChannels,
             walletAddress: nodeStatus.walletAddress ?? identity.address,
           }, null, 2));
           return;
@@ -75,7 +88,7 @@ export function registerBuyerStatusCommand(buyerCmd: Command): void {
           ['Pinned peer', buyerState?.pinnedPeerId ? chalk.cyan(buyerState.pinnedPeerId) : chalk.dim('none')],
           ['Deposits available', depositsAvailable ? chalk.green(`${depositsAvailable} USDC`) : chalk.dim('unavailable')],
           ['Deposits reserved', depositsReserved ? chalk.yellow(`${depositsReserved} USDC`) : chalk.dim('unavailable')],
-          ['Active channels', String(nodeStatus.activeChannels)],
+          ['Active channels', String(activeChannels)],
           ['Wallet address', nodeStatus.walletAddress ?? identity.address ?? chalk.dim('not configured')],
         );
 


### PR DESCRIPTION
## Summary
- make `antseed buyer status` count active buyer channels from the local channel store
- add USDC deposit/settled/unsettled amounts to `antseed buyer channels`

Closes #367
Closes #368

## Test plan
- [x] `pnpm --filter @antseed/cli typecheck`
- [x] `pnpm --filter @antseed/cli test` (73/73 passing)
