### PR TITLE
fix(desktop): reset chatAbortVisible in startNewChat — fixes #454

### DIFF
--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1491,6 +1491,10 @@ export function initChatModule({
     uiState.chatDeleteVisible = false;
     uiState.chatInputDisabled = false;
     uiState.chatSendDisabled = false;
+    // Reset abort visibility: a fresh session has no in-flight request.
+    // Without this, chatAbortVisible stays true when the user opens a new
+    // chat while another conversation is still streaming — #454.
+    uiState.chatAbortVisible = false;
     uiState.chatConversationTitle = 'New Chat';
     uiState.chatError = null;
     updateThreadMeta(null);

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1491,9 +1491,6 @@ export function initChatModule({
     uiState.chatDeleteVisible = false;
     uiState.chatInputDisabled = false;
     uiState.chatSendDisabled = false;
-    // Reset abort visibility: a fresh session has no in-flight request.
-    // Without this, chatAbortVisible stays true when the user opens a new
-    // chat while another conversation is still streaming — #454.
     uiState.chatAbortVisible = false;
     uiState.chatConversationTitle = 'New Chat';
     uiState.chatError = null;


### PR DESCRIPTION
## Problem

When a user opens a new/fresh session while another conversation is still streaming, the Send button shows **"Stop"** instead of **"Send"** — because `chatAbortVisible` was never reset.

## Root cause

`startNewChat()` resets `chatInputDisabled` and `chatSendDisabled` but omits `chatAbortVisible`:

```ts
// Before — chatAbortVisible keeps its previous value (true if another session was streaming)
uiState.chatInputDisabled = false;
uiState.chatSendDisabled = false;
// chatAbortVisible ← never touched
```

The abort button visibility is set in `syncActiveConversationSendingState()` which is called by `setConversationSending()` — but `startNewChat()` bypasses that call path entirely and writes `chatInputDisabled`/`chatSendDisabled` directly, leaving `chatAbortVisible` stale.

## Fix

Add `uiState.chatAbortVisible = false;` in `startNewChat()` before `notifyUiStateChanged()`. A fresh session has no in-flight request by definition.

```ts
function startNewChat(): void {
  // ...
  uiState.chatInputDisabled = false;
  uiState.chatSendDisabled = false;
  // Reset abort visibility: a fresh session has no in-flight request. #454
  uiState.chatAbortVisible = false;
  // ...
}
```

## Reproduce

1. Open AntStation, start a chat and send a long-running prompt.
2. While the first session is still streaming, open a new chat.
3. Without this fix: Send button shows "Stop" in the fresh session.
4. With this fix: Send button correctly shows the send arrow.

Closes #454