### PR TITLE
fix(desktop): stop hiding discover services by default

### DIFF
--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -247,9 +247,8 @@ const PROXY_RUNTIME_API_KEY = 'antseed-local';
 
 const CHAT_SYSTEM_PROMPT_ENV = 'ANTSEED_CHAT_SYSTEM_PROMPT';
 const CHAT_SYSTEM_PROMPT_FILE_ENV = 'ANTSEED_CHAT_SYSTEM_PROMPT_FILE';
-const CHAT_SERVICE_SCAN_MAX_PEERS = 20;
-const CHAT_SERVICE_MAX_OPTIONS = 120;
-const CHAT_SERVICE_MAX_OPTIONS_PER_PROVIDER = 40;
+const CHAT_SERVICE_MAX_OPTIONS = 1000;
+const CHAT_SERVICE_MAX_OPTIONS_PER_PROVIDER = 1000;
 
 function normalizeTokenCount(value: unknown): number {
   const parsed = Number(value);
@@ -551,7 +550,7 @@ async function discoverChatServiceCatalog(
   }
 
   const results: ChatServiceCatalogEntry[] = [];
-  for (const peer of peers.slice(0, CHAT_SERVICE_SCAN_MAX_PEERS)) {
+  for (const peer of peers) {
     const peerId = peer.peerId;
     const peerLabel = peer.displayName
       ? `${peer.displayName} (${peerId?.slice(0, 8) ?? ''})`
@@ -764,7 +763,20 @@ async function fetchOnChainEnrichment(
       onChainEnrichmentCache.set(addr, { fetchedAt: now, data });
       out.set(addr, data);
     } catch {
-      // Leave out of the result map; row will be dropped by the caller.
+      // Preserve Discover inventory when staking/channel RPC is unavailable.
+      // Request routing still performs its own eligibility checks; this view
+      // should not hide services merely because enrichment failed.
+      const sentinel: OnChainPeerEnrichment = {
+        agentId: 0,
+        stakeUsdc: '0',
+        stakedAt: 0,
+        onChainActiveChannelCount: 0,
+        onChainGhostCount: 0,
+        onChainTotalVolumeUsdc: '0',
+        onChainLastSettledAt: 0,
+      };
+      onChainEnrichmentCache.set(addr, { fetchedAt: now, data: sentinel });
+      out.set(addr, sentinel);
     }
   }));
 
@@ -793,8 +805,15 @@ async function buildDiscoverRows(
     const peerId = entry.peerId ?? '';
     if (!peerId) continue;
     const evmAddress = '0x' + peerId;
-    const enrichmentRow = enrichment.get(evmAddress);
-    if (!enrichmentRow || enrichmentRow.agentId === 0) continue;
+    const enrichmentRow = enrichment.get(evmAddress) ?? {
+      agentId: 0,
+      stakeUsdc: '0',
+      stakedAt: 0,
+      onChainActiveChannelCount: 0,
+      onChainGhostCount: 0,
+      onChainTotalVolumeUsdc: '0',
+      onChainLastSettledAt: 0,
+    };
 
     const stats = peerStats.get(peerId);
     const peerBlob = buyerStateDiscoveredPeers[peerId];
@@ -2513,16 +2532,14 @@ export function registerPiChatHandlers({
           .filter((a) => a.length === 42)
       ));
       const clients = await loadOnChainClients(configPath);
-      if (!clients) {
-        return { ok: true, data: [] as DiscoverRowEntry[] };
-      }
-      const { stakingClient, channelsClient } = clients;
-      const enrichment = await fetchOnChainEnrichment(
-        uniqueAddresses,
-        stakingClient,
-        channelsClient,
-        buyerStateOnChainStats,
-      );
+      const enrichment = clients
+        ? await fetchOnChainEnrichment(
+          uniqueAddresses,
+          clients.stakingClient,
+          clients.channelsClient,
+          buyerStateOnChainStats,
+        )
+        : new Map<string, OnChainPeerEnrichment>();
 
       // Network-wide stats from @antseed/network-stats. On non-mainnet chains and on any
       // failure this returns an empty map and buildDiscoverRows falls back to local stats.

--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
@@ -18,11 +18,11 @@ export const MAX_CHANNELS_SLIDER = 200;
 export const CHANNELS_SLIDER_STEP = 5;
 
 /**
- * Default minimum on-chain channel count for Discover. 20 hides brand-new peers
- * that haven't accumulated a track record while still showing modestly-active ones.
- * Users can lower the slider to 0 to see every peer.
+ * Default minimum on-chain channel count for Discover. Keep this at zero so
+ * Discover is an inventory view by default: every cached/discovered service is
+ * visible unless the user explicitly chooses a reputation/channel filter.
  */
-export const DEFAULT_MIN_ON_CHAIN_CHANNELS = 20;
+export const DEFAULT_MIN_ON_CHAIN_CHANNELS = 0;
 
 export type TimeWindow = 'any' | 'today' | 'week' | 'month';
 

--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
@@ -18,11 +18,11 @@ export const MAX_CHANNELS_SLIDER = 200;
 export const CHANNELS_SLIDER_STEP = 5;
 
 /**
- * Default minimum on-chain channel count for Discover. Keep this at zero so
- * Discover is an inventory view by default: every cached/discovered service is
- * visible unless the user explicitly chooses a reputation/channel filter.
+ * Default minimum on-chain channel count for Discover. 20 hides brand-new peers
+ * that haven't accumulated a track record while still showing modestly-active ones.
+ * Users can lower the slider to 0 to see every peer.
  */
-export const DEFAULT_MIN_ON_CHAIN_CHANNELS = 0;
+export const DEFAULT_MIN_ON_CHAIN_CHANNELS = 20;
 
 export type TimeWindow = 'any' | 'today' | 'week' | 'month';
 


### PR DESCRIPTION
## Summary
- keep the default Discover minimum channel threshold at 20
- stop limiting the service catalog to the first 20 peers / 120 options
- keep Discover rows available when staking/channel enrichment is unavailable or an agent is unstaked; the existing channel filter can still hide/show them intentionally

## Why
The buyer state can contain all discovered services while the Desktop Discover data source still returns only a subset. The hard catalog caps and enrichment-time row drops meant some services never reached the renderer, so changing filters could not reveal them. Discover should build a complete row inventory first, then let the UI filters decide what is visible.

## Validation
- pnpm --filter=@antseed/desktop run build:main
- pnpm --filter=@antseed/desktop run typecheck:renderer
- git diff --check

Note: the existing desktop test script currently fails locally because it runs `node --test dist/main` but build output is not a module entry at that path.
