### PR TITLE
Fix network lifetime totals and pricing peer filter

### DIFF
--- a/apps/network-stats/src/server.test.ts
+++ b/apps/network-stats/src/server.test.ts
@@ -144,6 +144,13 @@ describe('createServer — enriched: agent with totals', () => {
           lastUpdatedAt: number;
         } | null;
       }>;
+      totals: {
+        totalRequests: string;
+        totalInputTokens: string;
+        totalOutputTokens: string;
+        settlementCount: number;
+        sellerCount: number;
+      };
     };
     assert.equal(body.peers.length, 1);
     const stats = body.peers[0]!.onChainStats;
@@ -160,6 +167,11 @@ describe('createServer — enriched: agent with totals', () => {
     assert.equal(stats!.avgRequestsPerBuyer, 5);
     assert.equal(stats!.avgRequestsPerChannel, 5);
     assert.equal(typeof stats!.lastUpdatedAt, 'number');
+    assert.equal(body.totals.totalRequests, '5');
+    assert.equal(body.totals.totalInputTokens, '100');
+    assert.equal(body.totals.totalOutputTokens, '200');
+    assert.equal(body.totals.settlementCount, 1);
+    assert.equal(body.totals.sellerCount, 1);
   });
 });
 
@@ -201,7 +213,43 @@ describe('createServer — enriched: contract-backed peer uses sellerContract', 
   });
 });
 
-// ── Test 4: Enriched — agent with no events ───────────────────────────────────
+// ── Test 4: Enriched — network totals include inactive sellers ────────────────
+
+describe('createServer — enriched: network totals include inactive sellers', () => {
+  const PORT = nextPort();
+  const store = makeStore();
+  store.applyBatch('test', '0xcontract', [
+    makeEvent({ agentId: 88n, blockNumber: 102, inputTokens: 10n, outputTokens: 20n, requestCount: 1n }),
+    makeEvent({ agentId: 99n, blockNumber: 103, inputTokens: 30n, outputTokens: 40n, requestCount: 2n }),
+  ], 1);
+  const peers = [fakePeer('active', '0xactive')];
+  const poller = makePoller(peers);
+  const stakingClient = makeStakingClient(() => 88);
+  const handle = createServer({ poller, store, stakingClient, port: PORT });
+
+  before(async () => { await handle.start(); });
+  after(() => { handle.stop(); store.close(); });
+  beforeEach(() => { __resetAgentIdCacheForTests(); });
+
+  it('returns aggregate totals across all indexed sellers, not just active peers', async () => {
+    const res = await fetch(`http://localhost:${PORT}/stats`);
+    const body = await res.json() as {
+      peers: Array<{ onChainStats: { agentId: number; totalInputTokens: string; totalOutputTokens: string } | null }>;
+      totals: { totalRequests: string; totalInputTokens: string; totalOutputTokens: string; settlementCount: number; sellerCount: number };
+    };
+
+    assert.equal(body.peers[0]!.onChainStats?.agentId, 88);
+    assert.equal(body.peers[0]!.onChainStats?.totalInputTokens, '10');
+    assert.equal(body.peers[0]!.onChainStats?.totalOutputTokens, '20');
+    assert.equal(body.totals.totalRequests, '3');
+    assert.equal(body.totals.totalInputTokens, '40');
+    assert.equal(body.totals.totalOutputTokens, '60');
+    assert.equal(body.totals.settlementCount, 2);
+    assert.equal(body.totals.sellerCount, 2);
+  });
+});
+
+// ── Test 5: Enriched — agent with no events ───────────────────────────────────
 
 describe('createServer — enriched: agent with no events in store', () => {
   const PORT = nextPort();
@@ -222,7 +270,7 @@ describe('createServer — enriched: agent with no events in store', () => {
   });
 });
 
-// ── Test 4: Enriched — unstaked peer (agentId = 0) ────────────────────────────
+// ── Test 6: Enriched — unstaked peer (agentId = 0) ────────────────────────────
 
 describe('createServer — enriched: unstaked peer returns agentId 0', () => {
   const PORT = nextPort();
@@ -243,7 +291,7 @@ describe('createServer — enriched: unstaked peer returns agentId 0', () => {
   });
 });
 
-// ── Test 5: Enriched — missing peerId ─────────────────────────────────
+// ── Test 7: Enriched — missing peerId ────────────────────────────────────────
 
 describe('createServer — enriched: peer missing peerId', () => {
   const PORT = nextPort();
@@ -269,7 +317,7 @@ describe('createServer — enriched: peer missing peerId', () => {
   });
 });
 
-// ── Test 6: Cache is reused ───────────────────────────────────────────────────
+// ── Test 8: Cache is reused ───────────────────────────────────────────────────
 
 describe('createServer — enriched: cache reused across requests', () => {
   const PORT = nextPort();
@@ -303,7 +351,7 @@ describe('createServer — enriched: cache reused across requests', () => {
   });
 });
 
-// ── Test 7: Staking RPC failure — no cache, recovers on retry ────────────────
+// ── Test 9: Staking RPC failure — no cache, recovers on retry ────────────────
 
 describe('createServer — enriched: RPC failure does not cache', () => {
   const PORT = nextPort();
@@ -346,7 +394,7 @@ describe('createServer — enriched: RPC failure does not cache', () => {
   });
 });
 
-// ── Test 8: BigInt round-trip ─────────────────────────────────────────────────
+// ── Test 10: BigInt round-trip ────────────────────────────────────────────────
 
 describe('createServer — enriched: BigInt round-trip for large numbers', () => {
   const PORT = nextPort();

--- a/apps/network-stats/src/server.ts
+++ b/apps/network-stats/src/server.ts
@@ -143,9 +143,19 @@ export function createServer(deps: CreateServerDeps): { start(): Promise<void>; 
         }
       : null;
 
+    const networkTotals = store.getNetworkTotals();
+
     res.json({
       ...snapshot,
       peers: enrichedPeers,
+      totals: {
+        totalRequests: networkTotals.totalRequests.toString(),
+        totalInputTokens: networkTotals.totalInputTokens.toString(),
+        totalOutputTokens: networkTotals.totalOutputTokens.toString(),
+        settlementCount: networkTotals.settlementCount,
+        sellerCount: networkTotals.sellerCount,
+        lastUpdatedAt: networkTotals.lastUpdatedAt,
+      },
       ...(indexerPayload ? { indexer: indexerPayload } : {}),
     });
   });

--- a/apps/network-stats/src/store.ts
+++ b/apps/network-stats/src/store.ts
@@ -17,6 +17,15 @@ export interface SellerTotals {
   lastUpdatedAt: number;
 }
 
+export interface NetworkTotals {
+  totalRequests: bigint;
+  totalInputTokens: bigint;
+  totalOutputTokens: bigint;
+  settlementCount: number;
+  sellerCount: number;
+  lastUpdatedAt: number | null;
+}
+
 interface SellerRow {
   total_input_tokens: string;
   total_output_tokens: string;
@@ -62,6 +71,7 @@ export class SqliteStore {
   private _selectChannel!: Database.Statement<[number, string], BuyerOrChannelRow & { buyer: string }>;
   private _upsertChannel!: Database.Statement<[number, string, string, string, string, string, number, number, number]>;
   private _selectSellerTotals!: Database.Statement<[number], SellerTotalsRow>;
+  private _selectAllSellerTotals!: Database.Statement<[], SellerTotalsRow>;
   private _countBuyers!: Database.Statement<[number], { c: number }>;
   private _countChannels!: Database.Statement<[number], { c: number }>;
 
@@ -167,6 +177,10 @@ export class SqliteStore {
 
     this._selectSellerTotals = this.db.prepare(
       'SELECT total_request_count, total_input_tokens, total_output_tokens, settlement_count, first_settled_block, last_settled_block, first_seen_at, last_seen_at, last_updated_at FROM seller_metadata_totals WHERE agent_id = ?',
+    );
+
+    this._selectAllSellerTotals = this.db.prepare(
+      'SELECT total_request_count, total_input_tokens, total_output_tokens, settlement_count, first_settled_block, last_settled_block, first_seen_at, last_seen_at, last_updated_at FROM seller_metadata_totals',
     );
 
     this._countBuyers = this.db.prepare(
@@ -333,6 +347,34 @@ export class SqliteStore {
       avgRequestsPerChannel,
       avgRequestsPerBuyer,
       lastUpdatedAt: row.last_updated_at,
+    };
+  }
+
+  /** Returns cumulative totals across all indexed sellers, including sellers not currently online. */
+  getNetworkTotals(): NetworkTotals {
+    let totalRequests = 0n;
+    let totalInputTokens = 0n;
+    let totalOutputTokens = 0n;
+    let settlementCount = 0;
+    let sellerCount = 0;
+    let lastUpdatedAt: number | null = null;
+
+    for (const row of this._selectAllSellerTotals.all()) {
+      totalRequests += BigInt(row.total_request_count);
+      totalInputTokens += BigInt(row.total_input_tokens);
+      totalOutputTokens += BigInt(row.total_output_tokens);
+      settlementCount += row.settlement_count;
+      sellerCount += 1;
+      lastUpdatedAt = Math.max(lastUpdatedAt ?? 0, row.last_updated_at);
+    }
+
+    return {
+      totalRequests,
+      totalInputTokens,
+      totalOutputTokens,
+      settlementCount,
+      sellerCount,
+      lastUpdatedAt,
     };
   }
 

--- a/apps/payments/web/src/api.ts
+++ b/apps/payments/web/src/api.ts
@@ -162,10 +162,11 @@ export async function getBuyerUsage(): Promise<BuyerUsageTotals> {
 
 export interface NetworkStatsTotals {
   activePeers: number;
-  totalRequests: string;        // sum across peers, bigint as string
+  totalRequests: string;        // bigint as string
   totalInputTokens: string;
   totalOutputTokens: string;
   totalSettlements: number;
+  sellerCount?: number;
 }
 
 export interface NetworkStatsResponse {
@@ -179,8 +180,9 @@ export interface NetworkStatsResponse {
 }
 
 /**
- * Calls the network-stats `/stats` endpoint and aggregates per-peer totals
- * into a single network-wide snapshot.
+ * Calls the network-stats `/stats` endpoint. Newer network-stats servers expose
+ * top-level aggregate totals that include inactive historical sellers; fall back
+ * to aggregating active peers for compatibility with older deployments.
  */
 export async function getNetworkStats(networkStatsUrl: string): Promise<NetworkStatsResponse> {
   const url = `${networkStatsUrl.replace(/\/$/, '')}/stats`;
@@ -197,10 +199,31 @@ export async function getNetworkStats(networkStatsUrl: string): Promise<NetworkS
         settlementCount?: number;
       } | null;
     }>;
+    totals?: {
+      totalRequests?: string;
+      totalInputTokens?: string;
+      totalOutputTokens?: string;
+      settlementCount?: number;
+      sellerCount?: number;
+    };
     indexer?: NetworkStatsResponse['indexer'];
   };
   const peers = Array.isArray(body.peers) ? body.peers : [];
-  let activePeers = 0;
+  const activePeers = peers.filter((peer) => peer.onChainStats).length;
+
+  if (body.totals) {
+    return {
+      totals: {
+        activePeers,
+        totalRequests: body.totals.totalRequests ?? '0',
+        totalInputTokens: body.totals.totalInputTokens ?? '0',
+        totalOutputTokens: body.totals.totalOutputTokens ?? '0',
+        totalSettlements: Number(body.totals.settlementCount ?? 0),
+        ...(typeof body.totals.sellerCount === 'number' ? { sellerCount: body.totals.sellerCount } : {}),
+      },
+      indexer: body.indexer,
+    };
+  }
   let totalRequests = 0n;
   let totalInputTokens = 0n;
   let totalOutputTokens = 0n;
@@ -208,7 +231,6 @@ export async function getNetworkStats(networkStatsUrl: string): Promise<NetworkS
   for (const peer of peers) {
     const s = peer.onChainStats;
     if (!s) continue;
-    activePeers += 1;
     try {
       totalRequests += BigInt(s.totalRequests ?? '0');
       totalInputTokens += BigInt(s.totalInputTokens ?? '0');

--- a/apps/payments/web/src/views/DashboardView.tsx
+++ b/apps/payments/web/src/views/DashboardView.tsx
@@ -69,6 +69,7 @@ export function DashboardView({ config }: DashboardViewProps) {
     bigintFromString(networkStats?.totals.totalOutputTokens);
   const networkSettlements = networkStats?.totals.totalSettlements ?? 0;
   const networkPeers = networkStats?.totals.activePeers ?? 0;
+  const networkSellers = networkStats?.totals.sellerCount;
 
   return (
     <div className="dashboard-view">
@@ -85,7 +86,11 @@ export function DashboardView({ config }: DashboardViewProps) {
           <div className="stat-card">
             <div className="stat-card-label">Active peers</div>
             <div className="stat-card-value">{formatNumber(networkPeers)}</div>
-            <div className="stat-card-hint">Sellers with on-chain activity</div>
+            <div className="stat-card-hint">
+              {networkSellers != null
+                ? `${formatNumber(networkSellers)} sellers with lifetime activity`
+                : 'Sellers currently online with on-chain activity'}
+            </div>
           </div>
           <div className="stat-card">
             <div className="stat-card-label">Network requests</div>

--- a/apps/website/src/pages/network.tsx
+++ b/apps/website/src/pages/network.tsx
@@ -312,7 +312,7 @@ export default function PricingPage() {
     const q = query.toLowerCase();
     let list = models.filter(m => {
       if (q && !m.name.toLowerCase().includes(q) && !m.provider.toLowerCase().includes(q) && !m.id.toLowerCase().includes(q) && !m.tags.some(t => t.includes(q))) return false;
-      if (providerFilter && !m.peerNames.includes(providerFilter)) return false;
+      if (providerFilter && m.peerName !== providerFilter) return false;
       if (tagFilter && !m.tags.includes(tagFilter)) return false;
       // Price sliders: 100=Any, lower=stricter
       if (filters.maxInputPct < 100 && m.inputPrice > bounds.maxInput * filters.maxInputPct / 100) return false;

--- a/apps/website/src/pages/network.tsx
+++ b/apps/website/src/pages/network.tsx
@@ -52,9 +52,19 @@ interface PeerMetadata {
   onChainStats?: OnChainStats;
 }
 
+interface NetworkTotals {
+  totalRequests: string;
+  totalInputTokens: string;
+  totalOutputTokens: string;
+  settlementCount: number;
+  sellerCount: number;
+  lastUpdatedAt: number | null;
+}
+
 interface StatsResponse {
   peers: PeerMetadata[];
   updatedAt: string;
+  totals?: NetworkTotals;
 }
 
 /* ── Static model enrichment (logos, context, tags) ───────────────── */
@@ -235,6 +245,7 @@ export default function PricingPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [updatedAt, setUpdatedAt] = useState<string | null>(null);
+  const [networkTotals, setNetworkTotals] = useState<NetworkTotals | null>(null);
   const [query, setQuery] = useState('');
   const [providerFilter, setProviderFilter] = useState<string | null>(null);
   const [tagFilter, setTagFilter] = useState<string | null>(null);
@@ -252,6 +263,7 @@ export default function PricingPage() {
           const data = (await res.json()) as StatsResponse;
           setPeers(data.peers);
           setUpdatedAt(data.updatedAt);
+          setNetworkTotals(data.totals ?? null);
           setLoading(false);
           setError(false);
           return;
@@ -272,7 +284,12 @@ export default function PricingPage() {
   const uniqueServiceCount = useMemo(() => models.map(m => m.serviceId).length, [models]);
 
   // Totals and bounds for stats bar + sliders
-  const totalTokens = useMemo(() => peers.reduce((s, p) => s + parseInt(p.onChainStats?.totalInputTokens ?? '0', 10) + parseInt(p.onChainStats?.totalOutputTokens ?? '0', 10), 0), [peers]);
+  const totalTokens = useMemo(() => {
+    if (networkTotals) {
+      return parseInt(networkTotals.totalInputTokens, 10) + parseInt(networkTotals.totalOutputTokens, 10);
+    }
+    return peers.reduce((s, p) => s + parseInt(p.onChainStats?.totalInputTokens ?? '0', 10) + parseInt(p.onChainStats?.totalOutputTokens ?? '0', 10), 0);
+  }, [networkTotals, peers]);
 
   const bounds = useMemo(() => ({
     maxInput: Math.max(...models.map(m => m.inputPrice), 1),


### PR DESCRIPTION
## Summary
- expose top-level lifetime network totals from network-stats so inactive historical sellers are included
- use those aggregate totals on the website pricing page and payments portal, with active-peer fallback for older stats servers
- fix pricing provider chips so selecting a peer only shows rows from that selected peer

## Validation
- pnpm --filter=@antseed/network-stats build
- pnpm --filter=@antseed/website build
- pnpm --filter=@antseed/payments build