### PR TITLE
fix(payments): Count cached input tokens

### DIFF
--- a/packages/api-adapter/src/utils.ts
+++ b/packages/api-adapter/src/utils.ts
@@ -50,7 +50,7 @@ export function toNonNegativeInt(value: unknown): number {
 }
 
 export interface TokenUsage {
-  /** Total input tokens (includes cached for OpenAI, fresh-only for Anthropic). */
+  /** Total logical input tokens, including cached input tokens when reported. */
   inputTokens: number;
   outputTokens: number;
   /** Fresh (non-cached) input tokens. Always independent of cachedInputTokens. */
@@ -75,7 +75,7 @@ export function extractUsage(parsed: Record<string, unknown>): TokenUsage {
   }
 
   const hasPromptTokens = usage.prompt_tokens !== undefined && usage.prompt_tokens !== null;
-  const totalInput = toNonNegativeInt(usage.prompt_tokens ?? usage.input_tokens);
+  const rawInput = toNonNegativeInt(usage.prompt_tokens ?? usage.input_tokens);
   const outputTokens = toNonNegativeInt(usage.completion_tokens ?? usage.output_tokens);
 
   // Cache hits arrive in two competing shapes:
@@ -84,7 +84,7 @@ export function extractUsage(parsed: Record<string, unknown>): TokenUsage {
   //     input_tokens_details. fresh = total - cached.
   //   - Separate shape (Anthropic): cache_read_input_tokens is reported
   //     alongside input_tokens, where input_tokens is already fresh-only.
-  //     fresh = total.
+  //     fresh = input_tokens; total logical input = fresh + cached.
   // Some providers (e.g. Venice) emit BOTH fields for the same cache hit.
   // Discriminate by the input field, not the cache field: prompt_tokens or
   // input_tokens_details.cached_tokens always implies subset semantics.
@@ -100,10 +100,13 @@ export function extractUsage(parsed: Record<string, unknown>): TokenUsage {
   const isSubsetShape = hasPromptTokens || inputDetails.cached_tokens !== undefined;
   const cachedInputTokens = Math.max(subsetCached, separateCached);
   const freshInputTokens = isSubsetShape
-    ? Math.max(0, totalInput - cachedInputTokens)
-    : totalInput;
+    ? Math.max(0, rawInput - cachedInputTokens)
+    : rawInput;
+  const inputTokens = isSubsetShape
+    ? rawInput
+    : rawInput + cachedInputTokens;
 
-  return { inputTokens: totalInput, outputTokens, freshInputTokens, cachedInputTokens };
+  return { inputTokens, outputTokens, freshInputTokens, cachedInputTokens };
 }
 
 function toStringContentBlock(block: Record<string, unknown>): string {

--- a/packages/api-adapter/tests/extract-usage.test.ts
+++ b/packages/api-adapter/tests/extract-usage.test.ts
@@ -46,9 +46,9 @@ describe('extractUsage', () => {
       },
     });
     expect(result).toEqual({
-      inputTokens: 200,
+      inputTokens: 1000,        // total logical input = fresh + cached
       outputTokens: 100,
-      freshInputTokens: 200,   // already fresh-only
+      freshInputTokens: 200,    // already fresh-only
       cachedInputTokens: 800,
     });
   });
@@ -62,7 +62,7 @@ describe('extractUsage', () => {
       },
     });
     expect(result).toEqual({
-      inputTokens: 150,
+      inputTokens: 750,
       outputTokens: 75,
       freshInputTokens: 150,
       cachedInputTokens: 600,

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -649,10 +649,8 @@ export class BuyerPaymentManager {
       estimatedInputTokens = responseStats.reportedInputTokens ?? 0n;
       estimatedOutputTokens = responseStats.reportedOutputTokens ?? 0n;
       const cachedInputTokens = responseStats.reportedCachedInputTokens ?? 0n;
-      // For cost estimation, split total input into fresh vs cached.
-      // If cached tokens are reported, fresh = total - cached (OpenAI-style totals)
-      // or fresh = total (Anthropic-style where total is already fresh-only).
-      // Since the seller reports the split, trust the cached count and subtract.
+      // For cost estimation, reportedInputTokens is normalized to total logical
+      // input tokens (fresh + cached), so split fresh by subtracting cached.
       const freshInputTokens = cachedInputTokens > 0n
         ? BigInt(Math.max(0, Number(estimatedInputTokens) - Number(cachedInputTokens)))
         : estimatedInputTokens;

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
-import { Wallet } from 'ethers';
+import { AbiCoder, Wallet } from 'ethers';
 import { BuyerPaymentManager, type BuyerPaymentConfig } from '../src/payments/buyer-payment-manager.js';
 import { ChannelStore } from '../src/payments/channel-store.js';
 import type { PaymentMux } from '../src/p2p/payment-mux.js';
@@ -25,6 +25,12 @@ function createTestIdentity(): Identity {
 function fakePeerId(label: string): string {
   const hex = Buffer.from(label).toString('hex').padEnd(40, '0').slice(0, 40);
   return hex;
+}
+
+function decodeMetadataTokens(metadata: string): { inputTokens: bigint; outputTokens: bigint } {
+  const coder = AbiCoder.defaultAbiCoder();
+  const [, inputTokens, outputTokens] = coder.decode(['uint256', 'uint256', 'uint256', 'uint256'], metadata);
+  return { inputTokens, outputTokens };
 }
 
 function createMockPaymentMux(): PaymentMux & {
@@ -438,6 +444,28 @@ describe('BuyerPaymentManager', () => {
        Number(reportedOut) * TEST_PRICING.outputUsdPerMillion) / 1_000_000 * 1_000_000
     ));
     expect(BigInt(payload.cumulativeAmount)).toBe(reportedCost);
+  });
+
+  it('signPerRequestAuth includes cached tokens in metadata input total', async () => {
+    const sellerPeerId = fakePeerId('seller-cached-total');
+    const pricing = { inputUsdPerMillion: 3, outputUsdPerMillion: 15, cachedInputUsdPerMillion: 0.3 };
+    await manager.authorizeSpending(sellerPeerId, mux, 10_000n, pricing);
+
+    const { payload } = await manager.signPerRequestAuth(
+      sellerPeerId,
+      {
+        inputBytes: SAMPLE_INPUT,
+        outputBytes: SAMPLE_OUTPUT,
+        reportedInputTokens: 1000n,
+        reportedCachedInputTokens: 800n,
+        reportedOutputTokens: 100n,
+      },
+    );
+
+    const meta = decodeMetadataTokens(payload.metadata);
+    expect(meta.inputTokens).toBe(1000n);
+    expect(meta.outputTokens).toBe(100n);
+    expect(BigInt(payload.cumulativeAmount)).toBe(2340n);
   });
 
   it('signPerRequestAuth throws if no active session', async () => {

--- a/packages/node/tests/response-usage.test.ts
+++ b/packages/node/tests/response-usage.test.ts
@@ -29,6 +29,22 @@ describe('parseResponseUsage', () => {
     expect(usage.freshInputTokens).toBe(32);
   });
 
+  it('extracts total input tokens from Anthropic cached usage', () => {
+    const usage = parseResponseUsage(enc.encode(JSON.stringify({
+      usage: {
+        input_tokens: 200,
+        cache_read_input_tokens: 800,
+        output_tokens: 100,
+      },
+    })));
+    expect(usage).toEqual({
+      inputTokens: 1000,
+      outputTokens: 100,
+      freshInputTokens: 200,
+      cachedInputTokens: 800,
+    });
+  });
+
   it('returns zeros when the body has no usage field', () => {
     const usage = parseResponseUsage(enc.encode(JSON.stringify({ model: 'foo' })));
     expect(usage).toEqual({ inputTokens: 0, outputTokens: 0, freshInputTokens: 0, cachedInputTokens: 0 });


### PR DESCRIPTION
## Description

Fixes token usage normalization for Anthropic prompt-cache responses. Anthropic reports `input_tokens` as fresh-only while cache hits are reported separately, so payment metadata now records total logical input tokens instead of only fresh input.

## Release Notes

- Fixed on-chain token metadata for Anthropic prompt-cache usage so cached input tokens are included in input totals.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
