### PR TITLE
fix(buyer): Enforce pricing policy

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -72,8 +72,8 @@ export interface BuyerProxyConfig {
   peerCacheTtlMs?: number
   /**
    * Pin all requests to a specific peer ID for this session.
-   * The router is bypassed; the named peer is used directly if it is available
-   * and protocol-compatible. A 502 is returned if the peer cannot be reached.
+   * The named peer is used directly if it is available, protocol-compatible,
+   * and allowed by the router's buyer policy. A 502 is returned if the peer cannot be reached.
    */
   pinnedPeerId?: string
   /**
@@ -266,6 +266,9 @@ export function parsePersistedPeers(
     }
     if (typeof entry.defaultOutputUsdPerMillion === 'number') {
       peer.defaultOutputUsdPerMillion = entry.defaultOutputUsdPerMillion
+    }
+    if (typeof entry.defaultCachedInputUsdPerMillion === 'number') {
+      peer.defaultCachedInputUsdPerMillion = entry.defaultCachedInputUsdPerMillion
     }
     if (typeof entry.maxConcurrency === 'number') {
       peer.maxConcurrency = entry.maxConcurrency
@@ -580,6 +583,7 @@ export class BuyerProxy {
         providerServiceApiProtocols: p.providerServiceApiProtocols ?? null,
         defaultInputUsdPerMillion: p.defaultInputUsdPerMillion ?? 0,
         defaultOutputUsdPerMillion: p.defaultOutputUsdPerMillion ?? 0,
+        defaultCachedInputUsdPerMillion: p.defaultCachedInputUsdPerMillion ?? null,
         maxConcurrency: p.maxConcurrency ?? 0,
         currentLoad: p.currentLoad ?? null,
         // On-chain stats read authoritatively by the buyer from AntseedChannels.
@@ -1146,6 +1150,17 @@ export class BuyerProxy {
       res.end(`Pinned peer ${explicitPeerId.slice(0, 12)}... is currently unreachable. Try again in a moment.`)
       return
     }
+    const policySelectedPeer = router?.selectPeer(serializedReq, [selectedPeer]) ?? null
+    if (router && policySelectedPeer?.peerId !== selectedPeer.peerId) {
+      log(`Pinned peer ${selectedPeer.peerId.slice(0, 12)}... filtered out by buyer routing policy`)
+      res.writeHead(502, { 'content-type': 'text/plain' })
+      res.end(
+        `Pinned peer ${selectedPeer.peerId.slice(0, 12)}... is outside your buyer routing policy. `
+        + 'Pick a different service in Discover or adjust your buyer max pricing.',
+      )
+      return
+    }
+
     log(`Using pinned peer ${selectedPeer.peerId.slice(0, 12)}...`)
     const result = await this._dispatchToPeer(
       res,

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.70",
+  "version": "0.1.71",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/main/chat-service-catalog.ts
+++ b/apps/desktop/src/main/chat-service-catalog.ts
@@ -28,6 +28,7 @@ export type NetworkPeerAddress = {
   providerServiceCategories?: Record<string, { services: Record<string, string[]> }>;
   defaultInputUsdPerMillion?: number;
   defaultOutputUsdPerMillion?: number;
+  defaultCachedInputUsdPerMillion?: number;
 };
 
 export type ChatServiceCatalogEntry = {
@@ -40,6 +41,7 @@ export type ChatServiceCatalogEntry = {
   peerLabel?: string;
   inputUsdPerMillion?: number;
   outputUsdPerMillion?: number;
+  cachedInputUsdPerMillion?: number;
   categories?: string[];
   description?: string;
 };
@@ -82,7 +84,8 @@ export function resolveProviderServicePricing(
   serviceId: string,
   defaultInput?: number,
   defaultOutput?: number,
-): { inputUsdPerMillion?: number; outputUsdPerMillion?: number } {
+  defaultCachedInput?: number,
+): { inputUsdPerMillion?: number; outputUsdPerMillion?: number; cachedInputUsdPerMillion?: number } {
   const providerPricing = pricingMap?.[provider];
   const servicePricing = providerPricing?.services?.[serviceId];
   const defaultPricing = providerPricing?.defaults;
@@ -96,9 +99,13 @@ export function resolveProviderServicePricing(
     ?? defaultPricing?.outputUsdPerMillion
     ?? defaultPricing?.output
     ?? defaultOutput;
+  const cachedInputUsd = servicePricing?.cachedInputUsdPerMillion
+    ?? defaultPricing?.cachedInputUsdPerMillion
+    ?? defaultCachedInput;
   return {
     ...(inputUsd != null ? { inputUsdPerMillion: inputUsd } : {}),
     ...(outputUsd != null ? { outputUsdPerMillion: outputUsd } : {}),
+    ...(cachedInputUsd != null ? { cachedInputUsdPerMillion: cachedInputUsd } : {}),
   };
 }
 
@@ -140,6 +147,7 @@ export function buildChatServiceCatalogFromPeers(peers: NetworkPeerAddress[]): C
     const categoriesMap = peer.providerServiceCategories;
     const defaultInput = peer.defaultInputUsdPerMillion;
     const defaultOutput = peer.defaultOutputUsdPerMillion;
+    const defaultCachedInput = peer.defaultCachedInputUsdPerMillion;
 
     if (providerList.length > 0) {
       // Build rows from each provider's own announced service map. The flattened
@@ -159,12 +167,13 @@ export function buildChatServiceCatalogFromPeers(peers: NetworkPeerAddress[]): C
           const protocol = resolveProviderServiceProtocol(apiProtocols, provider, serviceId) ?? inferProviderProtocol(provider);
           if (!protocol) continue;
 
-          const { inputUsdPerMillion, outputUsdPerMillion } = resolveProviderServicePricing(
+          const { inputUsdPerMillion, outputUsdPerMillion, cachedInputUsdPerMillion } = resolveProviderServicePricing(
             pricingMap,
             provider,
             serviceId,
             defaultInput,
             defaultOutput,
+            defaultCachedInput,
           );
           const categories = categoriesMap?.[provider]?.services?.[serviceId];
 
@@ -178,6 +187,7 @@ export function buildChatServiceCatalogFromPeers(peers: NetworkPeerAddress[]): C
             ...(peerLabel ? { peerLabel } : {}),
             ...(inputUsdPerMillion != null ? { inputUsdPerMillion } : {}),
             ...(outputUsdPerMillion != null ? { outputUsdPerMillion } : {}),
+            ...(cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion } : {}),
             ...(categories?.length ? { categories } : {}),
           });
         }
@@ -198,12 +208,13 @@ export function buildChatServiceCatalogFromPeers(peers: NetworkPeerAddress[]): C
           }
           const protocol = resolveProviderServiceProtocol(apiProtocols, fallbackProvider, serviceId) ?? inferProviderProtocol(fallbackProvider);
           if (!protocol) continue;
-          const { inputUsdPerMillion, outputUsdPerMillion } = resolveProviderServicePricing(
+          const { inputUsdPerMillion, outputUsdPerMillion, cachedInputUsdPerMillion } = resolveProviderServicePricing(
             pricingMap,
             fallbackProvider,
             serviceId,
             defaultInput,
             defaultOutput,
+            defaultCachedInput,
           );
           const categories = categoriesMap?.[fallbackProvider]?.services?.[serviceId];
 
@@ -217,6 +228,7 @@ export function buildChatServiceCatalogFromPeers(peers: NetworkPeerAddress[]): C
             ...(peerLabel ? { peerLabel } : {}),
             ...(inputUsdPerMillion != null ? { inputUsdPerMillion } : {}),
             ...(outputUsdPerMillion != null ? { outputUsdPerMillion } : {}),
+            ...(cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion } : {}),
             ...(categories?.length ? { categories } : {}),
           });
         }
@@ -226,12 +238,13 @@ export function buildChatServiceCatalogFromPeers(peers: NetworkPeerAddress[]): C
           const protocol = inferProviderProtocol(provider);
           if (!protocol) continue;
 
-          const { inputUsdPerMillion, outputUsdPerMillion } = resolveProviderServicePricing(
+          const { inputUsdPerMillion, outputUsdPerMillion, cachedInputUsdPerMillion } = resolveProviderServicePricing(
             pricingMap,
             provider,
             provider,
             defaultInput,
             defaultOutput,
+            defaultCachedInput,
           );
           results.push({
             id: provider,
@@ -243,6 +256,7 @@ export function buildChatServiceCatalogFromPeers(peers: NetworkPeerAddress[]): C
             ...(peerLabel ? { peerLabel } : {}),
             ...(inputUsdPerMillion != null ? { inputUsdPerMillion } : {}),
             ...(outputUsdPerMillion != null ? { outputUsdPerMillion } : {}),
+            ...(cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion } : {}),
           });
         }
       }

--- a/apps/desktop/src/main/config-io.test.ts
+++ b/apps/desktop/src/main/config-io.test.ts
@@ -1,0 +1,134 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION,
+  DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION,
+  ensureConfig,
+  readConfig,
+} from './config-io.js';
+
+async function makeTempConfigPath(): Promise<{ dir: string; configPath: string }> {
+  const dir = await mkdtemp(join(tmpdir(), 'antseed-desktop-config-'));
+  return { dir, configPath: join(dir, 'config.json') };
+}
+
+function readBuyerMaxPricing(config: Record<string, unknown>): { input: unknown; output: unknown } {
+  const buyer = config.buyer as { maxPricing?: { defaults?: Record<string, unknown> } } | undefined;
+  const defaults = buyer?.maxPricing?.defaults ?? {};
+  return {
+    input: defaults.inputUsdPerMillion,
+    output: defaults.outputUsdPerMillion,
+  };
+}
+
+test('ensureConfig creates config with desktop buyer max pricing defaults', async (t) => {
+  const { dir, configPath } = await makeTempConfigPath();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await ensureConfig(configPath);
+
+  const config = await readConfig(configPath);
+  const pricing = readBuyerMaxPricing(config);
+  assert.equal(pricing.input, DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION);
+  assert.equal(pricing.output, DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION);
+});
+
+test('ensureConfig clamps buyer max pricing above desktop defaults', async (t) => {
+  const { dir, configPath } = await makeTempConfigPath();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await writeFile(configPath, JSON.stringify({
+    identity: { displayName: 'Existing User' },
+    buyer: {
+      proxyPort: 8377,
+      minPeerReputation: 50,
+      maxPricing: {
+        defaults: {
+          inputUsdPerMillion: 100,
+          outputUsdPerMillion: 100,
+        },
+      },
+    },
+  }, null, 2));
+
+  await ensureConfig(configPath);
+
+  const config = await readConfig(configPath);
+  const pricing = readBuyerMaxPricing(config);
+  assert.equal(pricing.input, DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION);
+  assert.equal(pricing.output, DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION);
+  assert.equal((config.identity as { displayName?: string }).displayName, 'Existing User');
+});
+
+test('ensureConfig clamps only buyer max pricing values above desktop defaults', async (t) => {
+  const { dir, configPath } = await makeTempConfigPath();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await writeFile(configPath, JSON.stringify({
+    buyer: {
+      maxPricing: {
+        defaults: {
+          inputUsdPerMillion: 4,
+          outputUsdPerMillion: 90,
+        },
+      },
+    },
+  }, null, 2));
+
+  await ensureConfig(configPath);
+
+  const config = await readConfig(configPath);
+  const pricing = readBuyerMaxPricing(config);
+  assert.equal(pricing.input, 4);
+  assert.equal(pricing.output, DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION);
+});
+
+test('ensureConfig fills missing buyer max pricing defaults for existing configs', async (t) => {
+  const { dir, configPath } = await makeTempConfigPath();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await writeFile(configPath, JSON.stringify({
+    identity: { displayName: 'Missing Pricing' },
+    buyer: {
+      proxyPort: 9123,
+      minPeerReputation: 42,
+    },
+  }, null, 2));
+
+  await ensureConfig(configPath);
+
+  const config = await readConfig(configPath);
+  const pricing = readBuyerMaxPricing(config);
+  assert.equal(pricing.input, DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION);
+  assert.equal(pricing.output, DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION);
+  assert.equal((config.buyer as { proxyPort?: number }).proxyPort, 9123);
+  assert.equal((config.buyer as { minPeerReputation?: number }).minPeerReputation, 42);
+});
+
+test('ensureConfig preserves buyer max pricing at or below desktop defaults', async (t) => {
+  const { dir, configPath } = await makeTempConfigPath();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await writeFile(configPath, JSON.stringify({
+    buyer: {
+      maxPricing: {
+        defaults: {
+          inputUsdPerMillion: 4,
+          outputUsdPerMillion: 20,
+        },
+      },
+    },
+  }, null, 2));
+
+  await ensureConfig(configPath);
+
+  const raw = await readFile(configPath, 'utf-8');
+  const config = JSON.parse(raw) as Record<string, unknown>;
+  const pricing = readBuyerMaxPricing(config);
+  assert.equal(pricing.input, 4);
+  assert.equal(pricing.output, 20);
+});

--- a/apps/desktop/src/main/config-io.ts
+++ b/apps/desktop/src/main/config-io.ts
@@ -5,6 +5,9 @@ import { randomUUID } from 'node:crypto';
 import { DEFAULT_CONFIG_PATH } from './constants.js';
 import { asString, asNumber } from './utils.js';
 
+export const DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION = 5;
+export const DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION = 30;
+
 const DEFAULT_CONFIG: Record<string, unknown> = {
   identity: { displayName: 'AntSeed Node' },
   seller: {
@@ -14,7 +17,12 @@ const DEFAULT_CONFIG: Record<string, unknown> = {
     pricing: { defaults: { inputUsdPerMillion: 10, outputUsdPerMillion: 10 } },
   },
   buyer: {
-    maxPricing: { defaults: { inputUsdPerMillion: 100, outputUsdPerMillion: 100 } },
+    maxPricing: {
+      defaults: {
+        inputUsdPerMillion: DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION,
+        outputUsdPerMillion: DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION,
+      },
+    },
     minPeerReputation: 50,
     proxyPort: 8377,
   },
@@ -24,16 +32,88 @@ const DEFAULT_CONFIG: Record<string, unknown> = {
   plugins: [],
 };
 
-/**
- * Ensure config.json exists. Creates it with defaults on first launch.
- */
-export async function ensureConfig(configPath = DEFAULT_CONFIG_PATH): Promise<void> {
-  if (existsSync(configPath)) return;
+function asRecordValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+async function writeConfigAtomic(config: Record<string, unknown>, configPath: string): Promise<void> {
   const dir = path.dirname(configPath);
   await mkdir(dir, { recursive: true });
   const tmp = path.join(dir, `.config.${randomUUID()}.json.tmp`);
-  await writeFile(tmp, JSON.stringify(DEFAULT_CONFIG, null, 2));
+  await writeFile(tmp, JSON.stringify(config, null, 2));
   await rename(tmp, configPath);
+}
+
+function migrateDesktopBuyerMaxPricing(config: Record<string, unknown>): {
+  config: Record<string, unknown>;
+  migrated: boolean;
+} {
+  const buyer = asRecordValue(config.buyer);
+  const maxPricing = asRecordValue(buyer.maxPricing);
+  const defaults = asRecordValue(maxPricing.defaults);
+
+  const input = defaults.inputUsdPerMillion;
+  const output = defaults.outputUsdPerMillion;
+
+  const nextDefaults = { ...defaults };
+  let migrated = false;
+
+  if (
+    typeof input !== 'number' ||
+    !Number.isFinite(input) ||
+    input > DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION
+  ) {
+    nextDefaults.inputUsdPerMillion = DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION;
+    migrated = true;
+  }
+
+  if (
+    typeof output !== 'number' ||
+    !Number.isFinite(output) ||
+    output > DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION
+  ) {
+    nextDefaults.outputUsdPerMillion = DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION;
+    migrated = true;
+  }
+
+  if (!migrated) return { config, migrated: false };
+
+  return {
+    config: {
+      ...config,
+      buyer: {
+        ...buyer,
+        maxPricing: {
+          ...maxPricing,
+          defaults: nextDefaults,
+        },
+      },
+    },
+    migrated: true,
+  };
+}
+
+/**
+ * Ensure config.json exists and legacy desktop defaults are migrated.
+ */
+export async function ensureConfig(configPath = DEFAULT_CONFIG_PATH): Promise<void> {
+  if (!existsSync(configPath)) {
+    await writeConfigAtomic(DEFAULT_CONFIG, configPath);
+    return;
+  }
+
+  const existing = await readConfig(configPath);
+  if (Object.keys(existing).length === 0) {
+    await writeConfigAtomic(DEFAULT_CONFIG, configPath);
+    return;
+  }
+
+  const migration = migrateDesktopBuyerMaxPricing(existing);
+  if (migration.migrated) {
+    await writeConfigAtomic(migration.config, configPath);
+  }
 }
 
 /**
@@ -81,11 +161,7 @@ export async function mergeConfig(
       }
     }
 
-    const dir = path.dirname(configPath);
-    await mkdir(dir, { recursive: true });
-    const tmp = path.join(dir, `.config.${randomUUID()}.json.tmp`);
-    await writeFile(tmp, JSON.stringify(merged, null, 2));
-    await rename(tmp, configPath);
+    await writeConfigAtomic(merged, configPath);
 
     result = merged;
   }).catch((err) => {

--- a/apps/desktop/src/main/pi-chat-engine.discover-catalog.test.ts
+++ b/apps/desktop/src/main/pi-chat-engine.discover-catalog.test.ts
@@ -20,9 +20,9 @@ test('buildChatServiceCatalogFromPeers keeps provider-specific service pricing f
         },
       },
       openai: {
-        defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 2 },
+        defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 2, cachedInputUsdPerMillion: 0.5 },
         services: {
-          'gpt-4o-mini': { inputUsdPerMillion: 0.15, outputUsdPerMillion: 0.6 },
+          'gpt-4o-mini': { inputUsdPerMillion: 0.15, outputUsdPerMillion: 0.6, cachedInputUsdPerMillion: 0.05 },
         },
       },
     },
@@ -41,6 +41,7 @@ test('buildChatServiceCatalogFromPeers keeps provider-specific service pricing f
   assert.equal(anthropic!.outputUsdPerMillion, 21);
   assert.equal(openai!.inputUsdPerMillion, 0.15);
   assert.equal(openai!.outputUsdPerMillion, 0.6);
+  assert.equal(openai!.cachedInputUsdPerMillion, 0.05);
   assert.equal(openai!.protocol, 'openai-chat-completions');
 });
 

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -46,6 +46,10 @@ import { DEFAULT_BUYER_STATE_PATH } from './constants.js';
 import { PROXY_PROVIDER_ID, normalizeProviderId, sanitizeProviderHint } from './chat-provider-hint.js';
 import { asErrorMessage } from './utils.js';
 import {
+  DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION,
+  DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION,
+} from './config-io.js';
+import {
   buildChatServiceCatalogFromPeers,
   sortChatServiceCatalogEntries,
   type ChatServiceCatalogEntry,
@@ -233,6 +237,12 @@ function augmentChatToolPath(): void {
 
 augmentChatToolPath();
 
+type BuyerMaxPricingDefaults = {
+  inputUsdPerMillion: number;
+  outputUsdPerMillion: number;
+  cachedInputUsdPerMillion?: number;
+};
+
 type DiscoverRowEntry = {
   rowKey: string;
   serviceId: string;
@@ -323,7 +333,68 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
+function normalizeNonNegativeNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+}
 
+async function loadBuyerMaxPricingDefaults(configPath: string): Promise<BuyerMaxPricingDefaults> {
+  try {
+    const raw = await readFile(configPath, 'utf8');
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const buyer = asRecord(parsed.buyer);
+    const maxPricing = asRecord(buyer?.maxPricing);
+    const defaults = asRecord(maxPricing?.defaults);
+    const input = normalizeNonNegativeNumber(defaults?.inputUsdPerMillion);
+    const output = normalizeNonNegativeNumber(defaults?.outputUsdPerMillion);
+    const cachedInput = normalizeNonNegativeNumber(defaults?.cachedInputUsdPerMillion);
+    return {
+      inputUsdPerMillion: input ?? DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION,
+      outputUsdPerMillion: output ?? DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION,
+      ...(cachedInput != null ? { cachedInputUsdPerMillion: cachedInput } : {}),
+    };
+  } catch {
+    return {
+      inputUsdPerMillion: DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION,
+      outputUsdPerMillion: DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION,
+    };
+  }
+}
+
+function isPriceAllowedByBuyerMax(
+  inputUsdPerMillion: number | null | undefined,
+  outputUsdPerMillion: number | null | undefined,
+  cachedInputUsdPerMillion: number | null | undefined,
+  maxPricing: BuyerMaxPricingDefaults,
+): boolean {
+  if (inputUsdPerMillion != null && inputUsdPerMillion > maxPricing.inputUsdPerMillion) {
+    return false;
+  }
+  if (outputUsdPerMillion != null && outputUsdPerMillion > maxPricing.outputUsdPerMillion) {
+    return false;
+  }
+  if (cachedInputUsdPerMillion != null) {
+    if (inputUsdPerMillion != null && cachedInputUsdPerMillion > inputUsdPerMillion) {
+      return false;
+    }
+    const maxCachedInput = maxPricing.cachedInputUsdPerMillion ?? maxPricing.inputUsdPerMillion;
+    if (cachedInputUsdPerMillion > maxCachedInput) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isCatalogEntryAllowedByBuyerMax(
+  entry: ChatServiceCatalogEntry,
+  maxPricing: BuyerMaxPricingDefaults,
+): boolean {
+  return isPriceAllowedByBuyerMax(
+    entry.inputUsdPerMillion,
+    entry.outputUsdPerMillion,
+    entry.cachedInputUsdPerMillion,
+    maxPricing,
+  );
+}
 
 function updateServiceProviderHints(
   serviceProviderHints: Map<string, string[]>,
@@ -390,6 +461,7 @@ function normalizeChatServiceCatalogEntry(raw: unknown): ChatServiceCatalogEntry
   const peerLabel = typeof entry.peerLabel === 'string' ? entry.peerLabel.trim() : undefined;
   const inputUsd = normalizeOptionalNumber(entry.inputUsdPerMillion);
   const outputUsd = normalizeOptionalNumber(entry.outputUsdPerMillion);
+  const cachedInputUsd = normalizeOptionalNumber(entry.cachedInputUsdPerMillion);
   const categories = Array.isArray(entry.categories) ? entry.categories.filter((c): c is string => typeof c === 'string') : undefined;
   const description = typeof entry.description === 'string' ? entry.description.trim() : undefined;
   return {
@@ -402,6 +474,7 @@ function normalizeChatServiceCatalogEntry(raw: unknown): ChatServiceCatalogEntry
     ...(peerLabel ? { peerLabel } : {}),
     ...(inputUsd != null && inputUsd >= 0 ? { inputUsdPerMillion: inputUsd } : {}),
     ...(outputUsd != null && outputUsd >= 0 ? { outputUsdPerMillion: outputUsd } : {}),
+    ...(cachedInputUsd != null && cachedInputUsd >= 0 ? { cachedInputUsdPerMillion: cachedInputUsd } : {}),
     ...(categories?.length ? { categories } : {}),
     ...(description ? { description } : {}),
   };
@@ -494,6 +567,7 @@ async function discoverChatServiceCatalog(
           : undefined,
         defaultInputUsdPerMillion: typeof p.defaultInputUsdPerMillion === 'number' ? p.defaultInputUsdPerMillion : undefined,
         defaultOutputUsdPerMillion: typeof p.defaultOutputUsdPerMillion === 'number' ? p.defaultOutputUsdPerMillion : undefined,
+        defaultCachedInputUsdPerMillion: typeof p.defaultCachedInputUsdPerMillion === 'number' ? p.defaultCachedInputUsdPerMillion : undefined,
       }))
       .filter((p) => p.peerId.length === 40); // EVM address peer IDs only (40 hex chars)
   } catch {
@@ -716,9 +790,11 @@ async function buildDiscoverRows(
 
     const stats = peerStats.get(peerId);
     const cachedPricingEntry = peerBlob?.providerPricing?.[entry.provider]?.services?.[entry.id];
-    const cachedInputUsdPerMillion = Number.isFinite(cachedPricingEntry?.cachedInputUsdPerMillion)
-      ? cachedPricingEntry!.cachedInputUsdPerMillion!
-      : null;
+    const cachedInputUsdPerMillion = Number.isFinite(entry.cachedInputUsdPerMillion)
+      ? entry.cachedInputUsdPerMillion!
+      : Number.isFinite(cachedPricingEntry?.cachedInputUsdPerMillion)
+        ? cachedPricingEntry!.cachedInputUsdPerMillion!
+        : null;
 
     const netForAgent = enrichmentRow.agentId > 0
       ? networkStats.get(enrichmentRow.agentId) ?? null
@@ -2352,7 +2428,9 @@ export function registerPiChatHandlers({
 
   ipcMain.handle('chat:ai-list-discover-rows', async () => {
     try {
-      const entries = await refreshServiceCatalogFromNetwork();
+      const buyerMaxPricing = await loadBuyerMaxPricingDefaults(configPath);
+      const entries = (await refreshServiceCatalogFromNetwork())
+        .filter((entry) => isCatalogEntryAllowedByBuyerMax(entry, buyerMaxPricing));
 
       const buyerPort = await resolveProxyPort(configPath);
       const statsMap = new Map<string, {
@@ -2487,7 +2565,13 @@ export function registerPiChatHandlers({
         }
       })();
 
-      const rows = await buildDiscoverRows(entries, statsMap, enrichment, discoveredPeersMap, networkStats);
+      const rows = (await buildDiscoverRows(entries, statsMap, enrichment, discoveredPeersMap, networkStats))
+        .filter((row) => isPriceAllowedByBuyerMax(
+          row.inputUsdPerMillion,
+          row.outputUsdPerMillion,
+          row.cachedInputUsdPerMillion,
+          buyerMaxPricing,
+        ));
       return { ok: true, data: rows };
     } catch (error) {
       return { ok: false, data: [] as DiscoverRowEntry[], error: asErrorMessage(error) };

--- a/apps/desktop/src/renderer/modules/settings.ts
+++ b/apps/desktop/src/renderer/modules/settings.ts
@@ -1,6 +1,6 @@
 import type { RendererUiState, ConfigFormData } from '../core/state';
 import { notifyUiStateChanged } from '../core/store';
-import { safeNumber, safeArray, safeString } from '../core/safe';
+import { safeNumber, safeString } from '../core/safe';
 
 type SettingsModuleOptions = {
   uiState: RendererUiState;
@@ -19,6 +19,8 @@ function asRecord(value: unknown): Record<string, unknown> {
 }
 
 const DESKTOP_DEV_MODE_KEY = 'antseed.desktop.devMode';
+const DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION = 5;
+const DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION = 30;
 
 function loadDesktopDevMode(): boolean {
   try {
@@ -65,8 +67,14 @@ export function initSettingsModule({
 
     applyConfigFormData({
       proxyPort: safeNumber(buyer.proxyPort, 8377),
-      maxInputUsdPerMillion: safeNumber(buyerMaxPricingDefaults.inputUsdPerMillion, 0),
-      maxOutputUsdPerMillion: safeNumber(buyerMaxPricingDefaults.outputUsdPerMillion, 0),
+      maxInputUsdPerMillion: safeNumber(
+        buyerMaxPricingDefaults.inputUsdPerMillion,
+        DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION,
+      ),
+      maxOutputUsdPerMillion: safeNumber(
+        buyerMaxPricingDefaults.outputUsdPerMillion,
+        DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION,
+      ),
       minRep: safeNumber(buyer.minPeerReputation, 0),
       paymentMethod: safeString(payments.preferredMethod, 'crypto'),
       devMode: uiState.devMode,

--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.test.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.test.ts
@@ -5,6 +5,7 @@ import {
   matchesMinStake,
   matchesLastSeen, matchesLastSettled,
   matchesMinChannels, rowChannelCount,
+  hasValidCachedInputPrice,
   applyFilters, applySort, paginate, totalPagesFor,
   MAX_INPUT_PRICE_SLIDER_USD, MAX_OUTPUT_PRICE_SLIDER_USD,
 } from './discover-filter-util';
@@ -53,6 +54,14 @@ test('matchesMaxOutputPrice filters rows by the output slider ceiling', () => {
   assert.ok(matchesMaxOutputPrice(mkRow({ outputUsdPerMillion: 0.4 }), 0.6));
   assert.ok(!matchesMaxOutputPrice(mkRow({ outputUsdPerMillion: 0.7 }), 0.6));
   assert.ok(!matchesMaxOutputPrice(mkRow({ outputUsdPerMillion: null }), 0.6));
+});
+
+test('hasValidCachedInputPrice rejects cached input above input', () => {
+  assert.ok(hasValidCachedInputPrice(mkRow({ inputUsdPerMillion: 1, cachedInputUsdPerMillion: null })));
+  assert.ok(hasValidCachedInputPrice(mkRow({ inputUsdPerMillion: 1, cachedInputUsdPerMillion: 0.5 })));
+  assert.ok(hasValidCachedInputPrice(mkRow({ inputUsdPerMillion: 1, cachedInputUsdPerMillion: 1 })));
+  assert.ok(!hasValidCachedInputPrice(mkRow({ inputUsdPerMillion: 1, cachedInputUsdPerMillion: 1.1 })));
+  assert.ok(!hasValidCachedInputPrice(mkRow({ inputUsdPerMillion: null, cachedInputUsdPerMillion: 0.5 })));
 });
 
 test('matchesMinStake compares base-6 USDC bigint to slider value', () => {

--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
@@ -18,11 +18,11 @@ export const MAX_CHANNELS_SLIDER = 200;
 export const CHANNELS_SLIDER_STEP = 5;
 
 /**
- * Default minimum on-chain channel count for Discover. 20 hides brand-new peers
- * that haven't accumulated a track record while still showing modestly-active ones.
- * Users can lower the slider to 0 to see every peer.
+ * Default minimum on-chain channel count for Discover. 120 hides brand-new peers
+ * that haven't accumulated a stronger track record. Users can lower the slider
+ * to 0 to see every peer.
  */
-export const DEFAULT_MIN_ON_CHAIN_CHANNELS = 20;
+export const DEFAULT_MIN_ON_CHAIN_CHANNELS = 120;
 
 export type TimeWindow = 'any' | 'today' | 'week' | 'month';
 
@@ -91,6 +91,13 @@ export function matchesMaxOutputPrice(row: DiscoverRow, maxPrice: number): boole
   return output <= maxPrice;
 }
 
+export function hasValidCachedInputPrice(row: DiscoverRow): boolean {
+  const cached = row.cachedInputUsdPerMillion;
+  if (cached == null) return true;
+  const input = row.inputUsdPerMillion;
+  return input != null && cached <= input;
+}
+
 export function matchesCategoryFilter(row: DiscoverRow, set: Set<string>): boolean {
   if (set.size === 0) return true;
   return row.categories.some((c) => set.has(c.toLowerCase()));
@@ -157,6 +164,7 @@ export function applyFilters(rows: DiscoverRow[], inputs: DiscoverFilterInputs):
     && matchesPeerFilter(row, inputs.peerSet)
     && matchesMaxInputPrice(row, inputs.maxInputPrice)
     && matchesMaxOutputPrice(row, inputs.maxOutputPrice)
+    && hasValidCachedInputPrice(row)
     && (inputs.chattedOnly ? hasBeenUsed(row) : true)
     && matchesMinStake(row, inputs.minStakeUsdc)
     && matchesLastSeen(row, inputs.lastSeenWindow, nowMs)

--- a/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
@@ -12,8 +12,6 @@ export function ConfigView({ active }: ConfigViewProps) {
 
   // Local form state — initialized from config, edited locally, saved on button click
   const [proxyPort, setProxyPort] = useState('8377');
-  const [maxInput, setMaxInput] = useState('0');
-  const [maxOutput, setMaxOutput] = useState('0');
   const [minRep, setMinRep] = useState('0');
   const [chainId, setChainId] = useState('base-mainnet');
   const [dirty, setDirty] = useState(false);
@@ -23,8 +21,6 @@ export function ConfigView({ active }: ConfigViewProps) {
   useEffect(() => {
     if (configFormData && !initialized) {
       setProxyPort(String(configFormData.proxyPort));
-      setMaxInput(String(configFormData.maxInputUsdPerMillion));
-      setMaxOutput(String(configFormData.maxOutputUsdPerMillion));
       setMinRep(String(configFormData.minRep));
       setChainId(configFormData.cryptoChainId || 'base-mainnet');
       setInitialized(true);
@@ -45,8 +41,6 @@ export function ConfigView({ active }: ConfigViewProps) {
     await actions.saveConfig({
       ...configFormData,
       proxyPort: parseInt(proxyPort, 10) || 8377,
-      maxInputUsdPerMillion: parseFloat(maxInput) || 0,
-      maxOutputUsdPerMillion: parseFloat(maxOutput) || 0,
       minRep: parseInt(minRep, 10) || 0,
       cryptoChainId: chainId,
     });
@@ -82,32 +76,6 @@ export function ConfigView({ active }: ConfigViewProps) {
                 className="form-input settings-control"
                 value={proxyPort}
                 onChange={(e) => { setProxyPort(e.target.value); markDirty(); }}
-              />
-            </label>
-            <label className="settings-item">
-              <div className="settings-copy">
-                <h4>Max Input Price</h4>
-                <p>Highest input token price you will accept (USD per 1M tokens).</p>
-              </div>
-              <input
-                type="number"
-                className="form-input settings-control"
-                step="0.01"
-                value={maxInput}
-                onChange={(e) => { setMaxInput(e.target.value); markDirty(); }}
-              />
-            </label>
-            <label className="settings-item">
-              <div className="settings-copy">
-                <h4>Max Output Price</h4>
-                <p>Highest output token price you will accept (USD per 1M tokens).</p>
-              </div>
-              <input
-                type="number"
-                className="form-input settings-control"
-                step="0.01"
-                value={maxOutput}
-                onChange={(e) => { setMaxOutput(e.target.value); markDirty(); }}
               />
             </label>
             <label className="settings-item">

--- a/plugins/router-local/src/router.test.ts
+++ b/plugins/router-local/src/router.test.ts
@@ -92,6 +92,42 @@ describe('LocalRouter', () => {
     expect(router.selectPeer(makeRequest('claude-sonnet-4-5-20250929'), [overpricedOutputPeer])).toBeNull();
   });
 
+  it('rejects peers when cached input price exceeds input price', () => {
+    const router = new LocalRouter({
+      maxPricing: {
+        defaults: { inputUsdPerMillion: 50, outputUsdPerMillion: 50 },
+      },
+    });
+
+    const invalidCachedPricePeer = makePeer({
+      providerPricing: {
+        anthropic: {
+          defaults: { inputUsdPerMillion: 5, outputUsdPerMillion: 20, cachedInputUsdPerMillion: 6 },
+        },
+      },
+    });
+
+    expect(router.selectPeer(makeRequest(), [invalidCachedPricePeer])).toBeNull();
+  });
+
+  it('rejects peers when cached input price exceeds buyer cached max', () => {
+    const router = new LocalRouter({
+      maxPricing: {
+        defaults: { inputUsdPerMillion: 50, outputUsdPerMillion: 50, cachedInputUsdPerMillion: 2 },
+      },
+    });
+
+    const expensiveCachedInputPeer = makePeer({
+      providerPricing: {
+        anthropic: {
+          defaults: { inputUsdPerMillion: 5, outputUsdPerMillion: 20, cachedInputUsdPerMillion: 3 },
+        },
+      },
+    });
+
+    expect(router.selectPeer(makeRequest(), [expensiveCachedInputPeer])).toBeNull();
+  });
+
   it('uses service-specific seller offer pricing when request service is present', () => {
     const router = new LocalRouter({
       maxPricing: {

--- a/plugins/router-local/src/router.ts
+++ b/plugins/router-local/src/router.ts
@@ -39,6 +39,9 @@ export class LocalRouter implements Router {
       defaults: {
         inputUsdPerMillion: config?.maxPricing?.defaults.inputUsdPerMillion ?? Number.POSITIVE_INFINITY,
         outputUsdPerMillion: config?.maxPricing?.defaults.outputUsdPerMillion ?? Number.POSITIVE_INFINITY,
+        ...(config?.maxPricing?.defaults.cachedInputUsdPerMillion != null
+          ? { cachedInputUsdPerMillion: config.maxPricing.defaults.cachedInputUsdPerMillion }
+          : {}),
       },
       ...(config?.maxPricing?.providers ? { providers: config.maxPricing.providers } : {}),
     };
@@ -90,7 +93,7 @@ export class LocalRouter implements Router {
       }
 
       const max = this._resolveBuyerMaxPrice(provider, requestedService);
-      if (offer.inputUsdPerMillion > max.inputUsdPerMillion || offer.outputUsdPerMillion > max.outputUsdPerMillion) {
+      if (this._offerExceedsMaxPrice(offer, max)) {
         continue;
       }
 
@@ -190,14 +193,14 @@ export class LocalRouter implements Router {
 
     if (service) {
       const serviceSpecific = providerPricing?.services?.[service];
-      if (serviceSpecific && this._isValidOffer(serviceSpecific)) {
-        return serviceSpecific;
+      if (serviceSpecific) {
+        return this._isValidOffer(serviceSpecific) ? serviceSpecific : null;
       }
     }
 
     const providerDefaults = providerPricing?.defaults;
-    if (providerDefaults && this._isValidOffer(providerDefaults)) {
-      return providerDefaults;
+    if (providerDefaults) {
+      return this._isValidOffer(providerDefaults) ? providerDefaults : null;
     }
 
     if (
@@ -207,6 +210,9 @@ export class LocalRouter implements Router {
       return {
         inputUsdPerMillion: peer.defaultInputUsdPerMillion,
         outputUsdPerMillion: peer.defaultOutputUsdPerMillion,
+        ...(this._isFiniteNonNegative(peer.defaultCachedInputUsdPerMillion)
+          ? { cachedInputUsdPerMillion: peer.defaultCachedInputUsdPerMillion }
+          : {}),
       };
     }
 
@@ -218,13 +224,13 @@ export class LocalRouter implements Router {
 
     if (service) {
       const serviceOverride = providerPricing?.services?.[service];
-      if (serviceOverride && this._isValidOffer(serviceOverride)) {
+      if (serviceOverride && this._isValidBuyerMaxPrice(serviceOverride)) {
         return serviceOverride;
       }
     }
 
     const providerDefaults = providerPricing?.defaults;
-    if (providerDefaults && this._isValidOffer(providerDefaults)) {
+    if (providerDefaults && this._isValidBuyerMaxPrice(providerDefaults)) {
       return providerDefaults;
     }
 
@@ -237,8 +243,29 @@ export class LocalRouter implements Router {
 
   private _isValidOffer(offer: TokenPricingUsdPerMillion): boolean {
     return (
-      this._isFiniteNonNegative(offer.inputUsdPerMillion) &&
-      this._isFiniteNonNegative(offer.outputUsdPerMillion)
+      this._isValidBuyerMaxPrice(offer) &&
+      (
+        offer.cachedInputUsdPerMillion === undefined ||
+        offer.cachedInputUsdPerMillion <= offer.inputUsdPerMillion
+      )
     );
+  }
+
+  private _isValidBuyerMaxPrice(pricing: TokenPricingUsdPerMillion): boolean {
+    return (
+      this._isFiniteNonNegative(pricing.inputUsdPerMillion) &&
+      this._isFiniteNonNegative(pricing.outputUsdPerMillion) &&
+      (
+        pricing.cachedInputUsdPerMillion === undefined ||
+        this._isFiniteNonNegative(pricing.cachedInputUsdPerMillion)
+      )
+    );
+  }
+
+  private _offerExceedsMaxPrice(offer: TokenPricingUsdPerMillion, max: TokenPricingUsdPerMillion): boolean {
+    const maxCachedInput = max.cachedInputUsdPerMillion ?? max.inputUsdPerMillion;
+    return offer.inputUsdPerMillion > max.inputUsdPerMillion
+      || offer.outputUsdPerMillion > max.outputUsdPerMillion
+      || (offer.cachedInputUsdPerMillion != null && offer.cachedInputUsdPerMillion > maxCachedInput);
   }
 }


### PR DESCRIPTION
## Description

Enforces buyer max pricing consistently across desktop Discover, router selection, and pinned buyer proxy requests. Desktop configs now default to 5 input / 30 output USD per 1M tokens, existing higher values are clamped, max price controls are hidden from Settings, and cached input prices above input prices are filtered out.

## Release Notes

- Desktop buyer max pricing now defaults to $5 input / $30 output per 1M tokens and clamps existing higher values.
- Discover and buyer routing now filter services above buyer max pricing or with cached input pricing above input pricing.
- Discover now defaults to a 120-channel minimum filter.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
