### PR TITLE
fix(desktop): Show peer display names

### DIFF
--- a/apps/desktop/src/renderer/core/state.ts
+++ b/apps/desktop/src/renderer/core/state.ts
@@ -58,6 +58,7 @@ export type ChatServiceOptionEntry = {
   count: number;
   value: string;
   peerId: string;
+  peerDisplayName: string | null;
   peerLabel: string;
   inputUsdPerMillion: number | null;
   outputUsdPerMillion: number | null;

--- a/apps/desktop/src/renderer/modules/chat.discover-rows.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.discover-rows.test.ts
@@ -29,3 +29,18 @@ test('projectRowsToChatServiceOptions dedupes by (provider, service, peer)', () 
   const options = projectRowsToChatServiceOptions(rows);
   assert.equal(options.length, 1);
 });
+
+test('projectRowsToChatServiceOptions preserves peer display name for UI labels', () => {
+  const row = normalizeDiscoverRow({
+    peerId: 'abc123',
+    serviceId: 'gpt-5',
+    peerDisplayName: 'Friendly Peer',
+    peerLabel: '0xabc123...',
+    selectionValue: 'openai\u0001gpt-5\u0001abc123',
+  });
+  assert.ok(row);
+
+  const [option] = projectRowsToChatServiceOptions([row!]);
+  assert.equal(option.peerDisplayName, 'Friendly Peer');
+  assert.equal(option.peerLabel, '0xabc123...');
+});

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -114,6 +114,7 @@ export function initChatModule({
     Pick<ChatServiceCatalogEntry, 'id' | 'label' | 'provider' | 'protocol' | 'count'>
   > & {
     peerId: string;
+    peerDisplayName: string | null;
     peerLabel: string;
     inputUsdPerMillion: number | null;
     outputUsdPerMillion: number | null;
@@ -320,7 +321,7 @@ export function initChatModule({
     return options
       .map(
         (e) =>
-          `${e.id}|${e.label}|${e.provider}|${e.peerId}|${e.peerLabel}|${e.protocol}|${String(e.count)}|${String(e.inputUsdPerMillion)}|${String(e.outputUsdPerMillion)}|${e.categories.join(',')}`,
+          `${e.id}|${e.label}|${e.provider}|${e.peerId}|${e.peerDisplayName}|${e.peerLabel}|${e.protocol}|${String(e.count)}|${String(e.inputUsdPerMillion)}|${String(e.outputUsdPerMillion)}|${e.categories.join(',')}`,
       )
       .join('\n');
   }
@@ -586,7 +587,7 @@ export function initChatModule({
     // When a peer is pinned, always show it — don't switch based on response metadata.
     if (uiState.chatSelectedPeerId) {
       const pinnedOption = uiState.chatServiceOptions.find((o) => o.peerId === uiState.chatSelectedPeerId);
-      uiState.chatRoutedPeer = pinnedOption?.peerLabel || uiState.chatSelectedPeerId.slice(0, 8);
+      uiState.chatRoutedPeer = pinnedOption?.peerDisplayName || pinnedOption?.peerLabel || uiState.chatSelectedPeerId.slice(0, 8);
     } else if (lastServingPeerId) {
       const knownPeer = Array.isArray(uiState.lastPeers)
         ? uiState.lastPeers.find((p) => p.peerId === lastServingPeerId)
@@ -907,7 +908,8 @@ export function initChatModule({
       id: normalizeChatServiceId(entry.id),
       label: String(entry.label ?? entry.id),
       provider: normalizeProviderId(entry.provider),
-      value: encodeChatServiceSelection(entry.id, entry.provider),
+      peerId: entry.peerId || undefined,
+      value: encodeChatServiceSelection(entry.id, entry.provider, entry.peerId),
     }));
   }
 
@@ -1022,6 +1024,7 @@ export function initChatModule({
       count: entry.count,
       value: encodeChatServiceSelection(entry.id, entry.provider, entry.peerId),
       peerId: entry.peerId,
+      peerDisplayName: entry.peerDisplayName,
       peerLabel: entry.peerLabel,
       inputUsdPerMillion: entry.inputUsdPerMillion,
       outputUsdPerMillion: entry.outputUsdPerMillion,
@@ -1991,7 +1994,7 @@ export function initChatModule({
     uiState.chatSelectedPeerId = peerId;
     if (activeConversation) {
       activeConversation.peerId = peerId || undefined;
-      activeConversation.peerLabel = selectedOption?.peerLabel || undefined;
+      activeConversation.peerLabel = selectedOption?.peerDisplayName || selectedOption?.peerLabel || undefined;
     }
     if (bridge?.chatAiSelectPeer) {
       void bridge.chatAiSelectPeer({

--- a/apps/desktop/src/renderer/modules/discover-rows.ts
+++ b/apps/desktop/src/renderer/modules/discover-rows.ts
@@ -64,6 +64,7 @@ export function projectRowsToChatServiceOptions(rows: DiscoverRow[]): ChatServic
       count: 1,
       value: row.selectionValue,
       peerId: row.peerId,
+      peerDisplayName: row.peerDisplayName,
       peerLabel: row.peerLabel,
       inputUsdPerMillion: row.inputUsdPerMillion,
       outputUsdPerMillion: row.outputUsdPerMillion,

--- a/apps/desktop/src/renderer/ui/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/ui/components/Sidebar.tsx
@@ -187,16 +187,19 @@ function groupByPeer(conversations: unknown[]): PeerGroup[] {
     }
 
     let group = groups.get(peerId);
+    const displayName = getPeerDisplayName(peerLabel);
     if (!group) {
-      const displayName = getPeerDisplayName(peerLabel) || peerId.slice(0, 12) + '...';
       group = {
         peerId,
         peerLabel,
-        displayName,
+        displayName: displayName || peerId.slice(0, 12) + '...',
         gradient: getPeerGradient(peerId),
         conversations: [],
       };
       groups.set(peerId, group);
+    } else if (displayName && group.displayName === peerId.slice(0, 12) + '...') {
+      group.peerLabel = peerLabel;
+      group.displayName = displayName;
     }
     group.conversations.push(conv);
   }

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -277,7 +277,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     [snap.chatServiceOptions, snap.chatSelectedServiceValue],
   );
   const peerDisplayName =
-    snap.chatRoutedPeer || currentServiceOption?.peerLabel || '';
+    snap.chatRoutedPeer || currentServiceOption?.peerDisplayName || currentServiceOption?.peerLabel || '';
 
   const applyServiceChange = useCallback(
     (value: string) => {


### PR DESCRIPTION
## Description

Fixes cases where the desktop chat sidebar and header showed a peer address instead of the peer’s friendly display name. The renderer now preserves `peerDisplayName` from discovery rows and prefers it in chat UI labels, while the sidebar updates address-based fallback labels when a display name becomes available.

## Release Notes

- Fixed desktop chat UI sometimes showing peer addresses instead of peer names

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [ ] Lint and unit tests pass locally with my changes

## Validation

- `npm -C apps/desktop run typecheck:renderer`
- `node --test apps/desktop/src/renderer/modules/chat.discover-rows.test.ts` *(fails before build because the TypeScript source imports `./discover-rows.js`, which is generated in dist)*
