### PR TITLE
fix(payments): Cap credit deposits

### DIFF
--- a/apps/cli/src/cli/commands/payments.ts
+++ b/apps/cli/src/cli/commands/payments.ts
@@ -1,4 +1,5 @@
 import type { Command } from 'commander';
+import { getGlobalOptions } from './types.js';
 
 export function registerPaymentsCommand(program: Command): void {
   program
@@ -7,11 +8,12 @@ export function registerPaymentsCommand(program: Command): void {
     .option('-p, --port <port>', 'Portal port', '3118')
     .action(async (options: { port: string }) => {
       const port = Number(options.port) > 0 ? Number(options.port) : 3118;
+      const globalOpts = getGlobalOptions(program);
 
       try {
         const { createServer } = await import('@antseed/payments');
         const identityHex = process.env['ANTSEED_IDENTITY_HEX'] || undefined;
-        const server = await createServer({ port, identityHex });
+        const server = await createServer({ port, dataDir: globalOpts.dataDir, identityHex });
         await server.listen({ port, host: '127.0.0.1' });
 
         const token = (server as unknown as { bearerToken?: string }).bearerToken ?? '';

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -331,7 +331,11 @@ ipcMain.handle('payments:open-portal', async (_event, tab?: string) => {
     const token = paymentsServer ? (paymentsServer as unknown as { bearerToken?: string }).bearerToken : '';
     const params = new URLSearchParams();
     if (token) params.set('token', token);
-    if (tab) params.set('tab', tab);
+    if (tab === 'deposit' || tab === 'deposits') {
+      params.set('action', 'deposit');
+    } else if (tab) {
+      params.set('tab', tab);
+    }
     const qs = params.toString();
     // In dev mode, open the Vite HMR dev server (which proxies /api to the Fastify port).
     // Set ANTSEED_PAYMENTS_DEV_URL to override (default: http://localhost:5175).

--- a/apps/desktop/src/renderer/ui/components/TitleBar.tsx
+++ b/apps/desktop/src/renderer/ui/components/TitleBar.tsx
@@ -76,7 +76,7 @@ export function TitleBar() {
 
   const handleAddCredits = useCallback(() => {
     setCreditsDropdownOpen(false);
-    actions.openPaymentsPortal?.();
+    actions.openPaymentsPortal?.('deposit');
   }, [actions]);
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -701,7 +701,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
               amount={snap.chatPaymentApprovalAmount}
               peerInfo={snap.chatPaymentApprovalPeerInfo}
               error={snap.chatPaymentApprovalError}
-              onAddCredits={() => actions.openPaymentsPortal?.()}
+              onAddCredits={() => actions.openPaymentsPortal?.('deposit')}
               onRetry={() => actions.retryAfterPayment()}
               onCancel={() => actions.rejectPaymentSession()}
             />
@@ -714,7 +714,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
             <LowBalanceWarning
               visible={snap.chatLowBalanceWarning}
               availableUsdc={snap.creditsAvailableUsdc}
-              onAddCredits={() => actions.openPaymentsPortal?.()}
+              onAddCredits={() => actions.openPaymentsPortal?.('deposit')}
             />
 
             {attachedFiles.length > 0 && (

--- a/apps/payments/web/src/App.tsx
+++ b/apps/payments/web/src/App.tsx
@@ -28,9 +28,23 @@ function parseTabFromUrl(): TabId {
   return VALID_TABS.has(raw as TabId) ? (raw as TabId) : 'dashboard';
 }
 
+function shouldOpenDepositFromUrl(): boolean {
+  const params = new URLSearchParams(window.location.search);
+  const action = params.get('action') ?? params.get('modal');
+  const tab = params.get('tab');
+  return action === 'deposit' || tab === 'deposit' || tab === 'deposits';
+}
+
 function writeTabToUrl(tab: TabId) {
   const url = new URL(window.location.href);
   url.searchParams.set('tab', tab);
+  window.history.replaceState({}, '', url.toString());
+}
+
+function clearDepositActionFromUrl() {
+  const url = new URL(window.location.href);
+  if (url.searchParams.get('action') === 'deposit') url.searchParams.delete('action');
+  if (url.searchParams.get('modal') === 'deposit') url.searchParams.delete('modal');
   window.history.replaceState({}, '', url.toString());
 }
 
@@ -40,7 +54,7 @@ export function App() {
   const [config, setConfig] = useState<PaymentConfig | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>(() => parseTabFromUrl());
   const [walletDrawerOpen, setWalletDrawerOpen] = useState(false);
-  const [actionModal, setActionModal] = useState<'deposit' | 'withdraw' | null>(null);
+  const [actionModal, setActionModal] = useState<'deposit' | 'withdraw' | null>(() => shouldOpenDepositFromUrl() ? 'deposit' : null);
   const [sessionExpired, setSessionExpired] = useState(false);
   const [isDark, setIsDark] = useState(() => {
     const saved = localStorage.getItem('antseed-payments-theme');
@@ -84,6 +98,13 @@ export function App() {
     writeTabToUrl(tab);
   }, []);
 
+  const openDeposit = useCallback(() => setActionModal('deposit'), []);
+  const openWithdraw = useCallback(() => setActionModal('withdraw'), []);
+  const closeActionModal = useCallback(() => {
+    setActionModal(null);
+    clearDepositActionFromUrl();
+  }, []);
+
   const buyerEvmAddress = config?.evmAddress ?? balance?.evmAddress ?? null;
 
   return (
@@ -100,9 +121,9 @@ export function App() {
         onOpenWalletDrawer={() => setWalletDrawerOpen(true)}
         onCloseWalletDrawer={() => setWalletDrawerOpen(false)}
         actionModal={actionModal}
-        onOpenDeposit={() => setActionModal('deposit')}
-        onOpenWithdraw={() => setActionModal('withdraw')}
-        onCloseActionModal={() => setActionModal(null)}
+        onOpenDeposit={openDeposit}
+        onOpenWithdraw={openWithdraw}
+        onCloseActionModal={closeActionModal}
         buyerEvmAddress={buyerEvmAddress}
         refreshBalance={refreshBalance}
       />
@@ -201,6 +222,7 @@ function AppShell({
             activeTab={activeTab}
             balance={balance}
             onOpenWallet={onOpenWalletDrawer}
+            onOpenDeposit={onOpenDeposit}
           />
           <AuthorizeWalletAlert />
           <main className="dash-content">
@@ -233,7 +255,8 @@ function AppShell({
         isOpen={actionModal === 'deposit'}
         onClose={onCloseActionModal}
         title="Deposit USDC"
-        subtitle="Add funds to your AntSeed account."
+        subtitle="Add credits to your AntSeed account with a guided two-step flow."
+        variant="deposit"
       >
         <DepositView
           config={config}

--- a/apps/payments/web/src/components/DepositView.scss
+++ b/apps/payments/web/src/components/DepositView.scss
@@ -55,6 +55,369 @@
   gap: 12px;
 }
 
+.deposit-trust-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.deposit-trust-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover { background: var(--card-hover); }
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
+}
+
+.deposit-trust-head-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1;
+}
+
+.deposit-trust-shield {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: var(--accent);
+  color: #06351d;
+  font-size: 14px;
+  font-weight: 800;
+  box-shadow: 0 0 0 4px var(--accent-dim);
+}
+
+.deposit-trust-title {
+  font-size: 13px;
+  font-weight: 800;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+}
+
+.deposit-trust-subtitle {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.deposit-trust-balance-summary {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+  flex-shrink: 0;
+
+  span {
+    font-size: 9px;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--text-muted);
+  }
+
+  strong {
+    font-size: 13px;
+    font-weight: 850;
+    color: var(--text-primary);
+  }
+
+  em {
+    font-style: normal;
+    font-size: 10px;
+    font-weight: 700;
+    color: var(--accent-text);
+  }
+}
+
+.deposit-trust-chevron {
+  display: inline-block;
+  color: var(--text-muted);
+  font-size: 18px;
+  line-height: 1;
+  transform: rotate(0deg);
+  transition: transform 0.15s ease;
+}
+
+
+.deposit-trust-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.deposit-trust-item {
+  padding: 9px 10px;
+  background: var(--input-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 9px;
+
+  span {
+    display: block;
+    margin-bottom: 2px;
+    font-size: 9px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--text-muted);
+  }
+
+  strong {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 12px;
+    font-weight: 700;
+    font-family: 'SF Mono', 'Fira Code', monospace;
+    color: var(--text-primary);
+  }
+
+  &--wide { grid-column: 1 / -1; }
+}
+
+.deposit-trust-foot {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--card-border);
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.deposit-details-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  background: rgba(0, 0, 0, 0.48);
+  backdrop-filter: blur(4px);
+}
+
+.deposit-details-modal {
+  width: min(720px, 100%);
+  max-height: min(680px, calc(100vh - 36px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--modal-bg, var(--card-bg));
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.3);
+}
+
+.deposit-details-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 18px 18px 14px;
+  border-bottom: 1px solid var(--card-border);
+
+  h3 {
+    margin: 2px 0 4px;
+    font-size: 18px;
+    line-height: 1.2;
+    color: var(--text-primary);
+  }
+
+  p {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.45;
+    color: var(--text-secondary);
+  }
+}
+
+.deposit-details-eyebrow {
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-text);
+}
+
+.deposit-details-close {
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--card-border);
+  border-radius: 999px;
+  background: var(--input-bg);
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+
+  &:hover { color: var(--text-primary); }
+}
+
+.deposit-details-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px 18px 18px;
+  overflow-y: auto;
+}
+
+.deposit-details-balance-hero {
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: var(--accent-dim);
+  border: 1px solid var(--accent-border);
+
+  span, small {
+    display: block;
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+
+  strong {
+    display: block;
+    margin: 2px 0;
+    font-size: 24px;
+    line-height: 1.1;
+    color: var(--text-primary);
+  }
+}
+
+.deposit-wizard {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  padding: 12px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+}
+
+.deposit-wizard-track {
+  position: absolute;
+  top: 37px;
+  left: calc(25% + 28px);
+  right: calc(25% + 28px);
+  z-index: 0;
+  height: 3px;
+  background: var(--card-border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.deposit-wizard-track-fill {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+  border-radius: inherit;
+  transition: width 0.2s ease;
+}
+
+.deposit-wizard-step {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+  padding: 8px 10px 10px;
+  border-radius: 13px;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+
+  &--active {
+    background: var(--input-bg);
+    border-color: var(--card-border);
+  }
+
+  &--complete {
+    color: var(--text-secondary);
+  }
+
+  &--locked {
+    opacity: 0.72;
+  }
+}
+
+.deposit-wizard-number {
+  width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--input-bg);
+  border: 1px solid var(--card-border);
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 900;
+
+  .deposit-wizard-step--active & {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #06351d;
+  }
+
+  .deposit-wizard-step--complete & {
+    background: var(--accent-dim);
+    border-color: var(--accent-border);
+    color: var(--accent-text);
+  }
+}
+
+.deposit-wizard-content { min-width: 0; }
+
+.deposit-wizard-kicker {
+  font-size: 9px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.deposit-wizard-title {
+  margin-top: 1px;
+  font-size: 13px;
+  font-weight: 850;
+  color: var(--text-primary);
+}
+
+.deposit-wizard-copy {
+  margin-top: 4px;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
+.deposit-connect-explainer {
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--accent-dim);
+  border: 1px solid var(--accent-border);
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+  text-align: center;
+}
+
 .deposit-connect-wrapper {
   display: flex;
   justify-content: center;
@@ -73,38 +436,6 @@
   font-size: 13px;
   color: var(--danger);
   text-align: center;
-}
-
-.deposit-connected {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 14px;
-  background: var(--accent-dim);
-  border: 1px solid var(--accent-border);
-  border-radius: 8px;
-}
-
-.deposit-connected-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: var(--accent);
-  box-shadow: 0 0 6px rgba(31, 216, 122, 0.4);
-  flex-shrink: 0;
-}
-
-.deposit-connected-addr {
-  font-size: 12px;
-  font-family: 'SF Mono', 'Fira Code', monospace;
-  color: var(--text-primary);
-}
-
-.deposit-connected-label {
-  margin-left: auto;
-  font-size: 11px;
-  color: var(--accent-text);
-  font-weight: 500;
 }
 
 .deposit-target-info {
@@ -201,6 +532,60 @@
   color: var(--text-muted);
   max-width: 280px;
   line-height: 1.5;
+}
+
+.deposit-balance-details {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0 14px 12px;
+
+  &--embedded {
+    padding: 10px 0 0;
+    margin-top: 10px;
+    border-top: 1px solid var(--card-border);
+  }
+}
+
+.deposit-balance-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--text-muted);
+
+  strong {
+    font-size: 13px;
+    font-weight: 750;
+    color: var(--text-primary);
+  }
+}
+
+.deposit-balance-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: -4px;
+
+  span {
+    padding: 3px 7px;
+    border-radius: 999px;
+    background: var(--input-bg);
+    border: 1px solid var(--card-border);
+    font-size: 10px;
+    font-weight: 650;
+    color: var(--text-muted);
+  }
+}
+
+.deposit-balance-cap {
+  margin-top: 2px;
+  padding-top: 9px;
+  border-top: 1px solid var(--card-border);
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-secondary);
 }
 
 .deposit-amount-head {

--- a/apps/payments/web/src/components/DepositView.tsx
+++ b/apps/payments/web/src/components/DepositView.tsx
@@ -4,11 +4,10 @@ import {
   useAccount,
   useChainId,
   useWriteContract,
-  useSimulateContract,
   useWaitForTransactionReceipt,
   useReadContract,
 } from 'wagmi';
-import { parseUnits } from 'viem';
+import { formatUnits, parseUnits } from 'viem';
 import type { BalanceData, PaymentConfig } from '../types';
 import { getErrorMessage, usePaymentNetwork } from '../payment-network';
 import './DepositView.scss';
@@ -17,6 +16,30 @@ const MIN_FIRST_DEPOSIT = 1; // USDC — matches AntseedDeposits.MIN_BUYER_DEPOS
 
 function formatUsd(n: number): string {
   return n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function parseUsd(value?: string | null): number {
+  const parsed = Number.parseFloat(value ?? '0');
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function formatAmountInput(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return '';
+  return n.toFixed(6).replace(/\.?(0+)$/, '');
+}
+
+function safeParseUsdc(value: string): bigint {
+  try {
+    return parseUnits(value || '0', 6);
+  } catch {
+    return 0n;
+  }
+}
+
+function getSuggestedDeposit(maxDeposit: number, isFirstDeposit: boolean): string {
+  const floor = isFirstDeposit ? MIN_FIRST_DEPOSIT : 0;
+  if (maxDeposit <= 0 || maxDeposit < floor) return '';
+  return formatAmountInput(Math.max(floor, Math.min(10, maxDeposit)));
 }
 
 interface DepositViewProps {
@@ -40,6 +63,13 @@ const DEPOSITS_ABI = [
 ] as const;
 
 const ERC20_ABI = [
+  {
+    name: 'balanceOf',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address' }],
+    outputs: [{ name: '', type: 'uint256' }],
+  },
   {
     name: 'approve',
     type: 'function',
@@ -124,42 +154,21 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
   const { address, isConnected } = useAccount();
   const connectedChainId = useChainId();
   const [amount, setAmount] = useState('');
-  const [step, setStep] = useState<'idle' | 'approving' | 'depositing' | 'done'>('idle');
+  const [step, setStep] = useState<'idle' | 'approving' | 'checking-allowance' | 'depositing' | 'done'>('idle');
   const [error, setError] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [trustDetailsOpen, setTrustDetailsOpen] = useState(false);
   const [customTarget, setCustomTarget] = useState('');
   const [customTargetEdited, setCustomTargetEdited] = useState(false);
 
-  const currentTotal = balance ? parseFloat(balance.total) : 0;
-  const creditLimit = balance ? parseFloat(balance.creditLimit) : 0;
-  const maxDeposit = Math.max(0, creditLimit - currentTotal);
+  const currentAvailable = parseUsd(balance?.available);
+  const currentReserved = parseUsd(balance?.reserved);
+  const currentTotal = parseUsd(balance?.total);
+  const creditLimit = parseUsd(balance?.creditLimit);
+  const balanceKnown = balance !== null;
+  const remainingCreditLimit = balanceKnown ? Math.max(0, creditLimit - currentTotal) : 0;
   const isFirstDeposit = currentTotal === 0;
   const minDeposit = isFirstDeposit ? MIN_FIRST_DEPOSIT : 0;
-
-  // Default amount: suggest 10 USDC capped by remaining headroom (min 1 on first deposit).
-  useEffect(() => {
-    if (amount !== '' || !balance) return;
-    if (maxDeposit <= 0) return;
-    const floor = isFirstDeposit ? MIN_FIRST_DEPOSIT : 0;
-    const suggested = Math.max(floor, Math.min(10, maxDeposit));
-    setAmount(suggested.toString());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [balance]);
-
-  const amountNum = amount ? parseFloat(amount) : 0;
-  let validationError: string | null = null;
-  if (amount !== '' && balance) {
-    if (isNaN(amountNum) || amountNum <= 0) {
-      validationError = 'Enter a valid amount';
-    } else if (amountNum < minDeposit) {
-      validationError = `Minimum first deposit is ${minDeposit} USDC`;
-    } else if (amountNum > maxDeposit) {
-      validationError = maxDeposit <= 0
-        ? 'You have reached your credit limit'
-        : `Exceeds your credit limit — max deposit is ${formatUsd(maxDeposit)} USDC`;
-    }
-  }
-  const isValidAmount = amount !== '' && !validationError && amountNum > 0;
 
   const {
     expectedChainId,
@@ -170,6 +179,58 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
     ensureCorrectNetwork,
   } = usePaymentNetwork(config);
   const defaultTarget = buyerAddress ?? address;
+
+  const {
+    data: walletUsdcRaw,
+    refetch: refetchWalletUsdc,
+    isLoading: walletUsdcLoading,
+    isFetching: walletUsdcFetching,
+  } = useReadContract({
+    address: config?.usdcContractAddress as `0x${string}`,
+    abi: ERC20_ABI,
+    functionName: 'balanceOf',
+    chainId: expectedChainId,
+    args: [address as `0x${string}`],
+    query: { enabled: isConnected && !!config && !!address },
+  });
+  const walletUsdcBalance = walletUsdcRaw === undefined ? null : Number.parseFloat(formatUnits(walletUsdcRaw, 6));
+  const walletUsdcKnown = walletUsdcBalance !== null && Number.isFinite(walletUsdcBalance);
+  const maxDeposit = Math.max(0, Math.min(remainingCreditLimit, walletUsdcKnown ? walletUsdcBalance : remainingCreditLimit));
+  const maxDepositReason = remainingCreditLimit <= 0
+    ? 'limit'
+    : walletUsdcKnown && walletUsdcBalance <= remainingCreditLimit
+      ? 'wallet'
+      : 'limit';
+
+  // Default amount: suggest 10 USDC capped by both remaining headroom and wallet USDC.
+  useEffect(() => {
+    if (amount !== '' || !balance) return;
+    const suggested = getSuggestedDeposit(maxDeposit, isFirstDeposit);
+    if (suggested) setAmount(suggested);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [balance, walletUsdcRaw]);
+
+  const amountNum = amount ? Number.parseFloat(amount) : 0;
+  let validationError: string | null = null;
+  if (amount !== '' && balance) {
+    if (!Number.isFinite(amountNum) || amountNum <= 0) {
+      validationError = 'Enter a valid amount';
+    } else if (!/^\d+(\.\d{0,6})?$/.test(amount.trim())) {
+      validationError = 'USDC supports up to 6 decimal places';
+    } else if (amountNum < minDeposit) {
+      validationError = `Minimum first deposit is ${minDeposit} USDC`;
+    } else if (!walletUsdcKnown) {
+      validationError = 'Loading your connected wallet USDC balance…';
+    } else if (amountNum > remainingCreditLimit) {
+      validationError = remainingCreditLimit <= 0
+        ? 'You have reached your credit limit'
+        : `You already have $${formatUsd(currentTotal)} in AntSeed. You can add $${formatUsd(remainingCreditLimit)} more.`;
+    } else if (walletUsdcKnown && amountNum > walletUsdcBalance) {
+      validationError = `Your connected wallet only has ${formatUsd(walletUsdcBalance)} USDC available.`;
+    }
+  }
+  const isValidAmount = amount !== '' && !validationError && amountNum > 0;
+
 
   // Pre-fill the override input with the signer/buyer address once available,
   // until the user manually edits it. This lets people see what the deposit
@@ -196,7 +257,12 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
     customTargetTrimmed.toLowerCase() !== (defaultTarget as string).toLowerCase();
 
   // Read on-chain allowance (always, when connected)
-  const { data: allowance, refetch: refetchAllowance } = useReadContract({
+  const {
+    data: allowance,
+    refetch: refetchAllowance,
+    isLoading: allowanceLoading,
+    isFetching: allowanceFetching,
+  } = useReadContract({
     address: config?.usdcContractAddress as `0x${string}`,
     abi: ERC20_ABI,
     functionName: 'allowance',
@@ -205,8 +271,12 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
     query: { enabled: isConnected && !!config && !!address },
   });
 
-  const usdcAmount = parseUnits(amount || '0', 6);
-  const hasAllowance = allowance !== undefined && allowance >= usdcAmount && usdcAmount > 0n;
+  const usdcAmount = safeParseUsdc(amount);
+  const allowanceKnown = allowance !== undefined;
+  const isCheckingAllowance = allowanceLoading || allowanceFetching || step === 'checking-allowance';
+  const hasAllowance = allowanceKnown && allowance >= usdcAmount && usdcAmount > 0n;
+  const allowanceShortfall = isValidAmount && allowanceKnown && allowance < usdcAmount;
+  const currentWizardStep = !isValidAmount ? 1 : hasAllowance ? 2 : 1;
 
   // Approve USDC
   const {
@@ -221,17 +291,6 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
     query: { enabled: step === 'approving' && !!approveTxHash },
   });
 
-  // Simulate deposit — only when allowance is sufficient
-  const { data: depositSim } = useSimulateContract({
-    address: config?.depositsContractAddress as `0x${string}`,
-    abi: DEPOSITS_ABI,
-    functionName: 'deposit',
-    chainId: expectedChainId,
-    args: [depositTarget as `0x${string}`, usdcAmount],
-    query: { enabled: hasAllowance && !!config && !!depositTarget, retry: 3, retryDelay: 2000 },
-  });
-
-  // Deposit (uses pre-simulated request)
   const {
     writeContract: writeDeposit,
     data: depositTxHash,
@@ -244,23 +303,19 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
     query: { enabled: step === 'depositing' && !!depositTxHash },
   });
 
-  // After approval confirms → refetch allowance (triggers simulation via hasAllowance)
+  // After approval confirms → refetch allowance. Keep the user on an explicit
+  // "checking" state instead of assuming approval immediately changed allowance.
   useEffect(() => {
     if (step !== 'approving' || !approveConfirmed) return;
-    refetchAllowance();
+    setStep('checking-allowance');
+    void refetchAllowance();
   }, [step, approveConfirmed, refetchAllowance]);
 
-  // Once simulation succeeds after approval → send deposit
+  // Once allowance is confirmed on-chain, let the user start step 2 manually.
   useEffect(() => {
-    if (step !== 'approving' || !depositSim?.request) return;
-    setStep('depositing');
-    writeDeposit({ ...depositSim.request, chainId: expectedChainId }, {
-      onError: (err) => {
-        setStep('idle');
-        setError(getErrorMessage(err));
-      },
-    });
-  }, [step, depositSim, expectedChainId, writeDeposit]);
+    if (step !== 'checking-allowance') return;
+    if (hasAllowance) setStep('idle');
+  }, [step, hasAllowance]);
 
   // After deposit confirms → done
   useEffect(() => {
@@ -285,11 +340,34 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
     resetApprove();
     resetDeposit();
 
-    // Allowance already sufficient — simulation is ready, send deposit directly
-    if (depositSim?.request) {
+    const walletResult = await refetchWalletUsdc();
+    const latestWalletUsdc = walletResult.data === undefined ? null : Number.parseFloat(formatUnits(walletResult.data, 6));
+    if (latestWalletUsdc === null || !Number.isFinite(latestWalletUsdc)) {
+      setError('Could not check your wallet USDC balance. Please try again.');
+      return;
+    }
+    if (amountNum > latestWalletUsdc) {
+      setError(`Your connected wallet only has ${formatUsd(latestWalletUsdc)} USDC available.`);
+      return;
+    }
+
+    const allowanceResult = await refetchAllowance();
+    const latestAllowance = allowanceResult.data;
+    if (latestAllowance === undefined) {
+      setError('Could not check your USDC approval. Please try again.');
+      return;
+    }
+
+    // Step 2: allowance is already sufficient — deposit directly.
+    if (latestAllowance >= usdcAmount) {
       setStep('depositing');
-      const { gas: _gas, ...depositRequest } = depositSim.request;
-      writeDeposit({ ...depositRequest, chainId: expectedChainId }, {
+      writeDeposit({
+        address: config.depositsContractAddress as `0x${string}`,
+        abi: DEPOSITS_ABI,
+        functionName: 'deposit',
+        chainId: expectedChainId,
+        args: [depositTarget as `0x${string}`, usdcAmount],
+      }, {
         onError: (err) => {
           setStep('idle');
           setError(getErrorMessage(err));
@@ -298,7 +376,8 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
       return;
     }
 
-    // Need approval first
+    // Step 1: approve USDC first. The user will click again to deposit after
+    // approval is confirmed and allowance has been rechecked.
     setStep('approving');
     writeApprove({
       address: config.usdcContractAddress as `0x${string}`,
@@ -317,12 +396,7 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
   function resetForm() {
     setStep('idle');
     setError(null);
-    if (maxDeposit > 0) {
-      const floor = isFirstDeposit ? MIN_FIRST_DEPOSIT : 0;
-      setAmount(Math.max(floor, Math.min(10, maxDeposit)).toString());
-    } else {
-      setAmount('');
-    }
+    setAmount(getSuggestedDeposit(maxDeposit, isFirstDeposit));
     resetApprove();
     resetDeposit();
   }
@@ -330,20 +404,33 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
   return (
     <div className="deposit-form">
       {!isConnected ? (
-        <div className="deposit-connect-wrapper">
-          <ConnectButton.Custom>
-            {({ openConnectModal, mounted }) => (
-              <button
-                type="button"
-                className="btn-primary"
-                onClick={openConnectModal}
-                disabled={!mounted}
-              >
-                Connect Wallet
-              </button>
-            )}
-          </ConnectButton.Custom>
-        </div>
+        <>
+          <DepositWizard
+            currentStep={1}
+            isApproved={false}
+            isCheckingAllowance={false}
+            isApproving={false}
+            isDepositing={false}
+            amount={amount || 'your chosen amount'}
+          />
+          <div className="deposit-connect-explainer">
+            Connect a wallet so AntSeed can check whether you already approved USDC. If you have, this wizard will jump directly to step 2.
+          </div>
+          <div className="deposit-connect-wrapper">
+            <ConnectButton.Custom>
+              {({ openConnectModal, mounted }) => (
+                <button
+                  type="button"
+                  className="btn-primary"
+                  onClick={openConnectModal}
+                  disabled={!mounted}
+                >
+                  Connect Wallet
+                </button>
+              )}
+            </ConnectButton.Custom>
+          </div>
+        </>
       ) : step === 'done' ? (
         <div className="deposit-success">
           <div className="deposit-success-icon">&#10003;</div>
@@ -363,26 +450,70 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
         </div>
       ) : (
         <>
-          <div className="deposit-connected">
-            <div className="deposit-connected-dot" />
-            <span className="deposit-connected-addr">{address?.slice(0, 6)}...{address?.slice(-4)}</span>
-            <span className="deposit-connected-label">Connected</span>
-          </div>
-
           {wrongChain && (
             <div className="status-msg" style={{ marginTop: 0, marginBottom: 16 }}>
               Wallet is on chain {walletChainId ?? connectedChainId}. Switch to {targetChainName} before depositing.
             </div>
           )}
 
+          <DepositWizard
+            currentStep={currentWizardStep}
+            isApproved={hasAllowance}
+            isCheckingAllowance={isCheckingAllowance}
+            isApproving={step === 'approving'}
+            isDepositing={step === 'depositing'}
+            amount={amount || '0'}
+          />
+
+          <DepositTrustCard
+            onOpenDetails={() => setTrustDetailsOpen(true)}
+            targetChainName={targetChainName}
+            walletAddress={address}
+            antseedAddress={depositTarget as string | undefined}
+            depositsContract={config?.depositsContractAddress}
+            usdcContract={config?.usdcContractAddress}
+            balanceKnown={balanceKnown}
+            currentTotal={currentTotal}
+            currentAvailable={currentAvailable}
+            currentReserved={currentReserved}
+            creditLimit={creditLimit}
+            remainingCreditLimit={remainingCreditLimit}
+            walletUsdcBalance={walletUsdcBalance}
+            walletUsdcKnown={walletUsdcKnown}
+            walletUsdcLoading={walletUsdcLoading || walletUsdcFetching}
+            maxDeposit={maxDeposit}
+            maxDepositReason={maxDepositReason}
+          />
+
+          <TrustDetailsModal
+            isOpen={trustDetailsOpen}
+            onClose={() => setTrustDetailsOpen(false)}
+            targetChainName={targetChainName}
+            walletAddress={address}
+            antseedAddress={depositTarget as string | undefined}
+            depositsContract={config?.depositsContractAddress}
+            usdcContract={config?.usdcContractAddress}
+            balanceKnown={balanceKnown}
+            currentTotal={currentTotal}
+            currentAvailable={currentAvailable}
+            currentReserved={currentReserved}
+            creditLimit={creditLimit}
+            remainingCreditLimit={remainingCreditLimit}
+            walletUsdcBalance={walletUsdcBalance}
+            walletUsdcKnown={walletUsdcKnown}
+            walletUsdcLoading={walletUsdcLoading || walletUsdcFetching}
+            maxDeposit={maxDeposit}
+            maxDepositReason={maxDepositReason}
+          />
+
           <div className="input-group">
             <div className="deposit-amount-head">
-              <label className="input-label">Amount (USDC)</label>
+              <label className="input-label">Amount to add (USDC)</label>
               {balance && maxDeposit > 0 && (
                 <button
                   type="button"
                   className="deposit-amount-max"
-                  onClick={() => setAmount(maxDeposit.toString())}
+                  onClick={() => setAmount(formatAmountInput(maxDeposit))}
                   disabled={step !== 'idle'}
                 >
                   Max ${formatUsd(maxDeposit)}
@@ -405,7 +536,7 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
                 {isFirstDeposit
                   ? `Min ${MIN_FIRST_DEPOSIT} USDC · `
                   : ''}
-                You can deposit up to ${formatUsd(maxDeposit)} more (credit limit ${formatUsd(creditLimit)})
+                Add up to ${formatUsd(maxDeposit)} now — ${formatUsd(remainingCreditLimit)} remaining limit, {walletUsdcKnown ? `${formatUsd(walletUsdcBalance)} USDC in wallet` : 'wallet balance loading'}.
               </span>
             ) : (
               <span className="hint">Loading your credit limit…</span>
@@ -477,13 +608,16 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
           <button
             className="btn-primary"
             onClick={handleDeposit}
-            disabled={step !== 'idle' || !isValidAmount || !config || isSwitchingChain || customTargetInvalid || !depositTarget}
+            disabled={step !== 'idle' || !isValidAmount || !config || isSwitchingChain || customTargetInvalid || !depositTarget || allowanceLoading || allowanceFetching || walletUsdcLoading || walletUsdcFetching || !walletUsdcKnown}
           >
             {isSwitchingChain ? `Switching to ${targetChainName}...` :
              wrongChain ? `Switch to ${targetChainName}` :
-             step === 'approving' ? 'Approving USDC...' :
+             walletUsdcLoading || walletUsdcFetching || !walletUsdcKnown ? 'Loading wallet USDC...' :
+             isCheckingAllowance ? 'Checking approval...' :
+             step === 'approving' ? 'Approve USDC in wallet...' :
              step === 'depositing' ? 'Depositing...' :
-             'Deposit USDC'}
+             allowanceShortfall ? `Step 1: Approve ${amount || '0'} USDC` :
+             'Step 2: Deposit USDC'}
           </button>
         </>
       )}
@@ -493,6 +627,229 @@ function CryptoDeposit({ config, balance, buyerAddress, onDeposited }: {
           {error}
         </div>
       )}
+    </div>
+  );
+}
+
+function shortAddress(addr?: string | null): string {
+  return addr ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : '—';
+}
+
+function DepositTrustCard({
+  onOpenDetails,
+  balanceKnown,
+  currentTotal,
+  maxDeposit,
+}: {
+  onOpenDetails: () => void;
+  balanceKnown: boolean;
+  currentTotal: number;
+  maxDeposit: number;
+}) {
+  return (
+    <div className="deposit-trust-card" role="note" aria-label="Deposit safety summary">
+      <button
+        type="button"
+        className="deposit-trust-toggle"
+        onClick={onOpenDetails}
+      >
+        <span className="deposit-trust-shield" aria-hidden="true">✓</span>
+        <span className="deposit-trust-head-copy">
+          <span className="deposit-trust-title">Safe deposit flow</span>
+          <span className="deposit-trust-subtitle">USDC stays on-chain in the AntSeed Deposits contract.</span>
+        </span>
+        <span className="deposit-trust-balance-summary">
+          <span>In AntSeed</span>
+          <strong>{balanceKnown ? `$${formatUsd(currentTotal)}` : 'Loading…'}</strong>
+          <em>{balanceKnown ? `Max $${formatUsd(maxDeposit)}` : 'Loading…'}</em>
+        </span>
+        <span className="deposit-trust-chevron" aria-hidden="true">›</span>
+      </button>
+    </div>
+  );
+}
+
+function TrustDetailsModal({
+  isOpen,
+  onClose,
+  targetChainName,
+  walletAddress,
+  antseedAddress,
+  depositsContract,
+  usdcContract,
+  balanceKnown,
+  currentTotal,
+  currentAvailable,
+  currentReserved,
+  creditLimit,
+  remainingCreditLimit,
+  walletUsdcBalance,
+  walletUsdcKnown,
+  walletUsdcLoading,
+  maxDeposit,
+  maxDepositReason,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  targetChainName: string;
+  walletAddress?: string;
+  antseedAddress?: string;
+  depositsContract?: string;
+  usdcContract?: string;
+  balanceKnown: boolean;
+  currentTotal: number;
+  currentAvailable: number;
+  currentReserved: number;
+  creditLimit: number;
+  remainingCreditLimit: number;
+  walletUsdcBalance: number | null;
+  walletUsdcKnown: boolean;
+  walletUsdcLoading: boolean;
+  maxDeposit: number;
+  maxDepositReason: 'wallet' | 'limit';
+}) {
+  useEffect(() => {
+    if (!isOpen) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="deposit-details-overlay" role="presentation" onClick={onClose}>
+      <div
+        className="deposit-details-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="deposit-details-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="deposit-details-head">
+          <div>
+            <div className="deposit-details-eyebrow">Deposit safety</div>
+            <h3 id="deposit-details-title">Safe deposit flow</h3>
+            <p>USDC stays on-chain in the AntSeed Deposits contract.</p>
+          </div>
+          <button type="button" className="deposit-details-close" onClick={onClose} aria-label="Close details">×</button>
+        </div>
+
+        <div className="deposit-details-body">
+          <div className="deposit-details-balance-hero">
+            <span>In AntSeed now</span>
+            <strong>{balanceKnown ? `$${formatUsd(currentTotal)}` : 'Loading…'}</strong>
+            <small>{balanceKnown ? `You can deposit up to $${formatUsd(maxDeposit)} now.` : 'Loading account balance and limit…'}</small>
+          </div>
+
+          <div className="deposit-balance-details deposit-balance-details--embedded">
+            <div className="deposit-balance-breakdown">
+              <span>Available {balanceKnown ? `$${formatUsd(currentAvailable)}` : 'Loading…'}</span>
+              <span>Reserved {balanceKnown ? `$${formatUsd(currentReserved)}` : 'Loading…'}</span>
+            </div>
+            <div className="deposit-balance-row">
+              <span>Account limit</span>
+              <strong>{balanceKnown ? `$${formatUsd(creditLimit)}` : 'Loading…'}</strong>
+            </div>
+            <div className="deposit-balance-row">
+              <span>Can add before limit</span>
+              <strong>{balanceKnown ? `$${formatUsd(remainingCreditLimit)}` : 'Loading…'}</strong>
+            </div>
+            <div className="deposit-balance-row">
+              <span>Wallet USDC</span>
+              <strong>{walletUsdcKnown ? `$${formatUsd(walletUsdcBalance ?? 0)}` : walletUsdcLoading ? 'Loading…' : '—'}</strong>
+            </div>
+            <div className="deposit-balance-cap">
+              {balanceKnown
+                ? <>Max deposit is ${formatUsd(maxDeposit)} based on your {maxDepositReason === 'wallet' ? 'connected wallet USDC balance' : 'remaining AntSeed limit'}. Your deposit availability grows as you use AntSeed and build account history.</>
+                : 'Loading your AntSeed balance and account limit…'}
+            </div>
+          </div>
+
+          <div className="deposit-trust-grid">
+            <div className="deposit-trust-item">
+              <span>Network</span>
+              <strong>{targetChainName}</strong>
+            </div>
+            <div className="deposit-trust-item">
+              <span>Pays from wallet</span>
+              <strong>{shortAddress(walletAddress)}</strong>
+            </div>
+            <div className="deposit-trust-item">
+              <span>Credits AntSeed account</span>
+              <strong>{shortAddress(antseedAddress)}</strong>
+            </div>
+            <div className="deposit-trust-item">
+              <span>USDC contract</span>
+              <strong>{shortAddress(usdcContract)}</strong>
+            </div>
+            <div className="deposit-trust-item deposit-trust-item--wide">
+              <span>Deposits contract</span>
+              <strong>{shortAddress(depositsContract)}</strong>
+            </div>
+          </div>
+
+          <div className="deposit-trust-foot">
+            You will see two wallet confirmations only when needed: first an ERC‑20 approval, then the actual deposit.
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DepositWizard({
+  currentStep,
+  isApproved,
+  isCheckingAllowance,
+  isApproving,
+  isDepositing,
+  amount,
+}: {
+  currentStep: 1 | 2;
+  isApproved: boolean;
+  isCheckingAllowance: boolean;
+  isApproving: boolean;
+  isDepositing: boolean;
+  amount: string;
+}) {
+  return (
+    <div className="deposit-wizard" aria-label="Deposit wizard">
+      <div className="deposit-wizard-track" aria-hidden="true">
+        <span className="deposit-wizard-track-fill" style={{ width: currentStep === 2 ? '100%' : '0%' }} />
+      </div>
+      <div className={`deposit-wizard-step ${currentStep === 1 ? 'deposit-wizard-step--active' : 'deposit-wizard-step--complete'}`}>
+        <div className="deposit-wizard-number">{isApproved ? '✓' : '1'}</div>
+        <div className="deposit-wizard-content">
+          <div className="deposit-wizard-kicker">Step 1</div>
+          <div className="deposit-wizard-title">Approve USDC</div>
+          <div className="deposit-wizard-copy">
+            {isCheckingAllowance
+              ? 'Checking your existing approval on-chain…'
+              : isApproved
+                ? 'Already approved. You can skip straight to step 2.'
+                : isApproving
+                  ? 'Confirm approval in your wallet. This does not move funds.'
+                  : `Permit AntSeed's Deposits contract to use ${amount} USDC. Approval only grants permission.`}
+          </div>
+        </div>
+      </div>
+      <div className={`deposit-wizard-step ${currentStep === 2 ? 'deposit-wizard-step--active' : 'deposit-wizard-step--locked'}`}>
+        <div className="deposit-wizard-number">2</div>
+        <div className="deposit-wizard-content">
+          <div className="deposit-wizard-kicker">Step 2</div>
+          <div className="deposit-wizard-title">Deposit credits</div>
+          <div className="deposit-wizard-copy">
+            {isDepositing
+              ? 'Confirm the deposit transaction. This moves USDC into your AntSeed balance.'
+              : isApproved
+                ? 'Approval detected. The next click deposits USDC into your AntSeed balance.'
+                : 'Locked until approval is confirmed.'}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/payments/web/src/layout/ActionModal.tsx
+++ b/apps/payments/web/src/layout/ActionModal.tsx
@@ -5,6 +5,7 @@ interface ActionModalProps {
   onClose: () => void;
   title: string;
   subtitle?: string;
+  variant?: 'default' | 'deposit';
   children: ReactNode;
 }
 
@@ -16,7 +17,7 @@ function CloseIcon() {
   );
 }
 
-export function ActionModal({ isOpen, onClose, title, subtitle, children }: ActionModalProps) {
+export function ActionModal({ isOpen, onClose, title, subtitle, variant = 'default', children }: ActionModalProps) {
   useEffect(() => {
     if (!isOpen) return;
     function onKey(e: KeyboardEvent) {
@@ -47,12 +48,22 @@ export function ActionModal({ isOpen, onClose, title, subtitle, children }: Acti
       aria-label={title}
       onClick={onClose}
     >
-      <div className="action-modal-card" onClick={(e) => e.stopPropagation()}>
+      <div className={`action-modal-card action-modal-card--${variant}`} onClick={(e) => e.stopPropagation()}>
         <header className="action-modal-head">
-          <div className="action-modal-head-text">
-            <h2 className="action-modal-title">{title}</h2>
-            {subtitle && <p className="action-modal-subtitle">{subtitle}</p>}
-          </div>
+          {variant === 'deposit' ? (
+            <div className="action-modal-deposit-hero">
+              <div className="action-modal-head-text">
+                <div className="action-modal-eyebrow">Deposit wizard</div>
+                <h2 className="action-modal-title">{title}</h2>
+                {subtitle && <p className="action-modal-subtitle">{subtitle}</p>}
+              </div>
+            </div>
+          ) : (
+            <div className="action-modal-head-text">
+              <h2 className="action-modal-title">{title}</h2>
+              {subtitle && <p className="action-modal-subtitle">{subtitle}</p>}
+            </div>
+          )}
           <button
             type="button"
             className="action-modal-close"

--- a/apps/payments/web/src/layout/TopBar.tsx
+++ b/apps/payments/web/src/layout/TopBar.tsx
@@ -5,6 +5,7 @@ interface TopBarProps {
   activeTab: TabId;
   balance: BalanceData | null;
   onOpenWallet: () => void;
+  onOpenDeposit: () => void;
 }
 
 const TAB_TITLES: Record<TabId, string> = {
@@ -34,7 +35,7 @@ function SignerIcon() {
   );
 }
 
-export function TopBar({ activeTab, balance, onOpenWallet }: TopBarProps) {
+export function TopBar({ activeTab, balance, onOpenWallet, onOpenDeposit }: TopBarProps) {
   const total = balance ? parseFloat(balance.total) : null;
 
   return (
@@ -44,20 +45,30 @@ export function TopBar({ activeTab, balance, onOpenWallet }: TopBarProps) {
         <div className="dash-topbar-subtitle">{TAB_SUBTITLES[activeTab]}</div>
       </div>
       <div className="dash-topbar-right">
-        <button
-          type="button"
-          className="dash-topbar-wallet"
-          onClick={onOpenWallet}
-          title="Open signer"
-        >
-          <span className="dash-topbar-wallet-icon"><SignerIcon /></span>
-          <span className="dash-topbar-wallet-text">
-            <span className="dash-topbar-wallet-label">AntSeed account</span>
-            <span className="dash-topbar-wallet-value">
-              {total !== null ? `$${formatUsd(total)}` : '—'}
+        <div className="dash-topbar-balance-group" aria-label="AntSeed account balance">
+          <button
+            type="button"
+            className="dash-topbar-wallet"
+            onClick={onOpenWallet}
+            title="Open signer"
+          >
+            <span className="dash-topbar-wallet-icon"><SignerIcon /></span>
+            <span className="dash-topbar-wallet-text">
+              <span className="dash-topbar-wallet-label">AntSeed account</span>
+              <span className="dash-topbar-wallet-value">
+                {total !== null ? `$${formatUsd(total)}` : '—'}
+              </span>
             </span>
-          </span>
-        </button>
+          </button>
+          <button
+            type="button"
+            className="dash-topbar-deposit-btn"
+            onClick={onOpenDeposit}
+            title="Deposit USDC"
+          >
+            Deposit
+          </button>
+        </div>
       </div>
     </header>
   );

--- a/apps/payments/web/src/styles/global.scss
+++ b/apps/payments/web/src/styles/global.scss
@@ -701,21 +701,29 @@ $dash-sidebar-width: 240px;
   &-title { font-size: 18px; font-weight: 600; color: var(--text-primary); }
   &-subtitle { font-size: 12px; color: var(--text-muted); }
   &-right { display: flex; align-items: center; gap: 12px; }
+  &-balance-group {
+    display: inline-flex;
+    align-items: stretch;
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 13px;
+    overflow: hidden;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+  }
   &-wallet {
     display: inline-flex;
     align-items: center;
     gap: 10px;
     padding: 8px 14px 8px 12px;
-    background: var(--card-bg);
-    border: 1px solid var(--card-border);
-    border-radius: 12px;
+    background: transparent;
+    border: none;
+    border-radius: 0;
     color: var(--text-secondary);
     cursor: pointer;
     transition: border-color 0.14s, background 0.14s, color 0.14s, transform 0.14s;
     font: inherit;
 
     &:hover {
-      border-color: var(--accent);
       color: var(--text-primary);
       transform: translateY(-1px);
     }
@@ -752,6 +760,24 @@ $dash-sidebar-width: 240px;
     font-variant-numeric: tabular-nums;
     line-height: 1.2;
     color: var(--text-primary);
+  }
+  &-deposit-btn {
+    border: none;
+    border-left: 1px solid var(--card-border);
+    background: var(--accent);
+    color: #06351d;
+    padding: 0 14px;
+    font: inherit;
+    font-size: 12px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: filter 0.14s, transform 0.14s;
+
+    &:hover {
+      filter: brightness(0.96);
+      transform: translateY(-1px);
+    }
+    &:active { transform: translateY(0); }
   }
 }
 
@@ -1321,7 +1347,7 @@ $dash-sidebar-width: 240px;
 }
 
 .empty-state-card {
-  width: min(460px, 100%);
+  width: min(720px, 100%);
   max-height: calc(100vh - 48px);
   overflow-y: auto;
   overflow-x: hidden;
@@ -1596,6 +1622,10 @@ $dash-sidebar-width: 240px;
     0 20px 60px -20px rgba(10, 14, 22, 0.35);
   animation: empty-state-rise 0.3s cubic-bezier(0.22, 1, 0.36, 1) both;
 
+  &--deposit {
+    width: min(560px, 100%);
+  }
+
   /* Flatten the inner DepositView/WithdrawView card so the modal reads as one surface */
   .deposit, .withdraw { width: 100%; min-width: 0; }
   .deposit > .card,
@@ -1619,6 +1649,11 @@ $dash-sidebar-width: 240px;
   gap: 16px;
   padding: 22px 24px 16px;
   border-bottom: 1px solid var(--card-border);
+
+  .action-modal-card--deposit & {
+    padding: 24px;
+    background: var(--page-bg);
+  }
 }
 
 .action-modal-head-text {
@@ -1634,6 +1669,12 @@ $dash-sidebar-width: 240px;
   font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--text-primary);
+
+  .action-modal-card--deposit & {
+    font-size: 22px;
+    font-weight: 800;
+    letter-spacing: -0.03em;
+  }
 }
 
 .action-modal-subtitle {
@@ -1641,7 +1682,29 @@ $dash-sidebar-width: 240px;
   font-size: 12px;
   line-height: 1.5;
   color: var(--text-muted);
+
+  .action-modal-card--deposit & {
+    max-width: 390px;
+    color: var(--text-secondary);
+  }
 }
+
+.action-modal-deposit-hero {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  min-width: 0;
+}
+
+
+.action-modal-eyebrow {
+  font-size: 10px;
+  font-weight: 800;
+  color: var(--accent-text);
+  text-transform: uppercase;
+  letter-spacing: 0.11em;
+}
+
 
 .action-modal-close {
   display: inline-flex;
@@ -1666,6 +1729,10 @@ $dash-sidebar-width: 240px;
 
 .action-modal-body {
   padding: 22px 24px 24px;
+
+  .action-modal-card--deposit & {
+    padding-top: 18px;
+  }
 }
 
 /* ── Authorize wallet: modal, alert, empty-state step, drawer warning ── */


### PR DESCRIPTION
## Description

Refines the payments deposit flow so deposit amounts are capped by both the buyer's remaining AntSeed credit limit and their connected wallet USDC balance. Adds a clearer deposit wizard, direct deposit entry points from desktop, and moves safety/account details into a viewport-bounded modal.

## Release Notes

- Fixed Max deposit to use the remaining deposit delta instead of the full limit
- Added wallet USDC balance checks before approval and deposit
- Added a guided deposit flow with safer account and contract details
- Opened desktop Add credits actions directly into the deposit flow

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [ ] Lint and unit tests pass locally with my changes
