### PR TITLE
fix(node): Prevent duplicate seller close attempts

### DIFF
--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -104,6 +104,9 @@ export class SellerPaymentManager {
   /** channelId -> number of failed close() attempts. In-memory only; resets on node restart. */
   private readonly _closeRetryCount = new Map<string, number>();
 
+  /** channelIds with an in-flight close() tx/estimate. Prevents duplicate close submissions. */
+  private readonly _closingChannels = new Set<string>();
+
   /** channelId -> cumulative amount last successfully settled on-chain by this
    *  process. Lets the idle-settle loop skip the `getSession` RPC when the
    *  local accepted cumulative hasn't moved since our last settle. */
@@ -227,6 +230,7 @@ export class SellerPaymentManager {
     this._spent.delete(channelId);
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
+    this._closingChannels.delete(channelId);
     this._reserveMax.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
     this._releaseAcceptedWaiters(channelId);
@@ -853,11 +857,17 @@ export class SellerPaymentManager {
       }
       return;
     } else {
+      if (this._closingChannels.has(channelId)) {
+        debugLog(`[SellerPayment] Close already in flight for ${channelId.slice(0, 18)}... — skipping duplicate request`);
+        return;
+      }
+
       const retries = this._closeRetryCount.get(channelId) ?? 0;
       if (retries >= SellerPaymentManager.MAX_CLOSE_RETRIES) {
         debugWarn(`[SellerPayment] close() failed ${retries} times for ${channelId.slice(0, 18)}... — falling back to timeout path`);
       } else {
         debugLog(`[SellerPayment] Closing channel ${channelId.slice(0, 18)}... cumulative=${amount} (attempt ${retries + 1}/${SellerPaymentManager.MAX_CLOSE_RETRIES})`);
+        this._closingChannels.add(channelId);
         try {
           await this._channelsClient.close(this._signer, channelId, amount, metadata, sig);
           this._channelStore.updateChannelStatus(channelId, 'settled', amount.toString());
@@ -866,6 +876,8 @@ export class SellerPaymentManager {
           debugWarn(`[SellerPayment] Failed to close channel (attempt ${retries + 1}): ${err instanceof Error ? err.message : err}`);
           this._closeRetryCount.set(channelId, retries + 1);
           if (!cleanupOnFailure) return;
+        } finally {
+          this._closingChannels.delete(channelId);
         }
       }
     }
@@ -875,6 +887,7 @@ export class SellerPaymentManager {
     this._spent.delete(channelId);
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
+    this._closingChannels.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
     this._releaseAcceptedWaiters(channelId);
     this._activeBuyers.delete(buyerPeerId);
@@ -1040,6 +1053,7 @@ export class SellerPaymentManager {
     this._spent.delete(channelId);
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
+    this._closingChannels.delete(channelId);
     this._reserveMax.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
     this._releaseAcceptedWaiters(channelId);

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -474,6 +474,28 @@ describe('SellerPaymentManager', () => {
     expect(metadata).toBe(encodeMetadata(ZERO_METADATA));
   });
 
+  it('settleSession suppresses duplicate in-flight close attempts for the same channel', async () => {
+    const channelId = makeChannelId(12);
+
+    const payload1 = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { isReserve: true });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, payload1, mux);
+
+    const payload2 = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { cumulativeAmount: 200_000n });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, payload2, mux);
+    manager.recordSpend(channelId, 50_000n);
+
+    let resolveClose!: (value: string) => void;
+    const closePromise = new Promise<string>((resolve) => { resolveClose = resolve; });
+    vi.spyOn(manager.channelsClient, 'close').mockReturnValue(closePromise);
+
+    const first = manager.settleSession(buyerIdentity.peerId);
+    const second = manager.settleSession(buyerIdentity.peerId);
+
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    resolveClose('0xclose-hash');
+    await Promise.all([first, second]);
+  });
+
   it('rejects SpendingAuth when cumulative exceeds on-chain deposit', async () => {
     const channelId = makeChannelId(40);
 


### PR DESCRIPTION
## Description

Prevents duplicate seller `close()` submissions for the same payment channel when disconnect and stale-session cleanup paths race under load.

The seller now tracks in-flight close attempts per channel and skips duplicate close requests until the first tx/estimate completes.

## Release Notes

- Fixed duplicate seller `close()` submissions for the same channel during concurrent cleanup

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
