### PR TITLE
Fix discover chat peer binding

### DIFF
--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -1514,6 +1514,8 @@ class PiConversationStore {
         usage: conversation.usage,
         totalTokens,
         totalEstimatedCostUsd: deriveCost(conversation.messages),
+        ...(conversation.peerId ? { peerId: conversation.peerId } : {}),
+        ...(conversation.peerLabel ? { peerLabel: conversation.peerLabel } : {}),
       });
     }
 
@@ -1532,12 +1534,19 @@ class PiConversationStore {
     return await this.readConversationFromPath(sessionPath);
   }
 
-  async create(service?: string, provider?: string): Promise<AiConversation> {
+  async create(service?: string, provider?: string, peerId?: string, peerLabel?: string): Promise<AiConversation> {
     const workspaceDir = await this.ensureWorkspaceDir();
     const manager = SessionManager.create(workspaceDir, this.sessionsDir);
     const providerId = normalizeProviderId(provider);
     const modelProvider = providerId ?? PROXY_PROVIDER_ID;
     manager.appendModelChange(modelProvider, normalizeServiceId(service));
+    const trimmedPeerId = peerId?.trim() ?? '';
+    if (trimmedPeerId) {
+      manager.appendCustomEntry(ANTSEED_PEER_CUSTOM_TYPE, {
+        peerId: trimmedPeerId,
+        ...(peerLabel ? { peerLabel } : {}),
+      } satisfies AntseedPeerData);
+    }
     const sessionPath = manager.getSessionFile();
     if (!sessionPath) {
       throw new Error('Failed to create persisted pi session');
@@ -2632,13 +2641,13 @@ export function registerPiChatHandlers({
   });
 
   ipcMain.handle('chat:ai-create-conversation', async (_event, service: string, provider?: string, peerId?: string) => {
-    const conversation = await store.create(service, provider);
     const trimmedPeerId = peerId?.trim() ?? '';
+    const peerLabel = trimmedPeerId
+      ? lastServiceCatalogEntries.find((e) => e.peerId === trimmedPeerId)?.peerLabel
+      : undefined;
+    const conversation = await store.create(service, provider, trimmedPeerId || undefined, peerLabel);
     if (trimmedPeerId) {
       preferredPeerByConversationId.set(conversation.id, trimmedPeerId);
-      // Resolve peer label from service options
-      const peerLabel = lastServiceCatalogEntries.find((e) => e.peerId === trimmedPeerId)?.peerLabel;
-      await store.setPeer(conversation.id, trimmedPeerId, peerLabel);
     } else {
       preferredPeerByConversationId.delete(conversation.id);
     }

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -320,7 +320,7 @@ export function initChatModule({
     return options
       .map(
         (e) =>
-          `${e.id}|${e.label}|${e.provider}|${e.protocol}|${String(e.count)}|${String(e.inputUsdPerMillion)}|${String(e.outputUsdPerMillion)}|${e.categories.join(',')}`,
+          `${e.id}|${e.label}|${e.provider}|${e.peerId}|${e.peerLabel}|${e.protocol}|${String(e.count)}|${String(e.inputUsdPerMillion)}|${String(e.outputUsdPerMillion)}|${e.categories.join(',')}`,
       )
       .join('\n');
   }
@@ -925,7 +925,12 @@ export function initChatModule({
 
     if (uiState.chatServiceOptions.length > 0) {
       const firstOption = decodeChatServiceSelection(uiState.chatServiceOptions[0].value);
-      if (firstOption.id.length > 0) return firstOption;
+      if (firstOption.id.length > 0) {
+        return {
+          ...firstOption,
+          peerId: firstOption.peerId ?? uiState.chatServiceOptions[0].peerId,
+        };
+      }
     }
 
     return { id: '', provider: null };
@@ -1601,7 +1606,8 @@ export function initChatModule({
     }
 
     try {
-      const result = await bridge.chatAiCreateConversation(selection.id, undefined, uiState.chatSelectedPeerId || undefined);
+      const peerId = (selection.peerId ?? uiState.chatSelectedPeerId) || undefined;
+      const result = await bridge.chatAiCreateConversation(selection.id, selection.provider ?? undefined, peerId);
       if (result.ok && result.data) {
         const conversationId = getConversationId(result.data);
         if (!conversationId) {
@@ -1828,7 +1834,7 @@ export function initChatModule({
           convId,
           content || ' ',
           selection.id || undefined,
-          undefined,
+          selection.provider ?? undefined,
           attachments,
         );
 
@@ -1877,7 +1883,7 @@ export function initChatModule({
               convId,
               content || ' ',
               selection.id || undefined,
-              undefined,
+              selection.provider ?? undefined,
               attachments,
             );
 

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -66,15 +66,15 @@ function generateDescription(serviceId: string, categories: string[], provider: 
   const lower = serviceId.toLowerCase();
   const prov = provider || 'a network peer';
 
-  if (lower.includes('claude')) return `Anthropic Claude model served by ${prov}.`;
-  if (lower.includes('gpt') || lower.includes('openai')) return `OpenAI-family model served by ${prov}.`;
-  if (lower.includes('llama')) return `Meta Llama open-weight model hosted by ${prov}.`;
-  if (lower.includes('deepseek')) return `DeepSeek model served by ${prov}.`;
-  if (lower.includes('mistral') || lower.includes('magistral') || lower.includes('ministral')) return `Mistral-family model served by ${prov}.`;
-  if (lower.includes('kimi')) return `Moonshot Kimi model served by ${prov}.`;
-  if (lower.includes('qwen')) return `Alibaba Qwen model served by ${prov}.`;
-  if (lower.includes('gemini') || lower.includes('gemma')) return `Google Gemini/Gemma model served by ${prov}.`;
-  if (lower.includes('flux') || lower.includes('sdxl')) return `Image generation model served by ${prov}.`;
+  if (lower.includes('claude')) return `Access to Anthropic's Claude model. Powered by ${prov}.`;
+  if (lower.includes('gpt') || lower.includes('openai')) return `OpenAI model access through ${prov}.`;
+  if (lower.includes('llama')) return `Meta's Llama open-weight model. Hosted by ${prov}.`;
+  if (lower.includes('deepseek')) return `DeepSeek reasoning model. Served by ${prov}.`;
+  if (lower.includes('mistral')) return `Mistral's flagship model. Strong multilingual and instruction following.`;
+  if (lower.includes('kimi')) return `Moonshot's Kimi reasoning model. High-performance math and code.`;
+  if (lower.includes('qwen')) return `Alibaba's Qwen model series. Multilingual and versatile.`;
+  if (lower.includes('gemini') || lower.includes('gemma')) return `Google's model. Powered by ${prov}.`;
+  if (lower.includes('flux') || lower.includes('sdxl')) return `Image generation model. Served by ${prov}.`;
   if (categories.length > 0) return `${categories.map(formatCategoryLabel).join(' & ')} service powered by ${prov}.`;
   return `AI service powered by ${prov}.`;
 }

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -66,15 +66,15 @@ function generateDescription(serviceId: string, categories: string[], provider: 
   const lower = serviceId.toLowerCase();
   const prov = provider || 'a network peer';
 
-  if (lower.includes('claude')) return `Access to Anthropic's Claude model. Powered by ${prov}.`;
-  if (lower.includes('gpt') || lower.includes('openai')) return `OpenAI model access through ${prov}.`;
-  if (lower.includes('llama')) return `Meta's Llama open-weight model. Hosted by ${prov}.`;
-  if (lower.includes('deepseek')) return `DeepSeek reasoning model. Served by ${prov}.`;
-  if (lower.includes('mistral')) return `Mistral's flagship model. Strong multilingual and instruction following.`;
-  if (lower.includes('kimi')) return `Moonshot's Kimi reasoning model. High-performance math and code.`;
-  if (lower.includes('qwen')) return `Alibaba's Qwen model series. Multilingual and versatile.`;
-  if (lower.includes('gemini') || lower.includes('gemma')) return `Google's model. Powered by ${prov}.`;
-  if (lower.includes('flux') || lower.includes('sdxl')) return `Image generation model. Served by ${prov}.`;
+  if (lower.includes('claude')) return `Anthropic Claude model served by ${prov}.`;
+  if (lower.includes('gpt') || lower.includes('openai')) return `OpenAI-family model served by ${prov}.`;
+  if (lower.includes('llama')) return `Meta Llama open-weight model hosted by ${prov}.`;
+  if (lower.includes('deepseek')) return `DeepSeek model served by ${prov}.`;
+  if (lower.includes('mistral') || lower.includes('magistral') || lower.includes('ministral')) return `Mistral-family model served by ${prov}.`;
+  if (lower.includes('kimi')) return `Moonshot Kimi model served by ${prov}.`;
+  if (lower.includes('qwen')) return `Alibaba Qwen model served by ${prov}.`;
+  if (lower.includes('gemini') || lower.includes('gemma')) return `Google Gemini/Gemma model served by ${prov}.`;
+  if (lower.includes('flux') || lower.includes('sdxl')) return `Image generation model served by ${prov}.`;
   if (categories.length > 0) return `${categories.map(formatCategoryLabel).join(' & ')} service powered by ${prov}.`;
   return `AI service powered by ${prov}.`;
 }


### PR DESCRIPTION
## Summary

- Preserve the selected Discover peer/provider when creating a new chat conversation.
- Persist the peer binding into the session at creation time so conversation summaries and the chats list immediately show the correct peer.
- Include peer identity in the service-options signature so peer-only catalog changes cannot leave stale selections.


## Tests
- pnpm --filter=@antseed/desktop run build:main
- pnpm --filter=@antseed/desktop run typecheck:renderer
- pnpm --filter=@antseed/desktop run build:renderer
- node --test apps/desktop/dist/main/*.test.js

Note: `pnpm --filter=@antseed/desktop run test` still fails because its script invokes `node --test dist/main`, and Node cannot resolve the directory entrypoint. Running the compiled test files directly passes