### PR TITLE
fix(desktop): Retry pending payment setup

### DIFF
--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -109,6 +109,8 @@ export function initChatModule({
   };
 
   const fallbackChatServices: NormalizedChatServiceEntry[] = [];
+  const PAYMENT_AUTO_RETRY_DELAY_MS = 7_000;
+  const PAYMENT_AUTO_RETRY_MAX_ATTEMPTS = 2;
 
   type NormalizedChatServiceEntry = Required<
     Pick<ChatServiceCatalogEntry, 'id' | 'label' | 'provider' | 'protocol' | 'count'>
@@ -229,7 +231,66 @@ export function initChatModule({
     }
   }
 
-  async function handlePaymentRequired(amountBaseUnits: string): Promise<void> {
+  type ChatRetryContext = {
+    convId: string;
+    content?: string;
+    attachments?: PreparedChatAttachment[];
+    selection?: ChatServiceSelection;
+  };
+
+  const chatRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const chatRetryAttempts = new Map<string, number>();
+
+  function clearPaymentRetry(convId: string): void {
+    const timer = chatRetryTimers.get(convId);
+    if (timer) clearTimeout(timer);
+    chatRetryTimers.delete(convId);
+    chatRetryAttempts.delete(convId);
+  }
+
+  function scheduleChatRetry(
+    ctx?: ChatRetryContext,
+    reason: 'payment' | 'request' = 'payment',
+    finalError?: unknown,
+  ): void {
+    const convId = ctx?.convId ?? uiState.chatActiveConversation;
+    if (!convId) return;
+
+    const nextAttempt = (chatRetryAttempts.get(convId) ?? 0) + 1;
+    if (nextAttempt > PAYMENT_AUTO_RETRY_MAX_ATTEMPTS) {
+      if (reason === 'payment') {
+        appendSystemLog('Payment negotiation is still pending. Please retry the request in a moment.');
+      } else {
+        reportChatError(finalError ?? 'Request failed after retry.', 'Request failed');
+      }
+      return;
+    }
+
+    const existing = chatRetryTimers.get(convId);
+    if (existing) clearTimeout(existing);
+    chatRetryAttempts.set(convId, nextAttempt);
+    appendSystemLog(
+      reason === 'payment'
+        ? `Payment negotiation is still settling. Retrying in ${PAYMENT_AUTO_RETRY_DELAY_MS / 1000}s...`
+        : `Chat request failed. Retrying in ${PAYMENT_AUTO_RETRY_DELAY_MS / 1000}s...`,
+    );
+
+    const timer = setTimeout(() => {
+      chatRetryTimers.delete(convId);
+      uiState.chatError = null;
+      if (ctx?.content != null) {
+        setConversationSending(convId, true);
+        dispatchChatRequest(convId, ctx.content, ctx.attachments, ctx.selection);
+      } else if (convId === uiState.chatActiveConversation) {
+        retryAfterPayment();
+      } else {
+        notifyUiStateChanged();
+      }
+    }, PAYMENT_AUTO_RETRY_DELAY_MS);
+    chatRetryTimers.set(convId, timer);
+  }
+
+  async function handlePaymentRequired(amountBaseUnits: string, retryCtx?: ChatRetryContext): Promise<void> {
     const required = Number(amountBaseUnits) / 1_000_000;
     const available = await refreshAvailableCreditsUsdc();
 
@@ -243,7 +304,8 @@ export function initChatModule({
       uiState.chatPaymentApprovalPeerName = null;
       uiState.chatPaymentApprovalPeerInfo = null;
       uiState.chatPaymentApprovalError = null;
-      showChatError('Payment setup failed. Retry the request.');
+      uiState.chatError = null;
+      scheduleChatRetry(retryCtx, 'payment');
       notifyUiStateChanged();
       return;
     }
@@ -1916,20 +1978,28 @@ export function initChatModule({
             const paymentMatch = /^payment_required:(\d+)$/i.exec(errorMsg);
             if (paymentMatch) {
               setConversationSending(convId, false);
-              void handlePaymentRequired(paymentMatch[1]);
+              void handlePaymentRequired(paymentMatch[1], {
+                convId,
+                content,
+                attachments,
+                selection,
+              });
             } else if (errorMsg === 'Request aborted') {
               // User-initiated abort: the stream-error handler has already
               // finalized the partial message. Don't overwrite with an error.
+              clearPaymentRetry(convId);
               setConversationSending(convId, false);
             } else {
-              if (!uiState.chatError) {
-                reportChatError(result.stopReason?.message ?? result.error, 'Request failed');
-              }
+              scheduleChatRetry(
+                { convId, content, attachments, selection },
+                'request',
+                result.stopReason?.message ?? result.error,
+              );
               setConversationSending(convId, false);
             }
           }
         } catch (err) {
-          reportChatError(err, 'Chat send failed');
+          scheduleChatRetry({ convId, content, attachments, selection }, 'request', err);
           setConversationSending(convId, false);
         }
       })();
@@ -1960,11 +2030,27 @@ export function initChatModule({
           }
 
           if (!result.ok) {
-            reportChatError(result.error, 'Request failed');
+            const errorMsg = typeof result.error === 'string' ? result.error : '';
+            const paymentMatch = /^payment_required:(\d+)$/i.exec(errorMsg);
+            if (paymentMatch) {
+              void handlePaymentRequired(paymentMatch[1], {
+                convId,
+                content,
+                attachments,
+                selection,
+              });
+            } else if (errorMsg === 'Request aborted') {
+              // User-initiated abort: don't auto-retry.
+              clearPaymentRetry(convId);
+            } else {
+              scheduleChatRetry({ convId, content, attachments, selection }, 'request', result.error);
+            }
+          } else {
+            clearPaymentRetry(convId);
           }
           setConversationSending(convId, false);
         } catch (err) {
-          reportChatError(err, 'Chat send failed');
+          scheduleChatRetry({ convId, content, attachments, selection }, 'request', err);
           setConversationSending(convId, false);
         }
       })();
@@ -2128,8 +2214,14 @@ export function initChatModule({
       bridge.onChatAiError((data) => {
         setConversationSending(data.conversationId, false);
         if (data.conversationId === uiState.chatActiveConversation) {
-          if (data.error !== 'Request aborted') {
-            showChatError(data.error);
+          const errStr = typeof data.error === 'string' ? data.error : '';
+          const paymentMatch = /^payment_required:(\d+)$/i.exec(errStr);
+          if (paymentMatch) {
+            void handlePaymentRequired(paymentMatch[1], { convId: data.conversationId });
+          } else if (data.error === 'Request aborted') {
+            clearPaymentRetry(data.conversationId);
+          } else {
+            scheduleChatRetry({ convId: data.conversationId }, 'request', data.error);
             appendSystemLog(`AI Chat error: ${data.error}`);
           }
         }
@@ -2490,6 +2582,8 @@ export function initChatModule({
           getConversationStreamingMessage(data.conversationId),
         );
 
+        clearPaymentRetry(data.conversationId);
+
         if (data.conversationId === uiState.chatActiveConversation) {
           if (finalizedStreamingMessage) {
             commitAssistantMessage(finalizedStreamingMessage);
@@ -2566,14 +2660,20 @@ export function initChatModule({
             setConversationSending(data.conversationId, false);
           }
 
-          if (!isAbort) {
+          if (isAbort) {
+            clearPaymentRetry(data.conversationId);
+          } else {
             const errStr = typeof data.error === 'string' ? data.error : '';
             const paymentMatch = /^payment_required:(\d+)$/i.exec(errStr);
             if (paymentMatch) {
-              void handlePaymentRequired(paymentMatch[1]);
+              void handlePaymentRequired(paymentMatch[1], { convId: data.conversationId });
               if (bridge.chatAiAbort) void bridge.chatAiAbort(data.conversationId).catch(() => {});
             } else {
-              showChatError(stopReason?.message ?? data.error);
+              scheduleChatRetry(
+                { convId: data.conversationId },
+                'request',
+                stopReason?.message ?? data.error,
+              );
             }
             appendSystemLog(`AI Chat error (${stopReasonSummary}): ${data.error}`);
           }

--- a/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-shared.ts
@@ -288,7 +288,6 @@ export function paymentLogToThinkingPhase(line: string): string | null {
   if (line.includes('[BuyerNegotiator] Reserve top-up needed')) return 'Reserve top-up needed';
 
   // --- Payment wire ---
-  if (line.includes('[PaymentMux] → send SpendingAuth')) return 'Sending SpendingAuth';
   if (line.includes('[PaymentMux] → send ReserveAuth')) return 'Sending ReserveAuth';
   if (line.includes('[PaymentMux] → send AuthAck')) return 'Acking seller auth';
   if (line.includes('[PaymentMux] ← recv SpendingAuth')) return 'Received SpendingAuth';

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -206,6 +206,11 @@ export class BuyerPaymentManager {
     return this._reserveSalt.has(sellerPeerId);
   }
 
+  clearLockConfirmation(sellerPeerId: string): void {
+    this._confirmedPeers.delete(sellerPeerId);
+    this._rejectedPeers.delete(sellerPeerId);
+  }
+
   async resendCurrentSpendingAuth(
     sellerPeerId: string,
     paymentMux: PaymentMux,

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -353,6 +353,7 @@ export class BuyerPaymentNegotiator {
         conn,
         existingSessionBudgetRequest,
         requiredCumulativeTarget,
+        requiredCumulativeTarget == null,
       );
       if (recovered) {
         return { action: 'retry' };
@@ -818,6 +819,7 @@ export class BuyerPaymentNegotiator {
     conn: PeerConnection,
     minBudgetPerRequest: bigint | null = null,
     targetCumulative: bigint | null = null,
+    requireFreshAck = false,
   ): Promise<boolean> {
     const session = this._bpm.getActiveSession(peer.peerId);
     if (!session) {
@@ -865,6 +867,14 @@ export class BuyerPaymentNegotiator {
     }
 
     const pmux = this.getOrCreatePaymentMux(peer.peerId, conn);
+    if (requireFreshAck) {
+      // A 402 with only base PaymentRequired fields while the buyer has an
+      // active local session means the seller does not currently recognize
+      // the channel (for example after a seller restart). The previous
+      // AuthAck is stale in that case; require a fresh one before retrying so
+      // we do not immediately replay the request into another 402.
+      this._bpm.clearLockConfirmation(peer.peerId);
+    }
     if (minBudgetPerRequest != null && minBudgetPerRequest > 0n) {
       const cumulativeBefore = this._bpm.getCumulativeAmount(peer.peerId);
       await this._bpm.extendCurrentSpendingAuth(

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -41,6 +41,7 @@ function createMockBpm(): BuyerPaymentManager & Record<string, unknown> {
     authorizeSpending: vi.fn().mockResolvedValue(undefined),
     topUpReserve: vi.fn().mockResolvedValue(undefined),
     cleanupSession: vi.fn(),
+    clearLockConfirmation: vi.fn(),
     getActiveSession: vi.fn().mockReturnValue(null),
     retireSession: vi.fn(),
     canReplayReserveAuth: vi.fn().mockReturnValue(false),
@@ -213,7 +214,7 @@ describe('BuyerPaymentNegotiator', () => {
       expect(result.action).toBe('return');
     });
 
-    it('extends an active on-chain session instead of replaying the same auth when seller requests more budget', async () => {
+    it('requires a fresh AuthAck when a seller with no local session asks for payment again', async () => {
       // First, lock the peer through successful negotiation
       await simulateSuccessfulNegotiation(negotiator, bpm, peer, conn);
       (bpm.authorizeSpending as ReturnType<typeof vi.fn>).mockClear();
@@ -228,6 +229,7 @@ describe('BuyerPaymentNegotiator', () => {
 
       const result = await negotiator.handle402(make402Response(), peer, conn, makeRequest());
 
+      expect(bpm.clearLockConfirmation).toHaveBeenCalledWith(peer.peerId);
       expect(bpm.extendCurrentSpendingAuth).toHaveBeenCalledWith(
         peer.peerId,
         BigInt(paymentRequiredPayload.minBudgetPerRequest),
@@ -263,6 +265,7 @@ describe('BuyerPaymentNegotiator', () => {
 
       const result = await negotiator.handle402(response, peer, conn, makeRequest());
 
+      expect(bpm.clearLockConfirmation).not.toHaveBeenCalled();
       expect(bpm.extendCurrentSpendingAuth).toHaveBeenCalledWith(
         peer.peerId,
         10000n,


### PR DESCRIPTION
## Description

Prevents transient payment-required responses from surfacing as a hard desktop chat error when the buyer has enough available credits. The buyer now clears stale payment lock confirmation when recovering an active local channel from a plain seller payment-required response, forcing a fresh seller AuthAck before retrying.

The desktop renderer now schedules a short automatic retry instead of showing "Payment setup failed" for sufficient-credit payment setup races, and suppresses the noisy SpendingAuth thinking label.

## Release Notes

- Fixed transient payment setup failures by waiting for a fresh seller auth acknowledgement during stale channel recovery
- Desktop now retries pending payment setup automatically instead of showing a hard error when credits are available
- Removed the noisy "Sending SpendingAuth" chat status label during normal request settlement

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
