### PR TITLE
feat(cli): auto-refresh plugins when their pinned core deps drift from CLI bundle

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -21,7 +21,7 @@
     "start:seed": "node dist/cli/index.js seed",
     "start:connect": "node dist/cli/index.js connect",
     "typecheck": "tsc --noEmit",
-    "test": "npm run build && node --test dist/config/*.test.js dist/cli/commands/**/*.test.js dist/proxy/*.test.js"
+    "test": "npm run build && node --test dist/config/*.test.js dist/cli/commands/**/*.test.js dist/proxy/*.test.js dist/plugins/*.test.js"
   },
   "dependencies": {
     "@antseed/api-adapter": "workspace:*",

--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -12,6 +12,8 @@ import type { NodePaymentsConfig } from '@antseed/node'
 import { OFFICIAL_BOOTSTRAP_NODES, parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery'
 import { setupShutdownHandler } from '../../shutdown.js'
 import { loadRouterPlugin, buildPluginConfig, getPackageVersions } from '../../../plugins/loader.js'
+import { ensurePluginsUpToDate } from '../../../plugins/drift.js'
+import { resolvePluginPackage } from '../../../plugins/registry.js'
 import { BuyerProxy } from '../../../proxy/buyer-proxy.js'
 import { resolveEffectiveBuyerConfig, type BuyerRuntimeOverrides } from '../../../config/effective.js'
 import type { BuyerCLIConfig } from '../../../config/types.js'
@@ -224,6 +226,9 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
           console.error(chalk.red(`Instance "${options.instance}" is a ${instance.type}, not a router.`))
           process.exit(1)
         }
+        // Refresh stale plugins before importing them. Best-effort; see
+        // ensurePluginsUpToDate / plugins/drift.ts for the full rationale.
+        await ensurePluginsUpToDate([resolvePluginPackage(instance.package)])
         const spinner = ora(`Loading router plugin "${instance.package}"...`).start()
         try {
           const plugin = await loadRouterPlugin(instance.package)
@@ -237,6 +242,9 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
           process.exit(1)
         }
       } else {
+        // Refresh stale plugins before importing them. Best-effort; see
+        // ensurePluginsUpToDate / plugins/drift.ts for the full rationale.
+        await ensurePluginsUpToDate([resolvePluginPackage(routerName)])
         const spinner = ora(`Loading router plugin "${routerName}"...`).start()
         try {
           const plugin = await loadRouterPlugin(routerName)

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -16,6 +16,7 @@ import type { AntseedConfig } from '../../../config/types.js'
 import { parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery'
 import { setupShutdownHandler } from '../../shutdown.js'
 import { loadProviderPlugin, buildPluginConfig, getPackageVersions } from '../../../plugins/loader.js'
+import { ensurePluginsUpToDate } from '../../../plugins/drift.js'
 import { resolveEffectiveSellerConfig, type SellerRuntimeOverrides } from '../../../config/effective.js'
 import type { SellerCLIConfig } from '../../../config/types.js'
 import { AntAgentProvider, loadAntAgent, type AntAgentDefinition } from '@antseed/ant-agent'
@@ -333,6 +334,17 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
         console.error(chalk.dim(`Configured providers: ${configuredProviderNames.join(', ') || '(none)'}`))
         process.exit(1)
       }
+
+      // Refresh any installed plugin whose pinned `@antseed/*` core deps are
+      // older than the versions the CLI itself bundles. Must run BEFORE the
+      // first `loadProviderPlugin` import below — once a plugin is `import()`-ed,
+      // refreshing it on disk has no effect on the running process.
+      // Best-effort: failures here log a warning and let startup continue
+      // with the existing (possibly stale) plugins.
+      const selectedProviderPackages = selectedProviderNames.map((name) =>
+        resolvePluginPackage(effectiveSellerConfig.providers[name]!.plugin),
+      )
+      await ensurePluginsUpToDate(selectedProviderPackages)
 
       const providers: Provider[] = []
       for (const providerName of selectedProviderNames) {

--- a/apps/cli/src/plugins/drift.test.ts
+++ b/apps/cli/src/plugins/drift.test.ts
@@ -1,0 +1,323 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  detectPluginDrift,
+  ensurePluginsUpToDate,
+  getCliBundledVersion,
+  getPluginPinnedCoreVersion,
+  type RefreshResult,
+} from './drift.js'
+
+/**
+ * Build a fake plugins dir on disk, populated with the given plugins and
+ * their `dependencies` maps. Returns the temp dir; caller is responsible
+ * for cleanup via `rmSync(dir, { recursive: true, force: true })`.
+ */
+function makeFakePluginsDir(plugins: Record<string, { version: string; dependencies?: Record<string, string> }>): string {
+  const root = mkdtempSync(join(tmpdir(), 'antseed-drift-test-'))
+  for (const [name, spec] of Object.entries(plugins)) {
+    const pluginDir = join(root, 'node_modules', ...name.split('/'))
+    mkdirSync(pluginDir, { recursive: true })
+    writeFileSync(
+      join(pluginDir, 'package.json'),
+      JSON.stringify({ name, version: spec.version, dependencies: spec.dependencies ?? {} }, null, 2),
+      'utf-8',
+    )
+  }
+  return root
+}
+
+test('getCliBundledVersion returns the version of a package bundled with the CLI', () => {
+  // chalk is a real dependency of the CLI and will resolve from this package's
+  // node_modules. We only assert it's a non-empty string — the exact value
+  // varies with the lockfile.
+  const v = getCliBundledVersion('chalk')
+  assert.equal(typeof v, 'string')
+  assert.ok((v ?? '').length > 0, 'chalk should resolve to a non-empty version string')
+})
+
+test('getCliBundledVersion returns null for a package that is not bundled', () => {
+  const v = getCliBundledVersion('@definitely-not-a-real-package/this-cannot-exist-12345')
+  assert.equal(v, null)
+})
+
+test('getPluginPinnedCoreVersion reads the pinned dep from the plugin package.json', () => {
+  const root = makeFakePluginsDir({
+    '@antseed/provider-openai': {
+      version: '0.2.40',
+      dependencies: { '@antseed/provider-core': '0.2.48' },
+    },
+  })
+  try {
+    assert.equal(
+      getPluginPinnedCoreVersion('@antseed/provider-openai', '@antseed/provider-core', root),
+      '0.2.48',
+    )
+    assert.equal(
+      getPluginPinnedCoreVersion('@antseed/provider-openai', '@antseed/node', root),
+      null,
+      'should return null when the plugin does not depend on the core package at all',
+    )
+    assert.equal(
+      getPluginPinnedCoreVersion('@antseed/not-installed', '@antseed/provider-core', root),
+      null,
+      'should return null when the plugin is not installed',
+    )
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('getPluginPinnedCoreVersion refuses paths that escape the plugins dir', () => {
+  // Even with a malicious plugin name containing path separators, the function
+  // must NOT read files outside the supplied plugins dir.
+  const root = mkdtempSync(join(tmpdir(), 'antseed-drift-test-'))
+  try {
+    // No file is created; we only need to confirm we get null (not a throw,
+    // not an external file read).
+    const malicious = getPluginPinnedCoreVersion('../../../../etc/passwd', '@antseed/provider-core', root)
+    assert.equal(malicious, null)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('detectPluginDrift flags plugins whose pinned core deps differ from CLI-bundled versions', () => {
+  const root = makeFakePluginsDir({
+    '@antseed/provider-openai': {
+      version: '0.2.40',
+      dependencies: { '@antseed/provider-core': '0.2.48' }, // STALE
+    },
+    '@antseed/provider-anthropic': {
+      version: '0.1.42',
+      dependencies: { '@antseed/provider-core': '0.2.49' }, // current
+    },
+  })
+  try {
+    const report = detectPluginDrift(
+      ['@antseed/provider-openai', '@antseed/provider-anthropic'],
+      root,
+      { '@antseed/provider-core': '0.2.49', '@antseed/node': null, '@antseed/router-core': null, '@antseed/api-adapter': null },
+    )
+    assert.equal(report.driftedPlugins.length, 1)
+    assert.equal(report.driftedPlugins[0]!.plugin, '@antseed/provider-openai')
+    assert.equal(report.driftedPlugins[0]!.staleCorePackages.length, 1)
+    assert.equal(report.driftedPlugins[0]!.staleCorePackages[0]!.pkg, '@antseed/provider-core')
+    assert.equal(report.driftedPlugins[0]!.staleCorePackages[0]!.pluginPinnedVersion, '0.2.48')
+    assert.equal(report.driftedPlugins[0]!.staleCorePackages[0]!.cliBundledVersion, '0.2.49')
+    assert.equal(report.missingPlugins.length, 0)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('detectPluginDrift reports missing plugins separately from drifted plugins', () => {
+  const root = makeFakePluginsDir({
+    '@antseed/provider-openai': {
+      version: '0.2.41',
+      dependencies: { '@antseed/provider-core': '0.2.49' },
+    },
+  })
+  try {
+    const report = detectPluginDrift(
+      ['@antseed/provider-openai', '@antseed/provider-anthropic'],
+      root,
+      { '@antseed/provider-core': '0.2.49', '@antseed/node': null, '@antseed/router-core': null, '@antseed/api-adapter': null },
+    )
+    assert.deepEqual(report.driftedPlugins, [])
+    assert.deepEqual(report.missingPlugins, ['@antseed/provider-anthropic'])
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('detectPluginDrift treats a plugin pin newer than the CLI bundle as drift too', () => {
+  // This is intentional: a newer plugin pin means the plugin was built
+  // against a core API the CLI may not yet ship. We surface that so the
+  // operator can decide whether to upgrade the CLI or hold back the plugin.
+  const root = makeFakePluginsDir({
+    '@antseed/provider-openai': {
+      version: '0.2.99',
+      dependencies: { '@antseed/provider-core': '0.3.0' }, // newer than bundled
+    },
+  })
+  try {
+    const report = detectPluginDrift(
+      ['@antseed/provider-openai'],
+      root,
+      { '@antseed/provider-core': '0.2.49', '@antseed/node': null, '@antseed/router-core': null, '@antseed/api-adapter': null },
+    )
+    assert.equal(report.driftedPlugins.length, 1)
+    assert.equal(report.driftedPlugins[0]!.staleCorePackages[0]!.pluginPinnedVersion, '0.3.0')
+    assert.equal(report.driftedPlugins[0]!.staleCorePackages[0]!.cliBundledVersion, '0.2.49')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('detectPluginDrift ignores core packages the CLI does not bundle', () => {
+  const root = makeFakePluginsDir({
+    '@antseed/provider-openai': {
+      version: '0.2.40',
+      dependencies: { '@antseed/provider-core': '0.2.48', '@antseed/router-core': '0.1.0' },
+    },
+  })
+  try {
+    // CLI bundles provider-core but NOT router-core. We should only complain
+    // about provider-core.
+    const report = detectPluginDrift(
+      ['@antseed/provider-openai'],
+      root,
+      { '@antseed/provider-core': '0.2.49', '@antseed/node': null, '@antseed/router-core': null, '@antseed/api-adapter': null },
+    )
+    assert.equal(report.driftedPlugins.length, 1)
+    assert.equal(report.driftedPlugins[0]!.staleCorePackages.length, 1)
+    assert.equal(report.driftedPlugins[0]!.staleCorePackages[0]!.pkg, '@antseed/provider-core')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('ensurePluginsUpToDate is a no-op when no plugins are passed', async () => {
+  let refreshCalls = 0
+  await ensurePluginsUpToDate([], {
+    log: () => {},
+    warn: () => {},
+    refresh: async () => { refreshCalls += 1; return { refreshed: [], failed: [] } },
+  })
+  assert.equal(refreshCalls, 0)
+})
+
+test('ensurePluginsUpToDate skips when ANTSEED_SKIP_PLUGIN_UPDATE_CHECK=1', async () => {
+  let refreshCalls = 0
+  await ensurePluginsUpToDate(['@antseed/provider-openai'], {
+    log: () => {},
+    warn: () => {},
+    refresh: async () => { refreshCalls += 1; return { refreshed: [], failed: [] } },
+    env: { ANTSEED_SKIP_PLUGIN_UPDATE_CHECK: '1' },
+  })
+  assert.equal(refreshCalls, 0)
+})
+
+test('ensurePluginsUpToDate skips third-party (non-trusted) plugins', async () => {
+  // Even if a non-trusted plugin is drifted, we don't auto-update it.
+  const root = makeFakePluginsDir({
+    '@third-party/some-plugin': {
+      version: '1.0.0',
+      dependencies: { '@antseed/provider-core': '0.2.48' },
+    },
+  })
+  try {
+    let refreshCalls = 0
+    const logs: string[] = []
+    await ensurePluginsUpToDate(['@third-party/some-plugin'], {
+      log: (m) => logs.push(m),
+      warn: () => {},
+      refresh: async () => { refreshCalls += 1; return { refreshed: [], failed: [] } },
+      pluginsDir: root,
+      bundledVersions: { '@antseed/provider-core': '0.2.49' },
+    })
+    assert.equal(refreshCalls, 0)
+    assert.ok(
+      logs.some((l) => l.includes('non-trusted')),
+      `expected a non-trusted notice in logs, got: ${JSON.stringify(logs)}`,
+    )
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('ensurePluginsUpToDate is silent on the happy path (no drift, no missing)', async () => {
+  const root = makeFakePluginsDir({
+    '@antseed/provider-openai': {
+      version: '0.2.41',
+      dependencies: { '@antseed/provider-core': '0.2.49' },
+    },
+  })
+  try {
+    let refreshCalls = 0
+    const logs: string[] = []
+    const warns: string[] = []
+    await ensurePluginsUpToDate(['@antseed/provider-openai'], {
+      log: (m) => logs.push(m),
+      warn: (m) => warns.push(m),
+      refresh: async () => { refreshCalls += 1; return { refreshed: [], failed: [] } },
+      pluginsDir: root,
+      bundledVersions: { '@antseed/provider-core': '0.2.49' },
+    })
+    assert.equal(refreshCalls, 0, 'should not call refresh when no drift')
+    assert.equal(logs.length, 0, `expected no logs on happy path, got: ${JSON.stringify(logs)}`)
+    assert.equal(warns.length, 0, `expected no warnings on happy path, got: ${JSON.stringify(warns)}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('ensurePluginsUpToDate triggers refresh on drift and reports success', async () => {
+  const root = makeFakePluginsDir({
+    '@antseed/provider-openai': {
+      version: '0.2.40',
+      dependencies: { '@antseed/provider-core': '0.2.48' }, // stale
+    },
+  })
+  try {
+    const refreshCalls: string[][] = []
+    const logs: string[] = []
+    await ensurePluginsUpToDate(['@antseed/provider-openai'], {
+      log: (m) => logs.push(m),
+      warn: () => {},
+      refresh: async (plugins) => {
+        refreshCalls.push(plugins)
+        return { refreshed: plugins, failed: [] } satisfies RefreshResult
+      },
+      pluginsDir: root,
+      bundledVersions: { '@antseed/provider-core': '0.2.49' },
+    })
+    assert.deepEqual(refreshCalls, [['@antseed/provider-openai']])
+    // Should mention the drift detection and the successful refresh.
+    assert.ok(logs.some((l) => l.includes('stale')), `expected drift warning, got: ${JSON.stringify(logs)}`)
+    assert.ok(logs.some((l) => l.includes('Refreshed')), `expected success message, got: ${JSON.stringify(logs)}`)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('ensurePluginsUpToDate logs a manual-retry hint and continues when refresh fails', async () => {
+  const root = makeFakePluginsDir({
+    '@antseed/provider-openai': {
+      version: '0.2.40',
+      dependencies: { '@antseed/provider-core': '0.2.48' },
+    },
+  })
+  try {
+    const warns: string[] = []
+    const logs: string[] = []
+    await ensurePluginsUpToDate(['@antseed/provider-openai'], {
+      log: (m) => logs.push(m),
+      warn: (m) => warns.push(m),
+      refresh: async (plugins) => ({
+        refreshed: [],
+        failed: plugins.map((p) => ({ plugin: p, reason: 'simulated EAI_AGAIN' })),
+      }),
+      pluginsDir: root,
+      bundledVersions: { '@antseed/provider-core': '0.2.49' },
+    })
+    assert.ok(
+      warns.some((w) => w.includes('Failed to refresh @antseed/provider-openai') && w.includes('EAI_AGAIN')),
+      `expected per-plugin failure warning, got: ${JSON.stringify(warns)}`,
+    )
+    assert.ok(
+      warns.some((w) => w.includes('Continuing startup')),
+      `expected continuation reassurance, got: ${JSON.stringify(warns)}`,
+    )
+    assert.ok(
+      warns.some((w) => w.includes('npm install')),
+      `expected manual-retry hint, got: ${JSON.stringify(warns)}`,
+    )
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/apps/cli/src/plugins/drift.ts
+++ b/apps/cli/src/plugins/drift.ts
@@ -1,0 +1,418 @@
+/**
+ * Plugin drift detection and auto-refresh.
+ *
+ * Background
+ * ----------
+ * The CLI ships with a known-good copy of `@antseed/provider-core` (and other
+ * shared packages) inside its own `node_modules`. Each installed plugin in
+ * `~/.antseed/plugins/node_modules/<pkg>/` has its OWN pinned version of
+ * `@antseed/provider-core` (because plugin `package.json`s use `workspace:*`
+ * during development, which pnpm/npm publish rewrites to an exact version).
+ *
+ * When a user runs `npm i -g @antseed/cli@latest`, the CLI's bundled
+ * `provider-core` updates — but the plugins in `~/.antseed/plugins/` do NOT.
+ * They keep their original pin, so plugin code keeps importing the OLD
+ * `provider-core` even though the CLI itself has the new one.
+ *
+ * This caused real production damage: a fix to the seller-side request
+ * relay (`stream_options.include_usage` injection) shipped in
+ * `@antseed/provider-core@0.2.49`, but sellers running the upgraded CLI
+ * were still importing `provider-core@0.2.48` from their plugins dir. The
+ * fix never took effect for them.
+ *
+ * What this module does
+ * ---------------------
+ * 1. Read the version of each `@antseed/*` core package the CLI itself
+ *    bundles (the "expected" version).
+ * 2. Read the version each installed trusted plugin has pinned in its own
+ *    `package.json` `dependencies` map (the "actual" version).
+ * 3. If any plugin pins a stale core version, run `npm install <plugin>@latest`
+ *    in `~/.antseed/plugins/` for each affected plugin. That naturally pulls
+ *    in the matching core version because workspace pinning is exact.
+ *
+ * The check is best-effort: any failure (network down, registry 5xx, npm
+ * timeout, permission denied) logs a warning and lets startup continue with
+ * the existing (possibly stale) plugins. We never block startup on registry
+ * health.
+ */
+
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { existsSync, readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join, resolve } from 'node:path'
+import chalk from 'chalk'
+import { getPluginsDir } from './manager.js'
+import { TRUSTED_PLUGINS } from './registry.js'
+
+const execFileAsync = promisify(execFile)
+
+/** Core packages whose drift between CLI-bundled and plugin-pinned versions matters. */
+const TRACKED_CORE_PACKAGES = [
+  '@antseed/provider-core',
+  '@antseed/node',
+  '@antseed/router-core',
+  '@antseed/api-adapter',
+] as const
+
+/** Hard timeout for a single `npm install` invocation during auto-refresh. */
+const NPM_INSTALL_TIMEOUT_MS = 60_000
+
+const requireFromHere = createRequire(import.meta.url)
+
+export interface PluginDrift {
+  /** Plugin package name, e.g. `@antseed/provider-openai`. */
+  plugin: string
+  /** Core packages on which this plugin pins a stale version. */
+  staleCorePackages: Array<{
+    pkg: string
+    pluginPinnedVersion: string
+    cliBundledVersion: string
+  }>
+}
+
+export interface DriftReport {
+  /** Plugins whose pinned core deps lag behind what the CLI itself bundles. */
+  driftedPlugins: PluginDrift[]
+  /** Plugins that were requested but are not installed in the plugins dir. */
+  missingPlugins: string[]
+}
+
+export interface RefreshResult {
+  /** Plugins that were successfully reinstalled at @latest. */
+  refreshed: string[]
+  /** Plugins where `npm install` failed; arr of `{plugin, reason}`. */
+  failed: Array<{ plugin: string; reason: string }>
+}
+
+/**
+ * Read the version of a package as bundled inside the CLI's own
+ * `node_modules`. For `@antseed/*` packages, this is the version the CLI
+ * was built against and the "source of truth" we want plugins to match.
+ *
+ * Resolution starts from this module's URL and walks up via Node's module
+ * resolution, so it always finds the CLI's own bundled copy (not a hoisted
+ * copy from elsewhere).
+ *
+ * Implementation note: many modern packages (e.g. chalk) declare `"exports"`
+ * fields that block direct resolution of `<pkg>/package.json`. To handle
+ * those, we first try `require.resolve('<pkg>/package.json')`, and on failure
+ * fall back to resolving the package's main entry and walking up its parent
+ * directories until we find a `package.json` whose `name` matches.
+ *
+ * Returns `null` if the package is not bundled with the CLI (which would be
+ * a build-time error for `@antseed/*` deps, but we don't want to crash the
+ * CLI over it at runtime).
+ */
+export function getCliBundledVersion(pkgName: string): string | null {
+  // Fast path: works for any package whose `exports` allows reading
+  // `package.json` directly (most packages, including all `@antseed/*` ones).
+  try {
+    const pkgJsonPath = requireFromHere.resolve(`${pkgName}/package.json`)
+    return readVersionFromPackageJson(pkgJsonPath)
+  } catch {
+    // Fall through to the entry-point resolution path.
+  }
+
+  // Second fallback: search the standard Node `node_modules` lookup paths
+  // directly for `<lookupPath>/<pkgName>/package.json`. This handles
+  // workspace packages that have an `exports` field WITHOUT a default
+  // resolvable entry (like @antseed/node, which only exposes named
+  // subpaths) — those fail BOTH `resolve('<pkg>/package.json')` AND
+  // `resolve('<pkg>')`, but the package.json is still on disk.
+  const lookupPaths = (requireFromHere.resolve.paths(pkgName) ?? []) as string[]
+  for (const dir of lookupPaths) {
+    const candidate = join(dir, ...pkgName.split('/'), 'package.json')
+    if (!existsSync(candidate)) continue
+    const v = readVersionFromPackageJson(candidate)
+    if (v) return v
+  }
+
+  // Third fallback: resolve the package's main entry and walk up to its
+  // package.json. Last resort for unusual layouts.
+  let entry: string
+  try {
+    entry = requireFromHere.resolve(pkgName)
+  } catch {
+    return null
+  }
+  let cur = entry
+  for (let i = 0; i < 16; i += 1) {
+    const parent = resolve(cur, '..')
+    if (parent === cur) break
+    cur = parent
+    const candidate = join(cur, 'package.json')
+    if (!existsSync(candidate)) continue
+    try {
+      const parsed = JSON.parse(readFileSync(candidate, 'utf-8')) as { name?: unknown; version?: unknown }
+      if (parsed.name === pkgName && typeof parsed.version === 'string') {
+        return parsed.version
+      }
+    } catch {
+      // try next ancestor
+    }
+  }
+  return null
+}
+
+function readVersionFromPackageJson(pkgJsonPath: string): string | null {
+  try {
+    const raw = readFileSync(pkgJsonPath, 'utf-8')
+    const parsed = JSON.parse(raw) as { version?: unknown }
+    return typeof parsed.version === 'string' ? parsed.version : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Read the version a given plugin pins for a given core package, by reading
+ * the plugin's own `package.json` `dependencies` map.
+ *
+ * We deliberately do NOT use Node's module resolution here, because we want
+ * the EXPECTED dependency version (what the plugin was built against) — not
+ * the resolved/hoisted version (which may already be newer if another
+ * plugin pulled it up). If the resolved version is newer than what this
+ * plugin pins, the plugin is still effectively running on a newer core, but
+ * it's a fragile state — the next reinstall could re-pin everything to a
+ * mismatched version. So we treat "plugin's declared dep mismatches CLI
+ * bundle" as drift even if the resolved version happens to match today.
+ *
+ * Returns `null` if the plugin is not installed, or if the plugin doesn't
+ * declare this core package as a dependency at all (in which case there's
+ * nothing to be drifted against).
+ */
+export function getPluginPinnedCoreVersion(
+  pluginPackage: string,
+  corePackage: string,
+  pluginsDir: string = getPluginsDir(),
+): string | null {
+  const pluginPkgJsonPath = resolve(
+    join(pluginsDir, 'node_modules', ...pluginPackage.split('/'), 'package.json'),
+  )
+  if (!existsSync(pluginPkgJsonPath)) return null
+
+  // Defense in depth: refuse to read outside the plugins dir even if a
+  // mischievous plugin name contains `..`. This mirrors the same check
+  // loader.ts performs before importing plugin code.
+  if (!pluginPkgJsonPath.startsWith(resolve(pluginsDir))) return null
+
+  try {
+    const raw = readFileSync(pluginPkgJsonPath, 'utf-8')
+    const parsed = JSON.parse(raw) as { dependencies?: Record<string, string> }
+    const dep = parsed.dependencies?.[corePackage]
+    if (typeof dep !== 'string' || dep.length === 0) return null
+    return dep
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Compare plugin-pinned core versions against CLI-bundled core versions and
+ * report any drift.
+ *
+ * `pluginPackages` should be the set of plugins the seller/buyer is about to
+ * load. We don't check plugins that aren't being used.
+ *
+ * "Drift" here means: the plugin's `dependencies[corePkg]` is a value that
+ * is not equal to the CLI-bundled version of `corePkg`. We treat any
+ * mismatch as drift — including, deliberately, the case where the plugin's
+ * pinned version is NEWER than the CLI's bundled version. That's also a
+ * fragile state (the plugin's importable surface may rely on APIs the CLI
+ * doesn't yet provide), and the user should know.
+ *
+ * We compare strings exactly, not via semver. plugins published from this
+ * monorepo have `workspace:*` deps rewritten to exact versions on publish,
+ * so the dep value is always a bare version like `0.2.48`. Range deps
+ * (`^0.2.0`, `~0.2.5`) are treated as drift unless they happen to literally
+ * equal the bundled version string — that's by design, because we can't
+ * tell from a range whether the resolved version is what we want, and
+ * forcing a re-resolve via `npm install` is the safe default.
+ */
+export function detectPluginDrift(
+  pluginPackages: string[],
+  pluginsDir: string = getPluginsDir(),
+  bundledVersions: Record<string, string | null> = computeBundledVersions(),
+): DriftReport {
+  const driftedPlugins: PluginDrift[] = []
+  const missingPlugins: string[] = []
+
+  for (const plugin of pluginPackages) {
+    const pluginPkgJsonPath = resolve(
+      join(pluginsDir, 'node_modules', ...plugin.split('/'), 'package.json'),
+    )
+    if (!existsSync(pluginPkgJsonPath)) {
+      missingPlugins.push(plugin)
+      continue
+    }
+
+    const stale: PluginDrift['staleCorePackages'] = []
+    for (const corePkg of TRACKED_CORE_PACKAGES) {
+      const cliVersion = bundledVersions[corePkg]
+      if (!cliVersion) continue
+      const pluginPin = getPluginPinnedCoreVersion(plugin, corePkg, pluginsDir)
+      if (pluginPin == null) continue
+      if (pluginPin !== cliVersion) {
+        stale.push({ pkg: corePkg, pluginPinnedVersion: pluginPin, cliBundledVersion: cliVersion })
+      }
+    }
+    if (stale.length > 0) {
+      driftedPlugins.push({ plugin, staleCorePackages: stale })
+    }
+  }
+
+  return { driftedPlugins, missingPlugins }
+}
+
+function computeBundledVersions(): Record<string, string | null> {
+  const out: Record<string, string | null> = {}
+  for (const pkg of TRACKED_CORE_PACKAGES) {
+    out[pkg] = getCliBundledVersion(pkg)
+  }
+  return out
+}
+
+/**
+ * Reinstall the given plugins at `@latest` to pull in fresh transitive deps
+ * (notably the right `@antseed/provider-core` pin).
+ *
+ * Best-effort: each plugin is installed independently; one failure does not
+ * abort the others. Each install has a 60-second timeout.
+ *
+ * SECURITY: only call this with plugins from the trusted-plugins registry
+ * (or otherwise known-safe). We don't validate that here because the
+ * caller is in a better position to enforce it; the typical caller is
+ * `ensurePluginsUpToDate` below, which DOES enforce the trust list.
+ */
+export async function refreshPlugins(plugins: string[]): Promise<RefreshResult> {
+  const refreshed: string[] = []
+  const failed: Array<{ plugin: string; reason: string }> = []
+
+  for (const plugin of plugins) {
+    try {
+      await execFileAsync(
+        'npm',
+        ['install', '--ignore-scripts', `${plugin}@latest`],
+        { cwd: getPluginsDir(), timeout: NPM_INSTALL_TIMEOUT_MS },
+      )
+      refreshed.push(plugin)
+    } catch (err) {
+      const reason = err instanceof Error
+        ? (err.message.split('\n').slice(0, 3).join(' / ') || err.name)
+        : String(err)
+      failed.push({ plugin, reason })
+    }
+  }
+
+  return { refreshed, failed }
+}
+
+/**
+ * Top-level helper: detect drift, log a summary, and (unless skipped) refresh
+ * the drifted plugins.
+ *
+ * Designed to be called once at startup of `seller start` / `buyer start`,
+ * BEFORE any plugin is dynamically imported. (Once imported, refreshing on
+ * disk has no effect on the running process — Node has already cached the
+ * old module.)
+ *
+ * Called with `pluginPackages = []` is a no-op.
+ *
+ * Env vars honored:
+ *  - `ANTSEED_SKIP_PLUGIN_UPDATE_CHECK=1`: skip the entire drift check.
+ *    Use this in air-gapped environments or CI where plugins are pre-baked.
+ *
+ * The function never throws on its own; refresh failures are logged and
+ * swallowed. The only way it errors is if the `pluginPackages` list itself
+ * triggers an internal logic bug.
+ */
+export async function ensurePluginsUpToDate(
+  pluginPackages: string[],
+  opts: {
+    /** Override for tests. Defaults to console.log/console.warn. */
+    log?: (msg: string) => void
+    warn?: (msg: string) => void
+    /** Override for tests. Defaults to `getPluginsDir()`. */
+    pluginsDir?: string
+    /** Override for tests so we don't actually shell out. */
+    refresh?: (plugins: string[]) => Promise<RefreshResult>
+    /** Override for tests so we don't read real CLI bundled versions. */
+    bundledVersions?: Record<string, string | null>
+    /** Override env var lookup for tests. */
+    env?: NodeJS.ProcessEnv
+  } = {},
+): Promise<void> {
+  const log = opts.log ?? ((m: string) => console.log(m))
+  const warn = opts.warn ?? ((m: string) => console.warn(m))
+  const env = opts.env ?? process.env
+
+  if (pluginPackages.length === 0) return
+  if (isTruthy(env['ANTSEED_SKIP_PLUGIN_UPDATE_CHECK'])) return
+
+  // Restrict to the trusted plugin set. We do NOT auto-update third-party
+  // plugins — those should be managed manually because their release
+  // cadence and trust model are out of our hands.
+  const trustedPackages = new Set(TRUSTED_PLUGINS.map((p) => p.package))
+  const eligible = pluginPackages.filter((p) => trustedPackages.has(p))
+  const skippedThirdParty = pluginPackages.filter((p) => !trustedPackages.has(p))
+  if (skippedThirdParty.length > 0) {
+    log(chalk.dim(
+      `Skipping plugin drift check for non-trusted package(s): ${skippedThirdParty.join(', ')}`,
+    ))
+  }
+  if (eligible.length === 0) return
+
+  const report = detectPluginDrift(
+    eligible,
+    opts.pluginsDir ?? getPluginsDir(),
+    opts.bundledVersions ?? computeBundledVersions(),
+  )
+
+  if (report.driftedPlugins.length === 0) {
+    // Quiet on the happy path — the existing "Package versions:" log line
+    // already surfaces what's installed.
+    return
+  }
+
+  log(chalk.yellow('⚠  Detected stale plugin core dependencies:'))
+  for (const drift of report.driftedPlugins) {
+    log(chalk.yellow(`   ${drift.plugin}:`))
+    for (const stale of drift.staleCorePackages) {
+      log(chalk.yellow(
+        `     ${stale.pkg}: plugin pins ${stale.pluginPinnedVersion}, CLI bundles ${stale.cliBundledVersion}`,
+      ))
+    }
+  }
+  log(chalk.dim('   Refreshing affected plugin(s) from npm…'))
+
+  const refresh = opts.refresh ?? refreshPlugins
+  const driftedPluginNames = report.driftedPlugins.map((d) => d.plugin)
+  const result = await refresh(driftedPluginNames)
+
+  if (result.refreshed.length > 0) {
+    log(chalk.green(`✓ Refreshed plugin(s): ${result.refreshed.join(', ')}`))
+  }
+  if (result.failed.length > 0) {
+    for (const f of result.failed) {
+      warn(chalk.yellow(
+        `   Failed to refresh ${f.plugin}: ${f.reason}`,
+      ))
+    }
+    warn(chalk.yellow(
+      `   Continuing startup with the previously-installed plugin version(s).`,
+    ))
+    warn(chalk.dim(
+      `   To retry manually: cd ${getPluginsDir()} && npm install ${result.failed.map((f) => `${f.plugin}@latest`).join(' ')}`,
+    ))
+  }
+}
+
+function isTruthy(value: string | undefined): boolean {
+  if (!value) return false
+  const v = value.trim().toLowerCase()
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on'
+}
+
+// Exported for tests / startup logging.
+export { TRACKED_CORE_PACKAGES }


### PR DESCRIPTION
## Problem

When a seller upgrades the CLI (`npm i -g @antseed/cli@latest`), the CLI's bundled `@antseed/provider-core` (and other shared packages) updates with it. **But the plugins in `~/.antseed/plugins/` keep their original pinned core deps**, because pnpm/npm publish rewrites `workspace:*` to an exact version — and that pin lives in the plugin's own `package.json` forever.

So a fix in `@antseed/provider-core` that ships in CLI `0.1.X+1` doesn't take effect for plugin-loaded providers until the plugin itself is reinstalled. This caused **real production damage**: the `stream_options.include_usage` seller-side fix from #458 landed in `provider-core@0.2.49`, but every seller running plugins pinned to `provider-core@0.2.48` silently kept hitting the old code path — **billing $0 for hours of inference** while their agents happily consumed tokens.

The desktop app already handles this (see #commit 8b4f18bc — `isBundledPluginRefreshNeeded`), refreshing installed plugin copies from the bundled set on every start. The CLI had no equivalent guard.

## What this PR does

On `seller start` and `buyer start`, **before any plugin is dynamically imported**, compare the version of each tracked `@antseed/*` core package:

| Source | "Expected" — what we want | "Actual" — what plugins use |
|---|---|---|
| `@antseed/provider-core` | Version bundled in CLI's own `node_modules` | Version pinned in each installed plugin's `package.json` `dependencies` |
| `@antseed/node` | ditto | ditto |
| `@antseed/router-core` | ditto | ditto |
| `@antseed/api-adapter` | ditto | ditto |

If any installed plugin pins a stale core version, run `npm install <plugin>@latest` in `~/.antseed/plugins/` for each affected plugin. That naturally pulls in the matching core version because the new plugin release pins it exactly.

## Behavior

| Scenario | Behavior |
|---|---|
| No plugins requested (empty list) | No-op |
| `ANTSEED_SKIP_PLUGIN_UPDATE_CHECK=1` | Skip entire check |
| Third-party (non-trusted) plugin requested | Skip with explanatory log; trust list = `TRUSTED_PLUGINS` registry |
| All plugins current | Silent (no extra noise on top of existing `Package versions:` log) |
| Plugin pin matches CLI bundle exactly | Treated as current, no refresh |
| Plugin pin lags CLI bundle | Refresh via `npm install <plugin>@latest` |
| Plugin pin is **newer** than CLI bundle | Also flagged — plugin built against newer core APIs may rely on surfaces the CLI doesn't yet provide. Operator decides whether to upgrade CLI or hold plugin back |
| `npm install` succeeds | Log `✓ Refreshed plugin(s): ...` |
| `npm install` fails (network, 5xx, permission) | Log warning, **continue startup** with previously-installed plugin. Print one-liner manual-retry hint |
| `npm install` hangs | 60-second hard timeout per invocation, then treated as failure |

## Safety rails

- **Trust list gating**: only refreshes packages on the `TRUSTED_PLUGINS` registry. Non-trusted third-party packages skipped with an explanatory log — their release cadence and trust model are out of our hands.
- **Per-install timeout**: 60s hard timeout on each `npm install`. A registry outage cannot take the fleet down.
- **Best-effort**: any failure logs a warning and lets startup continue. We never block startup on registry health.
- **Opt-out**: `ANTSEED_SKIP_PLUGIN_UPDATE_CHECK=1` for air-gapped sellers, CI workflows that pre-bake plugins, etc.
- **Path traversal defense**: `getPluginPinnedCoreVersion` refuses to read outside the plugins dir even with malicious plugin names (mirrors the same defense `loader.ts` already has before importing).
- **Quiet on the happy path**: zero extra logs when nothing is drifted.

## Implementation notes

- `getCliBundledVersion` has three resolution strategies, in order:
  1. `require.resolve('<pkg>/package.json')` — fast path, works for most packages.
  2. Walk `require.resolve.paths('<pkg>')` looking for `<node_modules>/<pkg>/package.json` — needed for packages with `exports` fields that don't expose `package.json` (e.g. `@antseed/node`).
  3. Resolve the package's main entry and walk up until we find a `package.json` whose `name` matches.
- The wire-in points in `seller start` / `buyer start` are intentionally placed **BEFORE** the first `loadProviderPlugin` / `loadRouterPlugin` call. Once a plugin is `import()`-ed, refreshing it on disk has no effect on the running process — Node has already cached the old module.
- Drift check runs only for the plugins the seller/buyer is actually loading on this invocation, not all installed plugins. This keeps the check fast and limits blast radius if anything goes wrong.

## Tests

14 new tests in `apps/cli/src/plugins/drift.test.ts` covering:

- CLI-bundled version resolution (existing, missing, `exports`-restricted)
- Plugin pinned-version reading (present, absent, path traversal defense)
- Drift detection (stale, current, missing-plugin, newer pins, ignored packages CLI doesn't bundle)
- `ensurePluginsUpToDate` (no-op on empty input, env opt-out, third-party skip, happy-path silence, success path, failure path with manual retry hint)

Also extends the `apps/cli` `test` script glob to include `dist/plugins/*.test.js` so the new tests actually run in CI.

```
# tests 89    (was 75 before this PR)
# pass 89
# fail 0
```

## Manual smoke test

```js
// from apps/cli, against a real built dist/
import('./dist/plugins/drift.js').then(({ getCliBundledVersion }) => {
  console.log('@antseed/provider-core:', getCliBundledVersion('@antseed/provider-core'));
  console.log('@antseed/node:', getCliBundledVersion('@antseed/node'));
  console.log('@antseed/api-adapter:', getCliBundledVersion('@antseed/api-adapter'));
  console.log('@antseed/router-core:', getCliBundledVersion('@antseed/router-core'));
});
// @antseed/provider-core: 0.2.49
// @antseed/node: 0.2.78
// @antseed/api-adapter: 0.1.37
// @antseed/router-core: null   ← correct: CLI doesn't depend on it directly
```

## Rollout

This change is purely a startup-side guard; it doesn't alter any wire protocol or persisted state. Sellers picking up this CLI version will get a one-time refresh of any drifted trusted plugins on their next restart. After that, the check is silent until the next CLI upgrade.

## Related

- #458 — the seller-side `stream_options.include_usage` fix that exposed this gap. After this PR lands and ships, sellers who upgrade the CLI will automatically get the fixed `provider-core` propagated into their plugins on next restart, without any manual `cd ~/.antseed/plugins && npm install` step.
- Desktop equivalent: `apps/desktop/src/main/plugins.ts` already does this via bundled-plugin refresh (`isBundledPluginRefreshNeeded`); this PR brings the CLI to parity using `npm install` instead (since the CLI doesn't ship a bundled-plugin set).
