### PR TITLE
fix: surface buyer network failures in AntStation

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -125,6 +125,28 @@ test('selectCandidatePeersForRouting keeps all peers when no protocol or provide
   assert.equal(result.routePlanByPeerId.size, 0)
 })
 
+test('status control endpoint reports cached discovery state without refreshing', async () => {
+  const peer = makePeer('a', ['anthropic'])
+  const proxy = makeBuyerProxyWithPeers([peer])
+  let refreshCalled = false
+  ;(proxy as any)._refreshPeersNow = async () => {
+    refreshCalled = true
+    return [peer]
+  }
+  ;(proxy as any)._cachedPeers = [peer]
+  ;(proxy as any)._lastDiscoveryPeerCount = 1
+
+  const req = makeProxyRequest({ path: '/_antseed/status' })
+  ;(req as typeof req & { method: string }).method = 'GET'
+  const res = await invokeProxy(proxy, req)
+  const body = JSON.parse(res.body) as { peerCache: { count: number }; discovery: { lastPeerCount: number } }
+
+  assert.equal(refreshCalled, false)
+  assert.equal(res.statusCode, 200)
+  assert.equal(body.peerCache.count, 1)
+  assert.equal(body.discovery.lastPeerCount, 1)
+})
+
 test('peer refresh control endpoint triggers immediate refresh', async () => {
   const refreshedPeer = makePeer('a', ['anthropic'])
   const proxy = makeBuyerProxyWithPeers([], [refreshedPeer])
@@ -243,6 +265,22 @@ test('selectCandidatePeersForRouting can still include peers without service pro
   assert.equal(result.candidatePeers[0]?.peerId, peerWithoutMetadata.peerId)
 })
 
+test('pinned proxy request reports when no sellers are discovered', async () => {
+  const proxy = makeBuyerProxyWithPeers([])
+  ;(proxy as any)._lastDiscoveryError = null
+  const req = makeProxyRequest({
+    headers: {
+      'x-antseed-pin-peer': 'a'.repeat(40),
+    },
+  })
+
+  const res = await invokeProxy(proxy, req)
+
+  assert.equal(res.statusCode, 502)
+  assert.match(res.body, /no_sellers_available/)
+  assert.match(res.body, /No AntSeed providers were discovered/)
+})
+
 test('pinned proxy request reports when the pinned peer is not discoverable', async () => {
   const pinnedPeerId = 'a'.repeat(40)
   const otherPeer = makePeer('b', ['openai'])
@@ -256,8 +294,9 @@ test('pinned proxy request reports when the pinned peer is not discoverable', as
   const res = await invokeProxy(proxy, req)
 
   assert.equal(res.statusCode, 502)
+  assert.match(res.body, /pinned_peer_not_discoverable/)
   assert.match(res.body, /is not reachable right now/)
-  assert.match(res.body, /It may be offline, not announcing, or temporarily unreachable/)
+  assert.match(res.body, /network\/NAT\/firewall/)
 })
 
 test('pinned proxy request reports explicit provider mismatch separately', async () => {
@@ -273,9 +312,9 @@ test('pinned proxy request reports explicit provider mismatch separately', async
   const res = await invokeProxy(proxy, req)
 
   assert.equal(res.statusCode, 502)
+  assert.match(res.body, /pinned_peer_provider_mismatch/)
   assert.match(res.body, /does not offer provider=openai/)
   assert.match(res.body, /Available providers: local-llm/)
-  assert.match(res.body, /x-antseed-provider header/)
 })
 
 test('pinned proxy request reports protocol or service mismatch when provider is available', async () => {
@@ -300,6 +339,7 @@ test('pinned proxy request reports protocol or service mismatch when provider is
   const res = await invokeProxy(proxy, req)
 
   assert.equal(res.statusCode, 502)
+  assert.match(res.body, /pinned_peer_service_mismatch/)
   assert.match(res.body, /does not support this request/)
   assert.match(res.body, /provider=local-llm/)
   assert.match(res.body, /protocol=openai-responses/)

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -103,6 +103,26 @@ const CARRY_FORWARD_TTL_MS = 2 * 60 * 60_000
 const PEER_FAILURE_THRESHOLD = 10
 const PEER_FAILURE_WINDOW_MS = 5 * 60_000
 
+type ProxyErrorHelp = Record<string, string | number | boolean | null>
+
+function writeProxyJsonError(
+  res: ServerResponse,
+  statusCode: number,
+  code: string,
+  message: string,
+  help?: ProxyErrorHelp,
+): void {
+  res.writeHead(statusCode, { 'content-type': 'application/json' })
+  res.end(JSON.stringify({
+    error: {
+      type: code,
+      code,
+      message,
+      ...(help ? { help } : {}),
+    },
+  }))
+}
+
 type TransformResult = { request: SerializedHttpRequest; streamRequested: boolean; requestedModel: string | null }
 type AdaptResponseMeta = { streamRequested: boolean; fallbackModel: string | null }
 
@@ -317,6 +337,10 @@ export class BuyerProxy {
   private _peerRefreshPromise: Promise<PeerInfo[]> | null = null
   private _lastStaleCacheLogAtMs = 0
   private _bgRefreshHandle: ReturnType<typeof setInterval> | null = null
+  private _lastDiscoveryStartedAtMs = 0
+  private _lastDiscoveryFinishedAtMs = 0
+  private _lastDiscoveryPeerCount = 0
+  private _lastDiscoveryError: string | null = null
 
   /**
    * Per-peer rolling failure counters. Entries are created on the first
@@ -663,11 +687,26 @@ export class BuyerProxy {
 
   private async _discoverPeersFromNetwork(): Promise<PeerInfo[]> {
     log('Discovering peers via DHT...')
-    const peers = await this._node.discoverPeers()
-    if (peers.length > 0) {
-      log(`Found ${peers.length} peer(s)`)
+    this._lastDiscoveryStartedAtMs = Date.now()
+    this._lastDiscoveryError = null
+    try {
+      const peers = await this._node.discoverPeers()
+      this._lastDiscoveryPeerCount = peers.length
+      if (peers.length > 0) {
+        log(`Found ${peers.length} peer(s)`)
+      } else {
+        log('Discovery completed with 0 peers')
+      }
+      return peers
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      this._lastDiscoveryError = message
+      this._lastDiscoveryPeerCount = 0
+      log(`Discovery failed: ${message}`)
+      throw err
+    } finally {
+      this._lastDiscoveryFinishedAtMs = Date.now()
     }
-    return peers
   }
 
   private async _refreshPeersNow(): Promise<PeerInfo[]> {
@@ -728,6 +767,32 @@ export class BuyerProxy {
     return this._refreshPeersNow()
   }
 
+  private _getStatusPayload(): Record<string, unknown> {
+    const cacheAgeMs = this._cacheLastUpdatedAtMs > 0 ? Date.now() - this._cacheLastUpdatedAtMs : null
+    return {
+      ok: true,
+      proxy: 'connected',
+      peerCache: {
+        count: this._cachedPeers.length,
+        lastUpdatedAtMs: this._cacheLastUpdatedAtMs,
+        ageMs: cacheAgeMs,
+        ttlMs: this._peerCacheTtlMs,
+        stale: cacheAgeMs === null || cacheAgeMs > this._peerCacheTtlMs,
+      },
+      discovery: {
+        refreshInProgress: this._peerRefreshPromise !== null,
+        lastStartedAtMs: this._lastDiscoveryStartedAtMs,
+        lastFinishedAtMs: this._lastDiscoveryFinishedAtMs,
+        lastPeerCount: this._lastDiscoveryPeerCount,
+        lastError: this._lastDiscoveryError,
+      },
+      routing: {
+        pinnedPeerId: this._pinnedPeer,
+        pinnedService: this._pinnedService,
+      },
+    }
+  }
+
   private _formatPeerSelectionDiagnostics(peers: PeerInfo[]): string {
     if (peers.length === 0) {
       return 'No peers discovered.'
@@ -765,6 +830,12 @@ export class BuyerProxy {
       res.setHeader('Access-Control-Allow-Headers', 'Content-Type')
       res.writeHead(204)
       res.end()
+      return
+    }
+
+    if (path === '/_antseed/status' && method === 'GET') {
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify(this._getStatusPayload()))
       return
     }
 
@@ -1010,8 +1081,16 @@ export class BuyerProxy {
     const peers = await this._getPeers()
     if (peers.length === 0) {
       log('No sellers available')
-      res.writeHead(502, { 'content-type': 'text/plain' })
-      res.end('No sellers available on the network. Is a seeder running?')
+      writeProxyJsonError(
+        res,
+        502,
+        'no_sellers_available',
+        'No AntSeed providers were discovered. Buyer runtime is online, but network discovery returned zero peers.',
+        {
+          action: 'Check internet, VPN, firewall, or try Scan Network again.',
+          lastDiscoveryError: this._lastDiscoveryError,
+        },
+      )
       return
     }
 
@@ -1073,12 +1152,12 @@ export class BuyerProxy {
       const logSource = serializedReq.headers['x-antseed-pin-peer'] ? 'x-antseed-pin-peer header' : '--peer flag or session pin'
       const diagnostics = this._formatPeerSelectionDiagnostics(discoveredPeers)
       log(`Pinned peer ${explicitPeerId.slice(0, 12)}... not discoverable in DHT (${logSource})`)
-      res.writeHead(502, { 'content-type': 'text/plain' })
-      res.end(
-        `Pinned peer ${explicitPeerId.slice(0, 12)}... is not reachable right now. `
-        + 'It may be offline, not announcing, or temporarily unreachable. '
-        + 'Pick a different service in Discover or try again later. '
-        + diagnostics,
+      writeProxyJsonError(
+        res,
+        502,
+        'pinned_peer_not_discoverable',
+        `Selected provider ${explicitPeerId.slice(0, 12)}... is not reachable right now. It may be offline, not announcing, or blocked by network/NAT/firewall.`,
+        { diagnostics },
       )
       return
     }
@@ -1097,23 +1176,24 @@ export class BuyerProxy {
         if (!providers.includes(explicitProvider)) {
           const providerList = providers.length > 0 ? providers.join(', ') : 'none'
           log(`Pinned peer ${explicitPeerId.slice(0, 12)}... does not offer explicit provider=${explicitProvider}`)
-          res.writeHead(502, { 'content-type': 'text/plain' })
-          res.end(
-            `Pinned peer ${explicitPeerId.slice(0, 12)}... does not offer provider=${explicitProvider}. `
-            + `Available providers: ${providerList}. `
-            + 'Remove or change the x-antseed-provider header, or pick a different peer. '
-            + diagnostics,
+          writeProxyJsonError(
+            res,
+            502,
+            'pinned_peer_provider_mismatch',
+            `Selected provider ${explicitPeerId.slice(0, 12)}... does not offer provider=${explicitProvider}. Available providers: ${providerList}.`,
+            { diagnostics },
           )
           return
         }
       }
 
       log(`Pinned peer ${explicitPeerId.slice(0, 12)}... filtered out by protocol/service match`)
-      res.writeHead(502, { 'content-type': 'text/plain' })
-      res.end(
-        `Pinned peer ${explicitPeerId.slice(0, 12)}... does not support this request `
-        + `(${protocolLabel}, ${providerLabel}, ${serviceLabel}). `
-        + `Pick a different service in Discover. ${diagnostics}`,
+      writeProxyJsonError(
+        res,
+        502,
+        'pinned_peer_service_mismatch',
+        `Selected provider ${explicitPeerId.slice(0, 12)}... does not support this request (${protocolLabel}, ${providerLabel}, ${serviceLabel}). Pick a different service in Discover.`,
+        { diagnostics },
       )
       return
     }
@@ -1129,8 +1209,12 @@ export class BuyerProxy {
     // if an invariant breaks.
     if (!selectedPeer) {
       log(`Invariant: pinned peer ${explicitPeerId.slice(0, 12)}... present in DHT but missing from narrowed candidate list`)
-      res.writeHead(502, { 'content-type': 'text/plain' })
-      res.end(`Pinned peer ${explicitPeerId.slice(0, 12)}... is currently unreachable. Try again in a moment.`)
+      writeProxyJsonError(
+        res,
+        502,
+        'pinned_peer_unreachable',
+        `Selected provider ${explicitPeerId.slice(0, 12)}... is currently unreachable. Try again in a moment or choose another provider.`,
+      )
       return
     }
     log(`Using pinned peer ${selectedPeer.peerId.slice(0, 12)}...`)
@@ -1473,7 +1557,18 @@ export class BuyerProxy {
         return { done: true }
       }
 
-      return { done: false, statusCode: 502, responseBody: Buffer.from(`P2P request failed: ${message}`), responseHeaders: { 'content-type': 'text/plain' }, errorMessage: message }
+      const body = JSON.stringify({
+        error: {
+          type: 'p2p_connection_failed',
+          code: 'p2p_connection_failed',
+          message: `P2P request failed: ${message}`,
+          help: {
+            action: 'Try another provider, scan the network again, or check VPN/firewall/NAT connectivity.',
+            peerId: selectedPeer.peerId,
+          },
+        },
+      })
+      return { done: false, statusCode: 502, responseBody: Buffer.from(body), responseHeaders: { 'content-type': 'application/json' }, errorMessage: message }
     }
   }
 }

--- a/apps/desktop/src/main/chat-stream-stop.test.ts
+++ b/apps/desktop/src/main/chat-stream-stop.test.ts
@@ -25,6 +25,18 @@ test('classifyChatStreamFailure detects timeout failures', () => {
   assert.equal(reason.retryable, true);
 });
 
+test('classifyChatStreamFailure detects AntSeed network reachability failures', () => {
+  const reason = classifyChatStreamFailure({
+    error: new Error('502 P2P request failed: Connection to 1d90f467689daa11bb22cc33dd44ee55ff667788 failed'),
+    stopReason: 'error',
+  });
+
+  assert.equal(reason.kind, 'network_error');
+  assert.equal(reason.source, 'transport');
+  assert.equal(reason.retryable, true);
+  assert.match(reason.message, /could not reach a provider/i);
+});
+
 test('classifyChatStreamFailure detects transport disconnects', () => {
   const reason = classifyChatStreamFailure({
     error: { message: 'socket hang up', code: 'ECONNRESET' },

--- a/apps/desktop/src/main/chat-stream-stop.ts
+++ b/apps/desktop/src/main/chat-stream-stop.ts
@@ -189,6 +189,19 @@ export function classifyChatStreamFailure({
   const statusCode = signals.statusCodes[0] ?? parseStatusCodeFromText(rawMessage);
   const errorCode = signals.errorCodes.find(Boolean) ?? parseErrorCodeFromText(rawMessage);
 
+  const antseedNetworkLike =
+    /\bno antseed providers were discovered\b|\bno sellers available\b|\bno peers discovered\b|\bp2p request failed\b|\bselected provider .* is not reachable\b|\bpinned peer .* not discoverable\b|\bconnection to [0-9a-f]{12,} (?:failed|timed out)\b/i.test(rawMessage);
+  if (antseedNetworkLike) {
+    return {
+      kind: 'network_error',
+      source: 'transport',
+      retryable: true,
+      message: 'AntStation could not reach a provider on the AntSeed network. The provider may be offline, blocked by VPN/firewall/NAT, or discovery has not found peers yet. Try Scan Network, choose another provider, or retry in a moment.',
+      ...(statusCode ? { statusCode } : {}),
+      ...(errorCode ? { errorCode } : {}),
+    };
+  }
+
   // Keep the text-based abort match narrow so transport-side aborts (e.g.
   // "connection aborted by remote") aren't misclassified as user-initiated.
   if (

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -1326,6 +1326,53 @@ async function isPortReachable(port: number, timeoutMs = 700): Promise<boolean> 
   });
 }
 
+type BuyerProxyStatusPayload = {
+  ok?: boolean;
+  peerCache?: { count?: unknown; stale?: unknown };
+  discovery?: {
+    refreshInProgress?: unknown;
+    lastPeerCount?: unknown;
+    lastError?: unknown;
+  };
+};
+
+function summarizeBuyerProxyStatus(status: BuyerProxyStatusPayload | null): string {
+  if (!status) {
+    return 'Buyer proxy is online, but AntStation could not read network discovery status.';
+  }
+
+  const peerCount = Number(status.peerCache?.count ?? 0) || 0;
+  const refreshInProgress = status.discovery?.refreshInProgress === true;
+  const lastError = typeof status.discovery?.lastError === 'string' && status.discovery.lastError.trim().length > 0
+    ? status.discovery.lastError.trim()
+    : null;
+
+  if (peerCount > 0) {
+    return `Buyer proxy has ${String(peerCount)} cached peer(s), but no compatible chat services were found.`;
+  }
+  if (lastError) {
+    return `AntSeed peer discovery failed: ${lastError}`;
+  }
+  if (refreshInProgress) {
+    return 'AntSeed peer discovery is still running. No providers have been found yet.';
+  }
+  return 'No AntSeed providers were discovered. Check internet/VPN/firewall, wait for providers to announce, or try Scan Network.';
+}
+
+async function fetchBuyerProxyStatus(port: number, timeoutMs = 1500): Promise<BuyerProxyStatusPayload | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/_antseed/status`, { signal: controller.signal });
+    if (!response.ok) return null;
+    return await response.json() as BuyerProxyStatusPayload;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function resolveProxyPort(configPath: string): Promise<number> {
   try {
     const raw = await stat(configPath);
@@ -2616,6 +2663,18 @@ export function registerPiChatHandlers({
       })();
 
       const rows = await buildDiscoverRows(entries, statsMap, enrichment, discoveredPeersMap, networkStats);
+      if (rows.length === 0) {
+        const proxyOnline = await isProxyAvailable(buyerPort);
+        if (!proxyOnline) {
+          return {
+            ok: false,
+            data: rows,
+            error: `Buyer proxy is not reachable on port ${String(buyerPort)}. Start Buyer runtime or check buyer.proxyPort in config.`,
+          };
+        }
+        const status = await fetchBuyerProxyStatus(buyerPort);
+        return { ok: false, data: rows, error: summarizeBuyerProxyStatus(status) };
+      }
       return { ok: true, data: rows };
     } catch (error) {
       return { ok: false, data: [] as DiscoverRowEntry[], error: asErrorMessage(error) };


### PR DESCRIPTION
## Summary

Fixes #373 by making AntStation/buyer-proxy network failures bounded, diagnosable, and user-visible instead of looking like an endless hang.

This PR intentionally does **not** change the underlying DHT/WebRTC/TURN behavior. It focuses on the UX/reliability layer around existing network failures:

- expose buyer-proxy discovery/cache status through a fast local status endpoint
- return structured buyer-proxy errors for common no-provider / unreachable-provider cases
- have AntStation use those diagnostics when service discovery returns zero rows
- classify AntSeed P2P/discovery failures as retryable network errors with an actionable message

## What changed

### Buyer proxy diagnostics

Added `GET /_antseed/status` in `apps/cli/src/proxy/buyer-proxy.ts`.

The endpoint is intentionally lightweight and does not trigger discovery. It reports:

- cached peer count
- cache age and staleness
- whether discovery refresh is currently in progress
- last discovery start/finish timestamps
- last discovery peer count
- last discovery error
- configured pinned peer/service routing hints

This gives desktop code a cheap way to ask whether the local buyer runtime is alive and what the network/discovery state looks like.

### Structured buyer proxy errors

Converted several plain-text 502 responses into JSON errors with stable codes and helpful messages:

- `no_sellers_available`
- `pinned_peer_not_discoverable`
- `pinned_peer_provider_mismatch`
- `pinned_peer_service_mismatch`
- `pinned_peer_unreachable`
- `p2p_connection_failed`

These responses still preserve HTTP failure semantics, but now callers can classify them without brittle text matching.

### Desktop empty-discovery handling

Updated `apps/desktop/src/main/pi-chat-engine.ts` so when provider/service discovery returns no rows, AntStation:

1. checks whether the buyer proxy is reachable
2. if reachable, queries `/_antseed/status`
3. returns a clear error explaining whether discovery is still running, failed, returned zero peers, or found peers but no compatible chat services

This should replace the confusing indefinite “Discovering services” state with a useful diagnosis such as:

> No AntSeed providers were discovered. Check internet/VPN/firewall, wait for providers to announce, or try Scan Network.

### Stream failure classification

Updated `apps/desktop/src/main/chat-stream-stop.ts` so AntSeed-specific network text such as:

- `No AntSeed providers were discovered`
- `No sellers available`
- `No peers discovered`
- `P2P request failed`
- `Connection to <peer> failed/timed out`

is classified as retryable `network_error` from `transport`, with a message suggesting Scan Network, another provider, or checking VPN/firewall/NAT.

## Tests

Added/updated tests for:

- status endpoint returning cached discovery state without forcing refresh
- no-seller structured buyer-proxy response
- pinned-provider structured error responses
- AntSeed P2P/network failure classification in desktop stream-stop handling

Verified locally:

```bash
pnpm --filter=@antseed/desktop run build:main
pnpm --filter=@antseed/desktop run typecheck:renderer
pnpm --filter=@antseed/desktop run build:renderer
pnpm --filter=@antseed/cli run build
pnpm --filter=@antseed/cli run typecheck
cd apps/cli && node --test dist/proxy/buyer-proxy.test.js
cd apps/desktop && node --test dist/main/chat-stream-stop.test.js
```

Results:

- buyer-proxy targeted tests: 30 passed / 0 failed
- chat-stream-stop targeted tests: 12 passed / 0 failed

## Notes

This PR is scoped to diagnostics and error surfacing. It does not attempt to solve TURN/relay/default ICE configuration or NAT traversal robustness; those are separate network-infrastructure concerns.
