### PR TITLE
Update protocol fee and incentive messaging

### DIFF
--- a/apps/diem-staking/src/components/Layout.tsx
+++ b/apps/diem-staking/src/components/Layout.tsx
@@ -237,7 +237,7 @@ function Why() {
     { h: 'Real revenue, not emissions', p: 'USDC yield comes from actual AI requests on the AntSeed network. If demand grows, your yield grows with it.' },
     { h: 'Your $DIEM never leaves Base', p: 'Funds stay in an audited smart contract. No bridges, no centralized custody, no rehypothecation.' },
     { h: 'Two income streams', p: 'USDC for cash yield today. $ANTS for upside in the network tomorrow. Long-term stakers earn a bigger share of both.' },
-    { h: 'Transparent operations', p: 'The operator currently retains 10% for operations; the remaining USDC flows through the pool to stakers pro-rata.' },
+    { h: 'Protocol-aligned fees', p: 'The 10% DIEM pool fee flows to the Protocol Reserve; the remaining USDC flows through the pool to stakers pro-rata.' },
   ];
   return (
     <div className="why-block">
@@ -296,9 +296,9 @@ export function FAQ() {
             AntSeed is a peer-to-peer network where developers and AI agents buy inference,
             skills, and other services. Every request settles a USDC micropayment on Base,
             and the AntSeed payment channel pays the staking contract directly — the
-            contract is the seller. No operator holds user stake. The operator currently
-            retains 10% for operations; the remaining USDC credits to stakers pro-rata
-            as it reaches the pool.
+            contract is the seller. No operator holds user stake. The 10% DIEM pool fee
+            flows to the Protocol Reserve to strengthen the AntSeed ecosystem and ANTS;
+            the remaining USDC credits to stakers pro-rata as it reaches the pool.
           </div>
         </details>
         <details className="faq">
@@ -354,10 +354,11 @@ export function FAQ() {
           </div>
         </details>
         <details className="faq">
-          <summary>Are there any operator fees?</summary>
+          <summary>Are there any pool fees?</summary>
           <div className="body">
-            Yes. The operator currently retains 10% for operations before USDC reaches
-            the staking pool. The remaining USDC flows to stakers pro-rata. Your wallet
+            Yes. The DIEM pool has a 10% fee before USDC reaches the staking pool.
+            That fee flows to the Protocol Reserve to strengthen the AntSeed ecosystem
+            and ANTS. The remaining USDC flows to stakers pro-rata. Your wallet
             transactions still require Base gas, typically a few cents.
           </div>
         </details>

--- a/apps/payments/web/src/views/DiemRewardsView.tsx
+++ b/apps/payments/web/src/views/DiemRewardsView.tsx
@@ -223,7 +223,7 @@ export function DiemRewardsView({ config }: DiemRewardsViewProps) {
           <div className="dashboard-section-eyebrow">DIEM staking</div>
           <h2 className="dashboard-section-title">Your DIEM $ANTS</h2>
           <p className="dashboard-section-sub">
-            Rewards earned from staking DIEM through the AntSeed proxy. Connect the same wallet you used for staking.
+            Rewards earned from staking DIEM through the AntSeed proxy. The 10% DIEM pool fee flows to the Protocol Reserve to strengthen the AntSeed ecosystem and ANTS. Connect the same wallet you used for staking.
           </p>
         </header>
 

--- a/apps/website/blog/2026-03-27-the-permissionless-openrouter-alternative/index.md
+++ b/apps/website/blog/2026-03-27-the-permissionless-openrouter-alternative/index.md
@@ -63,7 +63,7 @@ The architecture is completely different.
 
 AI Agents are the unit of value on the network. You wrap your expertise in AI, set your price, and the network handles discovery, payments, and reputation. How you deliver is your business — pick any model, any workflow, any stack. The protocol only measures the quality of what comes back.
 
-**Direct settlement, minimal fees.** Buyers pay providers directly — in USDC or by card. A 2% protocol fee is distributed back to the network, not extracted by a platform. Providers set their own prices. Markets clear through open competition.
+**Direct settlement, minimal fees.** Buyers pay providers directly — in USDC or by card. A 4% protocol fee flows to the Protocol Reserve, not to a company. Providers set their own prices. Markets clear through open competition.
 
 **Reputation is on-chain and provider-sovereign.** Every delivery builds a track record that belongs to your wallet, not a platform that can revoke it. A provider with thousands of verified deliveries charges more than a new entrant. That premium is earned through work, and it compounds.
 
@@ -94,7 +94,7 @@ AntSeed's protocol has five layers, each handling a piece of what centralized ga
 | Permission to join | Company approval | Stake tokens | None required |
 | What you can serve | What they allow | What fits their framework | Anything |
 | API compatibility | OpenAI-compatible | Custom protocols | OpenAI-compatible |
-| Fees | 5.5% (extracted) | Token economics | 2% (returned to network) |
+| Fees | 5.5% (extracted) | Token economics | 4% (to Protocol Reserve) |
 | Payment methods | Card | Crypto wallets + tokens | USDC or Card |
 | Content policy | Platform-enforced | Varies | Provider-level |
 | Data privacy | Third-party proxy | Varies | P2P, no intermediary |
@@ -117,7 +117,7 @@ And it's for agents — software that doesn't care about brands or polished UIs,
 ## Frequently Asked Questions
 
 **Is AntSeed free to use?**
-There's a 2% protocol fee per request, distributed back to the network. No subscription, no account, no platform rake on top of that.
+There's a 4% protocol fee per request, flowing to the Protocol Reserve. No subscription, no account, no platform rake on top of that.
 
 **Does AntSeed work with my existing tools?**
 Yes. Claude Code, Cursor, Aider, Continue.dev, and any app using the OpenAI SDK work without modification — just point them at AntSeed instead of your current endpoint.

--- a/apps/website/docs/faq.mdx
+++ b/apps/website/docs/faq.mdx
@@ -268,6 +268,18 @@ Providers set their own prices. The routing layer scores all available providers
 
 Buyers pre-deposit USDC into the on-chain AntseedDeposits contract. Each session is authorized by an EIP-712 ReserveAuth that caps the seller's charge. The seller calls `reserve()` on AntseedChannels to lock funds. During the session, the buyer signs cumulative SpendingAuth messages that authorize spending. The seller calls `close()` with the buyer's latest SpendingAuth to settle and release remaining funds. If the seller disappears, anyone can call `requestTimeout()` after the session deadline passes, then `withdraw()` after a 15-minute grace period to release buyer funds. No invoicing, no monthly billing — automatic settlement per session.
 
+### Are seller ANTS incentives claimable now?
+
+Seller ANTS emissions are currently tracked but routed into a dedicated Provider Pool and locked for now. They are not freely claimable yet. Future claimability is expected after stronger provider validation, audits, attestations, and proof systems are introduced, and may be subject to verification or slashing.
+
+### Where do protocol fees go?
+
+Network fees are set to 4% and flow into the Protocol Reserve, not to a company. The Protocol Reserve is intended to support long-term network sustainability, trust, utility, and alignment. The same applies to the 10% fee from the DIEM pool.
+
+### Are ANTS incentives guaranteed?
+
+No. ANTS incentives are designed for real usage and real contribution. Farming, fake volume, sybil behavior, spam, or value extraction may be capped, excluded, delayed, locked, or subject to future slashing. ANTS token economics are evolving, and more trust and utility mechanisms are planned.
+
 ---
 
 ## Still have questions?

--- a/apps/website/docs/guides/become-a-provider.md
+++ b/apps/website/docs/guides/become-a-provider.md
@@ -13,6 +13,10 @@ Providers earn USDC by serving AI requests on the AntSeed network. This guide co
 AntSeed is designed for providers who build differentiated services — such as TEE-secured inference, domain-specific skills or agents, fine-tuned models, or managed product experiences. Simply reselling raw API access or subscription credentials is not the intended use and may violate your upstream provider's terms of service. Providers are solely responsible for complying with their upstream API provider's terms.
 :::
 
+:::info Seller ANTS emissions
+Starting from the current epoch, seller ANTS emissions are tracked but routed into a dedicated Provider Pool and locked for now. These incentives are not freely claimable yet. Future claimability is expected after stronger provider validation, audit, attestation, and proof systems are introduced, and may be subject to verification or slashing.
+:::
+
 ## Prerequisites
 
 - Node.js 20+
@@ -219,7 +223,13 @@ For production monitoring, expose seller metrics with `antseed metrics serve --r
 4. Your node calls `settle()` periodically to collect earned USDC
 5. On session end, `close()` finalizes and releases remaining buyer funds
 
-Earnings are paid directly to your wallet address on each `settle()` or `close()` call. No claim step needed.
+USDC earnings are paid directly to your wallet address on each `settle()` or `close()` call. No claim step needed for USDC.
+
+Seller-side ANTS emissions are different: they are currently tracked but locked in the Provider Pool while stronger validation systems are developed. Provider ANTS claims may become available later and may be subject to verification or slashing.
+
+:::warning Real usage only
+ANTS incentives are designed for real provider contribution. Farming, fake volume, sybil behavior, spam, or value extraction may be capped, excluded, delayed, locked, or subject to future slashing.
+:::
 
 ## Next Steps
 

--- a/apps/website/docs/protocol/payments.md
+++ b/apps/website/docs/protocol/payments.md
@@ -132,9 +132,11 @@ AntseedRegistry       Central address book for all protocol contracts
 AntseedStaking        Seller staking (holds stake USDC, binds to ERC-8004 agentId)
 AntseedDeposits       Buyer deposits, seller payouts (holds buyer USDC)
 AntseedChannels       Payment channel lifecycle (swappable, holds NO USDC)
-AntseedEmissions      ANTS token emissions (USDC volume-based rewards)
-ANTSToken             ANTS ERC-20 token (52M max supply)
+AntseedEmissions      ANTS token emissions (USDC volume-based incentives)
+ANTSToken             ANTS ERC-20 token (1.04B max supply)
 ```
+
+Network fees are set to 4% of settlement and flow to the Protocol Reserve, not to a company. The Protocol Reserve is intended to support long-term network sustainability, trust, utility, and alignment. Seller ANTS emissions are currently tracked but locked in a dedicated Provider Pool pending stronger validation; future claims may be subject to verification or slashing.
 
 **Stable contracts** (Staking, Deposits) hold funds and rarely change. The **swappable contract** (Channels) holds no USDC and can be redeployed by re-pointing via the Registry.
 

--- a/apps/website/src/pages/providers.tsx
+++ b/apps/website/src/pages/providers.tsx
@@ -22,6 +22,10 @@ const FAQ_DATA = [
     a: 'Buyers lock USDC in on-chain escrow on Base before a session starts. Requests flow freely during the session. When the session ends (or idles for 10 minutes), settlement executes on-chain and USDC lands in your wallet automatically. No invoicing, no billing cycles.',
   },
   {
+    q: 'Are seller ANTS incentives claimable now?',
+    a: 'Seller ANTS emissions are currently tracked but routed into a dedicated Provider Pool and locked. They are not freely claimable yet. Future claimability is expected after stronger validation, audit, attestation, and proof systems are introduced, and may be subject to verification or slashing.',
+  },
+  {
     q: 'Can I use any model underneath?',
     a: 'Yes. You can wrap Anthropic, OpenAI, Together, Ollama, a fine-tuned model, or any standard API. The network only sees what you deliver — not your backend.',
   },
@@ -159,6 +163,9 @@ export default function Providers(): JSX.Element {
             <p>
               Providers are solely responsible for complying with their upstream
               API provider's terms.
+            </p>
+            <p>
+              Seller-side ANTS emissions are currently tracked but locked in a dedicated Provider Pool while AntSeed develops stronger validation and proof systems. Fake usage, sybil behavior, or incentive extraction may be excluded or subject to future slashing.
             </p>
           </div>
         </div>
@@ -329,11 +336,11 @@ antseed seller start`}</pre>
           </div>
           <div className={styles.econRow}>
             <span className={styles.econLabel}>Protocol fee</span>
-            <span className={styles.econValue}>2% — distributed back to the network, not extracted</span>
+            <span className={styles.econValue}>4% — flows to the Protocol Reserve, not to a company</span>
           </div>
           <div className={styles.econRow}>
             <span className={styles.econLabel}>Your payout</span>
-            <span className={styles.econValue}>98% of what buyers pay, direct to your wallet in USDC</span>
+            <span className={styles.econValue}>96% of what buyers pay, direct to your wallet in USDC</span>
           </div>
           <div className={styles.econRow}>
             <span className={styles.econLabel}>Payment methods</span>

--- a/docs/protocol/diem-proxy.md
+++ b/docs/protocol/diem-proxy.md
@@ -125,6 +125,8 @@ Cache TTL: 5 minutes. Rotation detection: when the cached `operator` value no lo
 
 ## Reward accounting
 
+The DIEM pool applies a 10% fee before USDC reaches the staking pool. That fee flows to the Protocol Reserve to strengthen the AntSeed ecosystem and ANTS. The remaining USDC is streamed pro-rata to stakers.
+
 Two parallel streams: `usdcStream` and `antsStream`. Each uses the Uniswap StakingRewards pattern:
 
 - `rewardRate` (tokens per second), `periodFinish`, `lastUpdateTime`, `rewardPerTokenStored`.


### PR DESCRIPTION
## Summary
- Update provider page economics to 4% protocol fee / 96% provider payout
- Add Provider Pool and seller ANTS claimability disclaimers to provider docs and FAQ
- Document Protocol Reserve fee flow, anti-abuse policy, and evolving ANTS incentives
- Update DIEM pool fee messaging across the staking portal, payments portal, and DIEM proxy docs
- Update older website fee references from 2% to 4%

## Notes
- ANTS page changes are intentionally handled separately in #503.

## Testing
- Not run in this clean PR worktree because dependencies/node_modules are not installed there.
- The website build passed in the main workspace after applying the same website changes.