### PR TITLE
fix(desktop): Clean reinstall router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable user-facing changes to AntSeed packages are documented here.
 
 This project uses selective package publishing. Each release entry lists the published packages affected by that release.
 
+## 2026-05-10 — Desktop router clean reinstall
+
+### Desktop
+
+- `@antseed/desktop@0.1.78`
+
+### Fixed
+
+- Fixed Desktop router recovery so stale or incomplete bundled router installs are deleted and recreated from the app bundle instead of being incrementally repaired.
+- Prevented the Desktop-started buyer runtime from retrying npm plugin repair after a successful bundled reinstall, keeping recovery offline on locked-down corporate networks.
+
 ## 2026-05-10 — Anthropic streaming token accounting fix
 
 ### Published

--- a/apps/cli/src/plugins/loader.ts
+++ b/apps/cli/src/plugins/loader.ts
@@ -1,9 +1,21 @@
 import { existsSync, readFileSync } from 'node:fs'
+import { builtinModules } from 'node:module'
 import path, { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { getPluginsDir, installPlugin } from './manager.js'
 import { TRUSTED_PLUGINS } from './registry.js'
 import type { AntseedProviderPlugin, AntseedRouterPlugin, PluginConfigKey } from '@antseed/node'
+
+const NODE_BUILTINS = new Set([
+  ...builtinModules,
+  ...builtinModules.map((name) => `node:${name}`),
+])
+
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false
+  const normalized = value.trim().toLowerCase()
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on'
+}
 
 function resolvePackageName(nameOrPackage: string): string {
   const legacy = LEGACY_PACKAGE_MAP[nameOrPackage]
@@ -78,6 +90,7 @@ async function ensureTrustedPluginInstallReady(
     || !existsSync(pkgJsonPath)
     || hasMissingDeclaredDependencyTree(pkgName, pluginsDir)
   if (!shouldInstall) return
+  if (isTruthyEnv(process.env['ANTSEED_SKIP_PLUGIN_UPDATE_CHECK'])) return
 
   const action = existsSync(entryPath)
     ? 'appears incomplete or stale. Reinstalling latest version...'
@@ -116,6 +129,7 @@ function hasMissingDeclaredDependencyTree(
       ...(manifestName.startsWith('@antseed/') ? parsed.peerDependencies ?? {} : {}),
     }
     for (const depName of Object.keys(deps)) {
+      if (NODE_BUILTINS.has(depName)) continue
       if (hasMissingDeclaredDependencyTree(depName, pluginsDir, visited)) return true
     }
     return false

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.77",
+  "version": "0.1.78",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/main/plugins.ts
+++ b/apps/desktop/src/main/plugins.ts
@@ -276,11 +276,18 @@ async function removeDefaultRouterRuntimePackages(): Promise<void> {
   }
 }
 
+async function resetBundledPluginInstall(): Promise<void> {
+  await rm(path.join(DEFAULT_PLUGINS_DIR, 'node_modules'), { recursive: true, force: true });
+  await rm(path.join(DEFAULT_PLUGINS_DIR, 'package-lock.json'), { force: true });
+  await rm(path.join(DEFAULT_PLUGINS_DIR, 'npm-shrinkwrap.json'), { force: true });
+}
+
 export async function installPluginFromBundle(packageName: string): Promise<boolean> {
   // In production builds, plugins are bundled into Resources/bundled-plugins/.
   const bundleRoot = path.join(process.resourcesPath ?? '', 'bundled-plugins');
   if (!existsSync(bundledPackagePath(bundleRoot, packageName))) return false;
 
+  await resetBundledPluginInstall();
   await ensurePluginsDirectory();
   const destRoot = path.join(DEFAULT_PLUGINS_DIR, 'node_modules');
 
@@ -448,15 +455,11 @@ export async function ensureDefaultPlugin(
         : `Required plugin "${packageName}" not found. Installing`,
   );
   try {
-    // Wipe any partial AntSeed runtime install before repairing. A half-copied
-    // @antseed/node from a previous broken setup can otherwise satisfy presence
-    // checks while still missing nested deps like `ethers`.
-    if (incompleteInstall) await removeDefaultRouterRuntimePackages();
-
     // 1. Try copying from the app bundle (production builds — instant, fully
     //    offline, no Node/npm required on the user machine).
     let installedFromBundle = false;
     try {
+      ctx.appendLog('connect', 'system', 'Resetting bundled router plugin install.');
       installedFromBundle = await installPluginFromBundle(packageName);
     } catch (bundleErr) {
       const message = bundleErr instanceof Error ? bundleErr.message : String(bundleErr);

--- a/apps/desktop/src/main/process-manager.ts
+++ b/apps/desktop/src/main/process-manager.ts
@@ -396,6 +396,10 @@ export class ProcessManager {
     const executableArgs = [...cliExecution.executableArgsPrefix, ...args];
     await this.ensureRuntimeNativeModules(mode, executable, cliExecution.isLocalDevScript);
     const childEnv: NodeJS.ProcessEnv = { ...process.env };
+    // Desktop repairs the default router from its own app bundle. Do not let
+    // the child CLI try an npm-based plugin refresh/install on locked-down
+    // machines where npm may be unavailable or behind corporate TLS proxies.
+    childEnv['ANTSEED_SKIP_PLUGIN_UPDATE_CHECK'] = '1';
     for (const [key, value] of Object.entries(opts.env ?? {})) {
       if (typeof key === 'string' && key.trim().length > 0) {
         childEnv[key] = String(value);
@@ -496,6 +500,7 @@ export class ProcessManager {
     const executableArgs = [...cliExecution.executableArgsPrefix, ...args];
 
     const childEnv = { ...process.env };
+    childEnv['ANTSEED_SKIP_PLUGIN_UPDATE_CHECK'] = '1';
     if (executable === process.execPath) {
       childEnv['ELECTRON_RUN_AS_NODE'] = '1';
     } else {


### PR DESCRIPTION
## Description

Changes Desktop router recovery to delete the existing plugin install tree and recreate it from the app bundle when the bundled router is missing, stale, or incomplete. This matches first-install behavior and avoids incremental repairs leaving stale files behind.

Also prevents the Desktop-started buyer runtime from retrying npm-based plugin repair after the bundled reinstall, so recovery remains offline on machines without npm or behind corporate TLS interception.

## Release Notes

- Fixed Desktop router recovery by deleting stale plugin installs and reinstalling from the app bundle
- Prevented Desktop from falling back to npm plugin repair after bundled recovery

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
