### PR TITLE
Fix payments portal deposit scroll and wallet actions

### DIFF
--- a/apps/desktop/src/renderer/ui/components/TitleBar.tsx
+++ b/apps/desktop/src/renderer/ui/components/TitleBar.tsx
@@ -74,7 +74,12 @@ export function TitleBar() {
     ? `$${parseFloat(creditsAvailableUsdc).toFixed(2)}`
     : '$0.00';
 
-  const handleAddCredits = useCallback(() => {
+  const handleManageCredits = useCallback(() => {
+    setCreditsDropdownOpen(false);
+    actions.openPaymentsPortal?.();
+  }, [actions]);
+
+  const handleDepositCredits = useCallback(() => {
     setCreditsDropdownOpen(false);
     actions.openPaymentsPortal?.('deposit');
   }, [actions]);
@@ -164,8 +169,11 @@ export function TitleBar() {
                 )}
               </div>
               <div className={styles.creditsDropdownActions}>
-                <button className={styles.creditsDropdownAddBtn} onClick={handleAddCredits}>
+                <button className={styles.creditsDropdownManageBtn} onClick={handleManageCredits}>
                   Manage
+                </button>
+                <button className={styles.creditsDropdownAddBtn} onClick={handleDepositCredits}>
+                  Deposit
                 </button>
               </div>
             </div>

--- a/apps/payments/web/src/App.tsx
+++ b/apps/payments/web/src/App.tsx
@@ -186,6 +186,7 @@ function AppShell({
   refreshBalance,
 }: AppShellProps) {
   const [justDeposited, setJustDeposited] = useState(false);
+  const [depositPromptDismissed, setDepositPromptDismissed] = useState(false);
 
   const isLoading = !balanceLoaded;
   const isEmptyBuyer =
@@ -196,7 +197,7 @@ function AppShell({
 
   let overlayPhase: OverlayPhase = null;
   if (justDeposited) overlayPhase = 'success';
-  else if (isEmptyBuyer) overlayPhase = 'deposit';
+  else if (isEmptyBuyer && !depositPromptDismissed) overlayPhase = 'deposit';
 
   const shellBlurred = isLoading || overlayPhase !== null;
 
@@ -207,6 +208,7 @@ function AppShell({
   }, [refreshBalance, onCloseActionModal]);
 
   const dismissSuccess = useCallback(() => setJustDeposited(false), []);
+  const dismissDepositPrompt = useCallback(() => setDepositPromptDismissed(true), []);
 
   return (
     <>
@@ -250,6 +252,7 @@ function AppShell({
         buyerAddress={buyerEvmAddress}
         onDeposited={handleDeposited}
         onContinue={dismissSuccess}
+        onDismissDeposit={dismissDepositPrompt}
       />
       <ActionModal
         isOpen={actionModal === 'deposit'}

--- a/apps/payments/web/src/hooks/useBodyScrollLock.ts
+++ b/apps/payments/web/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+let lockCount = 0;
+let previousOverflow = '';
+
+function lockBodyScroll() {
+  if (lockCount === 0) {
+    previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+  }
+  lockCount += 1;
+}
+
+function unlockBodyScroll() {
+  lockCount = Math.max(0, lockCount - 1);
+  if (lockCount === 0) {
+    document.body.style.overflow = previousOverflow;
+    previousOverflow = '';
+  }
+}
+
+export function useBodyScrollLock(isLocked: boolean) {
+  useEffect(() => {
+    if (!isLocked) return;
+    lockBodyScroll();
+    return unlockBodyScroll;
+  }, [isLocked]);
+}

--- a/apps/payments/web/src/layout/ActionModal.tsx
+++ b/apps/payments/web/src/layout/ActionModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, type ReactNode } from 'react';
+import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
 
 interface ActionModalProps {
   isOpen: boolean;
@@ -30,14 +31,7 @@ export function ActionModal({ isOpen, onClose, title, subtitle, variant = 'defau
     return () => window.removeEventListener('keydown', onKey, true);
   }, [isOpen, onClose]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [isOpen]);
+  useBodyScrollLock(isOpen);
 
   if (!isOpen) return null;
 

--- a/apps/payments/web/src/layout/EmptyStateOverlay.tsx
+++ b/apps/payments/web/src/layout/EmptyStateOverlay.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
 import type { BalanceData, PaymentConfig } from '../types';
 import { DepositView } from '../components/DepositView';
 import type { OverlayPhase } from '../App';
@@ -10,6 +11,7 @@ interface EmptyStateOverlayProps {
   buyerAddress: string | null;
   onDeposited: () => void;
   onContinue: () => void;
+  onDismissDeposit?: () => void;
 }
 
 function CopyIcon() {
@@ -25,6 +27,14 @@ function CheckIcon() {
   return (
     <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
       <path d="M3.5 8.5L6.5 11.5L12.5 5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M4 4L12 12M12 4L4 12" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
     </svg>
   );
 }
@@ -45,19 +55,13 @@ export function EmptyStateOverlay({
   buyerAddress,
   onDeposited,
   onContinue,
+  onDismissDeposit,
 }: EmptyStateOverlayProps) {
   const [copied, setCopied] = useState(false);
 
   const isVisible = phase !== null;
 
-  useEffect(() => {
-    if (!isVisible) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [isVisible]);
+  useBodyScrollLock(isVisible);
 
   if (!isVisible) return null;
 
@@ -77,6 +81,16 @@ export function EmptyStateOverlay({
       <div className="empty-state-card">
         {phase === 'deposit' ? (
           <>
+            {onDismissDeposit && (
+              <button
+                type="button"
+                className="empty-state-close"
+                onClick={onDismissDeposit}
+                aria-label="Close deposit prompt"
+              >
+                <CloseIcon />
+              </button>
+            )}
             <div className="empty-state-header">
               <div className="empty-state-eyebrow">Welcome to AntSeed</div>
               <h2 className="empty-state-title">Fund your AntSeed account</h2>

--- a/apps/payments/web/src/layout/LoaderOverlay.tsx
+++ b/apps/payments/web/src/layout/LoaderOverlay.tsx
@@ -1,18 +1,11 @@
-import { useEffect } from 'react';
+import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
 
 interface LoaderOverlayProps {
   isVisible: boolean;
 }
 
 export function LoaderOverlay({ isVisible }: LoaderOverlayProps) {
-  useEffect(() => {
-    if (!isVisible) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [isVisible]);
+  useBodyScrollLock(isVisible);
 
   if (!isVisible) return null;
 

--- a/apps/payments/web/src/layout/WalletDrawer.tsx
+++ b/apps/payments/web/src/layout/WalletDrawer.tsx
@@ -6,6 +6,7 @@ import { useSetOperator, useTransferOperator } from '../hooks/useSetOperator';
 import { useAuthorizedWallet } from '../context/AuthorizedWalletContext';
 import { Button } from '../components/Button';
 import { InfoHint } from '../components/InfoHint';
+import { useBodyScrollLock } from '../hooks/useBodyScrollLock';
 
 interface WalletDrawerProps {
   isOpen: boolean;
@@ -104,14 +105,7 @@ export function WalletDrawer({
     return () => window.removeEventListener('keydown', onKey);
   }, [isOpen, onClose]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [isOpen]);
+  useBodyScrollLock(isOpen);
 
   const hasOperator = Boolean(
     onChainOperator && onChainOperator.toLowerCase() !== ZERO_ADDR,

--- a/apps/payments/web/src/styles/global.scss
+++ b/apps/payments/web/src/styles/global.scss
@@ -1352,6 +1352,7 @@ $dash-sidebar-width: 240px;
   overflow-y: auto;
   overflow-x: hidden;
   display: flex;
+  position: relative;
   flex-direction: column;
   gap: 20px;
   padding: 26px 26px 22px;
@@ -1375,6 +1376,29 @@ $dash-sidebar-width: 240px;
   /* Drop redundant header text — the modal header and signer block already cover it */
   .deposit .card-section-title { display: none; }
   .deposit .wallet-role-hint { display: none; }
+}
+
+.empty-state-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  border: 1px solid var(--card-border);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color 0.14s, background 0.14s, border-color 0.14s;
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--accent);
+    background: var(--card-hover, rgba(148, 163, 184, 0.08));
+  }
 }
 
 .empty-state-header {


### PR DESCRIPTION
## Summary
- replace per-overlay body overflow toggles with a shared reference-counted scroll lock
- allow the first-time deposit prompt to be dismissed without depositing
- split the desktop credits dropdown into separate Manage and Deposit actions

## Testing
- pnpm --filter=@antseed/payments run typecheck
- pnpm --filter=@antseed/desktop run typecheck:renderer