### PR TITLE
fix(desktop): persist real upstream provider on every chat send

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/main/chat-provider-hint.test.ts
+++ b/apps/desktop/src/main/chat-provider-hint.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   PROXY_PROVIDER_ID,
   normalizeProviderId,
+  resolveModelProvider,
   sanitizeProviderHint,
 } from './chat-provider-hint.js';
 
@@ -41,4 +42,23 @@ test('sanitizeProviderHint returns null for missing or invalid input', () => {
   assert.equal(sanitizeProviderHint(null), null);
   assert.equal(sanitizeProviderHint(''), null);
   assert.equal(sanitizeProviderHint('   '), null);
+});
+
+test('resolveModelProvider yields the real upstream provider when known', () => {
+  // The pi-coding-agent's `setModel` writes Model.provider into the
+  // session log on every send. Returning the real upstream here means the
+  // persisted conversation provider stays consistent across turns instead
+  // of getting clobbered by the local proxy sentinel.
+  assert.equal(resolveModelProvider('openai'), 'openai');
+  assert.equal(resolveModelProvider(' Anthropic '), 'anthropic');
+  assert.equal(resolveModelProvider('local-llm'), 'local-llm');
+});
+
+test('resolveModelProvider falls back to the local sentinel when no provider', () => {
+  // Used as the auth-storage key for credential lookup, so callers can
+  // register the runtime API key under whichever name we return.
+  assert.equal(resolveModelProvider(undefined), PROXY_PROVIDER_ID);
+  assert.equal(resolveModelProvider(null), PROXY_PROVIDER_ID);
+  assert.equal(resolveModelProvider(''), PROXY_PROVIDER_ID);
+  assert.equal(resolveModelProvider(PROXY_PROVIDER_ID), PROXY_PROVIDER_ID);
 });

--- a/apps/desktop/src/main/chat-provider-hint.ts
+++ b/apps/desktop/src/main/chat-provider-hint.ts
@@ -28,3 +28,18 @@ export function sanitizeProviderHint(value: unknown): string | null {
   if (normalized === PROXY_PROVIDER_ID) return null;
   return normalized;
 }
+
+/**
+ * Resolve the `provider` field for the pi-ai `Model<any>` we hand to the
+ * local buyer proxy. `pi-coding-agent`'s `AgentSession.setModel` calls
+ * `sessionManager.appendModelChange(model.provider, model.id)` on every
+ * turn, so whatever we put here is what gets persisted into the
+ * conversation log. Use the real upstream provider when known so the
+ * persisted provider matches what the buyer proxy will actually pin
+ * the request to. Fall back to the local sentinel only when no upstream
+ * is known; the runtime API key must always be registered under the
+ * same name so credential lookup still works.
+ */
+export function resolveModelProvider(providerHint: unknown): string {
+  return sanitizeProviderHint(providerHint) ?? PROXY_PROVIDER_ID;
+}

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -43,7 +43,7 @@ import {
   persistChatWorkspaceDir,
 } from './chat-workspace.js';
 import { DEFAULT_BUYER_STATE_PATH } from './constants.js';
-import { PROXY_PROVIDER_ID, normalizeProviderId, sanitizeProviderHint } from './chat-provider-hint.js';
+import { normalizeProviderId, resolveModelProvider, sanitizeProviderHint } from './chat-provider-hint.js';
 import { asErrorMessage } from './utils.js';
 import { StakingClient, ChannelsClient, resolveChainConfig } from '@antseed/node';
 import {
@@ -1218,10 +1218,16 @@ function makeProxyService(
   // return errors like "Multimodal is not supported for model" for text-only
   // LLMs even when the provider catalog lists vision-capable siblings).
   const inputModalities: ('text' | 'image')[] = supportsMultimodal ? ['text', 'image'] : ['text'];
+  // Use the real upstream provider (when known) as `model.provider`.
+  // pi-coding-agent's `setModel` writes this field into the session log
+  // on every send via `appendModelChange`; using the real provider here
+  // means the persisted conversation provider stays consistent across
+  // turns instead of being clobbered by the local sentinel.
+  const runtimeProvider = resolveModelProvider(providerHint);
   const base = {
     id: serviceId,
     name: serviceId,
-    provider: PROXY_PROVIDER_ID,
+    provider: runtimeProvider,
     baseUrl: needsV1 ? `http://127.0.0.1:${port}/v1` : `http://127.0.0.1:${port}`,
     reasoning: true,
     input: inputModalities,
@@ -1914,9 +1920,6 @@ export function registerPiChatHandlers({
         void store.setPeer(conversationId, peerOverrideId, peerLabel);
       }
     }
-    const providerHint = resolveProviderHintForService(
-      providerOverride,
-    );
     const protocol = await resolveProtocolForSend(serviceId);
     // Determine vision support from the catalog entry for this (service, peer)
     // pair. We look for a `multimodal` category tag; sellers announce this via
@@ -1931,6 +1934,13 @@ export function registerPiChatHandlers({
     )) ?? lastServiceCatalogEntries.find((entry) => (
       entry.id.trim().toLowerCase() === normalizedServiceForCatalog
     ));
+    // Backfill the provider hint from the live catalog when the renderer
+    // didn't supply one — happens for legacy conversations whose
+    // persisted provider was the local sentinel and got sanitized to
+    // null on read. Using the catalog's provider here heals the session
+    // log on next turn (setModel writes the real provider).
+    const providerHint = resolveProviderHintForService(providerOverride)
+      ?? sanitizeProviderHint(catalogEntry?.provider);
     const supportsMultimodal = catalogEntry?.categories?.includes('multimodal') ?? false;
     const droppedImageCount = supportsMultimodal ? 0 : attachmentImages.length;
     if (droppedImageCount > 0) {
@@ -1951,8 +1961,11 @@ export function registerPiChatHandlers({
       supportsMultimodal,
     );
 
+    // Register the runtime API key under the same provider name we set on
+    // proxyModel.provider — pi-ai looks credentials up by that field.
+    const runtimeProviderKey = resolveModelProvider(providerHint);
     const authStorage = AuthStorage.inMemory();
-    authStorage.setRuntimeApiKey(PROXY_PROVIDER_ID, PROXY_RUNTIME_API_KEY);
+    authStorage.setRuntimeApiKey(runtimeProviderKey, PROXY_RUNTIME_API_KEY);
     const modelRegistry = ModelRegistry.inMemory(authStorage);
 
     // Pass the system prompt via resourceLoader so it is applied on every turn.

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1624,11 +1624,22 @@ export function initChatModule({
       return null;
     }
 
+    // Refuse to open a conversation without a known upstream provider.
+    // Without one, the buyer proxy cannot match a peer's advertised
+    // providers and every send returns a 502; the session is unusable.
+    // Force the user back to Discover to pick a fully resolved service.
+    if (!selection.provider) {
+      showChatError(
+        'Selected service has no upstream provider. Pick a service from Discover or refresh.',
+      );
+      return null;
+    }
+
     try {
       const peerId = (selection.peerId ?? uiState.chatSelectedPeerId) || undefined;
       const result = await bridge.chatAiCreateConversation(
         selection.id,
-        selection.provider ?? undefined,
+        selection.provider,
         peerId,
       );
       if (result.ok && result.data) {


### PR DESCRIPTION
Closing in favour of a much simpler fix — the `x-antseed-provider` header isn't actually required when peer is pinned (the buyer proxy resolves the route plan from peer + service ID alone). Replacement PR will just stop emitting the header.