### PR TITLE
fix(desktop): add visual boundary to assistant chat bubbles — fixes #424

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -260,10 +260,13 @@
     align-self: stretch;
     background: transparent;
     color: var(--text-primary);
-    border-left: 0;
     border-radius: 0;
     width: 100%;
-    padding: 0 16px;
+    // Left accent bar gives a clear visual anchor for where each assistant
+    // response starts — fixes the missing boundary reported in #424.
+    border-left: 2px solid var(--border);
+    padding: 0 16px 0 14px;
+    margin-top: 4px;
 
   :global {
     /* Tool group */


### PR DESCRIPTION
## Problem

In AntStation, assistant messages have no visual container — they render as full-width, transparent, borderless blocks. Users cannot tell at a glance where an assistant response starts, especially after a long streaming session where the viewport is pinned to the tail.

Root cause documented in #424: `&.other` in `ChatBubble.module.scss` has `background: transparent`, `border-left: 0`, `border-radius: 0`.

## Fix

Adds a **2px left accent bar** (`border-left: 2px solid var(--border)`) to `.other` chat bubbles, with matching padding adjustment so text aligns cleanly against the bar.

```scss
// Before
&.other {
  background: transparent;
  border-left: 0;         // ← no visual anchor
  padding: 0 16px;
}

// After  
&.other {
  background: transparent;
  border-left: 2px solid var(--border);  // ← clear start boundary
  padding: 0 16px 0 14px;               // ← offset for the bar
  margin-top: 4px;
}
```

The bar uses `var(--border)` so it respects light/dark theme and stays visually subtle — the goal is a scannable edge, not a heavy UI element. It does not add background fill or card shadow, keeping the reading experience clean.

## What this does not change

- No changes to user message (`.own`) styling.
- No changes to tool group, thinking block, or streaming behavior.
- Auto-scroll logic is untouched (scroll-to-message-start is a separate improvement, tracked in #424 option 3).

Closes #424