### PR TITLE
fix(metering): unwrap message.usage for Anthropic streaming SSE

### DIFF
--- a/packages/api-adapter/src/utils.ts
+++ b/packages/api-adapter/src/utils.ts
@@ -60,15 +60,26 @@ export interface TokenUsage {
 }
 
 export function extractUsage(parsed: Record<string, unknown>): TokenUsage {
-  // Direct shape: { usage: {...} } (OpenAI Chat, Anthropic Messages, etc.)
-  // Nested shape: { response: { usage: {...} } } (OpenAI Responses SSE
-  // `response.completed` events from the Codex backend bury usage under
-  // `response`).
+  // Direct shape: { usage: {...} } (OpenAI Chat, Anthropic Messages non-streaming)
+  // Nested shapes:
+  //   - { response: { usage: {...} } } — OpenAI Responses SSE `response.completed`
+  //     events from the Codex backend bury usage under `response`.
+  //   - { message: { usage: {...} } } — Anthropic Messages streaming
+  //     `message_start` event nests usage under `message`. This is where the
+  //     full input + cache_read_input_tokens + cache_creation_input_tokens
+  //     values live; without this unwrap, every cached Anthropic stream was
+  //     metered at only the small "fresh" tail count from `message_delta`,
+  //     making on-chain MetadataRecorded.inputTokens look absurdly low.
   let usage: Record<string, unknown> = {};
   if (parsed.usage && typeof parsed.usage === 'object') {
     usage = parsed.usage as Record<string, unknown>;
   } else if (parsed.response && typeof parsed.response === 'object') {
     const inner = parsed.response as Record<string, unknown>;
+    if (inner.usage && typeof inner.usage === 'object') {
+      usage = inner.usage as Record<string, unknown>;
+    }
+  } else if (parsed.message && typeof parsed.message === 'object') {
+    const inner = parsed.message as Record<string, unknown>;
     if (inner.usage && typeof inner.usage === 'object') {
       usage = inner.usage as Record<string, unknown>;
     }

--- a/packages/api-adapter/tests/extract-usage.test.ts
+++ b/packages/api-adapter/tests/extract-usage.test.ts
@@ -151,6 +151,34 @@ describe('extractUsage', () => {
     });
   });
 
+  it('unwraps Anthropic Messages streaming message_start (message.usage)', () => {
+    // Anthropic streaming SSE: `message_start` nests usage under `message`.
+    // Without unwrapping, the cached/cache-creation counts vanish and only the
+    // fresh tail from message_delta survives — producing absurdly low
+    // on-chain inputTokens for Anthropic agents.
+    const result = extractUsage({
+      type: 'message_start',
+      message: {
+        id: 'msg_123',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-sonnet-4-5',
+        usage: {
+          input_tokens: 23,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 15000,
+          output_tokens: 1,
+        },
+      },
+    });
+    expect(result).toEqual({
+      inputTokens: 15023,        // fresh + cached (Anthropic separate-shape)
+      outputTokens: 1,
+      freshInputTokens: 23,
+      cachedInputTokens: 15000,
+    });
+  });
+
   it('takes the larger cached count when subset and separate disagree', () => {
     // Defensive: if a provider reports mismatched values, prefer the larger one
     // and still apply subset semantics (since prompt_tokens is present).

--- a/packages/node/tests/response-usage.test.ts
+++ b/packages/node/tests/response-usage.test.ts
@@ -45,6 +45,32 @@ describe('parseResponseUsage', () => {
     });
   });
 
+  it('extracts cached + fresh + output from a real Anthropic streaming SSE', () => {
+    // Mirrors the shape Anthropic returns when the SDK sends a request that
+    // hits prompt cache: `message_start` carries the input/cache counts under
+    // `message.usage`, and `message_delta` carries only the running
+    // output_tokens. This was the exact failure mode reported on chain:
+    // inputTokens=23, outputTokens=21747 — the 15k cached tokens were dropped.
+    const stream = [
+      'event: message_start',
+      'data: {"type":"message_start","message":{"id":"msg_123","type":"message","role":"assistant","model":"claude-sonnet-4-5","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":23,"cache_creation_input_tokens":0,"cache_read_input_tokens":15000,"output_tokens":1}}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}',
+      '',
+      'event: message_delta',
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":21747}}',
+      '',
+    ].join('\n');
+    const usage = parseResponseUsage(enc.encode(stream));
+    expect(usage).toEqual({
+      inputTokens: 15023,
+      outputTokens: 21747,
+      freshInputTokens: 23,
+      cachedInputTokens: 15000,
+    });
+  });
+
   it('returns zeros when the body has no usage field', () => {
     const usage = parseResponseUsage(enc.encode(JSON.stringify({ model: 'foo' })));
     expect(usage).toEqual({ inputTokens: 0, outputTokens: 0, freshInputTokens: 0, cachedInputTokens: 0 });


### PR DESCRIPTION
## Summary

Anthropic-served agents have been reporting nonsensically low `inputTokens` on chain — e.g. a real `MetadataRecorded` event with `inputTokens: 23` and `outputTokens: 21747` over 13 requests. The 23 was just the fresh-tail input; ~15k cached tokens per request were silently being dropped on the floor before reaching `recordMetadata`.

## Root cause

`extractUsage()` in `packages/api-adapter/src/utils.ts` knew how to unwrap two SSE shapes:

- `parsed.usage` — OpenAI Chat / non-streaming Anthropic
- `parsed.response.usage` — OpenAI Responses SSE (`response.completed`)

…but **not** `parsed.message.usage`, which is where Anthropic Messages streaming puts the entire input/cache breakdown:

```
event: message_start
data: {"type":"message_start","message":{"usage":{
  "input_tokens": 23,
  "cache_read_input_tokens": 15000,
  "cache_creation_input_tokens": 0,
  "output_tokens": 1
}}}

event: message_delta
data: {"type":"message_delta","usage":{"output_tokens": 21747}}
```

The SSE walker in `parseResponseUsage` ran `extractUsage` on each event:

- `message_start` → all zeros (no `parsed.usage`, no `parsed.response.usage`)
- `message_delta` → only `output_tokens: 21747` survived

So input + cache evaporated. This produced exactly the `inputTokens: 23, outputTokens: 21747` pattern seen in the screenshot from chain.

## Knock-on effects of the bug

The same `extractUsage` powers four downstream consumers, all of which were getting wrong numbers for cached Anthropic traffic:

1. **On-chain `AntseedStats.MetadataRecorded`** — visibly broken in block explorer
2. **Seller → buyer `NeedAuth` payloads** — `inputTokens` / `cachedInputTokens` fields wrong
3. **Buyer-side cost validation** — tolerance check (`buyer-payment-negotiator.estimateCostFromResponse`) used a too-low buyer estimate, weakening the seller-claim guard
4. **Local SQLite metering / receipts** — stored as `provider-usage / high confidence` despite being wrong

After the fix all four consumers get correct numbers from a single source.

## Fix

Add a third unwrap branch in `extractUsage` for `parsed.message.usage`, mirroring the existing `parsed.response.usage` branch.

```ts
} else if (parsed.message && typeof parsed.message === 'object') {
  const inner = parsed.message as Record<string, unknown>;
  if (inner.usage && typeof inner.usage === 'object') {
    usage = inner.usage as Record<string, unknown>;
  }
}
```

Cache-read separate-shape semantics already work correctly downstream — the bug was purely the missing unwrap.

## Tests

- `packages/api-adapter/tests/extract-usage.test.ts` — unit case for an Anthropic `message_start` event with `cache_read_input_tokens: 15000`. Asserts `inputTokens: 15023, freshInputTokens: 23, cachedInputTokens: 15000`.
- `packages/node/tests/response-usage.test.ts` — full-stream walk reproducing the exact `inputTokens=23, outputTokens=21747` scenario from chain. Confirms the post-fix output is `15023 / 21747` with `cachedInputTokens: 15000`.

All 50 api-adapter tests + 592 node tests pass locally.

## Risk

Low. The new branch only fires when `parsed.usage` and `parsed.response.usage` are absent and `parsed.message.usage` exists — i.e. exclusively the Anthropic streaming case that was previously returning zeros. No existing passing path changes shape.
