### PR TITLE
Fix pricing page Venice stats and provider filter

### DIFF
--- a/apps/network-stats/src/server.test.ts
+++ b/apps/network-stats/src/server.test.ts
@@ -163,7 +163,45 @@ describe('createServer — enriched: agent with totals', () => {
   });
 });
 
-// ── Test 3: Enriched — agent with no events ───────────────────────────────────
+// ── Test 3: Enriched — contract-backed peer uses sellerContract ───────────────
+
+describe('createServer — enriched: contract-backed peer uses sellerContract', () => {
+  const PORT = nextPort();
+  const store = makeStore();
+  store.applyBatch('test', '0xcontract', [
+    makeEvent({ agentId: 77n, blockNumber: 101, inputTokens: 123n, outputTokens: 456n, requestCount: 7n }),
+  ], 1);
+  const peer = fakePeer('contract', '0xoperator');
+  peer.sellerContract = '1f228613116e2d08014dfdcc198377c8dedf18c9';
+  const peers = [peer];
+  const poller = makePoller(peers);
+  const seen: string[] = [];
+  const stakingClient = makeStakingClient((addr) => {
+    seen.push(addr);
+    return addr === '0x1f228613116e2d08014dfdcc198377c8dedf18c9' ? 77 : 0;
+  });
+  const handle = createServer({ poller, store, stakingClient, port: PORT });
+
+  before(async () => { await handle.start(); });
+  after(() => { handle.stop(); store.close(); });
+  beforeEach(() => {
+    __resetAgentIdCacheForTests();
+    seen.length = 0;
+  });
+
+  it('resolves stats by sellerContract instead of operator peerId', async () => {
+    const res = await fetch(`http://localhost:${PORT}/stats`);
+    const body = await res.json() as { peers: Array<{ onChainStats: { agentId: number; totalInputTokens: string; totalOutputTokens: string } | null }> };
+    assert.deepEqual(seen, ['0x1f228613116e2d08014dfdcc198377c8dedf18c9']);
+    const stats = body.peers[0]!.onChainStats;
+    assert.ok(stats !== null, 'onChainStats should not be null');
+    assert.equal(stats!.agentId, 77);
+    assert.equal(stats!.totalInputTokens, '123');
+    assert.equal(stats!.totalOutputTokens, '456');
+  });
+});
+
+// ── Test 4: Enriched — agent with no events ───────────────────────────────────
 
 describe('createServer — enriched: agent with no events in store', () => {
   const PORT = nextPort();

--- a/apps/network-stats/src/server.ts
+++ b/apps/network-stats/src/server.ts
@@ -33,12 +33,18 @@ interface CacheEntry {
 }
 const agentIdCache = new Map<string, CacheEntry>();
 
+function normalizeAddress(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const lower = value.toLowerCase();
+  return lower.startsWith('0x') ? lower : `0x${lower}`;
+}
+
 async function resolveAgentId(
   client: StakingClient,
   address: string | null | undefined,
 ): Promise<number | null> {
-  if (!address) return null;
-  const key = address.toLowerCase();
+  const key = normalizeAddress(address);
+  if (!key) return null;
   const cached = agentIdCache.get(key);
   if (cached !== undefined && cached.expiresAt > Date.now()) {
     return cached.agentId;
@@ -81,9 +87,11 @@ export function createServer(deps: CreateServerDeps): { start(): Promise<void>; 
 
     const enrichedPeers = await Promise.all(
       snapshot.peers.map(async (peer) => {
-        // peerId is the lowercased seller EVM address without the 0x prefix.
-        const peerId = (peer as { peerId?: string }).peerId;
-        const address = peerId ? `0x${peerId}` : null;
+        // peerId is the lowercased seller/operator EVM address without the 0x prefix.
+        // Contract-backed sellers (for example Venice's proxy) announce the
+        // settlement address separately; use that for on-chain volume lookup.
+        const { peerId, sellerContract } = peer as { peerId?: string; sellerContract?: string };
+        const address = normalizeAddress(sellerContract) ?? normalizeAddress(peerId);
         const agentId = await resolveAgentId(stakingClient, address);
         if (agentId === null || agentId === 0) {
           return { ...peer, onChainStats: null };


### PR DESCRIPTION
## Summary
- Use sellerContract when enriching network stats for contract-backed sellers like Venice.ai Proxy
- Fix provider chip filtering so selecting a peer only shows rows from that peer
- Prefer local stats endpoint first during localhost website development
- Add regression coverage for sellerContract stats lookup

## Validation
- ✅ pnpm --filter ./apps/website build
- ⚠️ pnpm --filter ./apps/network-stats build currently fails in this workspace because @antseed/node/@antseed/api-adapter workspace type artifacts are unavailable; same pre-existing workspace resolution issue observed before these changes