### PR TITLE
fix(desktop): keep browser preview in-app only

### DIFF
--- a/apps/desktop/src/main/chat-dev-tools.ts
+++ b/apps/desktop/src/main/chat-dev-tools.ts
@@ -4,40 +4,56 @@ import { existsSync } from 'node:fs';
 import { createConnection } from 'node:net';
 import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
 
+type SendToRenderer = (channel: string, payload: unknown) => void;
+
+function sendBrowserPreviewOpen(sendToRenderer: SendToRenderer | undefined, url: string): void {
+  if (!sendToRenderer) {
+    return;
+  }
+  try {
+    sendToRenderer('browser-preview:open', { url });
+  } catch {
+    // Renderer notifications are best-effort; do not fail the tool call.
+  }
+}
+
 const BrowserPreviewParams = Type.Object({
   url: Type.String({
     description: 'The URL to open in the browser preview panel (e.g. http://localhost:3000).',
   }),
 });
 
-export const browserPreviewTool: ToolDefinition = {
-  name: 'open_browser_preview',
-  label: 'Browser Preview',
-  description:
-    'Open a URL in the in-app browser preview panel. Call this tool after starting a dev ' +
-    'server with start_dev_server, when making visible UI changes, or when the user ' +
-    'asks to preview their work.',
-  parameters: BrowserPreviewParams,
-  async execute(_toolCallId, params) {
-    const { url } = params as Static<typeof BrowserPreviewParams>;
-    try {
-      new URL(url);
-    } catch {
-      return {
-        content: [{ type: 'text', text: `Invalid URL: ${url}` }],
-        details: { url, error: 'invalid URL' },
-        isError: true,
-      };
-    }
+export function createBrowserPreviewTool(sendToRenderer?: SendToRenderer): ToolDefinition {
+  return {
+    name: 'open_browser_preview',
+    label: 'Browser Preview',
+    description:
+      'Open a URL in the in-app browser preview panel. Call this tool after starting a dev ' +
+      'server with start_dev_server, when making visible UI changes, or when the user ' +
+      'asks to preview their work.',
+    parameters: BrowserPreviewParams,
+    async execute(_toolCallId, params) {
+      const { url } = params as Static<typeof BrowserPreviewParams>;
+      try {
+        new URL(url);
+      } catch {
+        return {
+          content: [{ type: 'text', text: `Invalid URL: ${url}` }],
+          details: { url, error: 'invalid URL' },
+          isError: true,
+        };
+      }
 
-    // The preview panel is opened automatically via browser-preview:open IPC
-    // emitted by pi-chat-engine on tool_execution_end
-    return {
-      content: [{ type: 'text', text: `Opened ${url} in the preview panel.` }],
-      details: { url },
-    };
-  },
-};
+      sendBrowserPreviewOpen(sendToRenderer, url);
+      return {
+        content: [{ type: 'text', text: `Opened ${url} in the preview panel.` }],
+        details: { url },
+      };
+    },
+  };
+}
+
+export const browserPreviewTool: ToolDefinition = createBrowserPreviewTool();
 
 const StartDevServerParams = Type.Object({
   command: Type.String({
@@ -107,149 +123,154 @@ function extractUrlFromOutput(output: string): string | null {
   return m ? m[0].replace('0.0.0.0', 'localhost') : null;
 }
 
-export const startDevServerTool: ToolDefinition = {
-  name: 'start_dev_server',
-  label: 'Start Dev Server',
-  description:
-    'Start a development server as a persistent background process. The server runs in ' +
-    'a detached session so it survives tool timeouts. Use this instead of bash for any ' +
-    'long-running dev server (npm run dev, pnpm run dev, vite, next dev, docusaurus start, etc.). ' +
-    'The tool waits for the server to be ready and returns the URL. After this, call ' +
-    'open_browser_preview with the returned URL to show it in the preview panel.',
-  parameters: StartDevServerParams,
-  async execute(_toolCallId, params, signal) {
-    const { command, cwd, port: expectedPort } = params as Static<typeof StartDevServerParams>;
+export function createStartDevServerTool(sendToRenderer?: SendToRenderer): ToolDefinition {
+  return {
+    name: 'start_dev_server',
+    label: 'Start Dev Server',
+    description:
+      'Start a development server as a persistent background process. The server runs in ' +
+      'a detached session so it survives tool timeouts. Use this instead of bash for any ' +
+      'long-running dev server (npm run dev, pnpm run dev, vite, next dev, docusaurus start, etc.). ' +
+      'The tool waits for the server to be ready, returns the URL, and opens it in the preview panel.',
+    parameters: StartDevServerParams,
+    async execute(_toolCallId, params, signal) {
+      const { command, cwd, port: expectedPort } = params as Static<typeof StartDevServerParams>;
 
-    if (!existsSync(cwd)) {
-      return {
-        content: [{ type: 'text', text: `Directory does not exist: ${cwd}` }],
-        details: { cwd, error: 'directory not found' },
-        isError: true,
-      };
-    }
-
-    const prev = runningDevServers.get(cwd);
-    if (prev) {
-      try { prev.kill(); } catch { /* ignore */ }
-      runningDevServers.delete(cwd);
-    }
-
-    let output = '';
-
-    const shellCommand = getDevServerShell(command);
-    const child = spawn(shellCommand.file, shellCommand.args, {
-      cwd,
-      detached: true, // new process group — immune to parent signals
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, BROWSER: 'none', FORCE_COLOR: '0' },
-      windowsHide: true,
-    });
-
-    if (!child.pid) {
-      return {
-        content: [{ type: 'text', text: `Failed to start dev server for command: ${command}` }],
-        details: { cwd, command, error: 'missing child pid' },
-        isError: true,
-      };
-    }
-
-    // Unref so the Electron process can exit even if the dev server is still running
-    child.unref();
-
-    child.on('exit', () => {
-      runningDevServers.delete(cwd);
-    });
-
-    const collectOutput = (chunk: Buffer) => {
-      output += chunk.toString();
-      // Cap collected output to avoid unbounded memory
-      if (output.length > 32_000) output = output.slice(-16_000);
-    };
-
-    let spawnError: string | null = null;
-    let exitCode: number | null = null;
-
-    child.stdout?.on('data', collectOutput);
-    child.stderr?.on('data', collectOutput);
-    child.on('error', (error) => {
-      spawnError = error.message;
-      output += `\n[spawn error] ${error.message}`;
-    });
-    child.on('exit', (code) => {
-      exitCode = code;
-    });
-
-    const killFn = () => {
-      try { killDetachedDevServer(child.pid!); } catch { /* ignore */ }
-    };
-
-    runningDevServers.set(cwd, { pid: child.pid, kill: killFn });
-
-    // Wait for the server to become ready
-    const startTime = Date.now();
-    const maxWaitMs = 30_000;
-
-    // If we know the port, poll for it
-    if (expectedPort) {
-      const ready = await waitForPort(expectedPort, maxWaitMs, signal ?? undefined);
-      if (ready) {
-        const url = `http://localhost:${expectedPort}`;
+      if (!existsSync(cwd)) {
         return {
-          content: [{ type: 'text', text: `Dev server running at ${url} (pid ${child.pid})` }],
-          details: { url, pid: child.pid, cwd },
+          content: [{ type: 'text', text: `Directory does not exist: ${cwd}` }],
+          details: { cwd, error: 'directory not found' },
+          isError: true,
         };
       }
-    }
 
-    // Otherwise, watch the output for a URL
-    const foundUrl = await new Promise<string | null>((resolve) => {
-      const deadline = startTime + maxWaitMs;
+      const prev = runningDevServers.get(cwd);
+      if (prev) {
+        try { prev.kill(); } catch { /* ignore */ }
+        runningDevServers.delete(cwd);
+      }
 
-      const poll = () => {
-        if (signal?.aborted) { resolve(null); return; }
-        const url = extractUrlFromOutput(output);
-        if (url) { resolve(url); return; }
-        if (Date.now() > deadline) { resolve(null); return; }
-        setTimeout(poll, 500);
+      let output = '';
+
+      const shellCommand = getDevServerShell(command);
+      const child = spawn(shellCommand.file, shellCommand.args, {
+        cwd,
+        detached: true, // new process group — immune to parent signals
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env, BROWSER: 'none', FORCE_COLOR: '0' },
+        windowsHide: true,
+      });
+
+      if (!child.pid) {
+        return {
+          content: [{ type: 'text', text: `Failed to start dev server for command: ${command}` }],
+          details: { cwd, command, error: 'missing child pid' },
+          isError: true,
+        };
+      }
+
+      // Unref so the Electron process can exit even if the dev server is still running
+      child.unref();
+
+      child.on('exit', () => {
+        runningDevServers.delete(cwd);
+      });
+
+      const collectOutput = (chunk: Buffer) => {
+        output += chunk.toString();
+        // Cap collected output to avoid unbounded memory
+        if (output.length > 32_000) output = output.slice(-16_000);
       };
-      poll();
-    });
 
-    if (foundUrl) {
-      // Give it a tiny bit more time after URL appears (compilation may still be running)
-      const port = parseInt(new URL(foundUrl).port, 10);
-      if (port) await waitForPort(port, 10_000, signal ?? undefined);
+      let spawnError: string | null = null;
+      let exitCode: number | null = null;
 
-      return {
-        content: [{ type: 'text', text: `Dev server running at ${foundUrl} (pid ${child.pid})` }],
-        details: { url: foundUrl, pid: child.pid, cwd },
+      child.stdout?.on('data', collectOutput);
+      child.stderr?.on('data', collectOutput);
+      child.on('error', (error) => {
+        spawnError = error.message;
+        output += `\n[spawn error] ${error.message}`;
+      });
+      child.on('exit', (code) => {
+        exitCode = code;
+      });
+
+      const killFn = () => {
+        try { killDetachedDevServer(child.pid!); } catch { /* ignore */ }
       };
-    }
 
-    if (spawnError || exitCode !== null) {
+      runningDevServers.set(cwd, { pid: child.pid, kill: killFn });
+
+      // Wait for the server to become ready
+      const startTime = Date.now();
+      const maxWaitMs = 30_000;
+
+      // If we know the port, poll for it
+      if (expectedPort) {
+        const ready = await waitForPort(expectedPort, maxWaitMs, signal ?? undefined);
+        if (ready) {
+          const url = `http://localhost:${expectedPort}`;
+          sendBrowserPreviewOpen(sendToRenderer, url);
+          return {
+            content: [{ type: 'text', text: `Dev server running at ${url} (pid ${child.pid})` }],
+            details: { url, pid: child.pid, cwd },
+          };
+        }
+      }
+
+      // Otherwise, watch the output for a URL
+      const foundUrl = await new Promise<string | null>((resolve) => {
+        const deadline = startTime + maxWaitMs;
+
+        const poll = () => {
+          if (signal?.aborted) { resolve(null); return; }
+          const url = extractUrlFromOutput(output);
+          if (url) { resolve(url); return; }
+          if (Date.now() > deadline) { resolve(null); return; }
+          setTimeout(poll, 500);
+        };
+        poll();
+      });
+
+      if (foundUrl) {
+        // Give it a tiny bit more time after URL appears (compilation may still be running)
+        const port = parseInt(new URL(foundUrl).port, 10);
+        if (port) await waitForPort(port, 10_000, signal ?? undefined);
+
+        sendBrowserPreviewOpen(sendToRenderer, foundUrl);
+        return {
+          content: [{ type: 'text', text: `Dev server running at ${foundUrl} (pid ${child.pid})` }],
+          details: { url: foundUrl, pid: child.pid, cwd },
+        };
+      }
+
+      if (spawnError || exitCode !== null) {
+        const tail = output.slice(-2000);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Dev server failed to stay running for command "${command}".\n\nOutput tail:\n${tail}`,
+            },
+          ],
+          details: { pid: child.pid, cwd, command, spawnError, exitCode, outputTail: tail },
+          isError: true,
+        };
+      }
+
+      // Server didn't produce a URL — return what we have
       const tail = output.slice(-2000);
       return {
         content: [
           {
             type: 'text',
-            text: `Dev server failed to stay running for command "${command}".\n\nOutput tail:\n${tail}`,
+            text: `Dev server started (pid ${child.pid}) but no URL detected within ${maxWaitMs / 1000}s.\n\nOutput tail:\n${tail}`,
           },
         ],
-        details: { pid: child.pid, cwd, command, spawnError, exitCode, outputTail: tail },
-        isError: true,
+        details: { pid: child.pid, cwd, outputTail: tail },
       };
-    }
+    },
+  };
+}
 
-    // Server didn't produce a URL — return what we have
-    const tail = output.slice(-2000);
-    return {
-      content: [
-        {
-          type: 'text',
-          text: `Dev server started (pid ${child.pid}) but no URL detected within ${maxWaitMs / 1000}s.\n\nOutput tail:\n${tail}`,
-        },
-      ],
-      details: { pid: child.pid, cwd, outputTail: tail },
-    };
-  },
-};
+export const startDevServerTool: ToolDefinition = createStartDevServerTool();

--- a/apps/desktop/src/main/chat-dev-tools.ts
+++ b/apps/desktop/src/main/chat-dev-tools.ts
@@ -1,4 +1,3 @@
-import { shell } from 'electron';
 import { type Static, Type } from '@sinclair/typebox';
 import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -15,15 +14,14 @@ export const browserPreviewTool: ToolDefinition = {
   name: 'open_browser_preview',
   label: 'Browser Preview',
   description:
-    'Open a URL in the user\'s system browser. Call this tool after starting a dev ' +
+    'Open a URL in the in-app browser preview panel. Call this tool after starting a dev ' +
     'server with start_dev_server, when making visible UI changes, or when the user ' +
     'asks to preview their work.',
   parameters: BrowserPreviewParams,
   async execute(_toolCallId, params) {
     const { url } = params as Static<typeof BrowserPreviewParams>;
-    let parsed: URL;
     try {
-      parsed = new URL(url);
+      new URL(url);
     } catch {
       return {
         content: [{ type: 'text', text: `Invalid URL: ${url}` }],
@@ -32,14 +30,10 @@ export const browserPreviewTool: ToolDefinition = {
       };
     }
 
-    const isLocal = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
-    if (isLocal) {
-      await shell.openExternal(url);
-    }
     // The preview panel is opened automatically via browser-preview:open IPC
     // emitted by pi-chat-engine on tool_execution_end
     return {
-      content: [{ type: 'text', text: isLocal ? `Opened ${url} in your browser and preview panel.` : `Opened ${url} in the preview panel.` }],
+      content: [{ type: 'text', text: `Opened ${url} in the preview panel.` }],
       details: { url },
     };
   },

--- a/apps/desktop/src/main/chat-system-prompt.ts
+++ b/apps/desktop/src/main/chat-system-prompt.ts
@@ -23,7 +23,7 @@ Available tools:
 - find: Find files by glob pattern (respects .gitignore)
 - ls: List directory contents
 - web_fetch: Fetch a public HTTP/HTTPS URL and return page content as readable text
-- open_browser_preview: Open a URL for user to preview in browser or preview panel
+- open_browser_preview: Open a URL for user to preview in the in-app preview panel
 - start_dev_server: Start a dev server as a background process that survives tool timeouts
 
 In addition to the tools above, you may have access to other custom tools depending on the peer's offering.

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -6,7 +6,7 @@ import { homedir } from 'node:os';
 import { createConnection } from 'node:net';
 import path from 'node:path';
 import type { AgentSession, AgentSessionEvent } from '@mariozechner/pi-coding-agent';
-import { browserPreviewTool, startDevServerTool } from './chat-dev-tools.js';
+import { createBrowserPreviewTool, createStartDevServerTool } from './chat-dev-tools.js';
 import {
   classifyChatStreamFailure,
   formatChatStreamStopForLog,
@@ -1967,7 +1967,11 @@ export function registerPiChatHandlers({
       authStorage,
       modelRegistry,
       model: proxyModel,
-      customTools: [webFetchTool, browserPreviewTool, startDevServerTool],
+      customTools: [
+        webFetchTool,
+        createBrowserPreviewTool(sendToRenderer),
+        createStartDevServerTool(sendToRenderer),
+      ],
       resourceLoader,
     });
 
@@ -2147,16 +2151,6 @@ export function registerPiChatHandlers({
           details,
         });
 
-        // Auto-open browser preview panel when a preview tool completes successfully
-        if (
-          !event.isError &&
-          (event.toolName === 'open_browser_preview' || event.toolName === 'start_dev_server')
-        ) {
-          const url = typeof details?.url === 'string' ? details.url : undefined;
-          if (url) {
-            sendToRenderer('browser-preview:open', { url });
-          }
-        }
         return;
       }
 


### PR DESCRIPTION
What
Updates desktop browser preview behavior so preview URLs open only inside Antseed’s in-app preview panel, and no longer launch the system web browser for localhost URLs.

Why
Browser preview should stay contained in Antseed. Opening an external browser was unnecessary and broke the expected preview-only workflow.

Testing
pnpm --filter=@antseed/desktop run build:main
node --test apps/desktop/dist/main/chat-system-prompt.test.js
No new tests were added; existing prompt tests were re-run and passed.

Checklist
 pnpm run build passes
 pnpm run test passes
 Breaking changes documented