### PR TITLE
fix(desktop): Suppress retries after stream done

### DIFF
--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -149,6 +149,7 @@ export function initChatModule({
   const sendingConversationIds = new Set<string>();
   const streamTurnsByConversation = new Map<string, number>();
   const streamStartedAtByConversation = new Map<string, number>();
+  const streamCompletedAtByConversation = new Map<string, number>();
   const localConversationMessages = new Map<string, ChatMessage[]>();
   const streamingMessagesByConversation = new Map<string, ChatMessage>();
   let newChatDraftVersion = 0;
@@ -1940,6 +1941,8 @@ export function initChatModule({
     if (!bridge) return;
 
     const selection = selectionOverride ?? getSelectedChatServiceSelection();
+    const requestStartedAt = Date.now();
+    streamCompletedAtByConversation.delete(convId);
 
     if (!selection.id) {
       reportChatError('No service is selected for this conversation.', 'Request failed');
@@ -1974,6 +1977,12 @@ export function initChatModule({
           }
 
           if (!result.ok) {
+            if ((streamCompletedAtByConversation.get(convId) ?? 0) >= requestStartedAt) {
+              clearPaymentRetry(convId);
+              setConversationSending(convId, false);
+              return;
+            }
+
             const errorMsg = typeof result.error === 'string' ? result.error : '';
             const paymentMatch = /^payment_required:(\d+)$/i.exec(errorMsg);
             if (paymentMatch) {
@@ -1999,6 +2008,12 @@ export function initChatModule({
             }
           }
         } catch (err) {
+          if ((streamCompletedAtByConversation.get(convId) ?? 0) >= requestStartedAt) {
+            clearPaymentRetry(convId);
+            setConversationSending(convId, false);
+            return;
+          }
+
           scheduleChatRetry({ convId, content, attachments, selection }, 'request', err);
           setConversationSending(convId, false);
         }
@@ -2582,6 +2597,7 @@ export function initChatModule({
           getConversationStreamingMessage(data.conversationId),
         );
 
+        streamCompletedAtByConversation.set(data.conversationId, Date.now());
         clearPaymentRetry(data.conversationId);
 
         if (data.conversationId === uiState.chatActiveConversation) {


### PR DESCRIPTION
## Description

Prevents the desktop renderer from retrying a chat request after the streaming response has already completed successfully. This avoids duplicate assistant messages when the streaming completion event arrives before a late error-like send result.

## Release Notes

- Fixed duplicate chat responses caused by retrying after a successful stream completion.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Validation:

```bash
pnpm -C apps/desktop run typecheck:renderer
```