### PR TITLE
Request usage chunks for chat completion streams

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -35,6 +35,7 @@ import {
   summarizeErrorResponse,
   requestWantsStreaming,
   rewriteServiceInBody,
+  ensureChatCompletionsUsageStreamOptions,
   isConnectionChurnError,
   isConnectionHealthy,
 } from './request-utils.js'
@@ -1243,6 +1244,14 @@ export class BuyerProxy {
         })
       }
     }
+
+    // For native OpenAI Chat Completions streaming requests (no transform
+    // path), inject `stream_options.include_usage = true` so the upstream
+    // LLM emits a final `usage` SSE chunk. Without this, the buyer's
+    // BuyerNegotiator records cost=0 / tokens=0 per request and the
+    // dashboard's spend gauge flatlines. The Anthropic→Chat and Responses→Chat
+    // transforms already do this themselves; calling it again is a no-op.
+    requestForPeer = ensureChatCompletionsUsageStreamOptions(requestForPeer)
 
     if (DEBUG()) {
       log(`Outbound request shape: ${summarizeRequestShape(requestForPeer)}`)

--- a/apps/cli/src/proxy/request-utils.test.ts
+++ b/apps/cli/src/proxy/request-utils.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { SerializedHttpRequest } from '@antseed/node'
+import { ensureChatCompletionsUsageStreamOptions } from './request-utils.js'
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+function makeRequest(body: unknown, overrides: Partial<SerializedHttpRequest> = {}): SerializedHttpRequest {
+  const encoded = enc.encode(JSON.stringify(body))
+  return {
+    requestId: 'req-1',
+    method: 'POST',
+    path: '/v1/chat/completions',
+    headers: {
+      'content-type': 'application/json',
+      'content-length': String(encoded.length),
+    },
+    body: encoded,
+    ...overrides,
+  } as SerializedHttpRequest
+}
+
+function bodyAsObject(req: SerializedHttpRequest): Record<string, unknown> {
+  return JSON.parse(dec.decode(req.body)) as Record<string, unknown>
+}
+
+test('injects stream_options.include_usage for streaming chat-completions requests', () => {
+  const req = makeRequest({
+    model: 'minimax-m2.7-highspeed',
+    messages: [{ role: 'user', content: 'hi' }],
+    stream: true,
+    tools: [],
+  })
+  const out = ensureChatCompletionsUsageStreamOptions(req)
+  const body = bodyAsObject(out)
+  assert.deepEqual(body.stream_options, { include_usage: true })
+  // content-length must be re-synced after body rewrite.
+  assert.equal(out.headers['content-length'], String(out.body.length))
+})
+
+test('preserves caller-supplied stream_options fields and forces include_usage=true', () => {
+  const req = makeRequest({
+    model: 'minimax-m2.7-highspeed',
+    stream: true,
+    stream_options: { include_obfuscation: false },
+    messages: [{ role: 'user', content: 'hi' }],
+  })
+  const out = ensureChatCompletionsUsageStreamOptions(req)
+  const body = bodyAsObject(out)
+  assert.deepEqual(body.stream_options, { include_obfuscation: false, include_usage: true })
+})
+
+test('is a no-op when include_usage is already true', () => {
+  const req = makeRequest({
+    stream: true,
+    stream_options: { include_usage: true },
+    messages: [{ role: 'user', content: 'hi' }],
+  })
+  const out = ensureChatCompletionsUsageStreamOptions(req)
+  // Same reference returned when nothing needs rewriting.
+  assert.equal(out, req)
+})
+
+test('does not touch non-streaming chat-completions requests', () => {
+  const req = makeRequest({
+    stream: false,
+    messages: [{ role: 'user', content: 'hi' }],
+  })
+  const out = ensureChatCompletionsUsageStreamOptions(req)
+  assert.equal(out, req)
+  const body = bodyAsObject(out)
+  assert.equal(body.stream_options, undefined)
+})
+
+test('does not touch non-chat-completions paths (e.g. /v1/responses)', () => {
+  const req = makeRequest(
+    { stream: true, input: 'hi' },
+    { path: '/v1/responses' },
+  )
+  const out = ensureChatCompletionsUsageStreamOptions(req)
+  assert.equal(out, req)
+})
+
+test('handles empty / non-JSON bodies gracefully', () => {
+  const req: SerializedHttpRequest = {
+    requestId: 'req-2',
+    method: 'POST',
+    path: '/v1/chat/completions',
+    headers: { 'content-type': 'application/json', 'content-length': '0' },
+    body: new Uint8Array(0),
+  } as SerializedHttpRequest
+  assert.equal(ensureChatCompletionsUsageStreamOptions(req), req)
+
+  const reqText: SerializedHttpRequest = {
+    ...req,
+    headers: { ...req.headers, 'content-type': 'text/plain' },
+    body: enc.encode('hi'),
+  }
+  assert.equal(ensureChatCompletionsUsageStreamOptions(reqText), reqText)
+})
+
+test('updates Content-Length header when present in capitalized form', () => {
+  const body = JSON.stringify({ stream: true, messages: [{ role: 'user', content: 'hi' }] })
+  const encoded = enc.encode(body)
+  const req: SerializedHttpRequest = {
+    requestId: 'req-3',
+    method: 'POST',
+    path: '/v1/chat/completions',
+    headers: {
+      'content-type': 'application/json',
+      'Content-Length': String(encoded.length),
+    },
+    body: encoded,
+  } as SerializedHttpRequest
+  const out = ensureChatCompletionsUsageStreamOptions(req)
+  assert.equal(out.headers['Content-Length'], String(out.body.length))
+})

--- a/apps/cli/src/proxy/request-utils.ts
+++ b/apps/cli/src/proxy/request-utils.ts
@@ -277,3 +277,44 @@ export function rewriteServiceInBody(
   }
   return { body: rewritten, headers: updatedHeaders }
 }
+
+/**
+ * Ensure a streaming OpenAI Chat Completions request includes
+ * `stream_options.include_usage = true` so the upstream LLM emits a final
+ * `usage` SSE chunk. Without it, providers like minimax (and many other
+ * OpenAI-compatible backends) return SSE streams with no usage data, which
+ * causes the buyer's BuyerNegotiator to record `cost=0 (in=0 out=0)` for
+ * every request and the dashboard's spend gauge to flatline at zero.
+ *
+ * Notes:
+ *  - Anthropic→Chat and Responses→Chat transforms in @antseed/api-adapter
+ *    already inject this option, but a buyer talking native chat-completions
+ *    has no transform path — hence this helper.
+ *  - Only applies to /v1/chat/completions requests with stream:true. We
+ *    leave non-streaming or non-chat-completions requests untouched (their
+ *    JSON response body always carries `usage` directly).
+ *  - Preserves an existing user-supplied `stream_options` object.
+ */
+export function ensureChatCompletionsUsageStreamOptions(
+  request: SerializedHttpRequest,
+): SerializedHttpRequest {
+  if (!request.path.toLowerCase().startsWith('/v1/chat/completions')) return request
+  if (!getHeader(request.headers, 'content-type').toLowerCase().includes('application/json')) return request
+  if (request.body.length === 0) return request
+  const parsed = parseJsonObject(request.body)
+  if (!parsed) return request
+  if (parsed.stream !== true) return request
+  const existing = parsed.stream_options && typeof parsed.stream_options === 'object' && !Array.isArray(parsed.stream_options)
+    ? (parsed.stream_options as Record<string, unknown>)
+    : {}
+  if (existing.include_usage === true) return request
+  const updatedBody = { ...parsed, stream_options: { ...existing, include_usage: true } }
+  const rewritten = new TextEncoder().encode(JSON.stringify(updatedBody))
+  const updatedHeaders = { ...request.headers }
+  if ('content-length' in updatedHeaders) {
+    updatedHeaders['content-length'] = String(rewritten.length)
+  } else if ('Content-Length' in updatedHeaders) {
+    updatedHeaders['Content-Length'] = String(rewritten.length)
+  }
+  return { ...request, headers: updatedHeaders, body: rewritten }
+}


### PR DESCRIPTION
## Summary
- Inject `stream_options.include_usage = true` for native streaming OpenAI Chat Completions requests
- Preserve existing stream_options fields and keep non-streaming/non-chat requests unchanged
- Add request-utils coverage for the rewrite and no-op cases

## Validation
- pnpm --filter=@antseed/cli test -- request-utils.test.ts
- pnpm --filter=@antseed/cli run typecheck