### PR TITLE
fix(node): Correct payment NeedAuth accounting

### DIFF
--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -789,7 +789,6 @@ export class BuyerPaymentManager {
     }
 
     const buyerService = payload.requestId ? this._requestService.get(payload.requestId) : undefined;
-    if (payload.requestId) this._requestService.delete(payload.requestId);
 
     const requiredCumulativeAmount = BigInt(payload.requiredCumulativeAmount);
     const currentCumulative = this._cumulativeAmount.get(sellerPeerId) ?? 0n;
@@ -801,6 +800,7 @@ export class BuyerPaymentManager {
       );
       return;
     }
+    if (payload.requestId) this._requestService.delete(payload.requestId);
 
     // Validate the seller's claimed cost if reported
     if (payload.lastRequestCost) {

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -369,7 +369,7 @@ export class SellerRequestHandler {
             debugLog(`[SellerHandler] Cost recorded: buyer=${buyerPeerId.slice(0, 12)}... cost=${costUsdc} cumulative=${cumulativeSpend} (in=${usage.inputTokens} cached=${usage.cachedInputTokens} out=${usage.outputTokens})`);
 
             const accepted = spm.getAcceptedCumulative(session.sessionId);
-            const requiredAmount = cumulativeSpend + costUsdc;
+            const requiredAmount = cumulativeSpend;
             debugLog(`[SellerHandler] Sending NeedAuth: cost=${costUsdc} cumulative=${cumulativeSpend} required=${requiredAmount}`);
             this._sendNeedAuthBestEffort(paymentMux, {
               channelId: session.sessionId,

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -566,6 +566,66 @@ describe('BuyerPaymentManager', () => {
     expect(mux.sentSpendingAuths.length).toBe(0);
   });
 
+  it('handleNeedAuth does not consume request service mapping for stale auths', async () => {
+    const sellerPeerId = fakePeerId('seller-needauth-service');
+    const channelId = await manager.authorizeSpending(
+      sellerPeerId,
+      mux,
+      10_000n,
+      1_000_000n,
+      { inputUsdPerMillion: 0.36, outputUsdPerMillion: 1.65, cachedInputUsdPerMillion: 0.07 },
+      {
+        defaults: { inputUsdPerMillion: 0.36, outputUsdPerMillion: 1.65, cachedInputUsdPerMillion: 0.07 },
+        services: {
+          'gpt-5.3-codex-spark': { inputUsdPerMillion: 5, outputUsdPerMillion: 30, cachedInputUsdPerMillion: 1 },
+        },
+      },
+    );
+    mux.sentSpendingAuths.length = 0;
+
+    await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requiredCumulativeAmount: '1000',
+      currentAcceptedCumulative: '0',
+      deposit: '1000000',
+    }, mux);
+    expect(mux.sentSpendingAuths.length).toBe(1);
+    mux.sentSpendingAuths.length = 0;
+
+    manager.trackRequestService('req-service-pricing', 'gpt-5.3-codex-spark');
+
+    await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requestId: 'req-service-pricing',
+      requiredCumulativeAmount: '500',
+      currentAcceptedCumulative: '1000',
+      deposit: '1000000',
+      lastRequestCost: '53000',
+      inputTokens: '10000',
+      freshInputTokens: '10000',
+      outputTokens: '100',
+      cachedInputTokens: '0',
+    }, mux);
+    expect(mux.sentSpendingAuths.length).toBe(0);
+
+    await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requestId: 'req-service-pricing',
+      requiredCumulativeAmount: '53000',
+      currentAcceptedCumulative: '1000',
+      deposit: '1000000',
+      lastRequestCost: '53000',
+      inputTokens: '10000',
+      freshInputTokens: '10000',
+      outputTokens: '100',
+      cachedInputTokens: '0',
+    }, mux);
+
+    expect(mux.sentSpendingAuths.length).toBe(1);
+    const sent = mux.sentSpendingAuths[0] as Record<string, unknown>;
+    expect(sent.cumulativeAmount).toBe('53000');
+  });
+
   it('handleNeedAuth ignores unknown seller', async () => {
     mux.sentSpendingAuths.length = 0;
 

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -9,7 +9,7 @@ import { MessageType, PAYMENT_CODE_CHANNEL_EXHAUSTED } from '../src/types/protoc
 function makeProvider(inputUsdPerMillion: number, outputUsdPerMillion: number, opts: {
   name: string;
   services: string[];
-  servicePricing?: Record<string, { inputUsdPerMillion: number; outputUsdPerMillion: number }>;
+  servicePricing?: Record<string, { inputUsdPerMillion: number; outputUsdPerMillion: number; cachedInputUsdPerMillion?: number }>;
 }): Provider {
   return {
     name: opts.name,
@@ -249,6 +249,182 @@ describe('SellerRequestHandler payment pricing selection', () => {
       currentAcceptedCumulative: '0',
       requiredCumulativeAmount: '0',
     }));
+  });
+
+  it('uses cumulative spend as NeedAuth required amount without double-counting the latest request', async () => {
+    const provider = makeProvider(1, 1, {
+      name: 'openai-responses',
+      services: ['gpt-5.3-codex-spark'],
+      servicePricing: {
+        'gpt-5.3-codex-spark': {
+          inputUsdPerMillion: 5,
+          outputUsdPerMillion: 30,
+          cachedInputUsdPerMillion: 1,
+        },
+      },
+    });
+    provider.handleRequest = vi.fn(async (req) => ({
+      requestId: req.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({
+        usage: {
+          prompt_tokens: 30426,
+          completion_tokens: 108,
+          prompt_tokens_details: { cached_tokens: 1920 },
+        },
+      })),
+    }));
+
+    const costUsdc = 147_690n;
+    let cumulativeSpend = 0n;
+    const sendNeedAuth = vi.fn();
+    const recordSpend = vi.fn((_sessionId: string, cost: bigint) => {
+      cumulativeSpend += cost;
+    });
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: {
+        hasSession: () => true,
+        getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '1000000' }),
+        recordSpend,
+        getCumulativeSpend: () => cumulativeSpend,
+        getAcceptedCumulative: () => 0n,
+        getReserveMax: () => 1_000_000n,
+        getPaymentRequirements: () => ({ minBudgetPerRequest: '10000', suggestedAmount: '1000000' }),
+        waitForPendingAuths: async () => {},
+        awaitAcceptedAtLeast: async () => true,
+      } as any,
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = {
+      send(frame: Uint8Array) {
+        sentFrames.push(frame);
+      },
+    } as any;
+    const paymentMux = {
+      sendNeedAuth,
+      sendPaymentRequired: vi.fn(),
+    } as any;
+
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    const request: SerializedHttpRequest = {
+      requestId: 'req-codex-cost',
+      method: 'POST',
+      path: '/v1/responses',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ model: 'gpt-5.3-codex-spark' })),
+    };
+
+    await mux.handleFrame({
+      type: MessageType.HttpRequest,
+      messageId: 1,
+      payload: encodeHttpRequest(request),
+    });
+
+    expect(sentFrames.length).toBeGreaterThan(0);
+    expect(recordSpend).toHaveBeenCalledWith('session-1', costUsdc);
+    expect(sendNeedAuth).toHaveBeenCalledOnce();
+    expect(sendNeedAuth).toHaveBeenCalledWith(expect.objectContaining({
+      requestId: request.requestId,
+      lastRequestCost: costUsdc.toString(),
+      requiredCumulativeAmount: costUsdc.toString(),
+      inputTokens: '30426',
+      cachedInputTokens: '1920',
+      freshInputTokens: '28506',
+      outputTokens: '108',
+    }));
+  });
+
+  it('keeps post-response NeedAuth below the reserve ceiling when cumulative spend is still covered', async () => {
+    const provider = makeProvider(1, 1, {
+      name: 'openai-responses',
+      services: ['gpt-5.3-codex-spark'],
+      servicePricing: {
+        'gpt-5.3-codex-spark': {
+          inputUsdPerMillion: 5,
+          outputUsdPerMillion: 30,
+          cachedInputUsdPerMillion: 1,
+        },
+      },
+    });
+    provider.handleRequest = vi.fn(async (req) => ({
+      requestId: req.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({
+        usage: {
+          prompt_tokens: 32048,
+          completion_tokens: 136,
+          prompt_tokens_details: { cached_tokens: 1920 },
+        },
+      })),
+    }));
+
+    const existingSpend = 835_714n;
+    const costUsdc = 156_640n;
+    const cumulativeAfterRequest = existingSpend + costUsdc;
+    const reserveMax = 1_000_000n;
+    let cumulativeSpend = existingSpend;
+    const sendNeedAuth = vi.fn();
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: {
+        hasSession: () => true,
+        getChannelByPeer: () => ({ sessionId: 'session-1', authMax: reserveMax.toString() }),
+        recordSpend: vi.fn((_sessionId: string, cost: bigint) => {
+          cumulativeSpend += cost;
+        }),
+        getCumulativeSpend: () => cumulativeSpend,
+        getAcceptedCumulative: () => existingSpend + 1n,
+        getReserveMax: () => reserveMax,
+        getPaymentRequirements: () => ({ minBudgetPerRequest: '10000', suggestedAmount: reserveMax.toString() }),
+        waitForPendingAuths: async () => {},
+        awaitAcceptedAtLeast: async () => true,
+      } as any,
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = {
+      send(frame: Uint8Array) {
+        sentFrames.push(frame);
+      },
+    } as any;
+    const paymentMux = {
+      sendNeedAuth,
+      sendPaymentRequired: vi.fn(),
+    } as any;
+
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({
+      type: MessageType.HttpRequest,
+      messageId: 1,
+      payload: encodeHttpRequest({
+        requestId: 'req-near-reserve',
+        method: 'POST',
+        path: '/v1/responses',
+        headers: { 'content-type': 'application/json' },
+        body: new TextEncoder().encode(JSON.stringify({ model: 'gpt-5.3-codex-spark' })),
+      }),
+    });
+
+    expect(cumulativeAfterRequest).toBeLessThan(reserveMax);
+    expect(sendNeedAuth).toHaveBeenCalledWith(expect.objectContaining({
+      lastRequestCost: costUsdc.toString(),
+      requiredCumulativeAmount: cumulativeAfterRequest.toString(),
+    }));
+    expect(BigInt(sendNeedAuth.mock.calls[0]![0].requiredCumulativeAmount)).toBeLessThanOrEqual(reserveMax);
   });
 
   it('skips the 402 / ReserveAuth handshake when the service is free', async () => {


### PR DESCRIPTION
## Description

Fixes buyer/seller payment channel drift during NeedAuth catch-up. The seller no longer double-counts the latest request when asking for a new cumulative SpendingAuth, and the buyer no longer lets stale NeedAuth frames consume request-specific service pricing metadata.

This addresses cases where a paid peer could repeatedly return `payment_required` despite sufficient buyer deposits, eventually surfacing as a desktop "Payment setup failed" error.

Also prevents duplicate in-flight `close()` submissions for the same seller channel when disconnect/stale-session cleanup races under load, and avoids attempting `close()` without a valid SpendingAuth.

## Release Notes

- Fixed payment channel accounting that could cause repeated `payment_required` errors with paid peers
- Fixed service-specific payment validation when stale NeedAuth messages arrive before the current authorization request
- Fixed duplicate seller `close()` submissions for the same channel during concurrent cleanup

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
