### PR TITLE
Update ANTS page token economics messaging

### DIFF
--- a/apps/website/src/pages/ants-token.module.css
+++ b/apps/website/src/pages/ants-token.module.css
@@ -78,6 +78,27 @@
   gap: 16px;
   flex-wrap: wrap;
 }
+.protocolNotice {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: -14px auto 32px;
+  padding: 10px 16px;
+  border: 1px solid rgba(31, 216, 122, 0.28);
+  border-radius: 999px;
+  background: rgba(31, 216, 122, 0.06);
+  color: #168f54 !important;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  text-decoration: none !important;
+  transition: background 0.15s, border-color 0.15s, transform 0.15s;
+}
+.protocolNotice:hover {
+  background: rgba(31, 216, 122, 0.1);
+  border-color: rgba(31, 216, 122, 0.45);
+  transform: translateY(-1px);
+}
 
 /* ── BUTTONS ── */
 .ctaPrimary {

--- a/apps/website/src/pages/ants-token.tsx
+++ b/apps/website/src/pages/ants-token.tsx
@@ -251,17 +251,17 @@ function EarnFlow(): JSX.Element {
           <text x="400" y="88" textAnchor="middle" className={styles.flowBoxSub}>stakes · serves</text>
         </g>
 
-        {/* $ANTS Mint */}
+        {/* $ANTS Emissions */}
         <g>
           <rect x="600" y="30" width="160" height="80" rx="14" className={styles.flowBoxMint} />
-          <text x="680" y="63" textAnchor="middle" className={styles.flowBoxTitleMint}>$ANTS Mint</text>
-          <text x="680" y="88" textAnchor="middle" className={styles.flowBoxSubMint}>epoch settle</text>
+          <text x="680" y="63" textAnchor="middle" className={styles.flowBoxTitleMint}>$ANTS Emissions</text>
+          <text x="680" y="88" textAnchor="middle" className={styles.flowBoxSubMint}>epoch tracking</text>
         </g>
 
         {/* Forward labels */}
         <text x="260" y="58" textAnchor="middle" className={styles.flowLineLabel}>USDC</text>
         <text x="540" y="58" textAnchor="middle" className={styles.flowLineLabel}>volume reported</text>
-        <text x="400" y="216" textAnchor="middle" className={styles.flowLineLabelGreen}>ANTS minted at epoch end</text>
+        <text x="400" y="216" textAnchor="middle" className={styles.flowLineLabelGreen}>ANTS emissions tracked</text>
 
         {/* USDC pellets: Buyer → Seller */}
         <circle r="5" className={styles.flowPellet}>
@@ -275,7 +275,7 @@ function EarnFlow(): JSX.Element {
           </animateMotion>
         </circle>
 
-        {/* ANTS return: Mint → Seller and Mint → Buyer */}
+        {/* ANTS emissions: tracked for sellers and buyers */}
         <circle r="6" className={styles.flowPelletGreen}>
           <animateMotion dur="4.8s" repeatCount="indefinite" begin="1.5s">
             <mpath href="#pMintSeller" />
@@ -317,7 +317,7 @@ export default function AntsToken(): JSX.Element {
   return (
     <Layout
       title="ANTS Token | AntSeed"
-      description="ANTS is earned by the people who build and use the network. Hard-capped at 1.04B with automatic halvings."
+      description="ANTS is the coordination and trust asset of the AntSeed network. Hard-capped at 1.04B with automatic halvings."
     >
 
       {/* ── HERO ── */}
@@ -332,10 +332,18 @@ export default function AntsToken(): JSX.Element {
           <span className={styles.statusText}>Tokens Restricted</span>
         </div>
         <p className={styles.heroSub}>
-          ANTS is earned, not bought. No pre-mine, no insider allocation — sellers and buyers who
-          create real economic activity on the network receive ANTS proportional to their
-          contribution. Hard-capped at 1.04B with automatic halvings.
+          ANTS is designed to become the coordination and trust asset of the AntSeed network.
+          No pre-mine, no insider allocation, no unfair head start, and no company extracting protocol fees.
+          ANTS distribution is meant for real users and providers who help the network grow.
         </p>
+        <a
+          href="https://x.com/AntSeedAI/status/2053924623935218044"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.protocolNotice}
+        >
+          Token economics are evolving →
+        </a>
         <div className={styles.heroCtas}>
           <a href={download.href} target="_blank" rel="noopener noreferrer" className={styles.ctaPrimary}>
             Download AntStation →
@@ -376,10 +384,9 @@ export default function AntsToken(): JSX.Element {
       {/* ── HOW TO EARN ── */}
       <section className={styles.earn}>
         <div className={styles.earnHeader}>
-          <h2>How you earn ANTS</h2>
+          <h2>ANTS incentives</h2>
           <p>
-            Every USDC dollar settled on-chain mints ANTS at epoch end.
-            No pre mining, no ANTS staking — your share tracks real activity.
+            ANTS emissions track eligible real activity on the network. Claimability and distribution may be subject to caps, validation, locking, and anti-abuse checks.
           </p>
         </div>
 
@@ -389,17 +396,17 @@ export default function AntsToken(): JSX.Element {
           <div className={styles.earnCard}>
             <div className={styles.earnStep}>01</div>
             <h3>As a seller</h3>
-            <p>Stake USDC, serve requests, settle on-chain. Your share of the 50% seller pool is proportional to your USDC volume that epoch. Capped at 50% of seller pool per seller.</p>
+            <p>Serve real requests and settle on-chain. Seller ANTS emissions are tracked but currently routed into a dedicated Provider Pool and locked while stronger provider validation, audits, attestations, and proof systems are introduced.</p>
           </div>
           <div className={styles.earnCard}>
             <div className={styles.earnStep}>02</div>
             <h3>As a buyer</h3>
-            <p>Deposit USDC, use the network, pay for AI services. Your share of the 20% buyer pool is proportional to your USDC spend that epoch. Diversity bonus for using multiple sellers.</p>
+            <p>Deposit USDC, use the network, and pay for AI services. Buyer incentives are designed for real demand and may be subject to caps, quality filters, and anti-abuse checks.</p>
           </div>
           <div className={styles.earnCard}>
             <div className={styles.earnStep}>03</div>
-            <h3>Claim each epoch</h3>
-            <p>At epoch end, call claim with the epoch numbers you participated in. ANTS are minted directly to your wallet. Unclaimed emissions remain claimable.</p>
+            <h3>Claimability</h3>
+            <p>Eligible buyer emissions may be claimable after epoch finalization. Seller emissions remain locked in the Provider Pool for now and may be subject to future verification or slashing before becoming claimable.</p>
           </div>
         </div>
       </section>
@@ -433,9 +440,9 @@ export default function AntsToken(): JSX.Element {
 
         <div className={styles.splitGrid}>
           {[
-            {pct: '50%', label: 'Sellers', desc: 'Pro-rata by USDC volume settled. Capped at 50% of seller pool per seller per epoch.', accent: true},
-            {pct: '20%', label: 'Buyers', desc: 'Pro-rata by USDC spent. Rewards active usage and seller diversity.', accent: false},
-            {pct: '15%', label: 'Protocol Reserve', desc: 'The protocol reserve allocation and seller cap overages flow here. Funds ecosystem growth.', accent: false},
+            {pct: '50%', label: 'Provider Pool', desc: 'Seller emissions are tracked and routed into a locked Provider Pool while stronger validation and proof systems are developed.', accent: true},
+            {pct: '20%', label: 'Buyers', desc: 'For eligible real usage. Buyer incentives may be capped, filtered, delayed, or excluded for anti-abuse reasons.', accent: false},
+            {pct: '15%', label: 'Protocol Reserve', desc: 'Supports long-term network sustainability, trust, utility, and alignment.', accent: false},
             {pct: '15%', label: 'Team', desc: 'Vested to core contributors. Aligned with long-term network health.', accent: false},
           ].map(s => (
             <div key={s.label} className={`${styles.splitCard} ${s.accent ? styles.splitCardAccent : ''}`}>
@@ -492,7 +499,10 @@ export default function AntsToken(): JSX.Element {
             {label: 'Max supply', value: '1,040,000,000 ANTS'},
             {label: 'Epoch duration', value: '1 week (604,800 seconds)'},
             {label: 'Halving interval', value: 'Every 104 epochs (~2 years)'},
-            {label: 'Network fee', value: '2% of settlement (200 bps), collected to community reserve pool'},
+            {label: 'Network fee', value: '4% of settlement, flowing to the Protocol Reserve — not to a company'},
+            {label: 'DIEM pool fee', value: '10% fee flows to the Protocol Reserve to strengthen the AntSeed ecosystem and ANTS'},
+            {label: 'Provider Pool', value: 'Seller ANTS emissions are tracked but locked pending stronger validation; future claims may be subject to verification or slashing'},
+            {label: 'Anti-abuse policy', value: 'Farming, fake volume, sybil behavior, spam, or value extraction may be capped, excluded, delayed, locked, or subject to future slashing'},
             {label: 'Transfers', value: 'Currently restricted'},
           ].map(r => (
             <div key={r.label} className={styles.contractsRow}>
@@ -505,8 +515,8 @@ export default function AntsToken(): JSX.Element {
 
       {/* ── BOTTOM CTA ── */}
       <section className={styles.bottomCta}>
-        <h2>Start earning ANTS</h2>
-        <p>Download AntStation, join the network as a provider or buyer, and start accumulating.</p>
+        <h2>Help build the network</h2>
+        <p>Download AntStation, use the network for real AI work, run a provider, and help improve the open-source protocol.</p>
         <div className={styles.bottomCtaBtns}>
           <a href={download.href} target="_blank" rel="noopener noreferrer" className={styles.ctaPrimary}>
             Download AntStation →


### PR DESCRIPTION
## Summary
- Reposition ANTS as the network coordination and trust asset
- Add token economics evolving link to the community letter on X
- Update ANTS incentives, Provider Pool, Protocol Reserve, fees, and anti-abuse copy
- Remove outdated direct-mint/claim language from the ANTS page

## Testing
- pnpm --filter=@antseed/website run build (passed in main workspace with the same ANTS page changes)
- PR worktree build could not run because that worktree has no node_modules installed