### PR TITLE
Fix assistant response boundaries and streaming anchor

### DIFF
--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -811,27 +811,6 @@ export function initChatModule({
     updateStreamingIndicator();
   }
 
-  // ---------------------------------------------------------------------------
-  // Scroll helper
-  // ---------------------------------------------------------------------------
-
-  function scrollChatToBottom(): void {
-    const container = document.querySelector<HTMLElement>('[data-chat-scroll]');
-    if (!container) return;
-    const threshold = 100;
-    const distanceFromBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight;
-    if (distanceFromBottom < threshold) {
-      container.scrollTop = container.scrollHeight;
-    }
-  }
-
-  function queueScrollChatToBottom(): void {
-    requestAnimationFrame(() => {
-      scrollChatToBottom();
-    });
-  }
-
   function cloneStreamingMessage(message: ChatMessage): ChatMessage {
     return {
       ...message,
@@ -858,7 +837,6 @@ export function initChatModule({
   function setStreamingMessage(message: ChatMessage | null): void {
     uiState.chatStreamingMessage = message ? cloneStreamingMessage(message) : null;
     notifyUiStateChangedSync();
-    if (message) queueScrollChatToBottom();
   }
 
   function getConversationStreamingMessage(convId: string): ChatMessage | null {

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -258,12 +258,20 @@
 
   &.other {
     align-self: stretch;
-    background: transparent;
+    background: color-mix(in srgb, var(--bg-card) 86%, var(--chat-area-bg));
     color: var(--text-primary);
-    border-left: 0;
-    border-radius: 0;
-    width: 100%;
-    padding: 0 16px;
+    border: 1px solid var(--border);
+    border-left: 3px solid rgba(var(--accent-rgb), 0.55);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-sm);
+    width: calc(100% - 32px);
+    padding: 12px 16px 10px;
+    margin: 4px auto 28px;
+
+    &:focus-within {
+      border-color: rgba(var(--accent-rgb), 0.32);
+      border-left-color: rgba(var(--accent-rgb), 0.7);
+    }
 
   :global {
     /* Tool group */
@@ -281,7 +289,7 @@
       left: 8px;
       appearance: none;
       border: 0;
-      background: var(--bg-primary);
+      background: var(--bg-card);
       display: inline-flex;
       align-items: center;
       gap: 4px;
@@ -656,6 +664,55 @@
 .chat-bubble-stats {
   color: var(--text-faint);
   font-size: inherit;
+}
+
+.chatBubbleBody {
+  min-width: 0;
+}
+
+.assistantHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 24px;
+  margin-bottom: 9px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-light);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.assistantAvatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 22px;
+  border-radius: 999px;
+  background: rgba(var(--accent-rgb), 0.12);
+  border: 1px solid rgba(var(--accent-rgb), 0.24);
+  color: var(--accent-green);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.assistantTitle {
+  color: var(--text-secondary);
+  letter-spacing: 0.01em;
+}
+
+.assistantHeader .chat-bubble-stats {
+  margin-left: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: right;
+  font-size: 11px;
+  font-weight: 400;
 }
 
 /* ===================================================================

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -704,13 +704,20 @@ function CopyResponseButton({ content }: { content: unknown }) {
 type ChatBubbleProps = {
   message: ChatMessage;
   streaming?: boolean;
+  streamingAnchor?: boolean;
   onOpenPreview?: (url: string) => void;
   /** Identifies the surrounding conversation so file-block previews can
    *  build `antseed-attachment://<conversationId>/<attachmentId>` URLs. */
   conversationId?: string;
 };
 
-export function ChatBubble({ message, streaming = false, onOpenPreview, conversationId }: ChatBubbleProps) {
+export function ChatBubble({
+  message,
+  streaming = false,
+  streamingAnchor = false,
+  onOpenPreview,
+  conversationId,
+}: ChatBubbleProps) {
   const [metaExpanded, setMetaExpanded] = useState(false);
   const metaParts = useMemo(() => buildChatMetaParts(message), [message]);
   const hasStreamingBlocks = useMemo(
@@ -748,16 +755,31 @@ export function ChatBubble({ message, streaming = false, onOpenPreview, conversa
     return <div className="chat-bubble-content">{JSON.stringify(message.content)}</div>;
   }, [message, isStreamingBubble, messagePrefix, onOpenPreview, conversationId]);
 
+  const isUserMessage = message.role === 'user';
+  const responseLabel = message.role === 'assistant' ? 'Assistant' : 'System';
+  const responseInitial = responseLabel.charAt(0);
   const bubbleMeta =
     metaParts.length > 0 && !isStreamingBubble ? (
       <span className={styles.chatBubbleStats}>{metaParts.join(' · ')}</span>
     ) : null;
 
   return (
-    <div className={`${styles.chatBubble} ${message.role === 'user' ? styles.own : styles.other}`}>
-      {bubbleMeta}
-      <div>{content}</div>
-      {message.role !== 'user' && !isStreamingBubble ? (
+    <div
+      className={`${styles.chatBubble} ${isUserMessage ? styles.own : styles.other}`}
+      data-chat-streaming-response={!isUserMessage && streamingAnchor ? 'true' : undefined}
+    >
+      {isUserMessage ? bubbleMeta : (
+        <div
+          className={styles.assistantHeader}
+          aria-label={isStreamingBubble ? `${responseLabel} response is streaming` : `${responseLabel} response`}
+        >
+          <span className={styles.assistantAvatar} aria-hidden="true">{responseInitial}</span>
+          <span className={styles.assistantTitle}>{responseLabel}</span>
+          {bubbleMeta}
+        </div>
+      )}
+      <div className={styles.chatBubbleBody}>{content}</div>
+      {!isUserMessage && !isStreamingBubble ? (
         <div className={styles.messageActions}>
           <CopyResponseButton content={message.content} />
         </div>

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -172,6 +172,8 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   const lastConversationIdRef = useRef<string | null>(snap.chatActiveConversation);
   const wasActiveRef = useRef<boolean>(active);
   const isUserScrolledUp = useRef(false);
+  const streamingAnchorSeenRef = useRef<string | null>(null);
+  const responseStartAnchoredRef = useRef(false);
   const isDragging = useRef(false);
   const visibleMessages = useMemo(() => {
     const msgs = Array.isArray(snap.chatMessages) ? (snap.chatMessages as ChatMessage[]) : [];
@@ -194,6 +196,9 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     const handleScroll = () => {
       const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
       isUserScrolledUp.current = !atBottom;
+      if (atBottom) {
+        responseStartAnchoredRef.current = false;
+      }
     };
     el.addEventListener('scroll', handleScroll, { passive: true });
     return () => el.removeEventListener('scroll', handleScroll);
@@ -223,15 +228,55 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     }
 
     isUserScrolledUp.current = false;
+    streamingAnchorSeenRef.current = null;
+    responseStartAnchoredRef.current = false;
     scrollChatToBottom();
     const frame = requestAnimationFrame(scrollChatToBottom);
     return () => cancelAnimationFrame(frame);
   }, [active, snap.chatActiveConversation, scrollChatToBottom]);
 
-  // Keep the view pinned to the bottom while the user is already at the bottom.
+  // When a new assistant response starts, anchor the top of that card in view
+  // instead of jumping straight to the newest token. This keeps the user's
+  // prompt and the beginning of the answer easy to find while long responses
+  // stream. If the user scrolls away afterward, keep respecting manual scroll.
   useEffect(() => {
     const el = scrollRef.current;
-    if (!el || isUserScrolledUp.current) {
+    const streamingMessage = snap.chatStreamingMessage as ChatMessage | null;
+    if (!el || !streamingMessage) {
+      if (!streamingMessage) streamingAnchorSeenRef.current = null;
+      return;
+    }
+
+    const routeRequestId =
+      typeof streamingMessage.meta?.routeRequestId === 'string' ? streamingMessage.meta.routeRequestId : '';
+    const createdAt = Number(streamingMessage.createdAt) || 0;
+    const anchorKey = `${snap.chatActiveConversation || 'new'}:${routeRequestId || createdAt || visibleMessages.length}`;
+    if (streamingAnchorSeenRef.current === anchorKey || isUserScrolledUp.current) {
+      return;
+    }
+
+    const frame = requestAnimationFrame(() => {
+      const anchor = el.querySelector<HTMLElement>('[data-chat-streaming-response="true"]');
+      if (!anchor) return;
+      const topPadding = 12;
+      const containerRect = el.getBoundingClientRect();
+      const anchorRect = anchor.getBoundingClientRect();
+      el.scrollTop = Math.max(0, el.scrollTop + anchorRect.top - containerRect.top - topPadding);
+      streamingAnchorSeenRef.current = anchorKey;
+      responseStartAnchoredRef.current = true;
+      isUserScrolledUp.current = false;
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [snap.chatStreamingMessage, visibleMessages.length, snap.chatActiveConversation]);
+
+  // Keep the view pinned to the bottom while the user is already at the bottom,
+  // but do not override the response-start anchor. If the user intentionally
+  // scrolls back to the bottom, the scroll handler clears that anchor and live
+  // token following resumes.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || isUserScrolledUp.current || responseStartAnchoredRef.current) {
       return;
     }
 
@@ -718,6 +763,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                 key={`streaming:${snap.chatActiveConversation || 'new'}`}
                 message={snap.chatStreamingMessage as ChatMessage}
                 streaming
+                streamingAnchor
                 onOpenPreview={handleOpenPreview}
                 conversationId={snap.chatActiveConversation || undefined}
               />


### PR DESCRIPTION
## Summary

This PR fixes the chat readability problem from #424 by making assistant turns visibly bounded and by anchoring new streaming replies at their start instead of immediately chasing the newest token.

### What changed

- Added a subtle assistant/system response card:
  - light card fill
  - 1px border
  - rounded corners
  - soft shadow
  - green left accent edge
  - extra turn spacing
- Added a persistent response header for non-user messages:
  - compact avatar/initial
  - `Assistant` / `System` label
  - existing metadata stays visible on completed responses
  - header appears while streaming too, so users immediately see where the reply begins
- Added a dedicated chat bubble body wrapper so long markdown/tool output remains contained inside the card.
- Improved streaming scroll behavior:
  - when a new assistant response starts, the chat scrolls to the top of that response card
  - the app no longer force-scrolls every streaming token to the bottom from the chat module
  - manual scrollback is still respected
  - if the user scrolls back to the bottom, normal live bottom-follow behavior resumes
- Kept user bubble styling, copy actions, markdown rendering, tool groups, and existing completed-response metadata behavior intact.

## Why

AMOS reported that assistant responses currently read like raw page content: no border, no fill, no header, and no visual anchor. With bottom-pinned streaming, long responses can leave the user looking at the middle/end of an answer with no clear indication where it started.

This PR addresses both sides:

1. visual boundaries make every assistant answer scannable as a distinct turn;
2. response-start anchoring keeps the start of a new answer visible when streaming begins.

Fixes #424

## Files changed

- `apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss`
  - styles assistant cards, header, avatar, body wrapper, and tool header background inside the new card
- `apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx`
  - renders the assistant/system header and exposes a streaming anchor marker
- `apps/desktop/src/renderer/ui/components/views/ChatView.tsx`
  - anchors new streaming responses at the start of the response card while preserving manual scroll behavior
- `apps/desktop/src/renderer/modules/chat.ts`
  - removes the old module-level streaming token bottom-scroll queue so the renderer can own the new scroll policy

## Checks

- `pnpm --filter=@antseed/desktop run typecheck:renderer` ✅
- `pnpm --filter=@antseed/desktop run build:renderer` ✅
- `pnpm --filter=@antseed/api-adapter run build` ✅
- `pnpm --filter=@antseed/node run build` ✅
- `pnpm --filter=@antseed/payments run build:server` ✅
- `pnpm --filter=@antseed/desktop run build:main` ✅
- `pnpm --filter=@antseed/desktop test` ✅ 66 passing tests

Note: `desktop test` emits expected npm `.npmrc` warnings and expected test log lines for mocked network-stats failure cases; all tests pass.

## Merge note

Do not merge until explicitly approved by maintainers.
