### PR TITLE
Show active dot on collapsed peer when a chat under it is running

### DIFF
--- a/apps/desktop/src/renderer/ui/components/Sidebar.module.scss
+++ b/apps/desktop/src/renderer/ui/components/Sidebar.module.scss
@@ -321,6 +321,20 @@
   animation: chat-conv-running-pulse 1.4s ease-in-out infinite;
 }
 
+/* Active indicator on a collapsed peer when one of its chats is running.
+   Same visual language as .chat-conv-running-dot so the user reads it as
+   the same "working" signal at a different scope. (Issue #461.) */
+.peer-group-running-dot {
+  flex-shrink: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent-green, #4ade80);
+  box-shadow: 0 0 0 0 rgba(var(--accent-green-rgb, 74, 222, 128), 0.6);
+  animation: chat-conv-running-pulse 1.4s ease-in-out infinite;
+  margin-right: 2px;
+}
+
 @keyframes chat-conv-running-pulse {
   0%, 100% {
     opacity: 1;

--- a/apps/desktop/src/renderer/ui/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/ui/components/Sidebar.tsx
@@ -250,6 +250,15 @@ function PeerGroupSection({
   const convsRef = useRef<HTMLDivElement>(null);
   const letter = (group.displayName || '?').charAt(0).toUpperCase();
 
+  // When the group is collapsed, surface a single running indicator on the
+  // peer header if any of its conversations is in flight — otherwise a user
+  // who collapses a peer can't tell that work is still happening underneath.
+  // When expanded, the existing per-chat dots are visible, so we don't
+  // duplicate the indicator at the peer level. (Issue #461.)
+  const hasRunningConv = !expanded && group.conversations.some(
+    (conv) => sendingConvIds.has(String(conv.id ?? '')),
+  );
+
   // Scroll the header into view and animate convs open when expanded
   useEffect(() => {
     if (expanded && headerRef.current) {
@@ -277,6 +286,14 @@ function PeerGroupSection({
           {letter}
         </span>
         <span className={styles.peerGroupName}>{group.displayName}</span>
+        {hasRunningConv && (
+          <span
+            className={styles.peerGroupRunningDot}
+            role="status"
+            aria-label={`A chat in ${group.displayName} is running`}
+            title="A chat in this peer is running"
+          />
+        )}
         {group.peerId && (
           <button
             className={styles.peerGroupAdd}


### PR DESCRIPTION
## Summary
- When a peer group is collapsed, surface a single running indicator on its header if any conversation under it is in flight
- Hide the peer-level indicator when the group is expanded so the existing per-chat dots aren't duplicated
- Reuse `chat-conv-running-pulse` so the indicator reads as the same "working" signal at peer scope

## Testing
- pnpm --filter=@antseed/desktop exec tsc -p tsconfig.renderer.json --noEmit
- Manual: collapse a peer mid-stream → dot appears on peer row; finish stream → dot disappears; expand peer → only per-chat dots show

Closes #461