### PR TITLE
fix(app): Show cached input pricing

### DIFF
--- a/apps/desktop/src/renderer/core/state.ts
+++ b/apps/desktop/src/renderer/core/state.ts
@@ -63,6 +63,7 @@ export type ChatServiceOptionEntry = {
   peerLabel: string;
   inputUsdPerMillion: number | null;
   outputUsdPerMillion: number | null;
+  cachedInputUsdPerMillion?: number | null;
   categories: string[];
   description: string;
 };

--- a/apps/desktop/src/renderer/modules/chat.discover-rows.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.discover-rows.test.ts
@@ -31,12 +31,13 @@ test('projectRowsToChatServiceOptions dedupes by (provider, service, peer)', () 
   assert.equal(options.length, 1);
 });
 
-test('projectRowsToChatServiceOptions preserves peer display name for UI labels', () => {
+test('projectRowsToChatServiceOptions preserves peer display name and cached input price', () => {
   const row = normalizeDiscoverRow({
     peerId: 'abc123',
     serviceId: 'gpt-5',
     peerDisplayName: 'Friendly Peer',
     peerLabel: '0xabc123...',
+    cachedInputUsdPerMillion: 0.5,
     selectionValue: 'openai\u0001gpt-5\u0001abc123',
   });
   assert.ok(row);
@@ -44,4 +45,5 @@ test('projectRowsToChatServiceOptions preserves peer display name for UI labels'
   const [option] = projectRowsToChatServiceOptions([row!]);
   assert.equal(option.peerDisplayName, 'Friendly Peer');
   assert.equal(option.peerLabel, '0xabc123...');
+  assert.equal(option.cachedInputUsdPerMillion, 0.5);
 });

--- a/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
@@ -67,6 +67,7 @@ test('new chat created while previous response is pending sends to its own peer'
       peerLabel: 'Peer A',
       inputUsdPerMillion: null,
       outputUsdPerMillion: null,
+      cachedInputUsdPerMillion: null,
       categories: [],
       description: '',
     },
@@ -82,6 +83,7 @@ test('new chat created while previous response is pending sends to its own peer'
       peerLabel: 'Peer B',
       inputUsdPerMillion: null,
       outputUsdPerMillion: null,
+      cachedInputUsdPerMillion: null,
       categories: [],
       description: '',
     },
@@ -201,12 +203,12 @@ test('discover-selected draft keeps its peer if another discover chat is opened 
     {
       id: 'model-a', label: 'Model A', provider: 'openai', protocol: 'openai-chat-completions', count: 1,
       value: `openai${SEP}model-a${SEP}peer-a`, peerId: 'peer-a', peerDisplayName: 'Peer A', peerLabel: 'Peer A',
-      inputUsdPerMillion: null, outputUsdPerMillion: null, categories: [], description: '',
+      inputUsdPerMillion: null, outputUsdPerMillion: null, cachedInputUsdPerMillion: null, categories: [], description: '',
     },
     {
       id: 'model-b', label: 'Model B', provider: 'openai', protocol: 'openai-chat-completions', count: 1,
       value: `openai${SEP}model-b${SEP}peer-b`, peerId: 'peer-b', peerDisplayName: 'Peer B', peerLabel: 'Peer B',
-      inputUsdPerMillion: null, outputUsdPerMillion: null, categories: [], description: '',
+      inputUsdPerMillion: null, outputUsdPerMillion: null, cachedInputUsdPerMillion: null, categories: [], description: '',
     },
   ];
 
@@ -313,12 +315,12 @@ test('sending from reopened conversation ignores unrelated global dropdown peer'
     {
       id: 'model-a', label: 'Model A', provider: 'openai', protocol: 'openai-chat-completions', count: 1,
       value: `openai${SEP}model-a${SEP}peer-a`, peerId: 'peer-a', peerDisplayName: 'Peer A', peerLabel: 'Peer A',
-      inputUsdPerMillion: null, outputUsdPerMillion: null, categories: [], description: '',
+      inputUsdPerMillion: null, outputUsdPerMillion: null, cachedInputUsdPerMillion: null, categories: [], description: '',
     },
     {
       id: 'model-b', label: 'Model B', provider: 'openai', protocol: 'openai-chat-completions', count: 1,
       value: `openai${SEP}model-b${SEP}peer-b`, peerId: 'peer-b', peerDisplayName: 'Peer B', peerLabel: 'Peer B',
-      inputUsdPerMillion: null, outputUsdPerMillion: null, categories: [], description: '',
+      inputUsdPerMillion: null, outputUsdPerMillion: null, cachedInputUsdPerMillion: null, categories: [], description: '',
     },
   ];
   uiState.chatSelectedServiceValue = `openai${SEP}model-b${SEP}peer-b`;

--- a/apps/desktop/src/renderer/modules/discover-rows.ts
+++ b/apps/desktop/src/renderer/modules/discover-rows.ts
@@ -70,6 +70,7 @@ export function projectRowsToChatServiceOptions(rows: DiscoverRow[]): ChatServic
       peerLabel: row.peerLabel,
       inputUsdPerMillion: row.inputUsdPerMillion,
       outputUsdPerMillion: row.outputUsdPerMillion,
+      cachedInputUsdPerMillion: row.cachedInputUsdPerMillion,
       categories: row.categories,
       description: '',
     });

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
@@ -308,7 +308,7 @@
 .card-body {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   padding: 12px;
 }
 
@@ -482,6 +482,7 @@
 /* ── Card content ───────────────────────────────────────────────────── */
 
 .card-name {
+  margin-top: 2px;
   font-size: 16px;
   font-weight: 500;
   color: var(--text-primary);
@@ -511,6 +512,7 @@
   font-weight: 400;
   color: var(--text-muted);
   line-height: 12px;
+  margin-bottom: 6px;
 }
 
 .pricing-input-group {

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
@@ -513,6 +513,24 @@
   line-height: 12px;
 }
 
+.pricing-input-group {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+.pricing-cached {
+  position: absolute;
+  top: 13px;
+  left: 0;
+  font-size: 10px;
+  line-height: 10px;
+  color: var(--text-muted);
+  opacity: 0.78;
+  white-space: nowrap;
+}
+
 .pricing-dot {
   width: 2px;
   height: 2px;

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -54,6 +54,7 @@ type CardItem = {
   description: string;
   inputUsdPerMillion: number | null;
   outputUsdPerMillion: number | null;
+  cachedInputUsdPerMillion: number | null;
   reputationScore: number | null; // 0-100 on-chain activity/reputation score
   channelCount: number;       // on-chain, from AntseedChannels.getAgentStats
   ghostCount: number;         // channels withdrawn without settled spend
@@ -109,6 +110,7 @@ function buildCards(options: ChatServiceOptionEntry[]): CardItem[] {
       description: opt.description || generateDescription(opt.id, opt.categories, opt.peerLabel || opt.provider),
       inputUsdPerMillion: opt.inputUsdPerMillion,
       outputUsdPerMillion: opt.outputUsdPerMillion,
+      cachedInputUsdPerMillion: opt.cachedInputUsdPerMillion ?? null,
       reputationScore: null,
       channelCount: 0,
       ghostCount: 0,
@@ -164,6 +166,7 @@ function buildCardsFromRows(rows: DiscoverRow[]): CardItem[] {
       description: generateDescription(row.serviceId, row.categories, peerLabel || row.provider),
       inputUsdPerMillion: row.inputUsdPerMillion,
       outputUsdPerMillion: row.outputUsdPerMillion,
+      cachedInputUsdPerMillion: row.cachedInputUsdPerMillion,
       reputationScore: row.onChainReputationScore,
       channelCount: row.onChainActiveChannelCount,
       ghostCount: row.onChainGhostCount,
@@ -594,7 +597,12 @@ function Card({
   const providerName = (item.peerLabel ? getPeerDisplayName(item.peerLabel) : '') || item.provider || 'Peer';
   const hasInput = item.inputUsdPerMillion != null;
   const hasOutput = item.outputUsdPerMillion != null;
-  const isFree = hasInput && hasOutput && item.inputUsdPerMillion === 0 && item.outputUsdPerMillion === 0;
+  const hasCachedInput = item.cachedInputUsdPerMillion != null;
+  const isFree = hasInput
+    && hasOutput
+    && item.inputUsdPerMillion === 0
+    && item.outputUsdPerMillion === 0
+    && (!hasCachedInput || item.cachedInputUsdPerMillion === 0);
   const lowReputation = isLowReputation(item.reputationScore);
   const reputationTooltip = formatReputationTooltip(item);
   const scoreBadgeRef = useRef<HTMLSpanElement>(null);
@@ -675,17 +683,22 @@ function Card({
         <div className={styles.cardPricing}>
           {isFree ? (
             <span className={styles.pricingFree}>Free</span>
-          ) : hasInput && hasOutput ? (
+          ) : (
             <>
-              <span>{formatPerMillionPrice(item.inputUsdPerMillion!)} input tokens</span>
-              <span className={styles.pricingDot} />
-              <span>{formatPerMillionPrice(item.outputUsdPerMillion!)} output tokens</span>
+              {(hasInput || hasCachedInput) && (
+                <span className={styles.pricingInputGroup}>
+                  {hasInput && <span>{formatPerMillionPrice(item.inputUsdPerMillion!)} input tokens</span>}
+                  {hasCachedInput && (
+                    <span className={styles.pricingCached}>
+                      {formatPerMillionPrice(item.cachedInputUsdPerMillion!)} cached input
+                    </span>
+                  )}
+                </span>
+              )}
+              {hasOutput && (hasInput || hasCachedInput) && <span className={styles.pricingDot} />}
+              {hasOutput && <span>{formatPerMillionPrice(item.outputUsdPerMillion!)} output tokens</span>}
             </>
-          ) : hasInput ? (
-            <span>{formatPerMillionPrice(item.inputUsdPerMillion!)} input tokens</span>
-          ) : hasOutput ? (
-            <span>{formatPerMillionPrice(item.outputUsdPerMillion!)} output tokens</span>
-          ) : null}
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Description

Displays cached-input token pricing on Desktop Discover cards when a peer advertises a cached input rate. The cached price appears directly below the regular input price in smaller text without increasing the card layout height, and Discover service options now carry cached pricing through the renderer projection.

## Release Notes

- Show cached-input token prices on Desktop Discover service cards

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes