### PR TITLE
fix(desktop): Keep chat peer pins scoped

### DIFF
--- a/apps/desktop/src/main/chat-peer-selection.test.ts
+++ b/apps/desktop/src/main/chat-peer-selection.test.ts
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ANTSEED_PEER_CUSTOM_TYPE,
+  normalizeChatPeerSelectionRequest,
+  resolveLatestPeerBinding,
+} from './chat-peer-selection.js';
+
+test('normalizeChatPeerSelectionRequest preserves legacy string payloads', () => {
+  assert.deepEqual(normalizeChatPeerSelectionRequest(' peer-123 '), {
+    conversationId: null,
+    peerId: 'peer-123',
+  });
+
+  assert.deepEqual(normalizeChatPeerSelectionRequest(null), {
+    conversationId: null,
+    peerId: null,
+  });
+});
+
+test('normalizeChatPeerSelectionRequest trims conversation-scoped payloads', () => {
+  assert.deepEqual(
+    normalizeChatPeerSelectionRequest({ conversationId: ' conv-1 ', peerId: ' peer-1 ' }),
+    {
+      conversationId: 'conv-1',
+      peerId: 'peer-1',
+    },
+  );
+});
+
+test('resolveLatestPeerBinding treats a newer clear entry as authoritative', () => {
+  const binding = resolveLatestPeerBinding([
+    {
+      type: 'custom',
+      customType: ANTSEED_PEER_CUSTOM_TYPE,
+      data: { peerId: 'peer-old', peerLabel: 'Old peer' },
+    },
+    {
+      type: 'custom',
+      customType: ANTSEED_PEER_CUSTOM_TYPE,
+      data: {},
+    },
+  ]);
+
+  assert.equal(binding, null);
+});
+
+test('resolveLatestPeerBinding returns the latest non-empty peer binding', () => {
+  const binding = resolveLatestPeerBinding([
+    {
+      type: 'custom',
+      customType: ANTSEED_PEER_CUSTOM_TYPE,
+      data: { peerId: 'peer-old', peerLabel: 'Old peer' },
+    },
+    {
+      type: 'custom',
+      customType: ANTSEED_PEER_CUSTOM_TYPE,
+      data: { peerId: ' peer-new ', peerLabel: ' New peer ' },
+    },
+  ]);
+
+  assert.deepEqual(binding, { peerId: 'peer-new', peerLabel: 'New peer' });
+});

--- a/apps/desktop/src/main/chat-peer-selection.ts
+++ b/apps/desktop/src/main/chat-peer-selection.ts
@@ -1,0 +1,64 @@
+export const ANTSEED_PEER_CUSTOM_TYPE = 'antseed:peer';
+
+export type ChatPeerSelectionRequest = {
+  conversationId?: string | null;
+  peerId?: string | null;
+};
+
+export type NormalizedChatPeerSelectionRequest = {
+  conversationId: string | null;
+  peerId: string | null;
+};
+
+export type PersistedPeerBinding = {
+  peerId: string;
+  peerLabel?: string;
+};
+
+type PersistedPeerSelectionEntry = {
+  type?: string;
+  customType?: string;
+  data?: unknown;
+};
+
+function normalizeOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function normalizeChatPeerSelectionRequest(
+  input: ChatPeerSelectionRequest | string | null,
+): NormalizedChatPeerSelectionRequest {
+  if (typeof input === 'string' || input === null) {
+    return {
+      conversationId: null,
+      peerId: normalizeOptionalString(input),
+    };
+  }
+
+  return {
+    conversationId: normalizeOptionalString(input.conversationId),
+    peerId: normalizeOptionalString(input.peerId),
+  };
+}
+
+export function resolveLatestPeerBinding(
+  entries: PersistedPeerSelectionEntry[],
+): PersistedPeerBinding | null {
+  for (let i = entries.length - 1; i >= 0; i -= 1) {
+    const entry = entries[i];
+    if (!entry || entry.type !== 'custom' || entry.customType !== ANTSEED_PEER_CUSTOM_TYPE) {
+      continue;
+    }
+
+    const data = entry.data as Record<string, unknown> | undefined;
+    const peerId = normalizeOptionalString(data?.peerId);
+    if (!peerId) {
+      return null;
+    }
+
+    const peerLabel = normalizeOptionalString(data?.peerLabel) ?? undefined;
+    return peerLabel ? { peerId, peerLabel } : { peerId };
+  }
+
+  return null;
+}

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -12,6 +12,12 @@ import {
   type ChatStreamStopReason,
 } from './chat-stream-stop.js';
 import {
+  ANTSEED_PEER_CUSTOM_TYPE,
+  normalizeChatPeerSelectionRequest,
+  resolveLatestPeerBinding,
+  type ChatPeerSelectionRequest,
+} from './chat-peer-selection.js';
+import {
   buildAttachmentPromptText,
   extractAttachmentImages,
   prepareChatAttachments,
@@ -1346,21 +1352,12 @@ function extractToolCallFromPartial(
   };
 }
 
-const ANTSEED_PEER_CUSTOM_TYPE = 'antseed:peer';
-
 type AntseedPeerData = { peerId: string; peerLabel?: string };
 
 function extractPeerFromEntries(manager: SessionManager): AntseedPeerData | null {
-  const entries = manager.getEntries();
-  // Walk backwards to find the latest antseed:peer custom entry
-  for (let i = entries.length - 1; i >= 0; i--) {
-    const entry = entries[i]!;
-    if (entry.type === 'custom' && 'customType' in entry && entry.customType === ANTSEED_PEER_CUSTOM_TYPE) {
-      const data = (entry as { data?: unknown }).data as AntseedPeerData | undefined;
-      if (data?.peerId) return data;
-    }
-  }
-  return null;
+  return resolveLatestPeerBinding(
+    manager.getEntries() as Array<{ type?: string; customType?: string; data?: unknown }>,
+  );
 }
 
 class PiConversationStore {
@@ -1536,6 +1533,12 @@ class PiConversationStore {
     const manager = await this.openSessionManager(id);
     if (!manager) return;
     manager.appendCustomEntry(ANTSEED_PEER_CUSTOM_TYPE, { peerId, peerLabel } satisfies AntseedPeerData);
+  }
+
+  async clearPeer(id: string): Promise<void> {
+    const manager = await this.openSessionManager(id);
+    if (!manager) return;
+    manager.appendCustomEntry(ANTSEED_PEER_CUSTOM_TYPE, {});
   }
 
   async delete(id: string): Promise<void> {
@@ -2715,19 +2718,31 @@ export function registerPiChatHandlers({
     return { ok: true };
   });
 
-  ipcMain.handle('chat:ai-select-peer', async (_event, peerId: string | null) => {
-    const normalizedPeerId = peerId && peerId.trim().length > 0 ? peerId.trim() : null;
-    if (!normalizedPeerId) {
-      preferredPeerByConversationId.clear();
+  ipcMain.handle('chat:ai-select-peer', async (_event, payload: ChatPeerSelectionRequest | string | null) => {
+    const { conversationId, peerId } = normalizeChatPeerSelectionRequest(payload);
+
+    if (conversationId) {
+      if (peerId) {
+        preferredPeerByConversationId.set(conversationId, peerId);
+        const peerLabel = lastServiceCatalogEntries.find((entry) => entry.peerId === peerId)?.peerLabel;
+        await store.setPeer(conversationId, peerId, peerLabel);
+      } else {
+        preferredPeerByConversationId.delete(conversationId);
+        await store.clearPeer(conversationId);
+      }
+    }
+
+    if (!peerId) {
       return { ok: true };
     }
+
     // Eager connection warmup via buyer proxy
     const proxyPort = await resolveProxyPort(configPath);
     try {
       const response = await fetch(`http://127.0.0.1:${proxyPort}/_antseed/connect`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ peerId: normalizedPeerId }),
+        body: JSON.stringify({ peerId }),
       });
       const result = await response.json() as { ok: boolean; error?: string };
       return { ok: result.ok, error: result.error };

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -236,8 +236,8 @@ const api = {
   chatAiAbort(conversationId?: string): Promise<{ ok: boolean }> {
     return ipcRenderer.invoke('chat:ai-abort', conversationId);
   },
-  chatAiSelectPeer(peerId: string | null): Promise<{ ok: boolean; error?: string }> {
-    return ipcRenderer.invoke('chat:ai-select-peer', peerId);
+  chatAiSelectPeer(payload: { conversationId?: string | null; peerId?: string | null }): Promise<{ ok: boolean; error?: string }> {
+    return ipcRenderer.invoke('chat:ai-select-peer', payload);
   },
   chatAiGetProxyStatus(): Promise<{ ok: boolean; data: { running: boolean; port: number } }> {
     return ipcRenderer.invoke('chat:ai-get-proxy-status');

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1978,13 +1978,20 @@ export function initChatModule({
     // depend on chatServiceOptions.value matching the encoded form exactly.
     // Fall back to looking up the option by value for the dropdown case.
     let peerId = explicitPeerId?.trim() ?? '';
+    const selectedOption = uiState.chatServiceOptions.find((o) => o.value === value);
     if (!peerId) {
-      const selectedOption = uiState.chatServiceOptions.find((o) => o.value === value);
       peerId = selectedOption?.peerId || '';
     }
     uiState.chatSelectedPeerId = peerId;
-    if (peerId && bridge?.chatAiSelectPeer) {
-      void bridge.chatAiSelectPeer(peerId).catch(() => undefined);
+    if (activeConversation) {
+      activeConversation.peerId = peerId || undefined;
+      activeConversation.peerLabel = selectedOption?.peerLabel || undefined;
+    }
+    if (bridge?.chatAiSelectPeer) {
+      void bridge.chatAiSelectPeer({
+        conversationId: uiState.chatActiveConversation,
+        peerId: peerId || null,
+      }).catch(() => undefined);
     }
 
     notifyUiStateChanged();
@@ -2006,8 +2013,15 @@ export function initChatModule({
   function clearPinnedPeer(): void {
     uiState.chatSelectedPeerId = '';
     uiState.chatRoutedPeer = '';
+    if (activeConversation) {
+      delete activeConversation.peerId;
+      delete activeConversation.peerLabel;
+    }
     if (bridge?.chatAiSelectPeer) {
-      void bridge.chatAiSelectPeer(null).catch(() => undefined);
+      void bridge.chatAiSelectPeer({
+        conversationId: uiState.chatActiveConversation,
+        peerId: null,
+      }).catch(() => undefined);
     }
     notifyUiStateChanged();
   }

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -172,7 +172,7 @@ export type DesktopBridge = {
   chatAiSend?: (conversationId: string, message: string, service?: string, provider?: string, attachments?: PreparedChatAttachment[]) => Promise<{ ok: boolean; error?: string }>;
   chatAiSendStream?: (conversationId: string, message: string, service?: string, provider?: string, attachments?: PreparedChatAttachment[]) => Promise<{ ok: boolean; error?: string; stopReason?: ChatAiStreamStopReason }>;
   chatAiAbort?: (conversationId?: string) => Promise<{ ok: boolean }>;
-  chatAiSelectPeer?: (peerId: string | null) => Promise<{ ok: boolean; error?: string }>;
+  chatAiSelectPeer?: (payload: { conversationId?: string | null; peerId?: string | null }) => Promise<{ ok: boolean; error?: string }>;
   chatAiGetProxyStatus?: () => Promise<{ ok: boolean; data: { running: boolean; port: number } }>;
   apiTryProxyRequest?: (params: {
     port: number;


### PR DESCRIPTION
## Description

Keeps peer pin changes scoped to the active desktop chat conversation instead of mutating every conversation binding. It also persists explicit peer switches and clears so the renderer, session file, and main-process routing stay aligned.

## Release Notes

- Fixed desktop chat peer switching so one conversation can no longer clear or overwrite another conversation's pinned peer
- Fixed service switches in an existing chat so the selected peer is persisted before the next request is routed

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [ ] Lint and unit tests pass locally with my changes
