### PR TITLE
fix(desktop): Avoid runtime collisions

### DIFF
--- a/apps/desktop/scripts/prepare-dist.mjs
+++ b/apps/desktop/scripts/prepare-dist.mjs
@@ -155,6 +155,12 @@ console.log('[prepare-dist] Native module prebuild installed for Electron.');
 // bundled-runtime/ and ship it as extraResources.
 
 const BUNDLED_RUNTIME_DIR = path.join(appDir, 'bundled-runtime');
+const EXPLICITLY_BUNDLED_PACKAGES = new Set([
+  '@antseed/router-local',
+  '@antseed/router-core',
+  '@antseed/node',
+  '@antseed/api-adapter',
+]);
 const NODE_BUILTINS = new Set([
   ...builtinModules,
   ...builtinModules.map((name) => `node:${name}`),
@@ -216,16 +222,18 @@ function copyDepTree(name, destRoot, visited) {
     return;
   }
 
-  const destDir = path.join(destRoot, ...name.split('/'));
-  mkdirSync(path.dirname(destDir), { recursive: true });
-  rmSync(destDir, { recursive: true, force: true });
-  cpSync(sourceDir, destDir, { recursive: true, dereference: true });
+  if (!EXPLICITLY_BUNDLED_PACKAGES.has(name)) {
+    const destDir = path.join(destRoot, ...name.split('/'));
+    mkdirSync(path.dirname(destDir), { recursive: true });
+    rmSync(destDir, { recursive: true, force: true });
+    cpSync(sourceDir, destDir, { recursive: true, dereference: true });
 
-  // Drop any nested node_modules to keep the bundled tree flat — every
-  // dependency lives at the top level of bundled-runtime/.
-  const nestedNm = path.join(destDir, 'node_modules');
-  if (existsSync(nestedNm)) {
-    rmSync(nestedNm, { recursive: true, force: true });
+    // Drop any nested node_modules to keep the bundled tree flat — every
+    // dependency lives at the top level of bundled-runtime/.
+    const nestedNm = path.join(destDir, 'node_modules');
+    if (existsSync(nestedNm)) {
+      rmSync(nestedNm, { recursive: true, force: true });
+    }
   }
 
   let pkg;


### PR DESCRIPTION
## Description

Prevents Desktop release packaging from copying explicitly bundled AntSeed packages twice into the same bundled-plugins destination. The bundled-runtime tree now still walks those packages for their dependencies, but skips materializing the packages that electron-builder.yml already copies directly.

This fixes the macOS release failure where electron-builder hit EEXIST while linking bundled-plugins/@antseed/api-adapter/package.json.

## Release Notes

- Fixed Desktop release packaging failure caused by duplicate bundled router runtime files

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
