### PR TITLE
fix(cli): persist sellerContract in buyer peer cache

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -470,6 +470,47 @@ test('parsePersistedPeers preserves provider metadata so routing filters still w
   assert.equal(result.routePlanByPeerId.get(validPeerId)?.provider, 'claude-oauth')
 })
 
+test('parsePersistedPeers restores sellerContract into peer.metadata', () => {
+  // Regression: dropping sellerContract through the persistence layer caused
+  // SellerAddressResolver to fall back to peerIdToAddress, so the buyer signed
+  // channelId derived from the peer wallet instead of the facade address.
+  // On-chain reserve() then reverted with InvalidSignature() because the
+  // contract derives channelId from msg.sender (the facade).
+  const facade = '1f228613116e2d08014dfdcc198377c8dedf18c9'
+  const [peer] = parsePersistedPeers(
+    {
+      discoveredPeers: [
+        {
+          peerId: validPeerId,
+          providers: ['openai'],
+          lastSeen: NOW - 1_000,
+          sellerContract: facade,
+        },
+      ],
+    },
+    NOW,
+  )
+  assert.ok(peer)
+  assert.equal(peer!.metadata?.sellerContract, facade)
+})
+
+test('parsePersistedPeers leaves metadata undefined when sellerContract is absent', () => {
+  const [peer] = parsePersistedPeers(
+    {
+      discoveredPeers: [
+        {
+          peerId: validPeerId,
+          providers: ['openai'],
+          lastSeen: NOW - 1_000,
+        },
+      ],
+    },
+    NOW,
+  )
+  assert.ok(peer)
+  assert.equal(peer!.metadata, undefined)
+})
+
 test('parsePersistedPeers filters non-string entries out of providers', () => {
   const result = parsePersistedPeers(
     {

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import type {
   AntseedNode,
   PeerInfo,
+  PeerMetadata,
   RequestStreamResponseMetadata,
   Router,
   SerializedHttpRequest,
@@ -283,6 +284,15 @@ export function parsePersistedPeers(
     }
     if (typeof entry.onChainStatsFetchedAt === 'number' && Number.isFinite(entry.onChainStatsFetchedAt)) {
       peer.onChainStatsFetchedAt = entry.onChainStatsFetchedAt
+    }
+    // Carry sellerContract through the persistence layer so the buyer's
+    // SellerAddressResolver can return the facade address for facade-fronted
+    // peers (e.g. DiemStakingProxy). Without this, the resolver falls back to
+    // peerIdToAddress(peerId), the buyer signs channelId derived from the peer
+    // wallet, and `reserve()` reverts on-chain with InvalidSignature() because
+    // the contract derives channelId from msg.sender (the facade).
+    if (typeof entry.sellerContract === 'string' && entry.sellerContract.length > 0) {
+      peer.metadata = { sellerContract: entry.sellerContract } as PeerMetadata
     }
     peers.push(peer)
   }
@@ -580,6 +590,9 @@ export class BuyerProxy {
         onChainTotalVolumeUsdcMicros: p.onChainTotalVolumeUsdcMicros ?? null,
         onChainLastSettledAtSec: p.onChainLastSettledAtSec ?? null,
         onChainStatsFetchedAt: p.onChainStatsFetchedAt ?? null,
+        // Persisted so cold-started buyers can still resolve the facade address
+        // for channelId derivation. See parsePersistedPeers for the round-trip.
+        sellerContract: p.metadata?.sellerContract ?? null,
         lastSeen: p.lastSeen,
         lastReachedAt: p.lastReachedAt ?? null,
       }


### PR DESCRIPTION
## Summary
- Buyer's persisted peer cache (`buyer.state.json`) serializes `PeerInfo` field-by-field in `_persistPeersToState` and never writes `metadata.sellerContract`. `parsePersistedPeers` rebuilds `PeerInfo` the same way and never restores it. After any cold start, `peer.metadata` is `undefined` for previously-discovered peers, `SellerAddressResolver` falls back to `peerIdToAddress(peerId)`, and the buyer signs `ReserveAuth` with `channelId = computeChannelId(buyer, peer-wallet, salt)` instead of the facade-derived channelId.
- The contract recomputes `channelId` from `msg.sender = facade` (e.g. `DiemStakingProxy`), so the recovered signer doesn't match the buyer → on-chain `reserve()` reverts with `InvalidSignature()`. This is not a metadata-codec version-skew issue — buyers running the latest codec hit it the moment they reload from disk.
- Persist `sellerContract` alongside the other peer fields and restore it into a minimal `peer.metadata` shim on read. The resolver only reads `metadata.sellerContract`, so a partial-cast assignment is sufficient and doesn't pollute the rest of the metadata blob.
- Two regression tests cover the round-trip and the no-`sellerContract` case.

## Test plan
- [x] `pnpm --filter @antseed/cli run typecheck` — clean
- [x] `pnpm --filter @antseed/cli test` — 75/75 pass, including new `parsePersistedPeers restores sellerContract into peer.metadata` and `parsePersistedPeers leaves metadata undefined when sellerContract is absent`