### PR TITLE
Fix/workspace restore on conv switch

### DIFF
--- a/apps/desktop/src/main/chat-system-prompt.ts
+++ b/apps/desktop/src/main/chat-system-prompt.ts
@@ -65,7 +65,9 @@ export function buildAntstationSystemPrompt(
   return `${resolvedBasePrompt}
 
 Workspace model:
-- All chats share the selected workspace path at the app level.
-- Conversation history is per chat, but repo and directory context are shared across chats until the workspace changes.
+- Each chat has its own workspace (folder/repo) that is stored when the chat is created.
+- When you switch to a different chat, the workspace automatically switches to that chat's stored workspace.
+- When starting a new chat, it uses whatever workspace is currently selected.
+- The workspace indicator in the UI shows the current workspace for the active chat.
 `.trim();
 }

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -147,6 +147,7 @@ type AiConversation = {
   createdAt: number;
   updatedAt: number;
   usage: AiUsageTotals;
+  workspacePath?: string;
 };
 
 type AiConversationSummary = {
@@ -162,6 +163,7 @@ type AiConversationSummary = {
   usage: AiUsageTotals;
   totalTokens: number;
   totalEstimatedCostUsd: number;
+  workspacePath?: string;
 };
 
 type RegisterPiChatHandlersOptions = {
@@ -1247,6 +1249,7 @@ class PiConversationStore {
     }
 
     const peerData = extractPeerFromEntries(manager);
+    const sessionCwd = manager.getCwd() || undefined;
     return {
       id: manager.getSessionId(),
       title: manager.getSessionName() || deriveTitle(messages),
@@ -1258,6 +1261,7 @@ class PiConversationStore {
       usage,
       ...(peerData?.peerId ? { peerId: peerData.peerId } : {}),
       ...(peerData?.peerLabel ? { peerLabel: peerData.peerLabel } : {}),
+      ...(sessionCwd ? { workspacePath: sessionCwd } : {}),
     };
   }
 
@@ -1303,6 +1307,7 @@ class PiConversationStore {
         totalEstimatedCostUsd: deriveCost(conversation.messages),
         ...(conversation.peerId ? { peerId: conversation.peerId } : {}),
         ...(conversation.peerLabel ? { peerLabel: conversation.peerLabel } : {}),
+        ...(conversation.workspacePath ? { workspacePath: conversation.workspacePath } : {}),
       });
     }
 
@@ -1325,6 +1330,7 @@ class PiConversationStore {
         totalEstimatedCostUsd: deriveCost(conversation.messages),
         ...(conversation.peerId ? { peerId: conversation.peerId } : {}),
         ...(conversation.peerLabel ? { peerLabel: conversation.peerLabel } : {}),
+        ...(conversation.workspacePath ? { workspacePath: conversation.workspacePath } : {}),
       });
     }
 

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -1249,6 +1249,8 @@ class PiConversationStore {
     }
 
     const peerData = extractPeerFromEntries(manager);
+    // SessionManager reads the cwd persisted in the session file; restoration
+    // across app restarts depends on that value reflecting the session workspace.
     const sessionCwd = manager.getCwd() || undefined;
     return {
       id: manager.getSessionId(),

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -1739,7 +1739,16 @@ export function registerPiChatHandlers({
     // one-shot session.agent.setSystemPrompt call would be overridden.)
     // Priority: user override (env/config) → AntStation default.
     const userSystemPrompt = await resolveSystemPrompt(configPath);
-    const chatWorkspaceDir = getCurrentChatWorkspaceDir();
+    const sessionWorkspaceDir = sessionManager.getCwd()?.trim();
+    const chatWorkspaceDir = sessionWorkspaceDir && existsSync(sessionWorkspaceDir)
+      ? sessionWorkspaceDir
+      : getCurrentChatWorkspaceDir();
+    if (sessionWorkspaceDir && sessionWorkspaceDir !== chatWorkspaceDir) {
+      appendSystemLog(
+        `Conversation workspace is no longer available: ${sessionWorkspaceDir}. `
+        + `Using current workspace instead: ${chatWorkspaceDir}`,
+      );
+    }
     const settingsManager = SettingsManager.create(chatWorkspaceDir, CHAT_AGENT_DIR);
     const resourceLoader = new DefaultResourceLoader({
       cwd: chatWorkspaceDir,

--- a/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
@@ -37,6 +37,22 @@ function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
   });
 }
 
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+type WorkspaceSetResult = { ok: boolean; data: { current: string; default: string } };
+
 type Conversation = {
   id: string;
   title: string;
@@ -557,6 +573,110 @@ test('opening a conversation restores its workspace path', async () => {
   await waitFor(() => workspaceCallLog.length >= 1, 2_000);
   assert.equal(workspaceCallLog[0], '/project-b');
   assert.equal(uiState.chatWorkspacePath, '/project-b');
+});
+
+test('rapid conversation switches keep the latest workspace selected', async () => {
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  uiState.appSetupComplete = true;
+  uiState.chatWorkspacePath = '/default/workspace';
+
+  const conversations: Conversation[] = [
+    {
+      id: 'conv-project-a',
+      title: 'Project A Chat',
+      service: 'model-a',
+      provider: 'openai',
+      peerId: 'peer-a',
+      messages: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+    {
+      id: 'conv-project-b',
+      title: 'Project B Chat',
+      service: 'model-b',
+      provider: 'openai',
+      peerId: 'peer-b',
+      messages: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+  ];
+
+  const workspaceCallLog: string[] = [];
+  const pendingWorkspaceSets = new Map<
+    string,
+    ReturnType<typeof createDeferred<WorkspaceSetResult>>
+  >();
+
+  const bridge: DesktopBridge = {
+    chatAiListConversations: async () => ({ ok: true, data: [...conversations] }),
+    chatAiGetWorkspaceGitStatus: async () => ({
+      ok: true,
+      data: {
+        available: true,
+        rootPath: uiState.chatWorkspacePath,
+        branch: 'main',
+        isDetached: false,
+        ahead: 0,
+        behind: 0,
+        stagedFiles: 0,
+        modifiedFiles: 0,
+        untrackedFiles: 0,
+        error: null,
+      },
+    }),
+    chatAiGetConversation: async (id) => {
+      const conv = conversations.find((c) => c.id === id);
+      if (!conv) return { ok: false, error: 'not found' };
+      const workspacePath = id === 'conv-project-a' ? '/project-a' : '/project-b';
+      return { ok: true, data: { ...conv, messages: [], workspacePath } };
+    },
+    chatAiSetWorkspace: async (workspacePath: string) => {
+      workspaceCallLog.push(workspacePath);
+      const deferred = createDeferred<WorkspaceSetResult>();
+      pendingWorkspaceSets.set(`${workspacePath}:${workspaceCallLog.length}`, deferred);
+      return deferred.promise;
+    },
+  };
+
+  const api = initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+  await api.refreshChatConversations();
+
+  await api.openConversation('conv-project-a');
+  await waitFor(() => workspaceCallLog.length === 1);
+  assert.equal(workspaceCallLog[0], '/project-a');
+
+  await api.openConversation('conv-project-b');
+  await waitFor(() => workspaceCallLog.length === 2);
+  assert.equal(workspaceCallLog[1], '/project-b');
+
+  // Let the latest switch finish first.
+  pendingWorkspaceSets.get('/project-b:2')?.resolve({
+    ok: true,
+    data: { current: '/project-b', default: '/default' },
+  });
+  await waitFor(() => uiState.chatWorkspacePath === '/project-b');
+
+  // Now a stale earlier switch finishes. The module should re-apply /project-b
+  // because the stale IPC call may have changed persisted main-process state.
+  pendingWorkspaceSets.get('/project-a:1')?.resolve({
+    ok: true,
+    data: { current: '/project-a', default: '/default' },
+  });
+  await waitFor(() => workspaceCallLog.length === 3);
+  assert.equal(workspaceCallLog[2], '/project-b');
+  pendingWorkspaceSets.get('/project-b:3')?.resolve({
+    ok: true,
+    data: { current: '/project-b', default: '/default' },
+  });
+
+  await waitFor(() => uiState.chatWorkspacePath === '/project-b');
+  assert.equal(uiState.chatActiveConversation, 'conv-project-b');
 });
 
 test('opening a conversation does not switch workspace if it matches the current one', async () => {

--- a/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
@@ -469,3 +469,137 @@ test('sending from reopened conversation ignores unrelated global dropdown peer'
   }
   await waitFor(() => uiState.chatSendingConversationIds.length === 0);
 });
+
+test('opening a conversation restores its workspace path', async () => {
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  uiState.appSetupComplete = true;
+  uiState.chatWorkspacePath = '/default/workspace';
+
+  const conversations: Conversation[] = [
+    {
+      id: 'conv-project-a',
+      title: 'Project A Chat',
+      service: 'model-a',
+      provider: 'openai',
+      peerId: 'peer-a',
+      messages: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+    {
+      id: 'conv-project-b',
+      title: 'Project B Chat',
+      service: 'model-b',
+      provider: 'openai',
+      peerId: 'peer-b',
+      messages: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+  ];
+
+  const workspaceCallLog: string[] = [];
+
+  const bridge: DesktopBridge = {
+    chatAiListConversations: async () => ({ ok: true, data: [...conversations] }),
+    chatAiGetWorkspace: async () => ({ ok: true, data: { current: '/default/workspace', default: '/default' } }),
+    chatAiGetWorkspaceGitStatus: async () => ({
+      ok: true,
+      data: {
+        available: true,
+        rootPath: '/default/workspace',
+        branch: 'main',
+        isDetached: false,
+        ahead: 0,
+        behind: 0,
+        stagedFiles: 0,
+        modifiedFiles: 0,
+        untrackedFiles: 0,
+        error: null,
+      },
+    }),
+    chatAiGetConversation: async (id) => {
+      const conv = conversations.find((c) => c.id === id);
+      if (!conv) return { ok: false, error: 'not found' };
+      // Simulate that conv-a was created in /project-a and conv-b in /project-b
+      const workspacePath = id === 'conv-project-a' ? '/project-a' : '/project-b';
+      return { ok: true, data: { ...conv, messages: [], workspacePath } };
+    },
+    chatAiSetWorkspace: async (workspacePath: string) => {
+      workspaceCallLog.push(workspacePath);
+      uiState.chatWorkspacePath = workspacePath;
+      return { ok: true, data: { current: workspacePath, default: '/default' } };
+    },
+  };
+
+  const api = initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+  await api.refreshChatConversations();
+
+  // Before opening any conversation, workspace is the default
+  assert.equal(uiState.chatWorkspacePath, '/default/workspace');
+
+  // Open conv-project-a — should restore workspace to /project-a
+  await api.openConversation('conv-project-a');
+
+  // Wait for the async restoreWorkspace call
+  await waitFor(() => workspaceCallLog.length >= 1, 2_000);
+  assert.equal(workspaceCallLog[0], '/project-a');
+  assert.equal(uiState.chatWorkspacePath, '/project-a');
+
+  // Open conv-project-b — should restore workspace to /project-b
+  workspaceCallLog.length = 0;
+  await api.openConversation('conv-project-b');
+
+  await waitFor(() => workspaceCallLog.length >= 1, 2_000);
+  assert.equal(workspaceCallLog[0], '/project-b');
+  assert.equal(uiState.chatWorkspacePath, '/project-b');
+});
+
+test('opening a conversation does not switch workspace if it matches the current one', async () => {
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  uiState.appSetupComplete = true;
+  uiState.chatWorkspacePath = '/project-a';
+
+  const conversation: Conversation = {
+    id: 'conv-project-a',
+    title: 'Project A Chat',
+    service: 'model-a',
+    provider: 'openai',
+    peerId: 'peer-a',
+    messages: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    usage: { inputTokens: 0, outputTokens: 0 },
+  };
+
+  const workspaceCallLog: string[] = [];
+
+  const bridge: DesktopBridge = {
+    chatAiListConversations: async () => ({ ok: true, data: [conversation] }),
+    chatAiGetConversation: async () => ({
+      ok: true,
+      data: { ...conversation, messages: [], workspacePath: '/project-a' },
+    }),
+    chatAiSetWorkspace: async (workspacePath: string) => {
+      workspaceCallLog.push(workspacePath);
+      return { ok: true, data: { current: workspacePath, default: '/default' } };
+    },
+  };
+
+  const api = initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+  await api.refreshChatConversations();
+
+  // The conversation's workspacePath matches current workspace (/project-a)
+  // so chatAiSetWorkspace should NOT be called
+  await api.openConversation('conv-project-a');
+
+  // Give a tick for any potential async calls
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  assert.equal(workspaceCallLog.length, 0, 'should not call chatAiSetWorkspace when workspace already matches');
+});

--- a/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
@@ -51,7 +51,9 @@ function createDeferred<T>(): {
   return { promise, resolve, reject };
 }
 
-type WorkspaceSetResult = { ok: boolean; data: { current: string; default: string } };
+type WorkspaceSetResult =
+  | { ok: true; data: { current: string; default: string } }
+  | { ok: false; error: string };
 
 type Conversation = {
   id: string;
@@ -677,6 +679,114 @@ test('rapid conversation switches keep the latest workspace selected', async () 
 
   await waitFor(() => uiState.chatWorkspacePath === '/project-b');
   assert.equal(uiState.chatActiveConversation, 'conv-project-b');
+});
+
+test('stale manual workspace failure does not overwrite the latest desired conversation workspace', async () => {
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  uiState.appSetupComplete = true;
+  uiState.chatWorkspacePath = '/current';
+
+  const conversations: Conversation[] = [
+    {
+      id: 'conv-project-a',
+      title: 'Project A Chat',
+      service: 'model-a',
+      provider: 'openai',
+      peerId: 'peer-a',
+      messages: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+    {
+      id: 'conv-project-b',
+      title: 'Project B Chat',
+      service: 'model-b',
+      provider: 'openai',
+      peerId: 'peer-b',
+      messages: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+  ];
+
+  const workspaceCallLog: string[] = [];
+  const pendingWorkspaceSets = new Map<
+    string,
+    ReturnType<typeof createDeferred<WorkspaceSetResult>>
+  >();
+
+  const bridge: DesktopBridge = {
+    pickDirectory: async () => ({ ok: true, path: '/manual' }),
+    chatAiListConversations: async () => ({ ok: true, data: [...conversations] }),
+    chatAiGetWorkspaceGitStatus: async () => ({
+      ok: true,
+      data: {
+        available: true,
+        rootPath: uiState.chatWorkspacePath,
+        branch: 'main',
+        isDetached: false,
+        ahead: 0,
+        behind: 0,
+        stagedFiles: 0,
+        modifiedFiles: 0,
+        untrackedFiles: 0,
+        error: null,
+      },
+    }),
+    chatAiGetConversation: async (id) => {
+      const conv = conversations.find((c) => c.id === id);
+      if (!conv) return { ok: false, error: 'not found' };
+      const workspacePath = id === 'conv-project-a' ? '/project-a' : '/project-b';
+      return { ok: true, data: { ...conv, messages: [], workspacePath } };
+    },
+    chatAiSetWorkspace: async (workspacePath: string) => {
+      workspaceCallLog.push(workspacePath);
+      const deferred = createDeferred<WorkspaceSetResult>();
+      pendingWorkspaceSets.set(`${workspacePath}:${workspaceCallLog.length}`, deferred);
+      return deferred.promise;
+    },
+  };
+
+  const api = initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+  await api.refreshChatConversations();
+
+  await api.openConversation('conv-project-a');
+  await waitFor(() => workspaceCallLog.length === 1);
+  assert.equal(workspaceCallLog[0], '/project-a');
+
+  const chooseWorkspacePromise = api.chooseWorkspace();
+  await waitFor(() => workspaceCallLog.length === 2);
+  assert.equal(workspaceCallLog[1], '/manual');
+
+  await api.openConversation('conv-project-b');
+  await waitFor(() => workspaceCallLog.length === 3);
+  assert.equal(workspaceCallLog[2], '/project-b');
+
+  pendingWorkspaceSets.get('/manual:2')?.resolve({ ok: false, error: 'manual failed' });
+  await chooseWorkspacePromise;
+
+  // If the stale manual failure reset desiredWorkspacePath, this older stale
+  // completion would not re-apply /project-b.
+  pendingWorkspaceSets.get('/project-a:1')?.resolve({
+    ok: true,
+    data: { current: '/project-a', default: '/default' },
+  });
+  await waitFor(() => workspaceCallLog.length === 4);
+  assert.equal(workspaceCallLog[3], '/project-b');
+
+  pendingWorkspaceSets.get('/project-b:3')?.resolve({
+    ok: true,
+    data: { current: '/project-b', default: '/default' },
+  });
+  pendingWorkspaceSets.get('/project-b:4')?.resolve({
+    ok: true,
+    data: { current: '/project-b', default: '/default' },
+  });
+  await waitFor(() => uiState.chatWorkspacePath === '/project-b');
 });
 
 test('opening a conversation does not switch workspace if it matches the current one', async () => {

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1437,10 +1437,13 @@ export function initChatModule({
         desiredWorkspacePath = result.data.current;
         notifyUiStateChanged();
         await refreshWorkspaceGitStatus();
+      } else {
+        desiredWorkspacePath = uiState.chatWorkspacePath || null;
       }
-      // If result.ok is false (e.g. workspace path no longer exists on disk),
-      // keep the current workspace — the user can still manually set it.
     } catch {
+      if (token === workspaceSwitchToken) {
+        desiredWorkspacePath = uiState.chatWorkspacePath || null;
+      }
       // Silently fail — the user can still manually set the workspace
     }
   }
@@ -1458,7 +1461,9 @@ export function initChatModule({
       desiredWorkspacePath = picked.path;
       const result = await bridge.chatAiSetWorkspace(picked.path);
       if (!result.ok || !result.data) {
-        desiredWorkspacePath = uiState.chatWorkspacePath || null;
+        if (token === workspaceSwitchToken) {
+          desiredWorkspacePath = uiState.chatWorkspacePath || null;
+        }
         showChatError(result.error || 'Failed to set workspace');
         return;
       }
@@ -1481,6 +1486,8 @@ export function initChatModule({
 
   async function openConversation(convId: string): Promise<void> {
     if (!bridge || !bridge.chatAiGetConversation) return;
+
+    const workspacePathAtOpen = uiState.chatWorkspacePath;
 
     uiState.chatActiveConversation = convId;
     uiState.chatRoutedPeerId = '';
@@ -1544,7 +1551,7 @@ export function initChatModule({
         if (
           typeof convWorkspacePath === 'string' &&
           convWorkspacePath.length > 0 &&
-          convWorkspacePath !== uiState.chatWorkspacePath
+          convWorkspacePath !== workspacePathAtOpen
         ) {
           void restoreWorkspace(convWorkspacePath);
         }

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -148,6 +148,8 @@ export function initChatModule({
   let serviceRefreshToken = 0;
   let serviceRefreshInProgress = false;
   let serviceSelectFocused = false;
+  let workspaceSwitchToken = 0;
+  let desiredWorkspacePath: string | null = uiState.chatWorkspacePath || null;
   const sendingConversationIds = new Set<string>();
   const streamTurnsByConversation = new Map<string, number>();
   const streamStartedAtByConversation = new Map<string, number>();
@@ -1378,6 +1380,7 @@ export function initChatModule({
       if (result.ok && result.data) {
         uiState.chatWorkspacePath = result.data.current;
         uiState.chatWorkspaceDefaultPath = result.data.default;
+        desiredWorkspacePath = result.data.current;
         notifyUiStateChanged();
         await refreshWorkspaceGitStatus();
       }
@@ -1412,11 +1415,26 @@ export function initChatModule({
   async function restoreWorkspace(workspacePath: string): Promise<void> {
     if (!bridge?.chatAiSetWorkspace) return;
 
+    const token = ++workspaceSwitchToken;
+    desiredWorkspacePath = workspacePath;
+
     try {
       const result = await bridge.chatAiSetWorkspace(workspacePath);
+      if (token !== workspaceSwitchToken) {
+        // A newer conversation/manual workspace selection won the race. The IPC
+        // call above may still have persisted this stale workspace in main, so
+        // re-apply the latest requested workspace to keep main and the UI aligned.
+        const latestWorkspacePath = desiredWorkspacePath;
+        if (latestWorkspacePath && latestWorkspacePath !== workspacePath) {
+          void restoreWorkspace(latestWorkspacePath);
+        }
+        return;
+      }
+
       if (result.ok && result.data) {
         uiState.chatWorkspacePath = result.data.current;
         uiState.chatWorkspaceDefaultPath = result.data.default;
+        desiredWorkspacePath = result.data.current;
         notifyUiStateChanged();
         await refreshWorkspaceGitStatus();
       }
@@ -1436,14 +1454,21 @@ export function initChatModule({
         return;
       }
 
+      const token = ++workspaceSwitchToken;
+      desiredWorkspacePath = picked.path;
       const result = await bridge.chatAiSetWorkspace(picked.path);
       if (!result.ok || !result.data) {
+        desiredWorkspacePath = uiState.chatWorkspacePath || null;
         showChatError(result.error || 'Failed to set workspace');
+        return;
+      }
+      if (token !== workspaceSwitchToken) {
         return;
       }
 
       uiState.chatWorkspacePath = result.data.current;
       uiState.chatWorkspaceDefaultPath = result.data.default;
+      desiredWorkspacePath = result.data.current;
       uiState.chatError = null;
       startNewChat();
       await refreshChatConversations();

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -34,6 +34,7 @@ type ChatConversationSummary = {
   service?: string;
   provider?: string;
   peerId?: string;
+  workspacePath?: string;
   createdAt?: number;
   updatedAt?: number;
   messageCount?: number;
@@ -1408,6 +1409,24 @@ export function initChatModule({
     }
   }
 
+  async function restoreWorkspace(workspacePath: string): Promise<void> {
+    if (!bridge?.chatAiSetWorkspace) return;
+
+    try {
+      const result = await bridge.chatAiSetWorkspace(workspacePath);
+      if (result.ok && result.data) {
+        uiState.chatWorkspacePath = result.data.current;
+        uiState.chatWorkspaceDefaultPath = result.data.default;
+        notifyUiStateChanged();
+        await refreshWorkspaceGitStatus();
+      }
+      // If result.ok is false (e.g. workspace path no longer exists on disk),
+      // keep the current workspace — the user can still manually set it.
+    } catch {
+      // Silently fail — the user can still manually set the workspace
+    }
+  }
+
   async function chooseWorkspace(): Promise<void> {
     if (!bridge?.pickDirectory || !bridge.chatAiSetWorkspace) return;
 
@@ -1495,6 +1514,15 @@ export function initChatModule({
         updateThreadMeta(activeConversation);
         uiState.chatError = null;
         notifyUiStateChanged();
+
+        const convWorkspacePath = conv.workspacePath;
+        if (
+          typeof convWorkspacePath === 'string' &&
+          convWorkspacePath.length > 0 &&
+          convWorkspacePath !== uiState.chatWorkspacePath
+        ) {
+          void restoreWorkspace(convWorkspacePath);
+        }
 
         const peerId = resolveConversationPeerId(activeConversation);
         if (peerId) debouncedFetchMeteringStats(peerId);


### PR DESCRIPTION
## What

Fixes workspace restoration when switching between chat conversations in AntStation.

- Persists each conversation’s workspace path.
- Restores the saved workspace when opening a conversation.
- Updates the chat system prompt to reflect the per-chat workspace model.
- Hardens workspace switching against async races during rapid conversation switches.
- Ensures sends use the conversation/session workspace instead of relying only on mutable global workspace state.

## Why

Chats can be tied to different folders/repos, but switching conversations previously did not reliably restore the correct workspace. This could leave the UI showing or using the wrong project context, especially when moving between conversations from different workspaces.

The additional hardening prevents stale async workspace restore calls from overwriting the latest selected workspace, and ensures chat sends execute in the workspace associated with the conversation.

## Testing

Added/updated renderer chat routing tests for workspace behavior:

- Opening a conversation restores its saved workspace path.
- Opening a conversation does not call workspace switching when the saved workspace already matches the current workspace.
- Rapid conversation switching keeps the latest conversation’s workspace selected and re-applies it if a stale async restore completes later.

Validated with:

- `pnpm -C apps/desktop typecheck:renderer`
- `pnpm -C apps/desktop exec tsc -p tsconfig.main.json --noEmit`
- `pnpm -C apps/desktop exec tsc --noEmit --target ES2022 --module ESNext --moduleResolution Bundler --jsx react-jsx --types node,vite/client src/renderer/modules/chat.peer-routing.test.ts`
- `pnpm -C apps/desktop exec tsx --test src/renderer/modules/chat.peer-routing.test.ts`
- `git diff --check`

## Checklist

- [ ] `pnpm run build` passes
- [ ] `pnpm run test` passes
- [x] Breaking changes documented

