### PR TITLE
fix(node): Avoid payment catch-up loops

### DIFF
--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -174,7 +174,12 @@ export class SellerRequestHandler {
           }
           let accepted = spm.getAcceptedCumulative(session.sessionId);
           const spent = spm.getCumulativeSpend(session.sessionId);
-          if (spent > 0n && spent >= accepted) {
+          const reserveMax = spm.getReserveMax(session.sessionId);
+          // If spend has caught up and there is no headroom left in the reserve,
+          // stop serving before accepting any additional request cost.
+          const isAtExactSpendLimit = spent > 0n && spent === accepted && reserveMax > 0n && accepted >= reserveMax;
+
+          if (spent > 0n && spent > accepted) {
             // Race cover: the buyer's SpendingAuth for the *previous* response's
             // NeedAuth may still be on the wire when this request arrives. The
             // per-buyer mutex in waitForPendingAuths only serializes *in-flight*
@@ -191,18 +196,16 @@ export class SellerRequestHandler {
               debugLog(`[SellerHandler] Caught up before 402 for ${buyerPeerId.slice(0, 12)}... (spent=${spent} accepted=${accepted})`);
             }
           }
-          if (spent > 0n && spent >= accepted) {
-            const reserveMax = spm.getReserveMax(session.sessionId);
+          if (spent > 0n && (spent > accepted || isAtExactSpendLimit)) {
             const providerPricing = this.resolveProviderPricing(provider, request);
             const baseRequirements = spm.getPaymentRequirements(
               request.requestId, buyerPeerId, providerPricing,
             );
-            // Tell the buyer *exactly* how much cumulative signed authorization
-            // the seller needs to unblock further requests. Without this the
-            // buyer can only guess via minBudgetPerRequest and may sign an
-            // amount that is still below `spent`, which the seller would then
-            // reject as underfunded — producing an infinite 402 loop.
-            const target = spent + BigInt(baseRequirements.minBudgetPerRequest);
+            // Tell the buyer exactly how much delivered spend remains unsigned.
+            // Do not add forward headroom here: SpendingAuth is claimable
+            // on-chain, so requiring more than `spent` would authorize payment
+            // for work the seller has not delivered.
+            const target = spent;
             const isFullyExhausted = reserveMax > 0n && (accepted >= reserveMax || target > reserveMax);
             const requirements = {
               ...baseRequirements,
@@ -222,7 +225,8 @@ export class SellerRequestHandler {
                 debugWarn(`[SellerHandler] Failed to close exhausted session: ${err instanceof Error ? err.message : err}`);
               });
             } else {
-              debugLog(`[SellerHandler] Budget exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} >= accepted=${accepted}) — returning 402 with requiredCumulativeAmount=${target}, awaiting higher SpendingAuth`);
+              const comparator = spent > accepted ? '>' : '==';
+              debugLog(`[SellerHandler] Budget exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} ${comparator} accepted=${accepted}) — returning 402 with requiredCumulativeAmount=${target}, awaiting higher SpendingAuth`);
             }
             mux.sendProxyResponse({
               requestId: request.requestId,

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -498,7 +498,149 @@ describe('SellerRequestHandler payment pricing selection', () => {
     expect(response.statusCode).toBe(200);
   });
 
-  it('stops serving once delivered spend has caught up to the last accepted auth', async () => {
+  it('continues serving when delivered spend exactly matches the last accepted auth', async () => {
+    const provider = makeProvider(1, 1, {
+      name: 'paid-tier',
+      services: ['local-test'],
+    });
+    provider.handleRequest = vi.fn(async (req) => ({
+      requestId: req.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ ok: true })),
+    }));
+
+    const sendPaymentRequired = vi.fn();
+    const sendNeedAuth = vi.fn();
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: {
+        hasSession: () => true,
+        getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '1000000' }),
+        recordSpend: vi.fn(),
+        getCumulativeSpend: () => 2_184n,
+        getAcceptedCumulative: () => 2_184n,
+        getReserveMax: () => 1_000_000n,
+        getPaymentRequirements: () => ({ minBudgetPerRequest: '50000', suggestedAmount: '1000000' }),
+        waitForPendingAuths: async () => {},
+        awaitAcceptedAtLeast: async () => false,
+      } as any,
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = {
+      send(frame: Uint8Array) {
+        sentFrames.push(frame);
+      },
+    } as any;
+    const paymentMux = {
+      sendNeedAuth,
+      sendPaymentRequired,
+    } as any;
+
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({
+      type: MessageType.HttpRequest,
+      messageId: 1,
+      payload: encodeHttpRequest({
+        requestId: 'req-exactly-covered',
+        method: 'POST',
+        path: '/v1/chat/completions',
+        headers: { 'content-type': 'application/json' },
+        body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })),
+      }),
+    });
+
+    expect(provider.handleRequest).toHaveBeenCalledOnce();
+    expect(sendPaymentRequired).not.toHaveBeenCalled();
+    expect(sendNeedAuth).toHaveBeenCalledOnce();
+
+    const responseFrames = sentFrames
+      .map((f) => decodeFrame(f))
+      .filter((d) => d?.message.type === MessageType.HttpResponse);
+    expect(responseFrames).toHaveLength(1);
+    const response = decodeHttpResponse(responseFrames[0]!.message.payload);
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('stops serving when delivered spend is already at the reserve ceiling', async () => {
+    const provider = makeProvider(1, 1, {
+      name: 'paid-tier',
+      services: ['local-test'],
+    });
+    provider.handleRequest = vi.fn(async (req) => ({
+      requestId: req.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ ok: true })),
+    }));
+
+    const settleSession = vi.fn(async () => {});
+    const sendPaymentRequired = vi.fn();
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: {
+        hasSession: () => true,
+        getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '1000000' }),
+        recordSpend: vi.fn(),
+        getCumulativeSpend: () => 1_000_000n,
+        getAcceptedCumulative: () => 1_000_000n,
+        getReserveMax: () => 1_000_000n,
+        getPaymentRequirements: () => ({ minBudgetPerRequest: '50000', suggestedAmount: '1000000' }),
+        waitForPendingAuths: async () => {},
+        awaitAcceptedAtLeast: async () => false,
+        settleSession,
+      } as any,
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = {
+      send(frame: Uint8Array) {
+        sentFrames.push(frame);
+      },
+    } as any;
+    const paymentMux = {
+      sendNeedAuth: vi.fn(),
+      sendPaymentRequired,
+    } as any;
+
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({
+      type: MessageType.HttpRequest,
+      messageId: 1,
+      payload: encodeHttpRequest({
+        requestId: 'req-ceiling',
+        method: 'POST',
+        path: '/v1/chat/completions',
+        headers: { 'content-type': 'application/json' },
+        body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })),
+      }),
+    });
+
+    expect(provider.handleRequest).not.toHaveBeenCalled();
+    expect(sendPaymentRequired).toHaveBeenCalledOnce();
+    expect(settleSession).toHaveBeenCalledOnce();
+    const response = decodeHttpResponse(decodeFrame(sentFrames[0]!)!.message.payload);
+    const body = JSON.parse(new TextDecoder().decode(response.body));
+    expect(response.statusCode).toBe(402);
+    expect(body).toMatchObject({
+      code: PAYMENT_CODE_CHANNEL_EXHAUSTED,
+      requiredCumulativeAmount: '1000000',
+      reserveMaxAmount: '1000000',
+    });
+  });
+
+  it('stops serving once delivered spend is ahead of the last accepted auth', async () => {
     const provider = makeProvider(1, 1, {
       name: 'paid-tier',
       services: ['local-test'],
@@ -567,7 +709,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     expect(response.statusCode).toBe(402);
   });
 
-  it('closes and flags the channel when the next required cumulative exceeds the reserve ceiling', async () => {
+  it('closes and flags the channel when unsigned delivered spend exceeds the reserve ceiling', async () => {
     const provider = makeProvider(1, 1, {
       name: 'paid-tier',
       services: ['local-test'],
@@ -588,7 +730,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
         hasSession: () => true,
         getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '950001' }),
         recordSpend: vi.fn(),
-        getCumulativeSpend: () => 950_001n,
+        getCumulativeSpend: () => 1_000_001n,
         getAcceptedCumulative: () => 950_001n,
         getReserveMax: () => 1_000_000n,
         getPaymentRequirements: () => ({ minBudgetPerRequest: '50000', suggestedAmount: '1000000' }),


### PR DESCRIPTION
## Description

Updates the seller payment gate so requests continue when delivered spend exactly matches the last accepted SpendingAuth. The seller now only blocks when delivered spend is ahead of accepted authorization, or when the reserve ceiling is already fully used, and catch-up requests ask only for already delivered spend rather than adding forward headroom.

## Release Notes

- Fixed repeated payment catch-up loops when a buyer was exactly caught up with seller spend
- Prevented sellers from requesting SpendingAuth above delivered spend during catch-up
- Stopped sellers from serving additional requests once an exactly settled channel has reached its reserve ceiling

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes