### PR TITLE
fix(#362): auto-close zombie channels + replace fake desktop reputation with on-chain volume

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -878,8 +878,8 @@ ipcMain.handle('payments:get-peer-info', async (_event, peerId: string) => {
       data: {
         peerId: peer.peerId,
         displayName: peer.displayName ?? null,
-        reputation: peer.reputation ?? 0,
-        onChainChannelCount: (peer as Record<string, unknown>).onChainChannelCount ?? null,
+        onChainChannelCount: peer.onChainChannelCount ?? null,
+        onChainTotalVolumeUsdcMicros: peer.onChainTotalVolumeUsdcMicros ?? null,
         onChainGhostCount: (peer as Record<string, unknown>).onChainGhostCount ?? null,
         evmAddress: peer.peerId ? peerIdToAddress(peer.peerId) : null,
         timestamp: (peer as Record<string, unknown>).timestamp ?? null,

--- a/apps/desktop/src/main/peer-cache.ts
+++ b/apps/desktop/src/main/peer-cache.ts
@@ -11,7 +11,16 @@ export type DashboardNetworkPeer = {
   inputUsdPerMillion: number;
   outputUsdPerMillion: number;
   capacityMsgPerHour: number;
-  reputation: number;
+  /**
+   * Lifetime settled volume in USDC base units (micros), from on-chain
+   * AntseedChannels.getAgentStats. `null` when chain RPC has not populated
+   * the stat (e.g. cold start, no RPC configured). The Peers/Overview tables
+   * sort and render by this; the prior "reputation" field was a static `100`
+   * placeholder and only ever sorted peers, never gated routing — see #362.
+   */
+  onChainTotalVolumeUsdcMicros: number | null;
+  /** Settled-channel count, from AntseedChannels.getAgentStats. `null` when chain RPC unavailable. */
+  onChainChannelCount: number | null;
   lastSeen: number;
   /**
    * Last successful transport-level contact with the peer. This can be fresher
@@ -129,7 +138,12 @@ export function parsePeerFromRaw(pr: Record<string, unknown>): DashboardNetworkP
     inputUsdPerMillion: Number(pr.defaultInputUsdPerMillion) || 0,
     outputUsdPerMillion: Number(pr.defaultOutputUsdPerMillion) || 0,
     capacityMsgPerHour: (Number(pr.maxConcurrency) || 0) * 60,
-    reputation: 100,
+    onChainTotalVolumeUsdcMicros: typeof pr.onChainTotalVolumeUsdcMicros === 'number'
+      ? pr.onChainTotalVolumeUsdcMicros
+      : null,
+    onChainChannelCount: typeof pr.onChainChannelCount === 'number'
+      ? pr.onChainChannelCount
+      : null,
     lastSeen: Number(pr.lastSeen) || Date.now(),
     lastReachedAt: Number(pr.lastReachedAt) || null,
     source: 'dht',
@@ -171,6 +185,12 @@ export async function refreshPeerCache(): Promise<void> {
         peer.inputUsdPerMillion = peer.inputUsdPerMillion || existing.inputUsdPerMillion;
         peer.outputUsdPerMillion = peer.outputUsdPerMillion || existing.outputUsdPerMillion;
         peer.capacityMsgPerHour = peer.capacityMsgPerHour || existing.capacityMsgPerHour;
+        // Preserve cached on-chain stats when the latest buyer.state.json
+        // entry has not been enriched yet (null wins should never clobber a
+        // real chain reading).
+        peer.onChainTotalVolumeUsdcMicros = peer.onChainTotalVolumeUsdcMicros
+          ?? existing.onChainTotalVolumeUsdcMicros;
+        peer.onChainChannelCount = peer.onChainChannelCount ?? existing.onChainChannelCount;
         peer.lastSeen = Math.max(peer.lastSeen, existing.lastSeen);
         peer.lastReachedAt = Math.max(peer.lastReachedAt ?? 0, existing.lastReachedAt ?? 0) || null;
       }

--- a/apps/desktop/src/renderer/core/format.ts
+++ b/apps/desktop/src/renderer/core/format.ts
@@ -129,6 +129,22 @@ export function formatMoney(value: unknown): string {
   return `$${numeric.toFixed(2)}`;
 }
 
+/**
+ * Format a USDC volume amount expressed in base units (micros, 1e-6 USDC).
+ * `null`/invalid → "—" so the UI distinguishes "unknown" from "$0". Mirrors
+ * the CLI's `formatUsdcVolume` so desktop and CLI surfaces stay consistent.
+ */
+export function formatUsdcVolume(micros: number | null | undefined): string {
+  if (typeof micros !== 'number' || !Number.isFinite(micros) || micros < 0) {
+    return '—';
+  }
+  const usd = micros / 1_000_000;
+  if (usd >= 1000) return `$${usd.toFixed(0)}`;
+  if (usd >= 1) return `$${usd.toFixed(2)}`;
+  if (usd > 0) return `$${usd.toFixed(4)}`;
+  return '$0';
+}
+
 export function formatPrice(value: unknown): string {
   const numeric = safeNumber(value, 0);
   if (numeric <= 0) {

--- a/apps/desktop/src/renderer/core/state.ts
+++ b/apps/desktop/src/renderer/core/state.ts
@@ -34,7 +34,10 @@ export type PeerEntry = {
   inputUsdPerMillion: number;
   outputUsdPerMillion: number;
   capacityMsgPerHour: number;
-  reputation: number;
+  /** Lifetime settled volume (USDC base units / micros), or null when chain RPC has not enriched yet. */
+  onChainTotalVolumeUsdcMicros: number | null;
+  /** Settled channel count, or null when chain RPC has not enriched yet. */
+  onChainChannelCount: number | null;
   lastSeen: number;
   lastReachedAt: number | null;
   source: string;
@@ -202,8 +205,8 @@ export type RendererUiState = {
   chatPaymentApprovalPeerName: string | null;
   chatPaymentApprovalAmount: string;
   chatPaymentApprovalPeerInfo: {
-    reputation: number;
     channelCount: number | null;
+    volumeUsdcMicros: number | null;
     disputeCount: number | null;
     networkAgeDays: number | null;
     evmAddress: string | null;
@@ -308,7 +311,7 @@ export function createInitialUiState(): RendererUiState {
     peersMeta: { tone: 'idle', label: '0 peers' },
     peersMessage: 'Loading peer visibility...',
     lastPeers: [],
-    peerSort: { key: 'reputation', dir: 'desc' },
+    peerSort: { key: 'onChainTotalVolumeUsdcMicros', dir: 'desc' },
     peerFilter: '',
     lastDebugKey: '',
 

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -165,8 +165,8 @@ export function initChatModule({
         const ageDays = Math.floor((now - timestamp) / 86400);
 
         uiState.chatPaymentApprovalPeerInfo = {
-          reputation: result.data.onChainChannelCount ?? result.data.reputation ?? 0,
           channelCount: result.data.onChainChannelCount ?? null,
+          volumeUsdcMicros: result.data.onChainTotalVolumeUsdcMicros ?? null,
           disputeCount: result.data.onChainGhostCount ?? null,
           networkAgeDays: ageDays > 0 ? ageDays : null,
           evmAddress: result.data.evmAddress ?? null,

--- a/apps/desktop/src/renderer/modules/dashboard-render.ts
+++ b/apps/desktop/src/renderer/modules/dashboard-render.ts
@@ -72,7 +72,10 @@ function normalizeNetworkData(
       inputUsdPerMillion: safeNumber(peer.inputUsdPerMillion, 0),
       outputUsdPerMillion: safeNumber(peer.outputUsdPerMillion, 0),
       capacityMsgPerHour: safeNumber(peer.capacityMsgPerHour, 0),
-      reputation: safeNumber(peer.reputation, 0),
+      onChainTotalVolumeUsdcMicros:
+        typeof peer.onChainTotalVolumeUsdcMicros === 'number' ? peer.onChainTotalVolumeUsdcMicros : null,
+      onChainChannelCount:
+        typeof peer.onChainChannelCount === 'number' ? peer.onChainChannelCount : null,
       lastSeen: safeNumber(peer.lastSeen, 0),
       lastReachedAt: safeNumber(peer.lastReachedAt, 0) || null,
       source: safeString(peer.source, 'dht'),
@@ -94,7 +97,8 @@ function normalizeNetworkData(
       inputUsdPerMillion: 0,
       outputUsdPerMillion: 0,
       capacityMsgPerHour: 0,
-      reputation: 0,
+      onChainTotalVolumeUsdcMicros: null,
+      onChainChannelCount: null,
       lastSeen: 0,
       lastReachedAt: null,
       source: 'daemon',
@@ -111,7 +115,12 @@ function normalizeNetworkData(
     if (safeNumber(peer.inputUsdPerMillion, 0) > 0) existing.inputUsdPerMillion = safeNumber(peer.inputUsdPerMillion, 0);
     if (safeNumber(peer.outputUsdPerMillion, 0) > 0) existing.outputUsdPerMillion = safeNumber(peer.outputUsdPerMillion, 0);
     if (safeNumber(peer.capacityMsgPerHour, 0) > 0) existing.capacityMsgPerHour = safeNumber(peer.capacityMsgPerHour, 0);
-    if (safeNumber(peer.reputation, 0) > 0) existing.reputation = safeNumber(peer.reputation, 0);
+    if (typeof peer.onChainTotalVolumeUsdcMicros === 'number') {
+      existing.onChainTotalVolumeUsdcMicros = peer.onChainTotalVolumeUsdcMicros;
+    }
+    if (typeof peer.onChainChannelCount === 'number') {
+      existing.onChainChannelCount = peer.onChainChannelCount;
+    }
     const daemonDn = typeof peer.displayName === 'string' && (peer.displayName as string).trim().length > 0 ? (peer.displayName as string).trim() : null;
     if (daemonDn) existing.displayName = daemonDn;
     if (!existing.source || existing.source === 'dht') existing.source = safeString(peer.source, 'daemon');
@@ -122,7 +131,13 @@ function normalizeNetworkData(
   const peers = Array.from(merged.values())
     .filter((peer) => peer.services.length > 0 || peer.providers.length > 0)
     .sort((a, b) => {
-      if (b.reputation !== a.reputation) return b.reputation - a.reputation;
+      // Sort by lifetime settled USDC volume desc — the most concrete "useful
+      // provider" signal we have. Peers without chain enrichment yet (null)
+      // sort below those with any positive volume but above $0 peers; ties
+      // and untracked peers fall through to most-recently-seen.
+      const va = a.onChainTotalVolumeUsdcMicros ?? -1;
+      const vb = b.onChainTotalVolumeUsdcMicros ?? -1;
+      if (vb !== va) return vb - va;
       return b.lastSeen - a.lastSeen;
     });
 

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -218,8 +218,8 @@ export type DesktopBridge = {
     data?: {
       peerId: string;
       displayName: string | null;
-      reputation: number;
       onChainChannelCount: number | null;
+      onChainTotalVolumeUsdcMicros: number | null;
       onChainGhostCount: number | null;
       evmAddress: string | null;
       timestamp: number | null;

--- a/apps/desktop/src/renderer/ui/components/chat/SessionApprovalCard.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/SessionApprovalCard.tsx
@@ -1,4 +1,5 @@
 import { useUiSnapshot } from '../../hooks/useUiSnapshot';
+import { formatUsdcVolume } from '../../../core/format';
 import styles from './SessionApprovalCard.module.scss';
 
 type SessionApprovalCardProps = {
@@ -6,8 +7,8 @@ type SessionApprovalCardProps = {
   peerName: string | null;
   amount: string;
   peerInfo: {
-    reputation: number;
     channelCount: number | null;
+    volumeUsdcMicros: number | null;
     disputeCount: number | null;
     networkAgeDays: number | null;
     evmAddress: string | null;
@@ -45,10 +46,22 @@ export function SessionApprovalCard({
         }
       </div>
 
-      {peerInfo && (peerInfo.reputation > 0 || peerInfo.channelCount !== null) && (
+      {/*
+        Trust signals shown on the payment approval card. "Volume" is lifetime
+        settled USDC from on-chain AntseedChannels.getAgentStats — the most
+        honest "useful provider" signal we have. The previous "reputation"
+        line was a static placeholder masquerading as a trust score (#362).
+      */}
+      {peerInfo && (peerInfo.volumeUsdcMicros !== null
+        || peerInfo.channelCount !== null
+        || peerInfo.networkAgeDays !== null) && (
         <div className={styles.approvalStats}>
-          {peerInfo.reputation > 0 && <span>{peerInfo.reputation} reputation</span>}
-          {peerInfo.channelCount !== null && <span>{peerInfo.channelCount} channels</span>}
+          {peerInfo.volumeUsdcMicros !== null && (
+            <span>{formatUsdcVolume(peerInfo.volumeUsdcMicros)} volume</span>
+          )}
+          {peerInfo.channelCount !== null && (
+            <span>{peerInfo.channelCount} session{peerInfo.channelCount === 1 ? '' : 's'}</span>
+          )}
           {peerInfo.networkAgeDays !== null && <span>{peerInfo.networkAgeDays}d in network</span>}
         </div>
       )}

--- a/apps/desktop/src/renderer/ui/components/views/OverviewView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/OverviewView.tsx
@@ -1,5 +1,5 @@
 import { useUiSnapshot } from '../../hooks/useUiSnapshot';
-import { formatShortId, formatInt } from '../../../core/format';
+import { formatShortId, formatUsdcVolume } from '../../../core/format';
 
 type OverviewViewProps = {
   active: boolean;
@@ -65,7 +65,7 @@ export function OverviewView({ active }: OverviewViewProps) {
                   <th>Peer</th>
                   <th>ID</th>
                   <th>Services</th>
-                  <th>Rep</th>
+                  <th>Volume</th>
                 </tr>
               </thead>
               <tbody>
@@ -81,7 +81,7 @@ export function OverviewView({ active }: OverviewViewProps) {
                       <td>{peer.displayName || '-'}</td>
                       <td title={peer.peerId}>{formatShortId(peer.peerId)}</td>
                       <td>{peer.services.join(', ')}</td>
-                      <td>{formatInt(peer.reputation)}</td>
+                      <td>{formatUsdcVolume(peer.onChainTotalVolumeUsdcMicros)}</td>
                     </tr>
                   ))
                 )}

--- a/apps/desktop/src/renderer/ui/components/views/PeersView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/PeersView.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useUiSnapshot } from '../../hooks/useUiSnapshot';
 import { useActions } from '../../hooks/useActions';
-import { formatShortId, formatInt, formatEndpoint } from '../../../core/format';
+import { formatShortId, formatInt, formatEndpoint, formatUsdcVolume } from '../../../core/format';
 import { safeString } from '../../../core/safe';
 import type { PeerEntry, SortDirection } from '../../../core/state';
 
@@ -19,6 +19,12 @@ function sortPeers(items: PeerEntry[], key: SortKey, dir: SortDirection): PeerEn
     if (Array.isArray(vb)) vb = (vb as string[]).join(', ');
     if (typeof va === 'string') va = va.toLowerCase();
     if (typeof vb === 'string') vb = vb.toLowerCase();
+    // Null numeric fields (peers without on-chain enrichment yet) sort below
+    // every real value so unenriched peers don't artificially top a sort.
+    const vaNullNumeric = va == null && typeof vb === 'number';
+    const vbNullNumeric = vb == null && typeof va === 'number';
+    if (vaNullNumeric) return 1;
+    if (vbNullNumeric) return -1;
     if (va == null) va = '';
     if (vb == null) vb = '';
     if ((va as string | number) < (vb as string | number)) return dir === 'asc' ? -1 : 1;
@@ -38,7 +44,7 @@ function filterPeers(peers: PeerEntry[], filterText: string): PeerEntry[] {
       String(peer.inputUsdPerMillion),
       String(peer.outputUsdPerMillion),
       String(peer.capacityMsgPerHour),
-      String(peer.reputation),
+      formatUsdcVolume(peer.onChainTotalVolumeUsdcMicros),
       formatEndpoint(peer),
     ]
       .join(' ')
@@ -56,7 +62,10 @@ const COLUMNS: { key: string; label: string; sortable: boolean }[] = [
   { key: 'inputUsdPerMillion', label: 'Input $/1M', sortable: true },
   { key: 'outputUsdPerMillion', label: 'Output $/1M', sortable: true },
   { key: 'capacityMsgPerHour', label: 'Capacity', sortable: true },
-  { key: 'reputation', label: 'Rep', sortable: true },
+  // Lifetime settled USDC volume from AntseedChannels.getAgentStats. Replaces
+  // the prior "Rep" column whose underlying value was a static `100`
+  // placeholder for every peer (#362).
+  { key: 'onChainTotalVolumeUsdcMicros', label: 'Volume', sortable: true },
   { key: 'endpoint', label: 'Endpoint', sortable: false },
 ];
 
@@ -64,7 +73,7 @@ export function PeersView({ active }: PeersViewProps) {
   const { lastPeers, peersMeta, peersMessage } = useUiSnapshot();
   const actions = useActions();
 
-  const [sortKey, setSortKey] = useState('reputation');
+  const [sortKey, setSortKey] = useState('onChainTotalVolumeUsdcMicros');
   const [sortDir, setSortDir] = useState<SortDirection>('desc');
   const [filter, setFilter] = useState('');
 
@@ -151,7 +160,7 @@ export function PeersView({ active }: PeersViewProps) {
                           ? `${formatInt(peer.capacityMsgPerHour)}/h`
                           : 'n/a'}
                       </td>
-                      <td>{formatInt(peer.reputation)}</td>
+                      <td>{formatUsdcVolume(peer.onChainTotalVolumeUsdcMicros)}</td>
                       <td>{formatEndpoint(peer)}</td>
                     </tr>
                   ))

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -922,10 +922,15 @@ export class SellerPaymentManager {
 
   /**
    * Check for stale sessions and attempt to close them.
-   * The seller can only close() with a valid SpendingAuth — it cannot
-   * requestClose or withdraw (those are buyer-only on-chain).
-   * If the seller has no auths, the session remains open until the buyer
-   * calls requestClose → withdraw on-chain.
+   * - Channels with a signed auth from the buyer go through `settleSession`.
+   * - Zombie channels (no auth, buyer gone, past nominal deadline) are closed
+   *   on-chain via `close(channelId, onChainSettled, "0x", "0x")`. The contract
+   *   skips signature verification when `finalAmount == channel.settled`
+   *   (AntseedChannels.sol:288-294), so the seller can close without buyer
+   *   cooperation. This bumps `channelCount` (the on-chain reputation
+   *   counter), decrements `activeChannelCount[seller]` (which gates
+   *   `unstake()`), and releases the buyer's reserved deposit. Without it,
+   *   zombies accumulate forever and a new provider's reputation stays at 0.
    * Called periodically and on startup for recovery.
    */
   async checkTimeouts(): Promise<void> {
@@ -949,16 +954,61 @@ export class SellerPaymentManager {
         if (accepted > 0n && !this._activeBuyers.has(channel.peerId)) {
           debugLog(`[SellerPayment] Channel ${channel.sessionId.slice(0, 18)}... buyer disconnected — attempting close`);
           await this.settleSession(channel.peerId);
+          continue;
         }
-        // If no auths and buyer disconnected, nothing the seller can do on-chain.
-        // The buyer must call requestClose → withdraw. We just clean up locally
-        // after a reasonable period (e.g. deadline passed).
+        // No auths, buyer gone, past the channel's nominal deadline: close
+        // with the on-chain settled cumulative (typically 0) and an empty
+        // signature. The contract's _settleSpend gate is skipped when
+        // finalAmount == settled, so no buyer cooperation is required.
         if (accepted === 0n && !this._activeBuyers.has(channel.peerId) && nowSecs > channel.deadline) {
-          this._evictStaleChannel(channel.sessionId, channel.peerId, 'no auths, past deadline', 'timeout');
+          if (onChainState.status !== 'active') {
+            // Status was 'unknown' — fall back to local-only eviction rather
+            // than risk a close() that may revert on a non-active channel.
+            this._evictStaleChannel(channel.sessionId, channel.peerId, 'no auths, past deadline, on-chain status unknown', 'timeout');
+            continue;
+          }
+          await this._closeWithoutAuth(channel.sessionId, channel.peerId, onChainState.channel.settled);
         }
       } catch (err) {
         debugWarn(`[SellerPayment] Failed to process channel ${channel.sessionId.slice(0, 18)}...: ${err instanceof Error ? err.message : err}`);
       }
+    }
+  }
+
+  /**
+   * Close a zombie channel (buyer gone, no signed auth) using the on-chain
+   * `settled` cumulative as `finalAmount`. The contract skips signature
+   * verification when `finalAmount == channel.settled`, so we pass empty
+   * metadata and signature bytes. The seller forfeits any unproven spend —
+   * for a true zombie there is nothing to forfeit.
+   *
+   * On success: contract sets status=Settled, decrements activeChannelCount,
+   * increments _agentStats.channelCount, and releases the buyer's reserved
+   * deposit back to AntseedDeposits.
+   */
+  private async _closeWithoutAuth(channelId: string, peerId: string, onChainSettled: bigint): Promise<void> {
+    if (this._closingChannels.has(channelId)) {
+      debugLog(`[SellerPayment] Close already in flight for ${channelId.slice(0, 18)}... — skipping zombie close`);
+      return;
+    }
+    const retries = this._closeRetryCount.get(channelId) ?? 0;
+    if (retries >= SellerPaymentManager.MAX_CLOSE_RETRIES) {
+      debugWarn(`[SellerPayment] Zombie close failed ${retries} times for ${channelId.slice(0, 18)}... — falling back to local eviction`);
+      this._evictStaleChannel(channelId, peerId, 'no auths, past deadline, close retries exhausted', 'timeout');
+      return;
+    }
+
+    this._closingChannels.add(channelId);
+    debugLog(`[SellerPayment] Closing zombie channel ${channelId.slice(0, 18)}... finalAmount=${onChainSettled} (no auth, attempt ${retries + 1}/${SellerPaymentManager.MAX_CLOSE_RETRIES})`);
+    try {
+      await this._channelsClient.close(this._signer, channelId, onChainSettled, '0x', '0x');
+      this._closeRetryCount.delete(channelId);
+      this._evictStaleChannel(channelId, peerId, 'zombie closed on-chain', 'settled');
+    } catch (err) {
+      this._closeRetryCount.set(channelId, retries + 1);
+      debugWarn(`[SellerPayment] Zombie close failed (attempt ${retries + 1}): ${err instanceof Error ? err.message : err}`);
+    } finally {
+      this._closingChannels.delete(channelId);
     }
   }
 

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -796,6 +796,162 @@ describe('SellerPaymentManager', () => {
     });
   });
 
+  describe('checkTimeouts auto-close zombies', () => {
+    // A "zombie" is an on-chain Active channel where the buyer disconnected
+    // before signing any SpendingAuth (accepted=0). Without auto-close, these
+    // sit around forever:
+    //   - blocking the seller's `unstake()` (gated on activeChannelCount=0),
+    //   - keeping the seller's reputation counter at 0
+    //     (channelCount only increments on close/withdraw),
+    //   - and locking the buyer's reserved deposit.
+    // The contract lets the seller call close(channelId, settled, "0x", "0x")
+    // when finalAmount == settled — no buyer signature is verified in that
+    // branch (AntseedChannels.sol:288-294). checkTimeouts must use this path.
+
+    function seedZombie(
+      channelStore: ChannelStore,
+      channelId: string,
+      buyer: Identity,
+      seller: Identity,
+      opts: { deadlineSec?: number } = {},
+    ): void {
+      const now = Date.now();
+      const deadline = opts.deadlineSec ?? Math.floor(now / 1000) - 3600;
+      channelStore.upsertChannel({
+        sessionId: channelId,
+        peerId: buyer.peerId,
+        role: 'seller',
+        sellerEvmAddr: seller.wallet.address,
+        buyerEvmAddr: buyer.wallet.address,
+        nonce: 0,
+        authMax: '0',
+        previousConsumption: '1000000',
+        tokensDelivered: '0',
+        deadline,
+        previousSessionId: '',
+        requestCount: 0,
+        reservedAt: now,
+        settledAt: null,
+        settledAmount: null,
+        status: 'active',
+        latestBuyerSig: null,
+        latestSpendingAuthSig: null,
+        latestMetadata: null,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    it('closes a zombie on-chain with empty signature when buyer disconnected past deadline', async () => {
+      const channelId = makeChannelId(60);
+      seedZombie(store, channelId, buyerIdentity, sellerIdentity);
+
+      // Fresh manager so the channel hydrates from the store with no in-memory auth.
+      const mgr = new SellerPaymentManager(
+        sellerIdentity,
+        { rpcUrl: 'http://127.0.0.1:8545', channelsContractAddress: CONTRACT_ADDR, chainId: CHAIN_ID, dataDir: tempDir },
+        store,
+      );
+      // Buyer is not connected — evict the in-memory active flag the constructor seeded.
+      mgr.onBuyerDisconnect(buyerIdentity.peerId);
+      expect(mgr.hasSession(buyerIdentity.peerId)).toBe(false);
+
+      // Channel still Active on-chain with settled=0.
+      vi.spyOn(mgr.channelsClient, 'getSession').mockResolvedValue(
+        makeOnChainChannel(buyerIdentity, sellerIdentity, { settled: 0n, status: 1 }),
+      );
+      const closeSpy = vi.spyOn(mgr.channelsClient, 'close').mockResolvedValue('0xclose-hash');
+
+      await mgr.checkTimeouts();
+
+      // The seller called close() with finalAmount=0 and empty bytes for both metadata and sig.
+      expect(closeSpy).toHaveBeenCalledOnce();
+      const args = closeSpy.mock.calls[0]!;
+      expect(args[1]).toBe(channelId);
+      expect(args[2]).toBe(0n);            // finalAmount == on-chain settled
+      expect(args[3]).toBe('0x');          // empty metadata
+      expect(args[4]).toBe('0x');          // empty signature — contract skips verification
+      expect(store.getChannel(channelId)!.status).toBe('settled');
+    });
+
+    it('does not close zombie before deadline has passed (buyer may still reconnect)', async () => {
+      const channelId = makeChannelId(61);
+      // Deadline 1h in the future — channel is fresh, buyer might come back.
+      seedZombie(store, channelId, buyerIdentity, sellerIdentity, {
+        deadlineSec: Math.floor(Date.now() / 1000) + 3600,
+      });
+
+      const mgr = new SellerPaymentManager(
+        sellerIdentity,
+        { rpcUrl: 'http://127.0.0.1:8545', channelsContractAddress: CONTRACT_ADDR, chainId: CHAIN_ID, dataDir: tempDir },
+        store,
+      );
+      mgr.onBuyerDisconnect(buyerIdentity.peerId);
+
+      vi.spyOn(mgr.channelsClient, 'getSession').mockResolvedValue(
+        makeOnChainChannel(buyerIdentity, sellerIdentity, { settled: 0n, status: 1 }),
+      );
+      const closeSpy = vi.spyOn(mgr.channelsClient, 'close').mockResolvedValue('0xclose-hash');
+
+      await mgr.checkTimeouts();
+
+      expect(closeSpy).not.toHaveBeenCalled();
+      expect(store.getChannel(channelId)!.status).toBe('active');
+    });
+
+    it('falls back to local eviction when zombie close exhausts retries', async () => {
+      const channelId = makeChannelId(62);
+      seedZombie(store, channelId, buyerIdentity, sellerIdentity);
+
+      const mgr = new SellerPaymentManager(
+        sellerIdentity,
+        { rpcUrl: 'http://127.0.0.1:8545', channelsContractAddress: CONTRACT_ADDR, chainId: CHAIN_ID, dataDir: tempDir },
+        store,
+      );
+      mgr.onBuyerDisconnect(buyerIdentity.peerId);
+
+      vi.spyOn(mgr.channelsClient, 'getSession').mockResolvedValue(
+        makeOnChainChannel(buyerIdentity, sellerIdentity, { settled: 0n, status: 1 }),
+      );
+      const closeSpy = vi.spyOn(mgr.channelsClient, 'close').mockRejectedValue(new Error('boom'));
+
+      // MAX_CLOSE_RETRIES = 3 — four ticks: three failed close attempts, then local eviction.
+      await mgr.checkTimeouts();
+      await mgr.checkTimeouts();
+      await mgr.checkTimeouts();
+      await mgr.checkTimeouts();
+
+      expect(closeSpy).toHaveBeenCalledTimes(3);
+      expect(store.getChannel(channelId)!.status).toBe('timeout');
+    });
+
+    it('uses the on-chain settled cumulative as finalAmount, not the local 0', async () => {
+      // Regression guard: if the channel was settled by an earlier process
+      // (e.g. a previous instance before restart), passing finalAmount=0 would
+      // revert with FinalAmountBelowSettled. The fix must read on-chain settled
+      // first and pass that through.
+      const channelId = makeChannelId(63);
+      seedZombie(store, channelId, buyerIdentity, sellerIdentity);
+
+      const mgr = new SellerPaymentManager(
+        sellerIdentity,
+        { rpcUrl: 'http://127.0.0.1:8545', channelsContractAddress: CONTRACT_ADDR, chainId: CHAIN_ID, dataDir: tempDir },
+        store,
+      );
+      mgr.onBuyerDisconnect(buyerIdentity.peerId);
+
+      vi.spyOn(mgr.channelsClient, 'getSession').mockResolvedValue(
+        makeOnChainChannel(buyerIdentity, sellerIdentity, { settled: 250_000n, status: 1 }),
+      );
+      const closeSpy = vi.spyOn(mgr.channelsClient, 'close').mockResolvedValue('0xclose-hash');
+
+      await mgr.checkTimeouts();
+
+      expect(closeSpy).toHaveBeenCalledOnce();
+      expect(closeSpy.mock.calls[0]![2]).toBe(250_000n);
+    });
+  });
+
   describe('settleSession idle-settle skip logic', () => {
     async function seedAcceptedAuth(
       mgr: SellerPaymentManager,


### PR DESCRIPTION
Closes #362.

## Why

Two coupled symptoms in #362:

1. **New providers see reputation as 0** despite serving real traffic. Buyers display `onChainChannelCount` from `AntseedChannels._agentStats[agentId].channelCount` — but that counter only ticks on `close()` / `withdraw-with-settle`, never on `reserve()` or `settle()`. Sellers in steady state reserve+settle but rarely close, so the counter never grows.
2. **Desktop "Rep" column was a lie**: `peer-cache.ts` literally hardcoded `reputation: 100` for every peer. It only affected sort order, never gated routing, and was never tied to anything on chain.

## What

### Commit 1 — `fix(node): auto-close zombie channels so seller reputation accrues`

In `SellerPaymentManager.checkTimeouts`, when a channel is past its nominal deadline, the buyer is gone, and there is no signed spending auth, the seller now closes on-chain instead of evicting locally:

```ts
channelsClient.close(channelId, onChainSettled, "0x", "0x")
```

This works because `AntseedChannels.sol:288-294` skips `_settleSpend` (and signature verification) when `finalAmount == channel.settled`. The contract still:

- ticks `_agentStats[agentId].channelCount` → reputation accrues for new providers (the headline #362 symptom)
- decrements `activeChannelCount[seller]` → unstake stops being blocked (Gekko's secondary observation in the issue)
- releases the buyer's reserved deposit back to `AntseedDeposits` automatically

**Safety:**
- New private `_closeWithoutAuth` helper reuses the existing `_closingChannels` mutex and `MAX_CLOSE_RETRIES` retry budget.
- Reads on-chain `settled` from `getSession` first, guarding the post-restart case where local `accepted=0` but on-chain `settled>0` (would otherwise revert with `FinalAmountBelowSettled`).
- Falls back to local-only eviction when `getSession` returns `unknown` or retries are exhausted, preserving prior behavior in the bad cases.

**Tests:** +4 cases in `seller-payment-manager.test.ts` covering closes-past-deadline, respects-deadline, retry-exhaustion fallback, and "uses on-chain settled, not local 0".

### Commit 2 — `refactor(desktop): replace placeholder "reputation" with on-chain volume`

Tear out the `reputation: 100` placeholder everywhere and replace with `onChainTotalVolumeUsdcMicros` (lifetime settled USDC from `getAgentStats`, already populated into `buyer.state.json`). Mirrors what the CLI has been doing for a while via `formatUsdcVolume`.

| Surface | Before | After |
|---|---|---|
| Peers view column | "Rep" (`100` for everyone) | "Volume" (real `$X.XX`, default sort desc) |
| Overview view column | "Rep" | "Volume" |
| Session approval card | "X reputation" line | `$X.XX volume`, `N session(s)`, `Yd in network` — only the rows we have data for |
| Sort behavior | tied at `100` | volume desc, nulls sink to bottom, tiebreak `lastSeen` |

`null` vs `0` is meaningful: `null` = "no chain enrichment yet" (renders as `—`), `0` = "agent has zero settled volume" (renders as `$0`). New `formatUsdcVolume()` helper in `core/format.ts` mirrors the CLI's version.

## Verification

- Node typecheck: clean
- Node tests: **602/602** (37/37 in `seller-payment-manager.test.ts` incl. the 4 new cases)
- Desktop main + renderer typecheck: clean
- Desktop main tests: **68/68**
- Renderer Vite build: clean

## Out of scope / follow-ups

- `pi-chat-engine.ts` has a misnamed `onChainActiveChannelCount` field that actually carries the settled count. Touches tests/discover-rows; left for a focused follow-up.
- Activity-tracking signals beyond settled volume (e.g. live channel count, recent activity) are orthogonal — once auto-close ticks the on-chain counter, settled volume + channel count are the right durable signals.
