### PR TITLE
Prepare assistant turn activity separation foundation

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -9,6 +9,7 @@ import styles from './ChatBubble.module.scss';
 import { AttachmentViewer, type ViewerAttachment } from './AttachmentViewer';
 import type { ChatMessage, ContentBlock } from './chat-shared';
 import {
+  buildAssistantTurnContent,
   buildChatMetaParts,
   formatToolExecutionLabel,
   getMyrmecochoryLabel,
@@ -652,7 +653,7 @@ function extractPlainText(content: unknown): string {
   return '';
 }
 
-function CopyResponseButton({ content }: { content: unknown }) {
+function CopyResponseButton({ message }: { message: ChatMessage }) {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
 
@@ -663,14 +664,17 @@ function CopyResponseButton({ content }: { content: unknown }) {
   }, []);
 
   const handleCopy = useCallback(() => {
-    const text = extractPlainText(content);
+    const copyContent = message.role === 'assistant'
+      ? buildAssistantTurnContent(message.content).responseBlocks
+      : message.content;
+    const text = extractPlainText(copyContent);
     if (!text) return;
     navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
       if (timerRef.current !== null) window.clearTimeout(timerRef.current);
       timerRef.current = window.setTimeout(() => setCopied(false), 2000);
     }).catch(() => {/* clipboard denied — silently ignore */});
-  }, [content]);
+  }, [message]);
 
   return (
     <Tooltip.Provider delayDuration={300}>
@@ -731,10 +735,9 @@ export function ChatBubble({ message, streaming = false, onOpenPreview, conversa
 
   const content = useMemo(() => {
     if (message.role === 'assistant') {
-      if (Array.isArray(message.content)) {
-        return renderAssistantBlocks(message.content as ContentBlock[], isStreamingBubble, messagePrefix, onOpenPreview, conversationId);
-      }
-      return <MarkdownContent text={String(message.content)} />;
+      const assistantTurnContent = buildAssistantTurnContent(message.content);
+      const inlineBlocks = assistantTurnContent.orderedParts.map((part) => part.block);
+      return renderAssistantBlocks(inlineBlocks, isStreamingBubble, messagePrefix, onOpenPreview, conversationId);
     }
 
     if (typeof message.content === 'string') {
@@ -759,7 +762,7 @@ export function ChatBubble({ message, streaming = false, onOpenPreview, conversa
       <div>{content}</div>
       {message.role !== 'user' && !isStreamingBubble ? (
         <div className={styles.messageActions}>
-          <CopyResponseButton content={message.content} />
+          <CopyResponseButton message={message} />
         </div>
       ) : null}
     </div>

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -665,7 +665,7 @@ function CopyResponseButton({ message }: { message: ChatMessage }) {
 
   const handleCopy = useCallback(() => {
     const copyContent = message.role === 'assistant'
-      ? buildAssistantTurnContent(message.content).responseBlocks
+      ? buildAssistantTurnContent(message.content).finalResponseBlocks
       : message.content;
     const text = extractPlainText(copyContent);
     if (!text) return;

--- a/apps/desktop/src/renderer/ui/components/chat/chat-shared.test.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-shared.test.ts
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  buildAssistantTurnContent,
   hasAssistantProcessContent,
   hasAssistantResponseContent,
   isAssistantProcessBlock,
@@ -25,6 +26,20 @@ test('assistant content split separates response blocks from background process 
 
   assert.deepEqual(parts.responseBlocks.map((block) => block.type), ['text', 'image']);
   assert.deepEqual(parts.processBlocks.map((block) => block.type), ['thinking', 'tool_use', 'tool_result']);
+});
+
+test('assistant turn content preserves original order while annotating response/process lanes', () => {
+  const turn = buildAssistantTurnContent([
+    { type: 'thinking', thinking: 'checking' },
+    { type: 'text', text: 'First answer chunk' },
+    { type: 'tool_use', id: 'tool-1', name: 'read' },
+    { type: 'text', text: 'Second answer chunk' },
+  ]);
+
+  assert.deepEqual(turn.orderedParts.map((part) => part.kind), ['process', 'response', 'process', 'response']);
+  assert.deepEqual(turn.orderedParts.map((part) => part.block.type), ['thinking', 'text', 'tool_use', 'text']);
+  assert.deepEqual(turn.responseBlocks.map((block) => block.type), ['text', 'text']);
+  assert.deepEqual(turn.processBlocks.map((block) => block.type), ['thinking', 'tool_use']);
 });
 
 test('assistant process block predicate is centralized for reasoning and tools', () => {

--- a/apps/desktop/src/renderer/ui/components/chat/chat-shared.test.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-shared.test.ts
@@ -1,0 +1,86 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  hasAssistantProcessContent,
+  hasAssistantResponseContent,
+  isAssistantProcessBlock,
+  isAssistantResponseBlock,
+  splitAssistantContentBlocks,
+  splitAssistantMessageContent,
+  type ChatMessage,
+  type ContentBlock,
+} from './chat-shared.js';
+
+test('assistant content split separates response blocks from background process blocks', () => {
+  const blocks: ContentBlock[] = [
+    { type: 'thinking', thinking: 'checking context' },
+    { type: 'tool_use', id: 'tool-1', name: 'read', input: { path: 'README.md' } },
+    { type: 'text', text: 'Final answer' },
+    { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'abc' } },
+    { type: 'tool_result', tool_use_id: 'tool-1', content: 'file contents' },
+  ];
+
+  const parts = splitAssistantContentBlocks(blocks);
+
+  assert.deepEqual(parts.responseBlocks.map((block) => block.type), ['text', 'image']);
+  assert.deepEqual(parts.processBlocks.map((block) => block.type), ['thinking', 'tool_use', 'tool_result']);
+});
+
+test('assistant process block predicate is centralized for reasoning and tools', () => {
+  assert.equal(isAssistantProcessBlock({ type: 'thinking', thinking: 'x' }), true);
+  assert.equal(isAssistantProcessBlock({ type: 'tool_use', name: 'bash' }), true);
+  assert.equal(isAssistantProcessBlock({ type: 'tool_result', content: 'ok' }), true);
+  assert.equal(isAssistantProcessBlock({ type: 'text', text: 'answer' }), false);
+  assert.equal(isAssistantResponseBlock({ type: 'text', text: 'answer' }), true);
+});
+
+test('unknown block types stay in the response path as a safe fallback', () => {
+  const parts = splitAssistantContentBlocks([
+    { type: 'custom_future_block', content: 'keep visible until intentionally routed' },
+  ]);
+
+  assert.deepEqual(parts.responseBlocks.map((block) => block.type), ['custom_future_block']);
+  assert.deepEqual(parts.processBlocks, []);
+});
+
+test('string assistant content is treated as response content', () => {
+  const parts = splitAssistantMessageContent({ role: 'assistant', content: 'plain response' });
+
+  assert.deepEqual(parts.responseBlocks, [{ type: 'text', text: 'plain response' }]);
+  assert.deepEqual(parts.processBlocks, []);
+});
+
+test('non-assistant messages never expose process blocks', () => {
+  const message: ChatMessage = {
+    role: 'user',
+    content: [
+      { type: 'text', text: 'hello' },
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'result' },
+    ],
+  };
+
+  const parts = splitAssistantMessageContent(message);
+
+  assert.deepEqual(parts.responseBlocks.map((block) => block.type), ['text', 'tool_result']);
+  assert.deepEqual(parts.processBlocks, []);
+});
+
+test('assistant content presence helpers report response and process availability', () => {
+  const mixed: ChatMessage = {
+    role: 'assistant',
+    content: [
+      { type: 'thinking', thinking: 'planning' },
+      { type: 'text', text: 'done' },
+    ],
+  };
+  const processOnly: ChatMessage = {
+    role: 'assistant',
+    content: [{ type: 'tool_use', name: 'grep' }],
+  };
+
+  assert.equal(hasAssistantResponseContent(mixed), true);
+  assert.equal(hasAssistantProcessContent(mixed), true);
+  assert.equal(hasAssistantResponseContent(processOnly), false);
+  assert.equal(hasAssistantProcessContent(processOnly), true);
+});

--- a/apps/desktop/src/renderer/ui/components/chat/chat-shared.test.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-shared.test.ts
@@ -40,6 +40,33 @@ test('assistant turn content preserves original order while annotating response/
   assert.deepEqual(turn.orderedParts.map((part) => part.block.type), ['thinking', 'text', 'tool_use', 'text']);
   assert.deepEqual(turn.responseBlocks.map((block) => block.type), ['text', 'text']);
   assert.deepEqual(turn.processBlocks.map((block) => block.type), ['thinking', 'tool_use']);
+  assert.deepEqual(turn.finalResponseBlocks.map((block) => block.type), ['text']);
+  assert.equal(turn.finalResponseBlocks[0]?.text, 'Second answer chunk');
+});
+
+test('assistant final response blocks skip progress text before the last process block', () => {
+  const turn = buildAssistantTurnContent([
+    { type: 'text', text: 'I will inspect the repo first.' },
+    { type: 'tool_use', id: 'tool-1', name: 'bash' },
+    { type: 'text', text: 'Repo is confirmed. I will inspect the renderer next.' },
+    { type: 'tool_use', id: 'tool-2', name: 'read' },
+    { type: 'text', text: 'Final answer' },
+  ]);
+
+  assert.deepEqual(
+    turn.responseBlocks.map((block) => block.text),
+    ['I will inspect the repo first.', 'Repo is confirmed. I will inspect the renderer next.', 'Final answer'],
+  );
+  assert.deepEqual(turn.finalResponseBlocks.map((block) => block.text), ['Final answer']);
+});
+
+test('assistant final response blocks fall back when no final text follows process activity', () => {
+  const turn = buildAssistantTurnContent([
+    { type: 'text', text: 'Only visible text' },
+    { type: 'tool_use', id: 'tool-1', name: 'bash' },
+  ]);
+
+  assert.deepEqual(turn.finalResponseBlocks.map((block) => block.text), ['Only visible text']);
 });
 
 test('assistant process block predicate is centralized for reasoning and tools', () => {

--- a/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
@@ -533,11 +533,29 @@ function asContentBlocks(content: unknown): ContentBlock[] {
   return [];
 }
 
+export type AssistantContentBlockKind = 'response' | 'process';
+
+export type AssistantContentBlockPart = {
+  kind: AssistantContentBlockKind;
+  block: ContentBlock;
+};
+
 export type AssistantMessageContentParts = {
   /** Blocks that represent the assistant-facing answer content for the main chat. */
   responseBlocks: ContentBlock[];
   /** Blocks that represent the assistant's background process, tools, and reasoning. */
   processBlocks: ContentBlock[];
+};
+
+export type AssistantTurnContent = AssistantMessageContentParts & {
+  /**
+   * Original assistant block order annotated with the lane it belongs to.
+   *
+   * This lets the current inline chat renderer keep existing behavior while
+   * future turn-level UI can render responseBlocks and processBlocks in
+   * separate, related lanes.
+   */
+  orderedParts: AssistantContentBlockPart[];
 };
 
 export function isAssistantProcessBlock(block: ContentBlock): boolean {
@@ -550,18 +568,26 @@ export function isAssistantResponseBlock(block: ContentBlock): boolean {
   return !isAssistantProcessBlock(block);
 }
 
-export function splitAssistantContentBlocks(content: unknown): AssistantMessageContentParts {
+export function buildAssistantTurnContent(content: unknown): AssistantTurnContent {
   const responseBlocks: ContentBlock[] = [];
   const processBlocks: ContentBlock[] = [];
+  const orderedParts: AssistantContentBlockPart[] = [];
 
   for (const block of asContentBlocks(content)) {
     if (isAssistantProcessBlock(block)) {
       processBlocks.push(block);
+      orderedParts.push({ kind: 'process', block });
     } else {
       responseBlocks.push(block);
+      orderedParts.push({ kind: 'response', block });
     }
   }
 
+  return { responseBlocks, processBlocks, orderedParts };
+}
+
+export function splitAssistantContentBlocks(content: unknown): AssistantMessageContentParts {
+  const { responseBlocks, processBlocks } = buildAssistantTurnContent(content);
   return { responseBlocks, processBlocks };
 }
 

--- a/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
@@ -451,13 +451,16 @@ export function buildChatMetaParts(msg: ChatMessage): string[] {
   if (msg.createdAt && Number(msg.createdAt) > 0) parts.push(formatChatTime(msg.createdAt));
 
   const blocks = Array.isArray(msg.content) ? (msg.content as ContentBlock[]) : null;
-  const stats = blocks ? countBlocks(blocks) : null;
   const assistantMeta = normalizeAssistantMeta(msg);
 
-  if (stats && msg.role === 'assistant') {
-    if (stats.toolUse > 0) parts.push(`${stats.toolUse} tool${stats.toolUse === 1 ? '' : 's'}`);
-    if (stats.thinking > 0) parts.push(`${stats.thinking} reasoning`);
-    if (stats.text > 0) parts.push(`${stats.text} text block${stats.text === 1 ? '' : 's'}`);
+  if (blocks && msg.role === 'assistant') {
+    const contentParts = splitAssistantMessageContent(msg);
+    const responseStats = countBlocks(contentParts.responseBlocks);
+    const processStats = countBlocks(contentParts.processBlocks);
+
+    if (processStats.toolUse > 0) parts.push(`${processStats.toolUse} tool${processStats.toolUse === 1 ? '' : 's'}`);
+    if (processStats.thinking > 0) parts.push(`${processStats.thinking} reasoning`);
+    if (responseStats.text > 0) parts.push(`${responseStats.text} text block${responseStats.text === 1 ? '' : 's'}`);
   }
 
   if (assistantMeta) {
@@ -528,6 +531,53 @@ function asContentBlocks(content: unknown): ContentBlock[] {
     return [{ type: 'text', text: content }];
   }
   return [];
+}
+
+export type AssistantMessageContentParts = {
+  /** Blocks that represent the assistant-facing answer content for the main chat. */
+  responseBlocks: ContentBlock[];
+  /** Blocks that represent the assistant's background process, tools, and reasoning. */
+  processBlocks: ContentBlock[];
+};
+
+export function isAssistantProcessBlock(block: ContentBlock): boolean {
+  return block.type === 'thinking' || block.type === 'tool_use' || block.type === 'tool_result';
+}
+
+export function isAssistantResponseBlock(block: ContentBlock): boolean {
+  // Safe fallback: unknown/new block types stay with the response path until
+  // they are intentionally routed into the background-process path here.
+  return !isAssistantProcessBlock(block);
+}
+
+export function splitAssistantContentBlocks(content: unknown): AssistantMessageContentParts {
+  const responseBlocks: ContentBlock[] = [];
+  const processBlocks: ContentBlock[] = [];
+
+  for (const block of asContentBlocks(content)) {
+    if (isAssistantProcessBlock(block)) {
+      processBlocks.push(block);
+    } else {
+      responseBlocks.push(block);
+    }
+  }
+
+  return { responseBlocks, processBlocks };
+}
+
+export function splitAssistantMessageContent(message: ChatMessage): AssistantMessageContentParts {
+  if (message.role !== 'assistant') {
+    return { responseBlocks: asContentBlocks(message.content), processBlocks: [] };
+  }
+  return splitAssistantContentBlocks(message.content);
+}
+
+export function hasAssistantProcessContent(message: ChatMessage): boolean {
+  return message.role === 'assistant' && splitAssistantMessageContent(message).processBlocks.length > 0;
+}
+
+export function hasAssistantResponseContent(message: ChatMessage): boolean {
+  return splitAssistantMessageContent(message).responseBlocks.length > 0;
 }
 
 function mergeAssistantMessages(base: ChatMessage, next: ChatMessage): ChatMessage {

--- a/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
@@ -549,6 +549,17 @@ export type AssistantMessageContentParts = {
 
 export type AssistantTurnContent = AssistantMessageContentParts & {
   /**
+   * Response blocks that represent the final assistant answer for copy/export.
+   *
+   * Assistant turns may include short progress/update text before or between
+   * tool calls. Those lines are useful in the chat transcript, but they lose
+   * context when copied as an answer. As a structure-based fallback, final
+   * response blocks are the response blocks after the last process block. If
+   * there are no response blocks after process activity, this falls back to all
+   * response blocks so simple/process-free answers still copy normally.
+   */
+  finalResponseBlocks: ContentBlock[];
+  /**
    * Original assistant block order annotated with the lane it belongs to.
    *
    * This lets the current inline chat renderer keep existing behavior while
@@ -583,7 +594,23 @@ export function buildAssistantTurnContent(content: unknown): AssistantTurnConten
     }
   }
 
-  return { responseBlocks, processBlocks, orderedParts };
+  const lastProcessIndex = orderedParts.reduce(
+    (lastIndex, part, index) => (part.kind === 'process' ? index : lastIndex),
+    -1,
+  );
+  const finalResponseBlocks = lastProcessIndex >= 0
+    ? orderedParts
+        .slice(lastProcessIndex + 1)
+        .filter((part) => part.kind === 'response')
+        .map((part) => part.block)
+    : responseBlocks;
+
+  return {
+    responseBlocks,
+    processBlocks,
+    finalResponseBlocks: finalResponseBlocks.length > 0 ? finalResponseBlocks : responseBlocks,
+    orderedParts,
+  };
 }
 
 export function splitAssistantContentBlocks(content: unknown): AssistantMessageContentParts {


### PR DESCRIPTION
## Summary

Prepares the AntStation chat foundation for separating each assistant turn into:

- `responseBlocks`: content intended for the main answer bubble
- `processBlocks`: thinking, tool usage, tool results, and other behind-the-scenes activity
- `orderedParts`: the original assistant block order annotated as `response` or `process`

This keeps the current inline chat UI behavior unchanged, while making the renderer consume a turn-level content model that can later support a two-lane assistant response UI: main answer in the center, related behind-the-scenes activity beside it.

## Why

Assistant messages currently mix final response content with process content such as reasoning and tool activity. The future UI should keep those pieces connected to the same assistant response while allowing them to render in separate lanes.

This PR intentionally focuses on the foundation only. It does not implement the future side-by-side process UI.

## Behavior

No chat layout or streaming UI changes.

Current visible behavior is preserved, with one small alignment change:

- Copying an assistant response now copies only response content, excluding structured process blocks like thinking/tools/tool results.

This does not parse markdown headings or infer a final-answer section from text. Text blocks remain response content by default.

## Validation

- `pnpm --filter=@antseed/desktop exec tsx --test src/renderer/ui/components/chat/chat-shared.test.ts`
- `pnpm --filter=@antseed/desktop exec tsc -p tsconfig.renderer.json --noEmit`
- `git diff --check`
