### PR TITLE
fix(desktop): Repair router plugin installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Desktop
 
-- `@antseed/desktop@0.1.74`
+- `@antseed/desktop@0.1.75`
 
 ### Fixed
 
 - Fixed `antseed buyer start` so trusted router plugins are repaired automatically when the plugin package is present but incomplete, including missing nested dependencies such as `ethers` under bundled Desktop installs.
 - Fixed Desktop plugin setup so bundled router repairs copy the runtime dependency tree needed by `@antseed/node`.
+- Fixed the Desktop setup screen so a transient router-plugin install failure no longer blocks the app after the buyer runtime and service catalog are available.
 - Added a manual install hint to missing third-party plugin errors.
 
 ## 2026-05-09 — Reputation, pricing, and cached-token fixes

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.74",
+  "version": "0.1.75",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/main/plugins.ts
+++ b/apps/desktop/src/main/plugins.ts
@@ -2,7 +2,7 @@ import { readFile, writeFile, readdir, mkdir, cp, rm } from 'node:fs/promises';
 import { existsSync, readFileSync } from 'node:fs';
 import { execFile as execFileCallback } from 'node:child_process';
 import { promisify } from 'node:util';
-import { createRequire } from 'node:module';
+import { builtinModules, createRequire } from 'node:module';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -14,6 +14,10 @@ const __dirname = path.dirname(__filename);
 
 const execFileAsync = promisify(execFileCallback);
 const requireFromHere = createRequire(import.meta.url);
+const NODE_BUILTINS = new Set([
+  ...builtinModules,
+  ...builtinModules.map((name) => `node:${name}`),
+]);
 
 export const DEFAULT_PLUGINS_DIR = path.join(homedir(), '.antseed', 'plugins');
 const DEFAULT_PLUGINS_PACKAGE_JSON = path.join(DEFAULT_PLUGINS_DIR, 'package.json');
@@ -136,7 +140,7 @@ function dependencyNamesForManifest(manifest: PackageManifest, includePeers: boo
   return Object.keys({
     ...(manifest.dependencies ?? {}),
     ...(includePeers ? manifest.peerDependencies ?? {} : {}),
-  });
+  }).filter((name) => !NODE_BUILTINS.has(name));
 }
 
 function findAppPackageDir(packageName: string): string | null {
@@ -288,11 +292,15 @@ export function setPluginAppendLog(fn: AppendLogFn): void {
 }
 
 export async function installPluginDependency(packageSpec: string): Promise<void> {
+  await installPluginDependencies([packageSpec]);
+}
+
+export async function installPluginDependencies(packageSpecs: string[]): Promise<void> {
   await ensurePluginsDirectory();
   const npm = resolveNpmInvocation();
-  _appendLog('connect', 'system', `Installing "${packageSpec}" via ${npm.bin}...`);
+  _appendLog('connect', 'system', `Installing ${packageSpecs.map((spec) => `"${spec}"`).join(', ')} via ${npm.bin}...`);
 
-  await execFileAsync(npm.bin, [...npm.leadingArgs, 'install', '--ignore-scripts', packageSpec], {
+  await execFileAsync(npm.bin, [...npm.leadingArgs, 'install', '--ignore-scripts', ...packageSpecs], {
     cwd: DEFAULT_PLUGINS_DIR,
     timeout: 120_000, // 2-minute hard limit
     env: {
@@ -312,6 +320,18 @@ export async function installPluginDependency(packageSpec: string): Promise<void
       ].filter((segment) => segment.length > 0).join(path.delimiter),
     },
   });
+}
+
+async function removeDefaultRouterRuntimePackages(): Promise<void> {
+  const packages = [
+    '@antseed/router-local',
+    '@antseed/router-core',
+    '@antseed/node',
+    '@antseed/api-adapter',
+  ];
+  for (const packageName of packages) {
+    await rm(packageNodeModulesPath(DEFAULT_PLUGINS_DIR, packageName), { recursive: true, force: true });
+  }
 }
 
 export async function installPluginFromBundle(packageName: string): Promise<boolean> {
@@ -471,19 +491,33 @@ export async function ensureDefaultPlugin(
         : `Required plugin "${packageName}" not found. Installing`,
   );
   try {
-    // 1. Try copying from the app bundle (production builds — instant, no network)
-    const installedFromBundle = await installPluginFromBundle(packageName);
+    // 1. Try copying from the app bundle (production builds — instant, no network).
+    // If bundle repair fails, remove the partial copied @antseed packages before
+    // falling back to npm. A half-copied @antseed/node can otherwise satisfy
+    // npm's peer check while still missing runtime deps like `ethers`.
+    let installedFromBundle = false;
+    try {
+      installedFromBundle = await installPluginFromBundle(packageName);
+    } catch (bundleErr) {
+      const message = bundleErr instanceof Error ? bundleErr.message : String(bundleErr);
+      ctx.appendLog('connect', 'system', `Bundled plugin repair failed: ${message}`);
+      await removeDefaultRouterRuntimePackages();
+    }
+
     if (installedFromBundle) {
       ctx.appendLog('connect', 'system', `Installed plugin "${packageName}" from app bundle.`);
     } else {
+      if (installed) await removeDefaultRouterRuntimePackages();
+
       // 2. Try local monorepo source (dev builds)
       const localSource = await resolveLocalPluginSource(packageName);
       ctx.appendLog('connect', 'system', localSource ? `Using local source: ${localSource}` : `Using npm registry (${resolveNpmInvocation().bin})...`);
       if (localSource) {
         await installPluginDependency(toFileInstallSpec(packageName, localSource));
       } else {
-        // 3. Fall back to npm registry
-        await installPluginDependency(packageName);
+        // 3. Fall back to npm registry. Install @antseed/node explicitly so npm
+        // repairs its runtime deps instead of treating a stale copied peer as OK.
+        await installPluginDependencies([`${packageName}@latest`, '@antseed/node@latest']);
       }
     }
     ctx.appendLog('connect', 'system', `Installed plugin "${packageName}".`);

--- a/apps/desktop/src/renderer/ui/AppShell.tsx
+++ b/apps/desktop/src/renderer/ui/AppShell.tsx
@@ -38,20 +38,23 @@ export function AppShell() {
       setSetupVisible(false);
       return;
     }
-    if (!snap.appSetupComplete) {
-      setSetupVisible(true);
-      return;
-    }
 
-    // If setup completed before the renderer observed it, keep the setup screen
-    // only until the first service catalog arrives. Once hidden, latch it hidden
-    // for the rest of the renderer session.
+    // The setup screen is a first-run bootstrap aid, not a hard gate. If the
+    // buyer runtime later starts successfully and services load, let the user
+    // into the app even if plugin setup reported a transient repair/install
+    // failure. This prevents a stale "Failed to install router plugin" status
+    // from covering a now-usable desktop session.
     if (hasServices) {
       const timer = setTimeout(() => {
         setSetupVisible(false);
         setSetupDismissed(true);
       }, 900);
       return () => clearTimeout(timer);
+    }
+
+    if (!snap.appSetupComplete) {
+      setSetupVisible(true);
+      return;
     }
 
     setSetupVisible(true);


### PR DESCRIPTION
## Description

Repairs AntStation router-plugin setup when an existing or partially bundled plugin install is missing runtime dependencies such as `ethers`. The repair path now clears partial AntSeed runtime packages and falls back to an npm install that explicitly refreshes both `@antseed/router-local` and `@antseed/node`, while the setup screen no longer blocks once services are available.

## Release Notes

- Fixed AntStation router plugin repair when bundled installs are missing nested runtime dependencies.
- Fixed AntStation getting stuck on the setup screen after a transient router-plugin install failure when services are already available.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Validation: `pnpm -C apps/desktop run build`