### PR TITLE
Handle closed seller connection sends best effort

### DIFF
--- a/packages/node/src/proxy/proxy-mux.ts
+++ b/packages/node/src/proxy/proxy-mux.ts
@@ -162,7 +162,7 @@ export class ProxyMux {
       payload,
     });
 
-    this._connection.send(frame);
+    this._safeSendFrame(frame, 'response', response.requestId);
   }
 
   /** Seller side: send a proxy response chunk. */
@@ -178,7 +178,7 @@ export class ProxyMux {
       payload,
     });
 
-    this._connection.send(frame);
+    this._safeSendFrame(frame, chunk.done ? 'response-end' : 'response-chunk', chunk.requestId);
   }
 
   /** Route an incoming frame to the correct handler based on message type. */
@@ -395,6 +395,16 @@ export class ProxyMux {
       headers: { 'content-type': 'text/plain' },
       body: new TextEncoder().encode(reason),
     });
+  }
+
+  private _safeSendFrame(frame: Uint8Array, kind: 'response' | 'response-chunk' | 'response-end', requestId: string): void {
+    try {
+      this._connection.send(frame);
+    } catch (err) {
+      debugLog(
+        `[ProxyMux] drop ${kind} reqId=${requestId.slice(0, 8)} because connection closed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
   }
 
   private _nextMessageId(): number {

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -244,13 +244,13 @@ export class SellerRequestHandler {
             // Auto-sign catch-up via NeedAuth so a transient underfund recovers
             // without the 402 round-tripping to the user.
             if (!isFullyExhausted) {
-              paymentMux.sendNeedAuth({
+              this._sendNeedAuthBestEffort(paymentMux, {
                 channelId: session.sessionId,
                 requiredCumulativeAmount: target.toString(),
                 currentAcceptedCumulative: accepted.toString(),
                 deposit: session.authMax ?? '0',
                 requestId: request.requestId,
-              });
+              }, buyerPeerId, 'budget-catch-up');
             }
             return;
           }
@@ -368,7 +368,7 @@ export class SellerRequestHandler {
             const accepted = spm.getAcceptedCumulative(session.sessionId);
             const requiredAmount = cumulativeSpend + costUsdc;
             debugLog(`[SellerHandler] Sending NeedAuth: cost=${costUsdc} cumulative=${cumulativeSpend} required=${requiredAmount}`);
-            paymentMux.sendNeedAuth({
+            this._sendNeedAuthBestEffort(paymentMux, {
               channelId: session.sessionId,
               requiredCumulativeAmount: requiredAmount.toString(),
               currentAcceptedCumulative: accepted.toString(),
@@ -380,7 +380,7 @@ export class SellerRequestHandler {
               cachedInputTokens: String(usage.cachedInputTokens),
               freshInputTokens: String(usage.freshInputTokens),
               service: this._extractRequestedService(request) ?? undefined,
-            });
+            }, buyerPeerId, 'post-response');
           }
         }
       } finally {
@@ -540,6 +540,21 @@ export class SellerRequestHandler {
       return provider.handleRequestStream(request, streamCallbacks);
     }
     return provider.handleRequest(request);
+  }
+
+  private _sendNeedAuthBestEffort(
+    paymentMux: PaymentMux,
+    payload: Parameters<PaymentMux['sendNeedAuth']>[0],
+    buyerPeerId: string,
+    phase: 'budget-catch-up' | 'post-response',
+  ): void {
+    try {
+      paymentMux.sendNeedAuth(payload);
+    } catch (err) {
+      debugWarn(
+        `[SellerHandler] NeedAuth send skipped (${phase}) for ${buyerPeerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`,
+      );
+    }
   }
 
   private _scheduleMetadataRefresh(): void {

--- a/packages/provider-core/src/base-provider.ts
+++ b/packages/provider-core/src/base-provider.ts
@@ -57,7 +57,9 @@ export class BaseProvider implements Provider {
     const isStreamingStart = response.headers[ANTSEED_STREAMING_RESPONSE_HEADER] === '1';
     if (isStreamingStart) {
       entry.responseStart = response;
-      entry.streamCallbacks?.onResponseStart(response);
+      this._invokeStreamCallback(requestId, 'response-start', () => {
+        entry.streamCallbacks?.onResponseStart(response);
+      });
       return;
     }
 
@@ -69,7 +71,9 @@ export class BaseProvider implements Provider {
     const entry = this._pending.get(chunk.requestId);
     if (!entry) return;
 
-    entry.streamCallbacks?.onResponseChunk(chunk);
+    this._invokeStreamCallback(chunk.requestId, chunk.done ? 'response-end' : 'response-chunk', () => {
+      entry.streamCallbacks?.onResponseChunk(chunk);
+    });
 
     if (chunk.data.length > 0) {
       entry.streamChunks.push(chunk.data);
@@ -103,6 +107,21 @@ export class BaseProvider implements Provider {
       ...response,
       headers,
     };
+  }
+
+  private _invokeStreamCallback(requestId: string, phase: string, callback: () => void): void {
+    try {
+      callback();
+    } catch (err) {
+      // Stream callbacks usually send frames back to the buyer. If the buyer has
+      // already disconnected, that send can throw (for example, "Cannot send in
+      // state closed"). Do not let a downstream delivery failure bubble into the
+      // upstream relay, where it would be misreported as a provider/Anthropic
+      // error and can cause the seller connection handler to unwind.
+      console.warn(
+        `[BaseProvider] stream callback skipped phase=${phase} reqId=${requestId.slice(0, 8)}: ${err instanceof Error ? err.message : err}`,
+      );
+    }
   }
 
   async init(): Promise<void> {


### PR DESCRIPTION
Drop seller proxy response/chunk frames best-effort when the buyer connection has already closed
Make NeedAuth sends best-effort in seller request handling
Prevent provider stream callback delivery failures from bubbling into upstream/provider errors