### PR TITLE
fix(desktop): scroll chat to bottom on reopen

### DIFF
--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -169,6 +169,8 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const fileInputId = useId();
   const prevInputDisabled = useRef<boolean>(snap.chatInputDisabled);
+  const lastConversationIdRef = useRef<string | null>(snap.chatActiveConversation);
+  const wasActiveRef = useRef<boolean>(active);
   const isUserScrolledUp = useRef(false);
   const isDragging = useRef(false);
   const visibleMessages = useMemo(() => {
@@ -197,6 +199,35 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     return () => el.removeEventListener('scroll', handleScroll);
   }, []);
 
+  const scrollChatToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    isUserScrolledUp.current = false;
+  }, []);
+
+  // Opening/reopening a conversation should land on the latest message, not the
+  // last scroll offset from a previous visit. Keep manual scrollback behavior
+  // during the current visit by only forcing bottom on conversation/view entry.
+  useEffect(() => {
+    const previousConversationId = lastConversationIdRef.current;
+    const wasActive = wasActiveRef.current;
+    const conversationChanged = previousConversationId !== snap.chatActiveConversation;
+    const becameActive = active && !wasActive;
+
+    lastConversationIdRef.current = snap.chatActiveConversation;
+    wasActiveRef.current = active;
+
+    if (!active || (!conversationChanged && !becameActive)) {
+      return;
+    }
+
+    isUserScrolledUp.current = false;
+    scrollChatToBottom();
+    const frame = requestAnimationFrame(scrollChatToBottom);
+    return () => cancelAnimationFrame(frame);
+  }, [active, snap.chatActiveConversation, scrollChatToBottom]);
+
   // Keep the view pinned to the bottom while the user is already at the bottom.
   useEffect(() => {
     const el = scrollRef.current;
@@ -204,11 +235,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
       return;
     }
 
-    const scrollToBottom = (): void => {
-      el.scrollTop = el.scrollHeight;
-    };
-
-    scrollToBottom();
+    scrollChatToBottom();
 
     if (typeof ResizeObserver === 'undefined') {
       return;
@@ -216,7 +243,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
 
     const observer = new ResizeObserver(() => {
       if (!isUserScrolledUp.current) {
-        scrollToBottom();
+        scrollChatToBottom();
       }
     });
 
@@ -224,7 +251,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     Array.from(el.children).forEach((child) => observer.observe(child));
 
     return () => observer.disconnect();
-  }, [visibleMessages, snap.chatStreamingMessage, snap.chatSending]);
+  }, [visibleMessages, snap.chatStreamingMessage, snap.chatSending, scrollChatToBottom]);
 
   // Re-focus the input when it transitions from disabled → enabled, and if a
   // draft is queued, ship the head of the queue as its own turn. Each draft


### PR DESCRIPTION
## What

Fixes #425.

When the user opens/reopens an AntStation chat conversation, force the message pane to land on the newest message at the bottom instead of preserving the previous scroll offset.

## Details

- Tracks the last active conversation id and whether the chat view just became active.
- Scrolls to bottom on conversation changes and on re-entering the chat view.
- Keeps existing manual scrollback behavior during the current visit: if the user scrolls up while a stream is active, new content does not force-scroll until they return to the bottom or reopen/switch conversations.
- Keeps the existing ResizeObserver bottom-pin behavior for users already at the bottom.

## Testing

- No projects matched the filters in "C:\Users\kagan\.antseed\projects"
- No projects matched the filters in "C:\Users\kagan\.antseed\projects"
- No projects matched the filters in "C:\Users\kagan\.antseed\projects"
- No projects matched the filters in "C:\Users\kagan\.antseed\projects"
- No projects matched the filters in "C:\Users\kagan\.antseed\projects"
