### PR TITLE
fix(desktop): stop sending x-antseed-provider header

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -420,12 +420,6 @@ function updateServiceProtocolMap(
   }
 }
 
-function resolveProviderHintForService(
-  explicitProvider?: string,
-): string | null {
-  return sanitizeProviderHint(explicitProvider);
-}
-
 function normalizePeerId(value: unknown): string | null {
   if (typeof value !== 'string') {
     return null;
@@ -1196,16 +1190,15 @@ function makeProxyService(
   serviceId: string,
   port: number,
   protocol: ChatServiceProtocol = 'anthropic-messages',
-  providerHint?: string | null,
   preferredPeerId?: string | null,
   spendingAuth?: string | null,
   supportsMultimodal: boolean = false,
 ): Model<any> {
+  // The buyer proxy resolves the route plan from the pinned peer + the
+  // service ID in the request body, so we don't need to send
+  // `x-antseed-provider`. Stripping it keeps internal labels (e.g. the
+  // local `antseed-proxy` SDK key) out of the wire entirely.
   const headers: Record<string, string> = {};
-  // Re-sanitize at the wire boundary: the local proxy sentinel must never
-  // be sent as `x-antseed-provider`, even if a caller forgot to filter it.
-  const sanitizedProviderHint = sanitizeProviderHint(providerHint);
-  if (sanitizedProviderHint) headers['x-antseed-provider'] = sanitizedProviderHint;
   if (preferredPeerId) headers['x-antseed-pin-peer'] = preferredPeerId;
   if (spendingAuth) headers['x-antseed-spending-auth'] = spendingAuth;
 
@@ -1849,7 +1842,6 @@ export function registerPiChatHandlers({
     conversationId: string,
     userMessage: string,
     serviceOverride?: string,
-    providerOverride?: string,
     attachments?: PreparedChatAttachment[],
     peerOverride?: string,
   ): Promise<{ ok: boolean; error?: string; stopReason?: ChatStreamStopReason }> => {
@@ -1914,9 +1906,6 @@ export function registerPiChatHandlers({
         void store.setPeer(conversationId, peerOverrideId, peerLabel);
       }
     }
-    const providerHint = resolveProviderHintForService(
-      providerOverride,
-    );
     const protocol = await resolveProtocolForSend(serviceId);
     // Determine vision support from the catalog entry for this (service, peer)
     // pair. We look for a `multimodal` category tag; sellers announce this via
@@ -1945,7 +1934,6 @@ export function registerPiChatHandlers({
       serviceId,
       proxyPort,
       protocol,
-      providerHint,
       preferredPeerId,
       null,
       supportsMultimodal,
@@ -2776,15 +2764,21 @@ export function registerPiChatHandlers({
 
   ipcMain.handle(
     'chat:ai-send-stream',
-    async (_event, conversationId: string, userMessage: string, service?: string, provider?: string, attachments?: PreparedChatAttachment[], peerId?: string) => {
-      return await runStreamingPrompt(conversationId, userMessage, service, provider, attachments, peerId);
+    async (_event, conversationId: string, userMessage: string, service?: string, _provider?: string, attachments?: PreparedChatAttachment[], peerId?: string) => {
+      // `_provider` is accepted for IPC ABI compatibility with older
+      // renderers but ignored — the buyer proxy resolves the route plan
+      // from the pinned peer + the service ID without a provider hint.
+      return await runStreamingPrompt(conversationId, userMessage, service, attachments, peerId);
     },
   );
 
   ipcMain.handle(
     'chat:ai-send',
-    async (_event, conversationId: string, userMessage: string, service?: string, provider?: string, attachments?: PreparedChatAttachment[], peerId?: string) => {
-      return await runStreamingPrompt(conversationId, userMessage, service, provider, attachments, peerId);
+    async (_event, conversationId: string, userMessage: string, service?: string, _provider?: string, attachments?: PreparedChatAttachment[], peerId?: string) => {
+      // `_provider` is accepted for IPC ABI compatibility with older
+      // renderers but ignored — the buyer proxy resolves the route plan
+      // from the pinned peer + the service ID without a provider hint.
+      return await runStreamingPrompt(conversationId, userMessage, service, attachments, peerId);
     },
   );
 


### PR DESCRIPTION
## Summary

Replaces #416 with the minimal fix: **stop sending `x-antseed-provider`**. The buyer proxy resolves the route plan for a pinned-peer request from the peer + the service ID in the request body alone (`apps/cli/src/proxy/buyer-proxy.ts:1093-1108` only checks `explicitProvider` when it's non-null). Antstation always pins the peer, so the header was redundant — and the only thing that gave internal SDK labels a way to leak onto the wire.

## Changes

- `makeProxyService` no longer sets `x-antseed-provider`. Only `x-antseed-pin-peer` and `x-antseed-spending-auth` go out.
- `resolveProviderHintForService` removed (now unused).
- `runStreamingPrompt` drops its `providerOverride` parameter.
- IPC handlers `chat:ai-send-stream` / `chat:ai-send` still accept (and ignore) the renderer's `provider` arg, for ABI compatibility with older renderers.
- Bumps `apps/desktop` to 0.1.65.

#415's read-path / write-path sanitize stays in place as belt-and-suspenders.

Net: 2 files changed, 15 insertions, 21 deletions.

## Test plan

- [x] `npm --prefix apps/desktop run build:main` — clean.
- [x] `npm --prefix apps/desktop run typecheck:renderer` — clean.
- [x] `node --test apps/desktop/dist/main/*.test.js` — 66/66 passing.

https://claude.ai/code/session_01SFHJYVP65g5MaA1vL4JGXs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFHJYVP65g5MaA1vL4JGXs)_