### PR TITLE
fix(node): tolerate buyer clock skew in peer discovery

### DIFF
--- a/packages/node/src/discovery/http-metadata-resolver.ts
+++ b/packages/node/src/discovery/http-metadata-resolver.ts
@@ -75,12 +75,21 @@ export class HttpMetadataResolver implements MetadataResolver {
       }
 
       const metadata = (await response.json()) as PeerMetadata;
+      const resolvedAtMs = Date.now();
+      metadata.resolvedAtMs = resolvedAtMs;
+      const serverDateHeader = response.headers.get('date');
+      const serverDateMs = serverDateHeader ? Date.parse(serverDateHeader) : NaN;
+      if (Number.isFinite(serverDateMs)) {
+        metadata.serverDateMs = serverDateMs;
+      }
       this.failedEndpoints.delete(endpointKey);
       debugLog(
         `[MetadataResolver] Resolved ${url}: peerId=${metadata.peerId?.slice(0, 12) ?? 'unknown'}... `
         + `displayName=${JSON.stringify(metadata.displayName ?? null)} `
         + `providers=${metadata.providers?.length ?? 0} `
-        + `ageMs=${typeof metadata.timestamp === 'number' ? Date.now() - metadata.timestamp : 'unknown'}`,
+        + `ageMs=${typeof metadata.timestamp === 'number' ? resolvedAtMs - metadata.timestamp : 'unknown'} `
+        + `serverAgeMs=${typeof metadata.timestamp === 'number' && metadata.serverDateMs !== undefined ? metadata.serverDateMs - metadata.timestamp : 'unknown'} `
+        + `clientServerSkewMs=${metadata.serverDateMs !== undefined ? resolvedAtMs - metadata.serverDateMs : 'unknown'}`,
       );
       return metadata;
     } catch (err) {

--- a/packages/node/src/discovery/peer-lookup.ts
+++ b/packages/node/src/discovery/peer-lookup.ts
@@ -28,6 +28,13 @@ export interface LookupConfig {
   requireValidSignature: boolean;
   allowStaleMetadata: boolean;
   maxAnnouncementAgeMs: number;
+  /**
+   * Maximum tolerated difference between the buyer's wall clock and the HTTP
+   * Date header returned by the seller metadata endpoint. When the skew exceeds
+   * this value, freshness checks use the seller's HTTP Date header instead of
+   * the buyer's local clock so misconfigured desktops can still discover peers.
+   */
+  maxClientServerClockSkewMs: number;
   maxResults: number;
   /**
    * Optional foreground DHT budget for findAll(). Each individual lookup still
@@ -41,6 +48,10 @@ export const DEFAULT_LOOKUP_CONFIG: Omit<LookupConfig, "dht" | "metadataResolver
   requireValidSignature: true,
   allowStaleMetadata: false,
   maxAnnouncementAgeMs: 30 * 60 * 1000,
+  // Some desktops have wall clocks hours ahead/behind real UTC. Metadata HTTP
+  // responses include a seller-side Date header; if buyer-vs-seller clock skew
+  // is larger than this, trust the seller Date for freshness instead.
+  maxClientServerClockSkewMs: 5 * 60 * 1000,
   // Old cap was 50, then 200; with subnet fan-out and larger live networks,
   // keep browse/discovery truncation comfortably above current scale while
   // still bounding downstream enrichment/rendering work.
@@ -316,13 +327,28 @@ export class PeerLookup {
       }
     }
 
-    if (!this.config.allowStaleMetadata && this.isStale(metadata)) {
-      debugWarn(
-        `[PeerLookup] Dropping metadata from ${endpoint}: stale `
-        + `ageMs=${Date.now() - metadata.timestamp} maxAgeMs=${this.config.maxAnnouncementAgeMs} `
-        + `peerId=${metadata.peerId?.slice(0, 12) ?? 'unknown'}...`,
-      );
-      return null;
+    if (!this.config.allowStaleMetadata) {
+      const freshness = this.getMetadataFreshness(metadata);
+      if (freshness.stale) {
+        debugWarn(
+          `[PeerLookup] Dropping metadata from ${endpoint}: stale `
+          + `ageMs=${freshness.ageMs} maxAgeMs=${this.config.maxAnnouncementAgeMs} `
+          + `reference=${freshness.reference} `
+          + `clientServerSkewMs=${freshness.clientServerSkewMs ?? 'unknown'} `
+          + `peerId=${metadata.peerId?.slice(0, 12) ?? 'unknown'}...`,
+        );
+        return null;
+      }
+      if (freshness.clockSkewSuspected) {
+        debugWarn(
+          `[PeerLookup] Accepting metadata from ${endpoint} using seller HTTP Date; `
+          + `client clock skew suspected clientAgeMs=${freshness.clientAgeMs} `
+          + `serverAgeMs=${freshness.ageMs} `
+          + `clientServerSkewMs=${freshness.clientServerSkewMs ?? 'unknown'} `
+          + `maxAgeMs=${this.config.maxAnnouncementAgeMs} `
+          + `peerId=${metadata.peerId?.slice(0, 12) ?? 'unknown'}...`,
+        );
+      }
     }
 
     debugLog(
@@ -339,8 +365,35 @@ export class PeerLookup {
     return verifySignature(metadata.peerId, signature, dataToVerify);
   }
 
+  getMetadataFreshness(metadata: PeerMetadata): {
+    ageMs: number;
+    clientAgeMs: number;
+    clientServerSkewMs?: number;
+    reference: "client" | "server";
+    stale: boolean;
+    clockSkewSuspected: boolean;
+  } {
+    const clientNowMs = metadata.resolvedAtMs ?? Date.now();
+    const clientAgeMs = clientNowMs - metadata.timestamp;
+    const serverDateMs = metadata.serverDateMs;
+    const clientServerSkewMs = serverDateMs !== undefined ? clientNowMs - serverDateMs : undefined;
+    const useServerDate = (
+      serverDateMs !== undefined
+      && clientServerSkewMs !== undefined
+      && Math.abs(clientServerSkewMs) > this.config.maxClientServerClockSkewMs
+    );
+    const ageMs = useServerDate ? serverDateMs - metadata.timestamp : clientAgeMs;
+    return {
+      ageMs,
+      clientAgeMs,
+      ...(clientServerSkewMs !== undefined ? { clientServerSkewMs } : {}),
+      reference: useServerDate ? "server" : "client",
+      stale: ageMs > this.config.maxAnnouncementAgeMs,
+      clockSkewSuspected: useServerDate,
+    };
+  }
+
   isStale(metadata: PeerMetadata): boolean {
-    const age = Date.now() - metadata.timestamp;
-    return age > this.config.maxAnnouncementAgeMs;
+    return this.getMetadataFreshness(metadata).stale;
   }
 }

--- a/packages/node/src/discovery/peer-metadata.ts
+++ b/packages/node/src/discovery/peer-metadata.ts
@@ -52,5 +52,17 @@ export interface PeerMetadata {
    * Stored as 40 lowercase hex chars (no `0x` prefix) matching `peerId` format.
    */
   sellerContract?: string;
+  /**
+   * Buyer-local observation time for this metadata fetch. Not signed and not
+   * encoded in metadata; used only for diagnostics/freshness decisions.
+   */
+  resolvedAtMs?: number;
+  /**
+   * Seller HTTP Date header observed during metadata fetch, in Unix ms. Not
+   * signed and not encoded in metadata. When present, buyers can judge the
+   * signed timestamp using the seller's wall clock instead of their own, which
+   * keeps discovery working for users whose local desktop clock is wrong.
+   */
+  serverDateMs?: number;
   signature: string;
 }

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1155,6 +1155,7 @@ export class AntseedNode extends EventEmitter {
       requireValidSignature: DEFAULT_LOOKUP_CONFIG.requireValidSignature,
       allowStaleMetadata: DEFAULT_LOOKUP_CONFIG.allowStaleMetadata,
       maxAnnouncementAgeMs: DEFAULT_LOOKUP_CONFIG.maxAnnouncementAgeMs,
+      maxClientServerClockSkewMs: DEFAULT_LOOKUP_CONFIG.maxClientServerClockSkewMs,
       maxResults: DEFAULT_LOOKUP_CONFIG.maxResults,
       maxFindAllDhtDurationMs: DEFAULT_LOOKUP_CONFIG.maxFindAllDhtDurationMs,
     };

--- a/packages/node/src/p2p/connection-manager.ts
+++ b/packages/node/src/p2p/connection-manager.ts
@@ -684,6 +684,7 @@ export class ConnectionManager extends EventEmitter {
       `HTTP/1.1 ${statusLine}\r\n` +
       `Content-Type: application/json\r\n` +
       `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+      `Date: ${new Date().toUTCString()}\r\n` +
       `Connection: close\r\n` +
       `\r\n` +
       body,

--- a/packages/node/tests/http-metadata-resolver.test.ts
+++ b/packages/node/tests/http-metadata-resolver.test.ts
@@ -145,7 +145,10 @@ describe('HttpMetadataResolver', () => {
 
     expect(first).toBeNull();
     expect(skipped).toBeNull();
-    expect(retried).toEqual(metadata);
+    expect(retried).toEqual(expect.objectContaining({
+      ...metadata,
+      resolvedAtMs: new Date('2026-01-01T00:00:01.001Z').getTime(),
+    }));
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 


### PR DESCRIPTION
## Summary
- record the metadata HTTP response Date header alongside buyer-local fetch time
- use seller HTTP Date for metadata freshness when buyer-vs-seller clock skew exceeds 5 minutes
- include Date in the built-in metadata HTTP response and log skew/freshness decisions

## Why
Some desktop buyers can have a badly skewed system clock. Fresh seller metadata was being fetched and signature-verified, but then rejected as stale because the buyer computed age from its incorrect local Date.now(). This preserves the existing 30-minute freshness window while using the live seller HTTP Date as the reference when client clock skew is obvious.

## Test
- pnpm --filter=@antseed/node run typecheck