### PR TITLE
fix(api-adapter): stop double-billing cached tokens when providers emit both cache shapes

### DIFF
--- a/packages/api-adapter/src/utils.ts
+++ b/packages/api-adapter/src/utils.ts
@@ -74,40 +74,34 @@ export function extractUsage(parsed: Record<string, unknown>): TokenUsage {
     }
   }
 
+  const hasPromptTokens = usage.prompt_tokens !== undefined && usage.prompt_tokens !== null;
   const totalInput = toNonNegativeInt(usage.prompt_tokens ?? usage.input_tokens);
   const outputTokens = toNonNegativeInt(usage.completion_tokens ?? usage.output_tokens);
 
-  // Cache hits — supports both shapes:
-  //   - OpenAI Chat:      usage.prompt_tokens_details.cached_tokens
-  //   - OpenAI Responses: usage.input_tokens_details.cached_tokens
-  // Both express the cached portion as a *subset* of the total input count.
+  // Cache hits arrive in two competing shapes:
+  //   - Subset shape (OpenAI Chat/Responses): cached_tokens is a subset of the
+  //     total input count, found under prompt_tokens_details or
+  //     input_tokens_details. fresh = total - cached.
+  //   - Separate shape (Anthropic): cache_read_input_tokens is reported
+  //     alongside input_tokens, where input_tokens is already fresh-only.
+  //     fresh = total.
+  // Some providers (e.g. Venice) emit BOTH fields for the same cache hit.
+  // Discriminate by the input field, not the cache field: prompt_tokens or
+  // input_tokens_details.cached_tokens always implies subset semantics.
   const promptDetails = usage.prompt_tokens_details && typeof usage.prompt_tokens_details === 'object'
     ? (usage.prompt_tokens_details as Record<string, unknown>)
     : {};
   const inputDetails = usage.input_tokens_details && typeof usage.input_tokens_details === 'object'
     ? (usage.input_tokens_details as Record<string, unknown>)
     : {};
-  const openaiCached = toNonNegativeInt(promptDetails.cached_tokens ?? inputDetails.cached_tokens);
+  const subsetCached = toNonNegativeInt(promptDetails.cached_tokens ?? inputDetails.cached_tokens);
+  const separateCached = toNonNegativeInt(usage.cache_read_input_tokens ?? usage.prompt_cache_hit_tokens);
 
-  // Anthropic: cache_read_input_tokens is separate from input_tokens (which is fresh-only)
-  const anthropicCached = toNonNegativeInt(usage.cache_read_input_tokens ?? usage.prompt_cache_hit_tokens);
-
-  let freshInputTokens: number;
-  let cachedInputTokens: number;
-
-  if (anthropicCached > 0) {
-    // Anthropic style: input_tokens is already fresh-only
-    freshInputTokens = totalInput;
-    cachedInputTokens = anthropicCached;
-  } else if (openaiCached > 0) {
-    // OpenAI style: prompt_tokens includes cached subset
-    freshInputTokens = Math.max(0, totalInput - openaiCached);
-    cachedInputTokens = openaiCached;
-  } else {
-    // No cache info — all tokens are fresh
-    freshInputTokens = totalInput;
-    cachedInputTokens = 0;
-  }
+  const isSubsetShape = hasPromptTokens || inputDetails.cached_tokens !== undefined;
+  const cachedInputTokens = Math.max(subsetCached, separateCached);
+  const freshInputTokens = isSubsetShape
+    ? Math.max(0, totalInput - cachedInputTokens)
+    : totalInput;
 
   return { inputTokens: totalInput, outputTokens, freshInputTokens, cachedInputTokens };
 }

--- a/packages/api-adapter/tests/extract-usage.test.ts
+++ b/packages/api-adapter/tests/extract-usage.test.ts
@@ -127,18 +127,42 @@ describe('extractUsage', () => {
     });
   });
 
-  it('prefers Anthropic cache field over OpenAI when both present', () => {
-    // Anthropic cache_read_input_tokens takes priority since it's checked first
+  it('handles Venice hybrid shape (prompt_tokens + duplicate cache_read_input_tokens)', () => {
+    // Venice's /v1/chat/completions emits both shapes for the same cache hit:
+    //   prompt_tokens (total, includes cached)
+    //   prompt_tokens_details.cached_tokens (subset)
+    //   cache_read_input_tokens (duplicate of the subset)
+    // Treating cache_read_input_tokens as an Anthropic-style separate count
+    // would double-bill the cached portion at the full input rate.
     const result = extractUsage({
       usage: {
-        input_tokens: 200,
-        output_tokens: 50,
-        cache_read_input_tokens: 500,
-        prompt_tokens_details: { cached_tokens: 300 },
+        prompt_tokens: 15926,
+        completion_tokens: 6,
+        total_tokens: 15932,
+        prompt_tokens_details: { cached_tokens: 15616 },
+        cache_read_input_tokens: 15616,
       },
     });
-    // Anthropic style: input_tokens is fresh-only
-    expect(result.freshInputTokens).toBe(200);
-    expect(result.cachedInputTokens).toBe(500);
+    expect(result).toEqual({
+      inputTokens: 15926,
+      outputTokens: 6,
+      freshInputTokens: 310,    // 15926 - 15616, NOT 15926
+      cachedInputTokens: 15616,
+    });
+  });
+
+  it('takes the larger cached count when subset and separate disagree', () => {
+    // Defensive: if a provider reports mismatched values, prefer the larger one
+    // and still apply subset semantics (since prompt_tokens is present).
+    const result = extractUsage({
+      usage: {
+        prompt_tokens: 1000,
+        completion_tokens: 50,
+        prompt_tokens_details: { cached_tokens: 600 },
+        cache_read_input_tokens: 800,
+      },
+    });
+    expect(result.freshInputTokens).toBe(200);   // 1000 - 800
+    expect(result.cachedInputTokens).toBe(800);
   });
 });


### PR DESCRIPTION
## Summary
- `extractUsage` previously checked the Anthropic-style `cache_read_input_tokens` field before the OpenAI-style `prompt_tokens_details.cached_tokens` subset. When an upstream provider returned both fields for the same cache hit, the parser treated `prompt_tokens` as fresh-only and added the cached count on top — so the cached portion of input was billed at the full input rate instead of the cached rate. Real-world impact observed: ~2.5× over-billing on cache-heavy chat sessions.
- Fix discriminates by which input field is set rather than which cache field is set. `prompt_tokens` (or `input_tokens_details.cached_tokens`) unambiguously means the subset shape; `cache_read_input_tokens` alone means the separate shape. When both cache counts are present we take the max and apply subset subtraction.
- Removes the prior test that enshrined the buggy precedence and adds a regression test that pins the hybrid response shape.

## Test plan
- [x] `pnpm --filter @antseed/api-adapter test` — 49/49 pass, including new `handles hybrid shape` and `takes the larger cached count when subset and separate disagree` cases
- [x] `pnpm --filter @antseed/api-adapter run build` — clean
- [x] `pnpm --filter @antseed/node run typecheck` — clean (consumer of `extractUsage` via `parseResponseUsage`)