### PR TITLE
fix(provider-core): inject stream_options.include_usage on streaming chat completions

### DIFF
--- a/packages/provider-core/src/http-relay.test.ts
+++ b/packages/provider-core/src/http-relay.test.ts
@@ -391,6 +391,111 @@ describe('HttpRelay', () => {
     expect(parsed.service).toBeUndefined();
   });
 
+  describe('stream_options.include_usage injection (chat-completions streaming)', () => {
+    function chatCompletionsRequest(body: Record<string, unknown>): SerializedHttpRequest {
+      return makeRequest({
+        path: '/v1/chat/completions',
+        body: new TextEncoder().encode(JSON.stringify(body)),
+      });
+    }
+
+    function relayWith(allowedServices: string[] = ['minimax-m2.7-highspeed']) {
+      const responses: SerializedHttpResponse[] = [];
+      const relay = new HttpRelay(
+        makeConfig({ allowedServices }),
+        { onResponse: (r) => responses.push(r) },
+      );
+      return { relay, responses };
+    }
+
+    function upstreamBody(): Record<string, unknown> {
+      const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+      return JSON.parse(new TextDecoder().decode(opts.body as Uint8Array)) as Record<string, unknown>;
+    }
+
+    it('injects include_usage=true on streaming chat-completions requests', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+      const { relay, responses } = relayWith();
+      await relay.handleRequest(chatCompletionsRequest({
+        model: 'minimax-m2.7-highspeed',
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+      }));
+      expect(responses[0]!.statusCode).toBe(200);
+      expect(upstreamBody().stream_options).toEqual({ include_usage: true });
+    });
+
+    it('preserves caller-supplied stream_options fields', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+      const { relay } = relayWith();
+      await relay.handleRequest(chatCompletionsRequest({
+        model: 'minimax-m2.7-highspeed',
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+        stream_options: { include_obfuscation: false },
+      }));
+      expect(upstreamBody().stream_options).toEqual({ include_obfuscation: false, include_usage: true });
+    });
+
+    it('does not override an explicit include_usage:false (operator escape hatch)', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+      const { relay } = relayWith();
+      await relay.handleRequest(chatCompletionsRequest({
+        model: 'minimax-m2.7-highspeed',
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+        stream_options: { include_usage: false },
+      }));
+      expect(upstreamBody().stream_options).toEqual({ include_usage: false });
+    });
+
+    it('leaves non-streaming chat-completions requests untouched', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+      const { relay } = relayWith();
+      await relay.handleRequest(chatCompletionsRequest({
+        model: 'minimax-m2.7-highspeed',
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      }));
+      expect(upstreamBody().stream_options).toBeUndefined();
+    });
+
+    it('leaves non-chat-completions paths untouched (e.g. /v1/responses)', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+      const responses: SerializedHttpResponse[] = [];
+      const relay = new HttpRelay(
+        makeConfig({ allowedServices: ['gpt-5.4'] }),
+        { onResponse: (r) => responses.push(r) },
+      );
+      await relay.handleRequest(makeRequest({
+        path: '/v1/responses',
+        body: new TextEncoder().encode(JSON.stringify({ model: 'gpt-5.4', input: 'hi', stream: true })),
+      }));
+      expect(upstreamBody().stream_options).toBeUndefined();
+    });
+
+    it('still defers to operator injectJsonFields override', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+      // Operator can still force their own value via OPENAI_BODY_INJECT_JSON.
+      const responses: SerializedHttpResponse[] = [];
+      const relay = new HttpRelay(
+        makeConfig({
+          allowedServices: ['minimax-m2.7-highspeed'],
+          injectJsonFields: { stream_options: { include_usage: false, include_obfuscation: true } },
+        }),
+        { onResponse: (r) => responses.push(r) },
+      );
+      await relay.handleRequest(chatCompletionsRequest({
+        model: 'minimax-m2.7-highspeed',
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: true,
+      }));
+      // injectJsonFields runs after our default injection and deep-merges,
+      // so an explicit operator override of include_usage wins.
+      expect(upstreamBody().stream_options).toEqual({ include_usage: false, include_obfuscation: true });
+    });
+  });
+
   it('strips body.service when body.model is already present', async () => {
     fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
 

--- a/packages/provider-core/src/http-relay.ts
+++ b/packages/provider-core/src/http-relay.ts
@@ -180,6 +180,29 @@ export class HttpRelay {
           // Remove the "service" field — upstream APIs don't understand it.
           delete transformed.service;
 
+          // Force `stream_options.include_usage = true` on streaming OpenAI Chat
+          // Completions requests. Without this, strict OpenAI-spec upstreams
+          // (e.g. api.minimax.io) return SSE streams with no `usage` chunk,
+          // which makes `parseResponseUsage` return zeros and causes the
+          // seller to record `cost=0 (in=0 out=0)` for every request —
+          // effectively giving away inference for free.
+          //
+          // We only touch `/v1/chat/completions` with `stream:true`, and we
+          // preserve any caller-supplied `stream_options` fields. We don't
+          // override an explicit `include_usage:false` (operators can still
+          // disable via `injectJsonFields` below if they really need to).
+          if (
+            request.path.toLowerCase().startsWith('/v1/chat/completions')
+            && transformed.stream === true
+          ) {
+            const existing = transformed.stream_options && typeof transformed.stream_options === 'object' && !Array.isArray(transformed.stream_options)
+              ? transformed.stream_options as Record<string, unknown>
+              : {};
+            if (existing.include_usage === undefined) {
+              transformed.stream_options = { ...existing, include_usage: true };
+            }
+          }
+
           const merged = this._config.injectJsonFields
             ? deepMerge(transformed, this._config.injectJsonFields)
             : transformed;


### PR DESCRIPTION
## Problem

Strict OpenAI-spec upstreams only emit a final `usage` SSE chunk on streaming chat-completions when the request body contains `stream_options.include_usage: true`. Without that chunk, `parseResponseUsage(responseBody)` returns zeros, the seller's `SellerHandler` records `cost=0 (in=0 cached=0 out=0)` for every request, and the buyer's deposits are never debited — effectively giving away inference for free.

### Production evidence

A seller hit this in production. Across ~2h of traffic:

- 115 / 115 requests logged `[SellerHandler] Cost recorded: cost=0 cumulative=0 (in=0 cached=0 out=0)`
- The dashboard's per-buyer spend gauge flatlined at $0 while the agent kept happily consuming tokens.
- Other buyers on the same seller using other formats were charged correctly, because their requests went through `transformOpenAIResponsesRequestToOpenAIChat` (in `packages/api-adapter/src/openai-responses.ts`), which already injects `stream_options.include_usage: true`.

The gap is the **native chat→chat path**: when both the buyer and the seller speak chat-completions, no `transform*` function runs end-to-end, so nothing injects `stream_options`.

## Fix

Inject `stream_options.include_usage: true` in the seller's `HttpRelay` (`packages/provider-core/src/http-relay.ts`), inside the existing JSON body normalization block — right after the `service`→`model` rewrite and before operator-level `injectJsonFields` deep-merge.

### Why seller-side (not buyer-side)

- Every provider plugin built on `@antseed/provider-core` gets the fix automatically (`provider-openai`, `provider-anthropic-compat`, `provider-openai-responses`, etc.) — no per-plugin change needed.
- Seller correctness no longer depends on buyer-side behavior; even older or third-party buyers that don't set `stream_options` still get metered correctly.
- A single rollout (rebuild seller image, redeploy) restores spend accounting across all sellers, regardless of which buyers call them.

### Behavior matrix

| Incoming request                                                             | What relay sends upstream                                          |
| ---------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| `/v1/chat/completions`, `stream:true`, no `stream_options`                   | Adds `stream_options: { include_usage: true }`                     |
| `/v1/chat/completions`, `stream:true`, `stream_options:{include_obfuscation:false}` | Merges → `{ include_obfuscation:false, include_usage:true }`       |
| `/v1/chat/completions`, `stream:true`, explicit `include_usage:false`        | Untouched (operator escape hatch)                                  |
| `/v1/chat/completions`, `stream:false` (or omitted)                          | Untouched (JSON responses carry usage natively)                    |
| `/v1/responses`, `/v1/messages`, anything else                               | Untouched                                                          |
| Operator sets `OPENAI_BODY_INJECT_JSON` with `stream_options`                | Operator wins (their `injectJsonFields` deep-merges *after* ours)  |

## Tests

Adds 6 unit tests in `http-relay.test.ts` covering each branch above. All 36 `@antseed/provider-core` tests pass; `typecheck` and `build` clean.

```
 Test Files  2 passed (2)
      Tests  36 passed (36)
```

## Relationship to #457

#457 attempted the same fix on the **buyer** side (`apps/cli/src/proxy/buyer-proxy.ts`). That works for buyers built on this CLI but doesn't help when third-party buyers or older CLI versions hit a strict upstream. With this seller-side fix landed, #457 becomes redundant for correctness — recommend closing it once this is merged. (Or keeping it as defense-in-depth; the second injection on the seller would be a no-op since we check `existing.include_usage === undefined`.)

## Rollout note

After this lands and `@antseed/provider-core` is published, sellers fronting strict OpenAI-spec upstreams (e.g. the `subscriptions` peer fronting `api.minimax.io`) need a redeploy for the fix to take effect. Until then, an immediate hotfix is to add to the seller's configmap:

```json
"bodyInjectJson": "{\"stream_options\":{\"include_usage\":true}}"
```

under the `openai`-plugin provider entry.
