### PR TITLE
fix(desktop): limit wallet USD amounts to 2 decimals

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
@@ -326,10 +326,10 @@ export function formatCompactNumber(value: unknown): string {
   return Math.floor(num).toLocaleString();
 }
 
-export function formatUsd(value: unknown, maxFractionDigits = 6): string {
+export function formatUsd(value: unknown, fractionDigits = 2): string {
   const num = Number(value);
-  if (!Number.isFinite(num) || num <= 0) return '0';
-  return num.toLocaleString([], { minimumFractionDigits: 0, maximumFractionDigits: maxFractionDigits });
+  if (!Number.isFinite(num) || num <= 0) return (0).toFixed(fractionDigits);
+  return num.toLocaleString([], { minimumFractionDigits: fractionDigits, maximumFractionDigits: fractionDigits });
 }
 
 export function getMyrmecochoryLabel(indexBase = 0): string {

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -955,10 +955,7 @@ function compactTokensFromFormatted(formatted: string): string {
 
 function compactUsd(raw: string): string {
   const n = Number(raw);
-  if (!Number.isFinite(n)) return `$${raw}`;
-  if (n === 0) return '$0.00';
-  if (n < 0.01) return `$${n.toFixed(4)}`;
-  if (n < 1) return `$${n.toFixed(3)}`;
+  if (!Number.isFinite(n)) return '$0.00';
   return `$${n.toFixed(2)}`;
 }
 
@@ -1029,7 +1026,7 @@ function ChatSessionStats({
           <div className={styles.sessionStatsGroupLabel}>Current payment channel</div>
           <div className={styles.sessionStatsRow}>
             <span>Cost</span>
-            <span>{sessionCost ? `$${sessionCost}` : '—'}</span>
+            <span>{sessionCost ? compactUsd(sessionCost) : '—'}</span>
           </div>
           <div className={styles.sessionStatsRow}>
             <span>Tokens</span>
@@ -1040,7 +1037,7 @@ function ChatSessionStats({
           <div className={styles.sessionStatsGroupLabel}>All-time with peer</div>
           <div className={styles.sessionStatsRow}>
             <span>Cost</span>
-            <span>{lifetimeCost ? `$${lifetimeCost}` : '—'}</span>
+            <span>{lifetimeCost ? compactUsd(lifetimeCost) : '—'}</span>
           </div>
           <div className={styles.sessionStatsRow}>
             <span>Tokens</span>


### PR DESCRIPTION
## Summary
- render ChatView wallet/session USD amounts with exactly two decimal places
- format session and lifetime costs in the usage popover instead of displaying raw strings
- default shared chat USD formatting to fixed two-decimal output for uiState costs

Closes #314

## Tests
- pnpm --filter=@antseed/desktop run typecheck:renderer
- pnpm --filter=@antseed/desktop run build:renderer
- pnpm --filter=@antseed/api-adapter run build && pnpm --filter=@antseed/node run build && pnpm --filter=@antseed/payments run build:server && pnpm --filter=@antseed/desktop test