### PR TITLE
Fix desktop multi-provider service pricing

### DIFF
--- a/apps/desktop/src/main/chat-service-catalog.ts
+++ b/apps/desktop/src/main/chat-service-catalog.ts
@@ -1,0 +1,252 @@
+export type ChatServiceProtocol = 'anthropic-messages' | 'openai-chat-completions' | 'openai-responses';
+
+export type NetworkPeerAddress = {
+  peerId?: string;
+  displayName?: string;
+  host: string;
+  port: number;
+  providers?: string[];
+  services?: string[];
+  providerServiceApiProtocols?: Record<string, { services: Record<string, string[]> }>;
+  providerPricing?: Record<string, {
+    defaults?: {
+      inputUsdPerMillion?: number;
+      outputUsdPerMillion?: number;
+      cachedInputUsdPerMillion?: number;
+      input?: number;
+      output?: number;
+    };
+    services?: Record<string, {
+      inputUsdPerMillion?: number;
+      outputUsdPerMillion?: number;
+      cachedInputUsdPerMillion?: number;
+      input?: number;
+      output?: number;
+    }>;
+  }>;
+  providerServiceCategories?: Record<string, { services: Record<string, string[]> }>;
+  defaultInputUsdPerMillion?: number;
+  defaultOutputUsdPerMillion?: number;
+};
+
+export type ChatServiceCatalogEntry = {
+  id: string;
+  label: string;
+  provider: string;
+  protocol: ChatServiceProtocol;
+  count: number;
+  peerId?: string;
+  peerLabel?: string;
+  inputUsdPerMillion?: number;
+  outputUsdPerMillion?: number;
+  categories?: string[];
+  description?: string;
+};
+
+const VALID_CHAT_SERVICE_PROTOCOLS = new Set<string>([
+  'anthropic-messages', 'openai-chat-completions', 'openai-responses',
+]);
+
+export function inferProviderProtocol(provider: string): ChatServiceProtocol | null {
+  if (provider === 'openai-responses') {
+    return 'openai-responses';
+  }
+  if (provider === 'openai' || provider === 'openrouter' || provider === 'local-llm') {
+    return 'openai-chat-completions';
+  }
+  if (provider === 'anthropic' || provider === 'claude-code' || provider === 'claude-oauth') {
+    return 'anthropic-messages';
+  }
+  return null;
+}
+
+export function resolveProviderServiceProtocol(
+  apiProtocols: NetworkPeerAddress['providerServiceApiProtocols'],
+  provider: string,
+  serviceId: string,
+): ChatServiceProtocol | null {
+  const protocols = apiProtocols?.[provider]?.services?.[serviceId];
+  if (!Array.isArray(protocols)) return null;
+  for (const p of protocols) {
+    if (VALID_CHAT_SERVICE_PROTOCOLS.has(p)) {
+      return p as ChatServiceProtocol;
+    }
+  }
+  return null;
+}
+
+export function resolveProviderServicePricing(
+  pricingMap: NetworkPeerAddress['providerPricing'],
+  provider: string,
+  serviceId: string,
+  defaultInput?: number,
+  defaultOutput?: number,
+): { inputUsdPerMillion?: number; outputUsdPerMillion?: number } {
+  const providerPricing = pricingMap?.[provider];
+  const servicePricing = providerPricing?.services?.[serviceId];
+  const defaultPricing = providerPricing?.defaults;
+  const inputUsd = servicePricing?.inputUsdPerMillion
+    ?? servicePricing?.input
+    ?? defaultPricing?.inputUsdPerMillion
+    ?? defaultPricing?.input
+    ?? defaultInput;
+  const outputUsd = servicePricing?.outputUsdPerMillion
+    ?? servicePricing?.output
+    ?? defaultPricing?.outputUsdPerMillion
+    ?? defaultPricing?.output
+    ?? defaultOutput;
+  return {
+    ...(inputUsd != null ? { inputUsdPerMillion: inputUsd } : {}),
+    ...(outputUsd != null ? { outputUsdPerMillion: outputUsd } : {}),
+  };
+}
+
+export function sortChatServiceCatalogEntries(entries: ChatServiceCatalogEntry[]): ChatServiceCatalogEntry[] {
+  const protocolRank = (protocol: ChatServiceProtocol): number => (
+    protocol === 'anthropic-messages'
+      ? 0
+      : protocol === 'openai-chat-completions'
+        ? 1
+        : 2
+  );
+
+  return entries.sort((a, b) => {
+    if (b.count !== a.count) {
+      return b.count - a.count;
+    }
+    if (protocolRank(a.protocol) !== protocolRank(b.protocol)) {
+      return protocolRank(a.protocol) - protocolRank(b.protocol);
+    }
+    if (a.provider !== b.provider) {
+      return a.provider.localeCompare(b.provider);
+    }
+    return a.id.localeCompare(b.id);
+  });
+}
+
+export function buildChatServiceCatalogFromPeers(peers: NetworkPeerAddress[]): ChatServiceCatalogEntry[] {
+  const results: ChatServiceCatalogEntry[] = [];
+  for (const peer of peers) {
+    const peerId = peer.peerId;
+    const peerLabel = peer.displayName
+      ? `${peer.displayName} (${peerId?.slice(0, 8) ?? ''})`
+      : peerId ? peerId.slice(0, 12) + '...' : undefined;
+
+    const providerList = peer.providers ?? [];
+    const serviceList = peer.services ?? [];
+    const apiProtocols = peer.providerServiceApiProtocols;
+    const pricingMap = peer.providerPricing;
+    const categoriesMap = peer.providerServiceCategories;
+    const defaultInput = peer.defaultInputUsdPerMillion;
+    const defaultOutput = peer.defaultOutputUsdPerMillion;
+
+    if (providerList.length > 0) {
+      // Build rows from each provider's own announced service map. The flattened
+      // `peer.services` list is peer-wide, so pairing every service with
+      // providerList[0] makes services belonging to a second provider inherit
+      // the first provider's defaults/pricing.
+      const emittedProviderServices = new Set<string>();
+      for (const provider of providerList) {
+        const providerServiceIds = new Set<string>([
+          ...Object.keys(pricingMap?.[provider]?.services ?? {}),
+          ...Object.keys(apiProtocols?.[provider]?.services ?? {}),
+          ...Object.keys(categoriesMap?.[provider]?.services ?? {}),
+        ]);
+
+        for (const serviceId of providerServiceIds) {
+          emittedProviderServices.add(`${provider}\u0000${serviceId}`);
+          const protocol = resolveProviderServiceProtocol(apiProtocols, provider, serviceId) ?? inferProviderProtocol(provider);
+          if (!protocol) continue;
+
+          const { inputUsdPerMillion, outputUsdPerMillion } = resolveProviderServicePricing(
+            pricingMap,
+            provider,
+            serviceId,
+            defaultInput,
+            defaultOutput,
+          );
+          const categories = categoriesMap?.[provider]?.services?.[serviceId];
+
+          results.push({
+            id: serviceId,
+            label: serviceId,
+            provider,
+            protocol,
+            count: 1,
+            ...(peerId ? { peerId } : {}),
+            ...(peerLabel ? { peerLabel } : {}),
+            ...(inputUsdPerMillion != null ? { inputUsdPerMillion } : {}),
+            ...(outputUsdPerMillion != null ? { outputUsdPerMillion } : {}),
+            ...(categories?.length ? { categories } : {}),
+          });
+        }
+      }
+
+      // Backward-compatible fallback for older state files that only contain a
+      // peer-wide `services` array. In that ambiguous shape we keep the old
+      // first-provider behavior, but do not override provider-specific rows
+      // already emitted above.
+      if (serviceList.length > 0) {
+        const fallbackProvider = providerList[0] ?? 'unknown';
+        for (const serviceId of serviceList) {
+          if (emittedProviderServices.size > 0 && emittedProviderServices.has(`${fallbackProvider}\u0000${serviceId}`)) {
+            continue;
+          }
+          if (emittedProviderServices.size > 0) {
+            continue;
+          }
+          const protocol = resolveProviderServiceProtocol(apiProtocols, fallbackProvider, serviceId) ?? inferProviderProtocol(fallbackProvider);
+          if (!protocol) continue;
+          const { inputUsdPerMillion, outputUsdPerMillion } = resolveProviderServicePricing(
+            pricingMap,
+            fallbackProvider,
+            serviceId,
+            defaultInput,
+            defaultOutput,
+          );
+          const categories = categoriesMap?.[fallbackProvider]?.services?.[serviceId];
+
+          results.push({
+            id: serviceId,
+            label: serviceId,
+            provider: fallbackProvider,
+            protocol,
+            count: 1,
+            ...(peerId ? { peerId } : {}),
+            ...(peerLabel ? { peerLabel } : {}),
+            ...(inputUsdPerMillion != null ? { inputUsdPerMillion } : {}),
+            ...(outputUsdPerMillion != null ? { outputUsdPerMillion } : {}),
+            ...(categories?.length ? { categories } : {}),
+          });
+        }
+      } else {
+        // No services listed — create one entry per provider as a fallback.
+        for (const provider of providerList) {
+          const protocol = inferProviderProtocol(provider);
+          if (!protocol) continue;
+
+          const { inputUsdPerMillion, outputUsdPerMillion } = resolveProviderServicePricing(
+            pricingMap,
+            provider,
+            provider,
+            defaultInput,
+            defaultOutput,
+          );
+          results.push({
+            id: provider,
+            label: provider,
+            provider,
+            protocol,
+            count: 1,
+            ...(peerId ? { peerId } : {}),
+            ...(peerLabel ? { peerLabel } : {}),
+            ...(inputUsdPerMillion != null ? { inputUsdPerMillion } : {}),
+            ...(outputUsdPerMillion != null ? { outputUsdPerMillion } : {}),
+          });
+        }
+      }
+    }
+  }
+
+  return sortChatServiceCatalogEntries(results);
+}

--- a/apps/desktop/src/main/pi-chat-engine.discover-catalog.test.ts
+++ b/apps/desktop/src/main/pi-chat-engine.discover-catalog.test.ts
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildChatServiceCatalogFromPeers } from './chat-service-catalog.js';
+
+test('buildChatServiceCatalogFromPeers keeps provider-specific service pricing for multi-provider peers', () => {
+  const peerId = 'a'.repeat(40);
+  const catalog = buildChatServiceCatalogFromPeers([{
+    peerId,
+    displayName: 'darksignal',
+    host: '127.0.0.1',
+    port: 6882,
+    providers: ['anthropic', 'openai'],
+    services: ['claude-sonnet-4-5-20250929', 'gpt-4o-mini'],
+    providerPricing: {
+      anthropic: {
+        defaults: { inputUsdPerMillion: 10, outputUsdPerMillion: 20 },
+        services: {
+          'claude-sonnet-4-5-20250929': { inputUsdPerMillion: 11, outputUsdPerMillion: 21 },
+        },
+      },
+      openai: {
+        defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 2 },
+        services: {
+          'gpt-4o-mini': { inputUsdPerMillion: 0.15, outputUsdPerMillion: 0.6 },
+        },
+      },
+    },
+    providerServiceApiProtocols: {
+      anthropic: { services: { 'claude-sonnet-4-5-20250929': ['anthropic-messages'] } },
+      openai: { services: { 'gpt-4o-mini': ['openai-chat-completions'] } },
+    },
+  }]);
+
+  const anthropic = catalog.find((entry) => entry.provider === 'anthropic' && entry.id === 'claude-sonnet-4-5-20250929');
+  const openai = catalog.find((entry) => entry.provider === 'openai' && entry.id === 'gpt-4o-mini');
+
+  assert.ok(anthropic);
+  assert.ok(openai);
+  assert.equal(anthropic!.inputUsdPerMillion, 11);
+  assert.equal(anthropic!.outputUsdPerMillion, 21);
+  assert.equal(openai!.inputUsdPerMillion, 0.15);
+  assert.equal(openai!.outputUsdPerMillion, 0.6);
+  assert.equal(openai!.protocol, 'openai-chat-completions');
+});
+
+test('buildChatServiceCatalogFromPeers falls back to each provider defaults for unpriced provider-specific services', () => {
+  const peerId = 'b'.repeat(40);
+  const catalog = buildChatServiceCatalogFromPeers([{
+    peerId,
+    host: '127.0.0.1',
+    port: 6882,
+    providers: ['anthropic', 'openai'],
+    providerPricing: {
+      anthropic: {
+        defaults: { inputUsdPerMillion: 10, outputUsdPerMillion: 20 },
+        services: { 'claude-haiku': {} },
+      },
+      openai: {
+        defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 2 },
+        services: { 'gpt-4o-mini': {} },
+      },
+    },
+    providerServiceApiProtocols: {
+      anthropic: { services: { 'claude-haiku': ['anthropic-messages'] } },
+      openai: { services: { 'gpt-4o-mini': ['openai-chat-completions'] } },
+    },
+  }]);
+
+  const openai = catalog.find((entry) => entry.provider === 'openai' && entry.id === 'gpt-4o-mini');
+
+  assert.ok(openai);
+  assert.equal(openai!.inputUsdPerMillion, 1);
+  assert.equal(openai!.outputUsdPerMillion, 2);
+});

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -45,6 +45,13 @@ import {
 import { DEFAULT_BUYER_STATE_PATH } from './constants.js';
 import { PROXY_PROVIDER_ID, normalizeProviderId, sanitizeProviderHint } from './chat-provider-hint.js';
 import { asErrorMessage } from './utils.js';
+import {
+  buildChatServiceCatalogFromPeers,
+  sortChatServiceCatalogEntries,
+  type ChatServiceCatalogEntry,
+  type ChatServiceProtocol,
+  type NetworkPeerAddress,
+} from './chat-service-catalog.js';
 import { StakingClient, ChannelsClient, resolveChainConfig } from '@antseed/node';
 import {
   AuthStorage,
@@ -181,36 +188,6 @@ type ActiveRun = {
   unsubscribe: () => void;
 };
 
-type NetworkPeerAddress = {
-  peerId?: string;
-  displayName?: string;
-  host: string;
-  port: number;
-  providers?: string[];
-  services?: string[];
-  providerServiceApiProtocols?: Record<string, { services: Record<string, string[]> }>;
-  providerPricing?: Record<string, { services: Record<string, { input: number; output: number }> }>;
-  providerServiceCategories?: Record<string, { services: Record<string, string[]> }>;
-  defaultInputUsdPerMillion?: number;
-  defaultOutputUsdPerMillion?: number;
-};
-
-type ChatServiceProtocol = 'anthropic-messages' | 'openai-chat-completions' | 'openai-responses';
-
-type ChatServiceCatalogEntry = {
-  id: string;
-  label: string;
-  provider: string;
-  protocol: ChatServiceProtocol;
-  count: number;
-  peerId?: string;
-  peerLabel?: string;
-  inputUsdPerMillion?: number;
-  outputUsdPerMillion?: number;
-  categories?: string[];
-  description?: string;
-};
-
 function augmentChatToolPath(): void {
   const currentPath = process.env['PATH'] ?? '';
   const segments = currentPath
@@ -330,45 +307,6 @@ function isChatServiceProtocol(value: unknown): value is ChatServiceProtocol {
     || value === 'openai-responses';
 }
 
-function inferProviderProtocol(provider: string): ChatServiceProtocol | null {
-  if (provider === 'openai-responses') {
-    return 'openai-responses';
-  }
-  if (provider === 'openai' || provider === 'openrouter' || provider === 'local-llm') {
-    return 'openai-chat-completions';
-  }
-  if (provider === 'anthropic' || provider === 'claude-code' || provider === 'claude-oauth') {
-    return 'anthropic-messages';
-  }
-  return null;
-}
-
-const VALID_CHAT_SERVICE_PROTOCOLS = new Set<string>([
-  'anthropic-messages', 'openai-chat-completions', 'openai-responses',
-]);
-
-/**
- * Resolve protocol for a service from the peer's announced providerServiceApiProtocols metadata.
- * Returns the first recognized chat protocol, or null if not found.
- */
-function resolveServiceProtocol(
-  apiProtocols: NetworkPeerAddress['providerServiceApiProtocols'],
-  serviceId: string,
-): ChatServiceProtocol | null {
-  if (!apiProtocols) return null;
-  for (const providerEntry of Object.values(apiProtocols)) {
-    const protocols = providerEntry?.services?.[serviceId];
-    if (Array.isArray(protocols)) {
-      for (const p of protocols) {
-        if (VALID_CHAT_SERVICE_PROTOCOLS.has(p)) {
-          return p as ChatServiceProtocol;
-        }
-      }
-    }
-  }
-  return null;
-}
-
 function normalizeServiceValue(value: unknown): string | null {
   if (typeof value !== 'string') {
     return null;
@@ -486,29 +424,6 @@ function normalizeChatServiceCatalogEntries(rawEntries: unknown[]): ChatServiceC
   return sortChatServiceCatalogEntries([...deduped.values()]);
 }
 
-function sortChatServiceCatalogEntries(entries: ChatServiceCatalogEntry[]): ChatServiceCatalogEntry[] {
-  const protocolRank = (protocol: ChatServiceProtocol): number => (
-    protocol === 'anthropic-messages'
-      ? 0
-      : protocol === 'openai-chat-completions'
-        ? 1
-        : 2
-  );
-
-  return entries.sort((a, b) => {
-    if (b.count !== a.count) {
-      return b.count - a.count;
-    }
-    if (protocolRank(a.protocol) !== protocolRank(b.protocol)) {
-      return protocolRank(a.protocol) - protocolRank(b.protocol);
-    }
-    if (a.provider !== b.provider) {
-      return a.provider.localeCompare(b.provider);
-    }
-    return a.id.localeCompare(b.id);
-  });
-}
-
 function limitChatServiceCatalogEntries(entries: ChatServiceCatalogEntry[]): ChatServiceCatalogEntry[] {
   if (entries.length <= CHAT_SERVICE_MAX_OPTIONS) {
     return entries;
@@ -589,69 +504,7 @@ async function discoverChatServiceCatalog(
     }
   }
 
-  const results: ChatServiceCatalogEntry[] = [];
-  for (const peer of peers) {
-    const peerId = peer.peerId;
-    const peerLabel = peer.displayName
-      ? `${peer.displayName} (${peerId?.slice(0, 8) ?? ''})`
-      : peerId ? peerId.slice(0, 12) + '...' : undefined;
-
-    const providerList = peer.providers ?? [];
-    const serviceList = peer.services ?? [];
-    const apiProtocols = peer.providerServiceApiProtocols;
-    const pricingMap = peer.providerPricing;
-    const categoriesMap = peer.providerServiceCategories;
-    const defaultInput = peer.defaultInputUsdPerMillion;
-    const defaultOutput = peer.defaultOutputUsdPerMillion;
-
-    if (serviceList.length > 0) {
-      // Use explicit service names when available.
-      for (const serviceId of serviceList) {
-        const provider = providerList[0] ?? 'unknown';
-        // Resolve protocol: first check peer metadata, then fall back to inference from provider name.
-        const protocol = resolveServiceProtocol(apiProtocols, serviceId) ?? inferProviderProtocol(provider);
-        if (!protocol) continue;
-
-        const providerPricing = pricingMap?.[provider]?.services?.[serviceId] as Record<string, unknown> | undefined;
-        const inputUsd = (providerPricing?.inputUsdPerMillion as number | undefined) ?? (providerPricing?.input as number | undefined) ?? defaultInput;
-        const outputUsd = (providerPricing?.outputUsdPerMillion as number | undefined) ?? (providerPricing?.output as number | undefined) ?? defaultOutput;
-        const categories = categoriesMap?.[provider]?.services?.[serviceId];
-
-        results.push({
-          id: serviceId,
-          label: serviceId,
-          provider,
-          protocol,
-          count: 1,
-          peerId,
-          peerLabel,
-          ...(inputUsd != null ? { inputUsdPerMillion: inputUsd } : {}),
-          ...(outputUsd != null ? { outputUsdPerMillion: outputUsd } : {}),
-          ...(categories?.length ? { categories } : {}),
-        });
-      }
-    } else if (providerList.length > 0) {
-      // No services listed — create one entry per provider as a fallback.
-      for (const provider of providerList) {
-        const protocol = inferProviderProtocol(provider);
-        if (!protocol) continue;
-
-        results.push({
-          id: provider,
-          label: provider,
-          provider,
-          protocol,
-          count: 1,
-          peerId,
-          peerLabel,
-          ...(defaultInput != null ? { inputUsdPerMillion: defaultInput } : {}),
-          ...(defaultOutput != null ? { outputUsdPerMillion: defaultOutput } : {}),
-        });
-      }
-    }
-  }
-
-  return sortChatServiceCatalogEntries(results);
+  return buildChatServiceCatalogFromPeers(peers);
 }
 
 type OnChainPeerEnrichment = {


### PR DESCRIPTION
## Summary
- Build desktop chat service catalog from provider-specific service maps instead of pairing flattened services with the first provider
- Preserve each provider's own service pricing, default pricing, protocol, and categories
- Add regression coverage for multi-provider peers like darksignal

## Tests
- pnpm -C apps/desktop build:main
- node --test apps/desktop/dist/main/pi-chat-engine.discover-catalog.test.js