### PR TITLE
Fix assistant chat response boundary

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -258,12 +258,15 @@
 
   &.other {
     align-self: stretch;
-    background: transparent;
+    background: var(--bg-card);
     color: var(--text-primary);
-    border-left: 0;
-    border-radius: 0;
-    width: 100%;
-    padding: 0 16px;
+    border: 1px solid var(--border);
+    border-left: 3px solid rgba(var(--accent-rgb), 0.55);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-sm);
+    width: calc(100% - 32px);
+    padding: 12px 16px 10px;
+    margin: 4px auto 28px;
 
   :global {
     /* Tool group */
@@ -281,7 +284,7 @@
       left: 8px;
       appearance: none;
       border: 0;
-      background: var(--bg-primary);
+      background: var(--bg-card);
       display: inline-flex;
       align-items: center;
       gap: 4px;
@@ -656,6 +659,53 @@
 .chat-bubble-stats {
   color: var(--text-faint);
   font-size: inherit;
+}
+
+.chatBubbleBody {
+  min-width: 0;
+}
+
+.assistantHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 22px;
+  margin-bottom: 8px;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.assistantAvatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 22px;
+  border-radius: 999px;
+  background: rgba(var(--accent-rgb), 0.12);
+  border: 1px solid rgba(var(--accent-rgb), 0.24);
+  color: var(--accent-green);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.assistantTitle {
+  color: var(--text-secondary);
+  letter-spacing: 0.01em;
+}
+
+.assistantHeader .chat-bubble-stats {
+  margin-left: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+  font-size: 11px;
+  font-weight: 400;
 }
 
 /* ===================================================================

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -748,16 +748,23 @@ export function ChatBubble({ message, streaming = false, onOpenPreview, conversa
     return <div className="chat-bubble-content">{JSON.stringify(message.content)}</div>;
   }, [message, isStreamingBubble, messagePrefix, onOpenPreview, conversationId]);
 
+  const isUserMessage = message.role === 'user';
   const bubbleMeta =
     metaParts.length > 0 && !isStreamingBubble ? (
       <span className={styles.chatBubbleStats}>{metaParts.join(' · ')}</span>
     ) : null;
 
   return (
-    <div className={`${styles.chatBubble} ${message.role === 'user' ? styles.own : styles.other}`}>
-      {bubbleMeta}
-      <div>{content}</div>
-      {message.role !== 'user' && !isStreamingBubble ? (
+    <div className={`${styles.chatBubble} ${isUserMessage ? styles.own : styles.other}`}>
+      {isUserMessage ? bubbleMeta : (
+        <div className={styles.assistantHeader} aria-label="Assistant response">
+          <span className={styles.assistantAvatar} aria-hidden="true">A</span>
+          <span className={styles.assistantTitle}>Assistant</span>
+          {bubbleMeta}
+        </div>
+      )}
+      <div className={styles.chatBubbleBody}>{content}</div>
+      {!isUserMessage && !isStreamingBubble ? (
         <div className={styles.messageActions}>
           <CopyResponseButton content={message.content} />
         </div>


### PR DESCRIPTION
## Summary\n- Give assistant chat messages a subtle card container with border, rounded corners, shadow, and accent edge so response boundaries are visible.\n- Add a compact Assistant header/avatar anchor at the start of every assistant response, including while streaming.\n- Keep user bubble styling and existing streaming/copy behavior unchanged.\n\nFixes #424\n\n## Checks\n- pnpm --filter=@antseed/desktop run typecheck:renderer\n- pnpm --filter=@antseed/desktop run build:renderer\n- pnpm run build:tier0\n- pnpm --filter=@antseed/payments run build\n- pnpm --filter=@antseed/desktop run test