### PR TITLE
Fix Desktop provider routing for multi-provider peers

### DIFF
--- a/apps/desktop/src/main/chat-provider-hint.test.ts
+++ b/apps/desktop/src/main/chat-provider-hint.test.ts
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   PROXY_PROVIDER_ID,
   normalizeProviderId,
+  providersForServiceMetadata,
   sanitizeProviderHint,
 } from './chat-provider-hint.js';
 
@@ -41,4 +42,46 @@ test('sanitizeProviderHint returns null for missing or invalid input', () => {
   assert.equal(sanitizeProviderHint(null), null);
   assert.equal(sanitizeProviderHint(''), null);
   assert.equal(sanitizeProviderHint('   '), null);
+});
+
+test('providersForServiceMetadata resolves MiniMax to openai instead of openai-responses', () => {
+  const providers = providersForServiceMetadata(
+    ['openai-responses', 'openai'],
+    {
+      providerServiceApiProtocols: {
+        'openai-responses': {
+          services: {
+            'gpt-5.5': ['openai-responses'],
+          },
+        },
+        openai: {
+          services: {
+            'minimax-m2.7-highspeed': ['openai-chat-completions'],
+          },
+        },
+      },
+      providerPricing: {
+        'openai-responses': {
+          services: {
+            'gpt-5.5': {},
+          },
+        },
+        openai: {
+          services: {
+            'minimax-m2.7-highspeed': {},
+          },
+        },
+      },
+    },
+    'minimax-m2.7-highspeed',
+  );
+
+  assert.deepEqual(providers, ['openai']);
+});
+
+test('providersForServiceMetadata falls back to first provider without per-service metadata', () => {
+  assert.deepEqual(
+    providersForServiceMetadata(['openai-responses', 'openai'], {}, 'legacy-service'),
+    ['openai-responses'],
+  );
 });

--- a/apps/desktop/src/main/chat-provider-hint.ts
+++ b/apps/desktop/src/main/chat-provider-hint.ts
@@ -28,3 +28,54 @@ export function sanitizeProviderHint(value: unknown): string | null {
   if (normalized === PROXY_PROVIDER_ID) return null;
   return normalized;
 }
+
+export type ServiceProviderMetadata = {
+  providerServiceApiProtocols?: Record<string, { services?: Record<string, string[]> }>;
+  providerPricing?: Record<string, { services?: Record<string, unknown> }>;
+  providerServiceCategories?: Record<string, { services?: Record<string, string[]> }>;
+};
+
+/**
+ * Resolve the peer providers that actually advertise metadata for a service.
+ *
+ * Some peers expose multiple upstream provider lanes at once (for example
+ * `openai-responses` for GPT models and `openai` for MiniMax). The Desktop
+ * chat model must bind the selected service to the provider lane that owns
+ * that service; otherwise the SDK can pick the wrong API shape and turn a
+ * MiniMax chat-completions request into an unsupported `/v1/responses` call.
+ */
+export function providersForServiceMetadata(
+  providerList: string[],
+  metadata: ServiceProviderMetadata,
+  serviceId: string,
+): string[] {
+  const providers = new Set<string>();
+
+  for (const [provider, entry] of Object.entries(metadata.providerServiceApiProtocols ?? {})) {
+    if (Array.isArray(entry?.services?.[serviceId])) {
+      providers.add(provider);
+    }
+  }
+  for (const [provider, entry] of Object.entries(metadata.providerPricing ?? {})) {
+    if (entry?.services?.[serviceId]) {
+      providers.add(provider);
+    }
+  }
+  for (const [provider, entry] of Object.entries(metadata.providerServiceCategories ?? {})) {
+    if (Array.isArray(entry?.services?.[serviceId])) {
+      providers.add(provider);
+    }
+  }
+
+  if (providers.size === 0 && providerList.length > 0) {
+    providers.add(providerList[0]!);
+  }
+
+  const providerRank = new Map(providerList.map((provider, index) => [provider, index]));
+  return [...providers].sort((left, right) => {
+    const leftRank = providerRank.get(left) ?? Number.MAX_SAFE_INTEGER;
+    const rightRank = providerRank.get(right) ?? Number.MAX_SAFE_INTEGER;
+    if (leftRank !== rightRank) return leftRank - rightRank;
+    return left.localeCompare(right);
+  });
+}

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -43,7 +43,12 @@ import {
   persistChatWorkspaceDir,
 } from './chat-workspace.js';
 import { DEFAULT_BUYER_STATE_PATH } from './constants.js';
-import { PROXY_PROVIDER_ID, normalizeProviderId, sanitizeProviderHint } from './chat-provider-hint.js';
+import {
+  PROXY_PROVIDER_ID,
+  normalizeProviderId,
+  providersForServiceMetadata,
+  sanitizeProviderHint,
+} from './chat-provider-hint.js';
 import { asErrorMessage } from './utils.js';
 import { StakingClient, ChannelsClient, resolveChainConfig } from '@antseed/node';
 import {
@@ -351,19 +356,19 @@ const VALID_CHAT_SERVICE_PROTOCOLS = new Set<string>([
  * Resolve protocol for a service from the peer's announced providerServiceApiProtocols metadata.
  * Returns the first recognized chat protocol, or null if not found.
  */
-function resolveServiceProtocol(
+function resolveServiceProtocolForProvider(
   apiProtocols: NetworkPeerAddress['providerServiceApiProtocols'],
+  provider: string,
   serviceId: string,
 ): ChatServiceProtocol | null {
-  if (!apiProtocols) return null;
-  for (const providerEntry of Object.values(apiProtocols)) {
-    const protocols = providerEntry?.services?.[serviceId];
-    if (Array.isArray(protocols)) {
-      for (const p of protocols) {
-        if (VALID_CHAT_SERVICE_PROTOCOLS.has(p)) {
-          return p as ChatServiceProtocol;
-        }
-      }
+  const protocols = apiProtocols?.[provider]?.services?.[serviceId];
+  if (!Array.isArray(protocols)) {
+    return null;
+  }
+
+  for (const p of protocols) {
+    if (VALID_CHAT_SERVICE_PROTOCOLS.has(p)) {
+      return p as ChatServiceProtocol;
     }
   }
   return null;
@@ -605,30 +610,42 @@ async function discoverChatServiceCatalog(
     const defaultOutput = peer.defaultOutputUsdPerMillion;
 
     if (serviceList.length > 0) {
-      // Use explicit service names when available.
+      // Use explicit service names when available. A peer can advertise multiple
+      // providers (for example `openai-responses` for GPT and `openai` for
+      // MiniMax). Bind each service to the provider that actually advertises
+      // metadata for it; otherwise Desktop can choose the wrong SDK protocol
+      // and route MiniMax through /v1/responses.
       for (const serviceId of serviceList) {
-        const provider = providerList[0] ?? 'unknown';
-        // Resolve protocol: first check peer metadata, then fall back to inference from provider name.
-        const protocol = resolveServiceProtocol(apiProtocols, serviceId) ?? inferProviderProtocol(provider);
-        if (!protocol) continue;
+        for (const provider of providersForServiceMetadata(
+          providerList,
+          {
+            providerServiceApiProtocols: apiProtocols,
+            providerPricing: pricingMap,
+            providerServiceCategories: categoriesMap,
+          },
+          serviceId,
+        )) {
+          const protocol = resolveServiceProtocolForProvider(apiProtocols, provider, serviceId) ?? inferProviderProtocol(provider);
+          if (!protocol) continue;
 
-        const providerPricing = pricingMap?.[provider]?.services?.[serviceId] as Record<string, unknown> | undefined;
-        const inputUsd = (providerPricing?.inputUsdPerMillion as number | undefined) ?? (providerPricing?.input as number | undefined) ?? defaultInput;
-        const outputUsd = (providerPricing?.outputUsdPerMillion as number | undefined) ?? (providerPricing?.output as number | undefined) ?? defaultOutput;
-        const categories = categoriesMap?.[provider]?.services?.[serviceId];
+          const providerPricing = pricingMap?.[provider]?.services?.[serviceId] as Record<string, unknown> | undefined;
+          const inputUsd = (providerPricing?.inputUsdPerMillion as number | undefined) ?? (providerPricing?.input as number | undefined) ?? defaultInput;
+          const outputUsd = (providerPricing?.outputUsdPerMillion as number | undefined) ?? (providerPricing?.output as number | undefined) ?? defaultOutput;
+          const categories = categoriesMap?.[provider]?.services?.[serviceId];
 
-        results.push({
-          id: serviceId,
-          label: serviceId,
-          provider,
-          protocol,
-          count: 1,
-          peerId,
-          peerLabel,
-          ...(inputUsd != null ? { inputUsdPerMillion: inputUsd } : {}),
-          ...(outputUsd != null ? { outputUsdPerMillion: outputUsd } : {}),
-          ...(categories?.length ? { categories } : {}),
-        });
+          results.push({
+            id: serviceId,
+            label: serviceId,
+            provider,
+            protocol,
+            count: 1,
+            peerId,
+            peerLabel,
+            ...(inputUsd != null ? { inputUsdPerMillion: inputUsd } : {}),
+            ...(outputUsd != null ? { outputUsdPerMillion: outputUsd } : {}),
+            ...(categories?.length ? { categories } : {}),
+          });
+        }
       }
     } else if (providerList.length > 0) {
       // No services listed — create one entry per provider as a fallback.
@@ -1906,7 +1923,7 @@ export function registerPiChatHandlers({
         void store.setPeer(conversationId, peerOverrideId, peerLabel);
       }
     }
-    const protocol = await resolveProtocolForSend(serviceId);
+    const protocol = await resolveProtocolForSend(serviceId, preferredPeerId);
     // Determine vision support from the catalog entry for this (service, peer)
     // pair. We look for a `multimodal` category tag; sellers announce this via
     // serviceCategories in their peer metadata. Absent catalog info, we fall
@@ -2439,15 +2456,33 @@ export function registerPiChatHandlers({
     return serviceCatalogRefreshPromise;
   };
 
-  const resolveProtocolForSend = async (serviceId: string): Promise<ChatServiceProtocol> => {
+  const resolveProtocolForSend = async (serviceId: string, peerId?: string | null): Promise<ChatServiceProtocol> => {
     const normalizedServiceId = serviceId.trim().toLowerCase();
+    const normalizedPeerId = peerId?.trim().toLowerCase() ?? '';
+
+    const findCatalogMatch = (entries: ChatServiceCatalogEntry[]): ChatServiceProtocol | null => {
+      const peerMatch = normalizedPeerId
+        ? entries.find((entry) => (
+            entry.id.trim().toLowerCase() === normalizedServiceId
+            && entry.peerId?.trim().toLowerCase() === normalizedPeerId
+          ))
+        : null;
+      if (peerMatch) return peerMatch.protocol;
+      return entries.find((entry) => entry.id.trim().toLowerCase() === normalizedServiceId)?.protocol ?? null;
+    };
+
+    const existingCatalogMatch = findCatalogMatch(lastServiceCatalogEntries);
+    if (existingCatalogMatch) {
+      return existingCatalogMatch;
+    }
+
     const existing = serviceProtocolMap.get(normalizedServiceId);
-    if (existing) {
+    if (existing && !normalizedPeerId) {
       return existing;
     }
 
     const refreshed = await refreshServiceCatalogFromNetwork();
-    return refreshed.find((entry) => entry.id.trim().toLowerCase() === normalizedServiceId)?.protocol ?? 'anthropic-messages';
+    return findCatalogMatch(refreshed) ?? existing ?? 'anthropic-messages';
   };
 
   ipcMain.handle('chat:ai-get-proxy-status', async () => {


### PR DESCRIPTION
## Summary\n- Bind Desktop chat catalog entries to the provider that actually advertises each service, instead of assuming the peer's first provider owns every service.\n- Resolve send-time protocol by selected peer + service so MiniMax on multi-provider peers stays on OpenAI chat-completions.\n- Add regression coverage for MiniMax being advertised under `openai` while GPT services use `openai-responses`.\n\n## Context\nDesktop logs showed MiniMax requests on Dark Signal being sent through `openai-responses`, which adapted them to `/v1/responses`. MiniMax only supports `/v1/chat/completions`, so upstream returned `404 page not found`.\n\n@claude please review.\n\n## Tests\n- `pnpm --filter=@antseed/api-adapter build`\n- `pnpm --filter=@antseed/node build`\n- `pnpm --filter=@antseed/payments build:server`\n- `pnpm --filter=@antseed/desktop exec tsc -p tsconfig.main.json --noEmit`\n- `pnpm --filter=@antseed/desktop exec tsc -p tsconfig.renderer.json --noEmit`\n- `cd apps/desktop && node --test 'dist/main/*.test.js'`\n\nNote: `pnpm --filter=@antseed/desktop test` currently fails because Node 22 treats `node --test dist/main` as a missing module path. Running the compiled test files directly passes.