### PR TITLE
fix(desktop): pick API protocol per (service, peer), not per service

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.65",
+  "version": "0.1.66",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -1906,13 +1906,18 @@ export function registerPiChatHandlers({
         void store.setPeer(conversationId, peerOverrideId, peerLabel);
       }
     }
-    const protocol = await resolveProtocolForSend(serviceId);
-    // Determine vision support from the catalog entry for this (service, peer)
-    // pair. We look for a `multimodal` category tag; sellers announce this via
-    // serviceCategories in their peer metadata. Absent catalog info, we fall
-    // back to text-only so we never blindly forward images to a model whose
-    // upstream will reject them (DeepInfra, for example, returns
-    // "Multimodal is not supported for model: …" for text-only LLMs).
+    // Catalog entry for this (service, peer) pair drives both the API
+    // protocol (so we hit /v1/chat/completions vs /v1/responses vs
+    // /v1/messages on the right peer) and vision-capability info. Look
+    // up the peer-specific row first, then fall back to any row
+    // matching the service alone if the user has no peer pinned.
+    //
+    // We look for a `multimodal` category tag; sellers announce this
+    // via serviceCategories in their peer metadata. Absent catalog
+    // info, we fall back to text-only so we never blindly forward
+    // images to a model whose upstream will reject them (DeepInfra,
+    // for example, returns "Multimodal is not supported for model: …"
+    // for text-only LLMs).
     const normalizedServiceForCatalog = serviceId.trim().toLowerCase();
     const catalogEntry = lastServiceCatalogEntries.find((entry) => (
       entry.id.trim().toLowerCase() === normalizedServiceForCatalog
@@ -1920,6 +1925,13 @@ export function registerPiChatHandlers({
     )) ?? lastServiceCatalogEntries.find((entry) => (
       entry.id.trim().toLowerCase() === normalizedServiceForCatalog
     ));
+    // Prefer the peer-aware protocol from the catalog entry. The global
+    // serviceProtocolMap is first-write-wins per serviceId across all
+    // peers, so when one peer offers a service via openai-chat-completions
+    // and another via openai-responses, the map can return the wrong
+    // protocol for the peer we're actually pinned to. Fall back to the
+    // map only when we have no catalog row to read from.
+    const protocol = catalogEntry?.protocol ?? await resolveProtocolForSend(serviceId);
     const supportsMultimodal = catalogEntry?.categories?.includes('multimodal') ?? false;
     const droppedImageCount = supportsMultimodal ? 0 : attachmentImages.length;
     if (droppedImageCount > 0) {


### PR DESCRIPTION
## Summary

Follow-up to #417. After dropping the `x-antseed-provider` header, the buyer proxy routes a pinned-peer request based on the URL path the client used. We were picking that path via `resolveProtocolForSend(serviceId)`, which reads `serviceProtocolMap` — first-write-wins **per serviceId across every peer** (`apps/desktop/src/main/pi-chat-engine.ts:408-419`).

So if peer A advertises `gpt-4o` via `openai-chat-completions` and peer B advertises it via `openai-responses`, both rows go into the catalog but the map only stores one protocol for `gpt-4o`. Sending to peer B can land on `/v1/chat/completions`, and the proxy either adapts the request the wrong way or the upstream rejects it.

## Fix

`runStreamingPrompt` already looks up a peer-aware `catalogEntry` for vision-capability detection (`apps/desktop/src/main/pi-chat-engine.ts:1917-1922`). Use its `protocol` directly. Fall back to `resolveProtocolForSend` only when no catalog row is available — cold start, or a persisted conversation referencing a peer that just dropped out of the DHT.

Net diff: 2 files, +20/-8.

## Test plan

- [x] `npm --prefix apps/desktop run build:main` — clean.
- [x] `npm --prefix apps/desktop run typecheck:renderer` — clean.
- [x] `node --test apps/desktop/dist/main/*.test.js` — 66/66 passing.

Bumps `apps/desktop` to 0.1.66.

https://claude.ai/code/session_01SFHJYVP65g5MaA1vL4JGXs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SFHJYVP65g5MaA1vL4JGXs)_