### PR TITLE
fix(app): Improve desktop discover pagination

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
@@ -22,9 +22,9 @@
 .cards-inner {
   width: 100%;
   height: 100%;
-  max-width: 960px;
+  max-width: 1440px;
   margin: 0 auto;
-  padding: 32px 0 16px;
+  padding: 32px 16px 16px;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -186,7 +186,7 @@
   flex: 1;
   min-height: 0;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(var(--discover-columns, 3), minmax(0, 1fr));
   grid-auto-rows: min-content;
   align-content: flex-start;
   gap: 12px;
@@ -194,14 +194,26 @@
 }
 
 @media (max-width: 780px) {
+  .cards-inner {
+    padding-inline: 12px;
+  }
+
   .card-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
   }
 }
 
 @media (max-width: 520px) {
   .card-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr !important;
+  }
+
+  .pagination-bar {
+    align-items: flex-start;
+  }
+
+  .status-text {
+    white-space: normal;
   }
 }
 
@@ -227,6 +239,16 @@
   display: flex;
   align-items: center;
   gap: 4px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.page-ellipsis {
+  min-width: 20px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
 }
 
 .page-btn {

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
+import type { CSSProperties } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
 import type { ChatServiceOptionEntry, DiscoverRow } from '../../../core/state';
@@ -225,13 +226,53 @@ type DiscoverWelcomeProps = {
   onStartChatting: (serviceValue: string, peerId?: string) => void;
 };
 
-const PAGE_SIZE = 9;
+const MIN_CARD_WIDTH_PX = 280;
+const GRID_GAP_PX = 12;
+const CARD_ESTIMATED_HEIGHT_PX = 208;
+const DEFAULT_PAGE_SIZE = 9;
+
+type PaginationToken = number | 'ellipsis';
+
+function estimatePageSize(): number {
+  if (typeof window === 'undefined') return DEFAULT_PAGE_SIZE;
+
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+
+  let columns = 1;
+  if (viewportWidth > 520) columns = 2;
+  if (viewportWidth > 780) {
+    const estimatedColumns = Math.floor((viewportWidth + GRID_GAP_PX) / (MIN_CARD_WIDTH_PX + GRID_GAP_PX));
+    columns = Math.max(3, estimatedColumns);
+  }
+
+  const usableHeight = Math.max(360, viewportHeight - 320);
+  const rows = Math.max(1, Math.floor((usableHeight + GRID_GAP_PX) / (CARD_ESTIMATED_HEIGHT_PX + GRID_GAP_PX)));
+  return Math.max(columns, columns * rows);
+}
+
+function buildPaginationTokens(page: number, totalPages: number): PaginationToken[] {
+  if (totalPages <= 5) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  if (page <= 3) {
+    return [1, 2, 3, 'ellipsis', totalPages - 1, totalPages];
+  }
+
+  if (page >= totalPages - 2) {
+    return [1, 2, 'ellipsis', totalPages - 2, totalPages - 1, totalPages];
+  }
+
+  return [1, 'ellipsis', page - 1, page, page + 1, 'ellipsis', totalPages];
+}
 
 export function DiscoverWelcome({ serviceOptions, onStartChatting }: DiscoverWelcomeProps) {
   const snap = useUiSnapshot();
   const rows = snap.discoverRows;
 
   const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(() => estimatePageSize());
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [drawerClosing, setDrawerClosing] = useState(false);
 
@@ -244,6 +285,21 @@ export function DiscoverWelcome({ serviceOptions, onStartChatting }: DiscoverWel
   }, []);
 
   const filterState = useDiscoverFilters(rows);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const updatePageSize = () => {
+      setPageSize((prev) => {
+        const next = estimatePageSize();
+        return prev === next ? prev : next;
+      });
+    };
+
+    updatePageSize();
+    window.addEventListener('resize', updatePageSize);
+    return () => window.removeEventListener('resize', updatePageSize);
+  }, []);
 
   const hasActiveFilters =
     filterState.categorySet.size > 0 ||
@@ -283,10 +339,10 @@ export function DiscoverWelcome({ serviceOptions, onStartChatting }: DiscoverWel
     filterState.sortKey,
   ]);
 
-  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   const currentPage = Math.min(page, totalPages);
-  const pageStart = (currentPage - 1) * PAGE_SIZE;
-  const paged = filtered.slice(pageStart, pageStart + PAGE_SIZE);
+  const pageStart = (currentPage - 1) * pageSize;
+  const paged = filtered.slice(pageStart, pageStart + pageSize);
   const rangeStart = filtered.length === 0 ? 0 : pageStart + 1;
   const rangeEnd = pageStart + paged.length;
   const statusText = `${rangeStart}-${rangeEnd} of ${filtered.length} total service${filtered.length === 1 ? '' : 's'}`;
@@ -369,13 +425,13 @@ export function DiscoverWelcome({ serviceOptions, onStartChatting }: DiscoverWel
 
           <div className={styles.resultsArea}>
             {!hasNetworkData ? (
-              <div className={styles.cardGrid}>
-                {Array.from({ length: 9 }, (_, i) => (
+              <div className={styles.cardGrid} style={{ '--discover-columns': Math.max(1, Math.ceil(Math.sqrt(pageSize))) } as CSSProperties}>
+                {Array.from({ length: pageSize }, (_, i) => (
                   <SkeletonCard key={i} />
                 ))}
               </div>
             ) : filtered.length > 0 ? (
-              <div className={styles.cardGrid}>
+              <div className={styles.cardGrid} style={{ '--discover-columns': Math.max(1, Math.ceil(Math.sqrt(pageSize))) } as CSSProperties}>
                 {paged.map((item) => (
                   <Card
                     key={item.value || item.name}
@@ -441,7 +497,7 @@ function Pagination({
   totalPages: number;
   onPageChange: (p: number) => void;
 }) {
-  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+  const tokens = buildPaginationTokens(page, totalPages);
   return (
     <nav className={styles.pagination} aria-label="Pagination">
       <button
@@ -452,16 +508,26 @@ function Pagination({
       >
         ‹
       </button>
-      {pages.map((n) => (
-        <button
-          key={n}
-          className={`${styles.pageBtn}${n === page ? ` ${styles.pageBtnActive}` : ''}`}
-          onClick={() => onPageChange(n)}
-          aria-current={n === page ? 'page' : undefined}
-        >
-          {n}
-        </button>
-      ))}
+      {tokens.map((token, index) => {
+        if (token === 'ellipsis') {
+          return (
+            <span key={`ellipsis-${index}`} className={styles.pageEllipsis} aria-hidden="true">
+              …
+            </span>
+          );
+        }
+
+        return (
+          <button
+            key={token}
+            className={`${styles.pageBtn}${token === page ? ` ${styles.pageBtnActive}` : ''}`}
+            onClick={() => onPageChange(token)}
+            aria-current={token === page ? 'page' : undefined}
+          >
+            {token}
+          </button>
+        );
+      })}
       <button
         className={styles.pageBtn}
         disabled={page === totalPages}


### PR DESCRIPTION
## Description

Update the desktop Discover view to use available screen space more effectively on larger resolutions.
The grid now shows more service cards per page when the window is larger, and pagination uses a condensed page-number display.

## Release Notes

- Improved the desktop Discover view to show more services on larger windows
- Updated Discover pagination to use a more compact page-number layout

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [ ] Lint and unit tests pass locally with my changes
