### PR TITLE
Increase default proxy upload limit for Codex

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -115,6 +115,7 @@ Pricing is configured in USD per 1M tokens with role-specific defaults and optio
   },
   "seller": {
     "publicAddress": "peer.example.com:6882",
+    "maxUploadBodyBytes": 134217728,
     "providers": {
       "anthropic": {
         "plugin": "anthropic",
@@ -193,6 +194,9 @@ antseed config seller set providers.anthropic.services.claude-sonnet-4-5-2025092
 
 # Seller public address override for load-balanced deployments
 antseed config seller set publicAddress "peer.example.com:6882"
+
+# Raise the seller per-request upload cap (bytes) for large Codex-style payloads
+antseed config seller set maxUploadBodyBytes 134217728
 
 # Buyer max pricing
 antseed config buyer set maxPricing.defaults.inputUsdPerMillion 25

--- a/apps/cli/src/cli/commands/seller/start.test.ts
+++ b/apps/cli/src/cli/commands/seller/start.test.ts
@@ -7,6 +7,7 @@ import {
   buildSellerRuntimeOverridesFromFlags,
   buildSellerPluginRuntimeEnv,
   mergeSellerRuntimeEnv,
+  parseOptionalPositiveIntegerEnv,
   selectSellerProviderNames,
 } from './start.js';
 
@@ -233,6 +234,14 @@ test('seller start merge keeps explicit pricing when runtime env also contains p
   assert.equal(merged['ANTSEED_INPUT_USD_PER_MILLION'], '0.05');
   assert.equal(merged['ANTSEED_OUTPUT_USD_PER_MILLION'], '0.1');
   assert.equal(merged['ANTSEED_MAX_CONCURRENCY'], '10');
+});
+
+test('parseOptionalPositiveIntegerEnv accepts positive integer env values', () => {
+  assert.equal(parseOptionalPositiveIntegerEnv('134217728'), 134217728);
+  assert.equal(parseOptionalPositiveIntegerEnv(' 134217728 '), 134217728);
+  assert.equal(parseOptionalPositiveIntegerEnv('0'), undefined);
+  assert.equal(parseOptionalPositiveIntegerEnv('123abc'), undefined);
+  assert.equal(parseOptionalPositiveIntegerEnv('not-a-number'), undefined);
 });
 
 test('selectSellerProviderNames defaults to all configured providers', () => {

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -176,6 +176,14 @@ function toUSDCBaseUnits(value: string | undefined, fallbackBaseUnits: string): 
   return String(Math.round(parsed * 1_000_000))
 }
 
+export function parseOptionalPositiveIntegerEnv(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined
+  const trimmed = value.trim()
+  if (!/^\d+$/.test(trimmed)) return undefined
+  const parsed = Number(trimmed)
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined
+}
+
 export function buildSellerRuntimeOverridesFromFlags(options: {
   reserve?: number
   inputUsdPerMillion?: number
@@ -285,8 +293,6 @@ export function mergeSellerRuntimeEnv(
 
   return merged
 }
-
-
 
 export function registerSellerStartCommand(sellerCmd: Command): void {
   sellerCmd
@@ -478,6 +484,11 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
       console.log(chalk.dim(`  min settle delta: ${minSettleDelta} base units`))
       console.log(chalk.dim(`  reserve floor: ${effectiveSellerConfig.reserveFloor}`))
       console.log(chalk.dim(`  max concurrent buyers: ${effectiveSellerConfig.maxConcurrentBuyers}`))
+      const maxUploadBodyBytes = parseOptionalPositiveIntegerEnv(process.env['ANTSEED_MAX_UPLOAD_BODY_BYTES'])
+        ?? effectiveSellerConfig.maxUploadBodyBytes
+      if (maxUploadBodyBytes !== undefined) {
+        console.log(chalk.dim(`  max upload body bytes: ${maxUploadBodyBytes}`))
+      }
       console.log('')
 
       const nodeSpinner = ora('Starting seeding daemon...').start()
@@ -498,6 +509,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
         dataDir: globalOpts.dataDir,
         ...(dhtPort ? { dhtPort } : {}),
         ...(signalingPort ? { signalingPort } : {}),
+        ...(maxUploadBodyBytes !== undefined ? { maxUploadBodyBytes } : {}),
         payments: {
           enabled: paymentsEnabled,
           paymentMethod: preferredMethod,
@@ -632,7 +644,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
           syntheticDetails.push({
             sessionId,
             buyerPeerId: 'unknown',
-              provider: primaryProviderName,
+            provider: primaryProviderName,
             startedAt: startedAtTs,
             lastActivityAt: now,
             totalRequests: 0,

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -166,6 +166,36 @@ test('loadConfig preserves seller publicAddress override', async () => {
   );
 });
 
+test('loadConfig preserves seller maxUploadBodyBytes setting', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      seller: {
+        maxUploadBodyBytes: 134217728,
+      },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.equal(config.seller.maxUploadBodyBytes, 134217728);
+    }
+  );
+});
+
+test('loadConfig rejects invalid seller maxUploadBodyBytes setting', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      seller: {
+        maxUploadBodyBytes: 123,
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        async () => loadConfig(configPath),
+        /seller\.maxUploadBodyBytes/
+      );
+    }
+  );
+});
+
 test('loadConfig preserves seller agentDir setting', async () => {
   await withTempConfig(
     JSON.stringify({

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -190,6 +190,7 @@ function mergeSellerConfig(
       maxConcurrentBuyers: defaults.maxConcurrentBuyers,
       providers: mergeSellerProviders(defaults.providers, undefined),
       publicAddress: defaults.publicAddress,
+      ...(typeof defaults.maxUploadBodyBytes === 'number' ? { maxUploadBodyBytes: defaults.maxUploadBodyBytes } : {}),
       ...(defaults.agentDir ? { agentDir: defaults.agentDir } : {}),
     };
   }
@@ -205,6 +206,11 @@ function mergeSellerConfig(
     publicAddress: typeof value['publicAddress'] === 'string'
       ? value['publicAddress']
       : defaults.publicAddress,
+    ...(typeof value['maxUploadBodyBytes'] === 'number'
+      ? { maxUploadBodyBytes: value['maxUploadBodyBytes'] }
+      : typeof defaults.maxUploadBodyBytes === 'number'
+        ? { maxUploadBodyBytes: defaults.maxUploadBodyBytes }
+        : {}),
     ...(normalizeAgentDir(value['agentDir'], defaults.agentDir)),
   };
 }

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -88,6 +88,8 @@ export interface SellerCLIConfig {
   agentDir?: string | Record<string, string>;
   /** Publicly reachable seller address override announced in metadata, e.g. "peer.example.com:6882". */
   publicAddress?: string;
+  /** Maximum upload body size (bytes) accepted from buyers per request. Default: 64 MiB. */
+  maxUploadBodyBytes?: number;
 }
 
 /**

--- a/apps/cli/src/config/validation.ts
+++ b/apps/cli/src/config/validation.ts
@@ -7,6 +7,7 @@ import type {
 
 const SERVICE_CATEGORY_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const MAX_PUBLIC_ADDRESS_LENGTH = 255;
+const MIN_SELLER_UPLOAD_BODY_BYTES = 1024 * 1024;
 
 function validatePricingLeaf(
   path: string,
@@ -146,6 +147,13 @@ export function validateConfig(config: AntseedConfig): string[] {
 
   if (!Number.isFinite(config.seller.reserveFloor) || config.seller.reserveFloor < 0) {
     errors.push('seller.reserveFloor must be a non-negative finite number');
+  }
+
+  if (
+    config.seller.maxUploadBodyBytes !== undefined &&
+    (!Number.isInteger(config.seller.maxUploadBodyBytes) || config.seller.maxUploadBodyBytes < MIN_SELLER_UPLOAD_BODY_BYTES)
+  ) {
+    errors.push('seller.maxUploadBodyBytes must be an integer >= 1048576');
   }
 
   if (config.seller.agentDir !== undefined) {

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -1167,6 +1167,70 @@ export class BuyerProxy {
     }
   }
 
+  private _parseMaxUploadBodyBytes(headers: Record<string, string>): number | null {
+    const raw = headers['x-antseed-max-upload-body-bytes']
+    if (!raw) return null
+    const parsed = Number.parseInt(raw, 10)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+  }
+
+  private _formatUploadLimitError(
+    statusCode: number,
+    body: Uint8Array,
+    headers: Record<string, string>,
+    requestBytes: number,
+    requestedService: string | null,
+  ): string | null {
+    if (statusCode !== 413) return null
+    const bodyText = Buffer.from(body).toString('utf-8').trim()
+    if (!/upload body exceeds per-request limit/i.test(bodyText)) return null
+
+    const maxBytes = this._parseMaxUploadBodyBytes(headers)
+    const requestSize = this._formatBytes(requestBytes)
+    const maxSize = maxBytes != null ? this._formatBytes(maxBytes) : 'the seller upload limit'
+    const service = requestedService ? ` for ${requestedService}` : ''
+    return `Request body${service} is ${requestSize}, but the selected seller allows ${maxSize} per request. `
+      + 'This commonly happens when Codex sends a large repository context to /v1/responses. '
+      + 'Reduce Codex context, exclude large/generated files, or pick a seller with a higher seller.maxUploadBodyBytes limit.'
+  }
+
+  private _withFriendlyUploadLimitError(
+    response: SerializedHttpResponse,
+    requestBytes: number,
+    requestedService: string | null,
+  ): SerializedHttpResponse {
+    const message = this._formatUploadLimitError(
+      response.statusCode,
+      response.body,
+      response.headers,
+      requestBytes,
+      requestedService,
+    )
+    if (!message) return response
+    return {
+      ...response,
+      headers: { ...response.headers, 'content-type': 'application/json' },
+      body: Buffer.from(JSON.stringify({
+        error: {
+          type: 'upload_body_too_large',
+          code: 'upload_body_too_large',
+          message,
+          requestBytes,
+          sellerMaxUploadBodyBytes: this._parseMaxUploadBodyBytes(response.headers),
+        },
+      })),
+    }
+  }
+
+  private _formatBytes(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes < 0) return 'unknown size'
+    const mib = bytes / (1024 * 1024)
+    if (mib >= 1) return `${mib.toFixed(mib >= 10 ? 0 : 1)} MiB`
+    const kib = bytes / 1024
+    if (kib >= 1) return `${kib.toFixed(kib >= 10 ? 0 : 1)} KiB`
+    return `${bytes} B`
+  }
+
   /**
    * Dispatch a request to a specific peer. Returns `{ done: true }` if the response
    * was sent to the client (success or non-retryable error), or retry info if the
@@ -1296,6 +1360,7 @@ export class BuyerProxy {
           responseForClient = adaptResponse(response)
         }
         responseForClient = adaptOpenAICompatibleErrorResponse(responseForClient, requestProtocol)
+        responseForClient = this._withFriendlyUploadLimitError(responseForClient, requestForPeer.body.length, requestedService)
         if (responseForClient.statusCode === 402) {
           responseForClient = inject402PeerId(responseForClient, selectedPeer.peerId)
         }
@@ -1367,6 +1432,7 @@ export class BuyerProxy {
           response = adaptResponse(response)
         }
         response = adaptOpenAICompatibleErrorResponse(response, requestProtocol)
+        response = this._withFriendlyUploadLimitError(response, requestForPeer.body.length, requestedService)
         if (response.statusCode === 402) {
           response = inject402PeerId(response, selectedPeer.peerId)
         }

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -130,6 +130,7 @@ interface NodeConfig {
   identityStore?: IdentityStore; // Pluggable identity storage backend
   dhtPort?: number;           // Default: 6881 for seller, 0 (OS-assigned) for buyer
   signalingPort?: number;     // Default: 6882 for seller
+  maxUploadBodyBytes?: number; // Default: 64 MiB per request
   bootstrapNodes?: Array<{ host: string; port: number }>;
   payments?: {
     enabled?: boolean;
@@ -152,6 +153,7 @@ interface NodeConfig {
 | `identityStore` | `FileIdentityStore` | Pluggable identity storage backend (see [Identity Storage](#identity-storage)) |
 | `dhtPort` | `6881` / `0` | UDP port for DHT. Seller defaults to 6881, buyer uses OS-assigned |
 | `signalingPort` | `6882` | TCP port for P2P signaling and incoming connections (seller only) |
+| `maxUploadBodyBytes` | `64 MiB` | Maximum request body a seller accepts per proxied upload. Raise this for large Codex-style `/v1/responses` payloads while keeping the aggregate pending-upload budget bounded. |
 | `bootstrapNodes` | AntSeed nodes | Additional DHT bootstrap nodes merged with the official AntSeed infrastructure |
 | `payments` | disabled | Optional seller-side payment channel + settlement lifecycle wiring |
 

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -145,6 +145,8 @@ export interface NodeConfig {
   requestTimeoutMs?: number;  // Default: 30000
   /** Maximum buffered body size (bytes) while reconstructing streaming responses. Default: 16 MiB. */
   maxStreamBufferBytes?: number;
+  /** Maximum upload body size (bytes) a seller will accept per request. Default: 64 MiB. */
+  maxUploadBodyBytes?: number;
   /** Maximum wall time allowed for a streaming response. Default: 5 minutes. */
   maxStreamDurationMs?: number;
   /** Allow private/loopback IPs in DHT lookups. Default: false. Set true for local testing. */
@@ -1114,6 +1116,7 @@ export class AntseedNode extends EventEmitter {
       sessionTracker: this._sessionTracker,
       channelsClient: this._channelsClient,
       announcer: this._announcer,
+      maxUploadBodyBytes: this._config.maxUploadBodyBytes,
       emit: (event, ...args) => this.emit(event, ...args),
     });
 
@@ -1489,7 +1492,9 @@ export class AntseedNode extends EventEmitter {
       return existing;
     }
 
-    const mux = new ProxyMux(conn);
+    const mux = new ProxyMux(conn, {
+      maxUploadBodyBytes: this._config.maxUploadBodyBytes,
+    });
     this._muxes.set(peerId, mux);
     return mux;
   }

--- a/packages/node/src/proxy/proxy-mux.ts
+++ b/packages/node/src/proxy/proxy-mux.ts
@@ -33,7 +33,7 @@ type RequestHandler = (request: SerializedHttpRequest) => void | Promise<void>;
 
 /** Per-request upload size cap, total budget, and stall timeout. */
 export interface ProxyMuxUploadLimits {
-  /** Max body bytes for a single upload. Default: 32 MiB. Buyer receives 413 on violation. */
+  /** Max body bytes for a single upload. Default: 64 MiB. Buyer receives 413 on violation. */
   maxUploadBodyBytes?: number;
   /** Max bytes across ALL concurrent in-progress uploads. Default: 256 MiB. */
   maxTotalPendingUploadBytes?: number;
@@ -41,9 +41,13 @@ export interface ProxyMuxUploadLimits {
   uploadTimeoutMs?: number;
 }
 
-const DEFAULT_MAX_UPLOAD_BODY_BYTES       = 32  * 1024 * 1024; // 32 MiB
-const DEFAULT_MAX_TOTAL_PENDING_BYTES     = 256 * 1024 * 1024; // 256 MiB
-const DEFAULT_UPLOAD_TIMEOUT_MS           = 120_000;            // 2 min
+// Codex-style /v1/responses requests can include large repository context.
+// Raising the per-request cap to 64 MiB accommodates those requests while the
+// separate 256 MiB aggregate pending-upload budget continues to bound seller
+// memory exposure across concurrent uploads.
+export const DEFAULT_MAX_UPLOAD_BODY_BYTES = 64  * 1024 * 1024; // 64 MiB
+const DEFAULT_MAX_TOTAL_PENDING_BYTES      = 256 * 1024 * 1024; // 256 MiB
+const DEFAULT_UPLOAD_TIMEOUT_MS            = 120_000;            // 2 min
 
 interface PendingUpload {
   headerReq: SerializedHttpRequest;

--- a/packages/node/src/proxy/proxy-mux.ts
+++ b/packages/node/src/proxy/proxy-mux.ts
@@ -396,7 +396,10 @@ export class ProxyMux {
     this.sendProxyResponse({
       requestId,
       statusCode,
-      headers: { 'content-type': 'text/plain' },
+      headers: {
+        'content-type': 'text/plain',
+        ...(statusCode === 413 ? { 'x-antseed-max-upload-body-bytes': String(this._maxUploadBodyBytes) } : {}),
+      },
       body: new TextEncoder().encode(reason),
     });
   }

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -24,6 +24,7 @@ export interface SellerRequestHandlerDeps {
   sessionTracker: SellerSessionTracker | null;
   channelsClient: ChannelsClient | null;
   announcer: PeerAnnouncer | null;
+  maxUploadBodyBytes?: number;
   emit: (event: string, ...args: unknown[]) => boolean;
 }
 
@@ -54,7 +55,9 @@ export class SellerRequestHandler {
     buyerPeerId: string,
     paymentMux: PaymentMux,
   ): { mux: ProxyMux } {
-    const mux = new ProxyMux(conn);
+    const mux = new ProxyMux(conn, {
+      maxUploadBodyBytes: this._deps.maxUploadBodyBytes,
+    });
 
     mux.onProxyRequest(async (request: SerializedHttpRequest) => {
       debugLog(`[SellerHandler] Received request: ${request.method} ${request.path} (reqId=${request.requestId.slice(0, 8)})`);

--- a/packages/node/tests/proxy-mux-upload.test.ts
+++ b/packages/node/tests/proxy-mux-upload.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { ProxyMux } from '../src/proxy/proxy-mux.js';
+import { DEFAULT_MAX_UPLOAD_BODY_BYTES, ProxyMux } from '../src/proxy/proxy-mux.js';
 import {
   decodeHttpRequest,
   decodeHttpRequestChunk,
@@ -248,6 +248,10 @@ describe('ProxyMux chunked upload — seller side', () => {
 });
 
 describe('ProxyMux upload limits — storage protection', () => {
+  it('defaults the per-request upload limit to 64 MiB', () => {
+    expect(DEFAULT_MAX_UPLOAD_BODY_BYTES).toBe(64 * 1024 * 1024);
+  });
+
   it('rejects upload that exceeds per-request limit with 413', async () => {
     const statusCodes: number[] = [];
     // Limit: anything larger than one upload chunk (ANTSEED_UPLOAD_CHUNK_SIZE - 1 bytes)

--- a/packages/node/tests/proxy-mux-upload.test.ts
+++ b/packages/node/tests/proxy-mux-upload.test.ts
@@ -3,6 +3,7 @@ import { DEFAULT_MAX_UPLOAD_BODY_BYTES, ProxyMux } from '../src/proxy/proxy-mux.
 import {
   decodeHttpRequest,
   decodeHttpRequestChunk,
+  decodeHttpResponse,
   encodeHttpRequestChunk,
 } from '../src/proxy/request-codec.js';
 import { MessageType } from '../src/types/protocol.js';
@@ -254,14 +255,16 @@ describe('ProxyMux upload limits — storage protection', () => {
 
   it('rejects upload that exceeds per-request limit with 413', async () => {
     const statusCodes: number[] = [];
+    const maxBytesHeaders: string[] = [];
     // Limit: anything larger than one upload chunk (ANTSEED_UPLOAD_CHUNK_SIZE - 1 bytes)
     const sellerMux = createMux(
       (f) => {
         const { type, payload } = decodeFrameHeader(f);
         if (type === MessageType.HttpResponse) {
-          const view = new DataView(payload.buffer, payload.byteOffset);
-          const idLen = view.getUint16(0);
-          statusCodes.push(view.getUint16(2 + idLen));
+          const response = decodeHttpResponse(payload);
+          statusCodes.push(response.statusCode);
+          const maxBytes = response.headers['x-antseed-max-upload-body-bytes'];
+          if (maxBytes) maxBytesHeaders.push(maxBytes);
         }
       },
       { maxUploadBodyBytes: ANTSEED_UPLOAD_CHUNK_SIZE - 1 },
@@ -286,6 +289,7 @@ describe('ProxyMux upload limits — storage protection', () => {
 
     expect(statusCodes).toHaveLength(1);
     expect(statusCodes[0]).toBe(413);
+    expect(maxBytesHeaders[0]).toBe(String(ANTSEED_UPLOAD_CHUNK_SIZE - 1));
     expect(sellerMux.pendingUploadCount()).toBe(0);
     expect(sellerMux.pendingUploadBytes()).toBe(0);
   });


### PR DESCRIPTION
## Summary
- Raise the default per-request ProxyMux upload cap from 32 MiB to 64 MiB for Codex-style /v1/responses payloads
- Keep the 256 MiB aggregate pending-upload budget unchanged to bound seller memory exposure
- Add a unit test locking the new default

## Validation
- pnpm --filter=@antseed/node test -- proxy-mux-upload.test.ts
- pnpm --filter=@antseed/node run typecheck