### PR TITLE
fix(desktop): stop leaking antseed-proxy as upstream provider

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.63",
+  "version": "0.1.64",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/main/chat-provider-hint.test.ts
+++ b/apps/desktop/src/main/chat-provider-hint.test.ts
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  PROXY_PROVIDER_ID,
+  normalizeProviderId,
+  sanitizeProviderHint,
+} from './chat-provider-hint.js';
+
+test('normalizeProviderId trims and lowercases real provider names', () => {
+  assert.equal(normalizeProviderId(' OpenAI '), 'openai');
+  assert.equal(normalizeProviderId('Anthropic'), 'anthropic');
+});
+
+test('normalizeProviderId returns null for empty or non-string input', () => {
+  assert.equal(normalizeProviderId(''), null);
+  assert.equal(normalizeProviderId('   '), null);
+  assert.equal(normalizeProviderId(undefined), null);
+  assert.equal(normalizeProviderId(null), null);
+  assert.equal(normalizeProviderId(123), null);
+});
+
+test('sanitizeProviderHint strips the local proxy sentinel', () => {
+  // Regression: the buyer proxy rejects a request as
+  //   "Pinned peer ... does not offer provider=antseed-proxy"
+  // when this internal label leaks into x-antseed-provider. Treating
+  // the sentinel as "no hint" makes the buyer proxy auto-select.
+  assert.equal(sanitizeProviderHint(PROXY_PROVIDER_ID), null);
+  assert.equal(sanitizeProviderHint('ANTSEED-PROXY'), null);
+  assert.equal(sanitizeProviderHint('  antseed-proxy  '), null);
+});
+
+test('sanitizeProviderHint preserves real upstream provider names', () => {
+  assert.equal(sanitizeProviderHint('openai'), 'openai');
+  assert.equal(sanitizeProviderHint(' Anthropic '), 'anthropic');
+  assert.equal(sanitizeProviderHint('local-llm'), 'local-llm');
+});
+
+test('sanitizeProviderHint returns null for missing or invalid input', () => {
+  assert.equal(sanitizeProviderHint(undefined), null);
+  assert.equal(sanitizeProviderHint(null), null);
+  assert.equal(sanitizeProviderHint(''), null);
+  assert.equal(sanitizeProviderHint('   '), null);
+});

--- a/apps/desktop/src/main/chat-provider-hint.ts
+++ b/apps/desktop/src/main/chat-provider-hint.ts
@@ -1,0 +1,30 @@
+/**
+ * Internal local provider ID used by the desktop's pi-ai SDK config to
+ * route requests at the local buyer proxy on 127.0.0.1. It must never
+ * leak onto the wire as the `x-antseed-provider` header — the buyer proxy
+ * matches that header against a peer's advertised upstream providers
+ * (e.g. `openai`, `anthropic`) and rejects unknown values with a 502.
+ */
+export const PROXY_PROVIDER_ID = 'antseed-proxy';
+
+export function normalizeProviderId(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+/**
+ * Returns the upstream provider ID to send as `x-antseed-provider`, or
+ * null if the value is empty or is the local proxy sentinel. Centralised
+ * so the read path, the write path, and the outbound header path can
+ * never persist or transmit `antseed-proxy` as if it were a real
+ * upstream provider.
+ */
+export function sanitizeProviderHint(value: unknown): string | null {
+  const normalized = normalizeProviderId(value);
+  if (!normalized) return null;
+  if (normalized === PROXY_PROVIDER_ID) return null;
+  return normalized;
+}

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -43,6 +43,7 @@ import {
   persistChatWorkspaceDir,
 } from './chat-workspace.js';
 import { DEFAULT_BUYER_STATE_PATH } from './constants.js';
+import { PROXY_PROVIDER_ID, normalizeProviderId, sanitizeProviderHint } from './chat-provider-hint.js';
 import { asErrorMessage } from './utils.js';
 import { StakingClient, ChannelsClient, resolveChainConfig } from '@antseed/node';
 import {
@@ -294,7 +295,6 @@ const CHAT_AGENT_DIR = path.join(CHAT_DATA_DIR, 'pi-agent');
 
 const DEFAULT_PROXY_PORT = 8377;
 const DEFAULT_CHAT_SERVICE = 'claude-sonnet-4-20250514';
-const PROXY_PROVIDER_ID = 'antseed-proxy';
 const PROXY_RUNTIME_API_KEY = 'antseed-local';
 
 const CHAT_SYSTEM_PROMPT_ENV = 'ANTSEED_CHAT_SYSTEM_PROMPT';
@@ -328,14 +328,6 @@ function isChatServiceProtocol(value: unknown): value is ChatServiceProtocol {
   return value === 'anthropic-messages'
     || value === 'openai-chat-completions'
     || value === 'openai-responses';
-}
-
-function normalizeProviderId(value: unknown): string | null {
-  if (typeof value !== 'string') {
-    return null;
-  }
-  const normalized = value.trim().toLowerCase();
-  return normalized.length > 0 ? normalized : null;
 }
 
 function inferProviderProtocol(provider: string): ChatServiceProtocol | null {
@@ -431,8 +423,7 @@ function updateServiceProtocolMap(
 function resolveProviderHintForService(
   explicitProvider?: string,
 ): string | null {
-  const explicit = normalizeProviderId(explicitProvider);
-  return explicit ?? null;
+  return sanitizeProviderHint(explicitProvider);
 }
 
 function normalizePeerId(value: unknown): string | null {
@@ -1211,7 +1202,10 @@ function makeProxyService(
   supportsMultimodal: boolean = false,
 ): Model<any> {
   const headers: Record<string, string> = {};
-  if (providerHint) headers['x-antseed-provider'] = providerHint;
+  // Re-sanitize at the wire boundary: the local proxy sentinel must never
+  // be sent as `x-antseed-provider`, even if a caller forgot to filter it.
+  const sanitizedProviderHint = sanitizeProviderHint(providerHint);
+  if (sanitizedProviderHint) headers['x-antseed-provider'] = sanitizedProviderHint;
   if (preferredPeerId) headers['x-antseed-pin-peer'] = preferredPeerId;
   if (spendingAuth) headers['x-antseed-spending-auth'] = spendingAuth;
 
@@ -1491,7 +1485,7 @@ class PiConversationStore {
       id: manager.getSessionId(),
       title: manager.getSessionName() || deriveTitle(messages),
       service: normalizeServiceId(context.model?.modelId),
-      provider: normalizeProviderId(context.model?.provider) ?? undefined,
+      provider: sanitizeProviderHint(context.model?.provider) ?? undefined,
       messages,
       createdAt,
       updatedAt,
@@ -1586,9 +1580,12 @@ class PiConversationStore {
   async create(service?: string, provider?: string, peerId?: string, peerLabel?: string): Promise<AiConversation> {
     const workspaceDir = await this.ensureWorkspaceDir();
     const manager = SessionManager.create(workspaceDir, this.sessionsDir);
-    const providerId = normalizeProviderId(provider);
-    const modelProvider = providerId ?? PROXY_PROVIDER_ID;
-    manager.appendModelChange(modelProvider, normalizeServiceId(service));
+    // Persist '' (not the local proxy sentinel) when no real upstream
+    // provider is known. The sentinel used to leak through to the
+    // `x-antseed-provider` header on send and trip the buyer proxy's
+    // pinned-peer provider check, returning a confusing 502.
+    const providerId = sanitizeProviderHint(provider) ?? '';
+    manager.appendModelChange(providerId, normalizeServiceId(service));
     const trimmedPeerId = peerId?.trim() ?? '';
     if (trimmedPeerId) {
       manager.appendCustomEntry(ANTSEED_PEER_CUSTOM_TYPE, {


### PR DESCRIPTION
## Summary

Fixes a regression where the desktop app's pi-chat-engine would persist the local proxy sentinel (`antseed-proxy`) as a conversation's upstream provider whenever no real provider was known, then re-emit it on every subsequent send as the `x-antseed-provider` HTTP header. The buyer proxy matches that header against the pinned peer's advertised providers and rejects unknown values, producing the confusing user-visible error:

> 502 Pinned peer 0e49122e76bd... does not offer provider=antseed-proxy. Available providers: openai. Remove or change the x-antseed-provider header, or pick a different peer.

`PROXY_PROVIDER_ID` ("antseed-proxy") is an internal label the desktop's pi-ai SDK config uses to wire up the OpenAI/Anthropic SDK to the local buyer proxy. It must never leave the machine.

## Changes

- New module `apps/desktop/src/main/chat-provider-hint.ts` exporting `PROXY_PROVIDER_ID`, `normalizeProviderId`, and `sanitizeProviderHint` (drops empty values **and** the local proxy sentinel).
- `pi-chat-engine.ts` applies the rule at all three boundaries:
  - **Write path** (`PiConversationStore.create`): persist `''` instead of the sentinel when no real provider is known.
  - **Read path** (`buildConversationFromManager`): existing sessions with the sentinel come back as no-hint, so old conversations heal automatically.
  - **Wire boundary** (`makeProxyService`): defence-in-depth re-sanitize before setting the `x-antseed-provider` header.

Without a hint, the buyer proxy auto-selects a peer that supports the service.

## Test plan

- [x] New unit tests in `chat-provider-hint.test.ts` cover the sentinel-stripping and the preserved real-provider cases (`openai`, `anthropic`, `local-llm`, plus case/whitespace/null/undefined edges).
- [x] `npm --prefix apps/desktop run build:main` — clean.
- [x] `npm --prefix apps/desktop run typecheck:renderer` — clean.
- [x] `node --test apps/desktop/dist/main/*.test.js` — all 66 desktop main tests pass (5 new + 61 existing).

https://claude.ai/code/session_01SFHJYVP65g5MaA1vL4JGXs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFHJYVP65g5MaA1vL4JGXs)_