### PR TITLE
docs(integrations/codex): add routing-verification step + document gotchas

### DIFF
--- a/apps/website/docs/guides/using-the-api.md
+++ b/apps/website/docs/guides/using-the-api.md
@@ -86,11 +86,7 @@ Claude Code sends requests to `/v1/messages` and the proxy routes them to the be
 
 ## Codex
 
-```bash
-export OPENAI_BASE_URL=http://localhost:8377/v1
-export OPENAI_API_KEY=unused
-codex
-```
+Recent Codex versions (0.40+) ignore `OPENAI_BASE_URL` and `OPENAI_API_KEY` and only read `~/.codex/config.toml`. See the [Codex integration page](/integrations/codex) for the profile-based setup, the routing-verification check, and known gotchas (project-local configs, `-c` flag pitfalls).
 
 ## curl
 

--- a/apps/website/src/integrations/integrations.ts
+++ b/apps/website/src/integrations/integrations.ts
@@ -250,6 +250,8 @@ model_provider = "antseed"
 
 # Optional: make AntSeed the default profile so you don't need --profile every time.
 # profile = "antseed"`,
+        note:
+          'This must be your **user-level** `~/.codex/config.toml`. Codex silently ignores `model_provider` / `model_providers` if they appear in a project-local `./.codex/config.toml` and prints a one-line warning at launch (see Troubleshooting).',
       },
       {
         kind: 'gui',
@@ -278,11 +280,32 @@ model_provider = "antseed"
         command: 'codex --profile antseed',
         note: 'Or pin a model for one session: `codex --profile antseed --model deepseek-v4-flash`.',
       },
+      {
+        label: 'Verify inference is actually paid through AntSeed',
+        command: 'open http://localhost:3118   # or: antseed buyer status',
+        outputLabel: 'What to look for after one real prompt',
+        output: `Deposits available: 4.289391 USDC → 3.289391 USDC
+Deposits reserved:           0 USDC → 1 USDC`,
+        note:
+          'The buyer dashboard at http://localhost:3118 is the authoritative real-time signal: a non-zero `Reserved` (channel opened) and/or a drop in `Available` (settled spend) after a real prompt confirms AntSeed served the request. The `antseed buyer status` CLI output is cached and may lag the dashboard — refresh the web view for confirmation. Do not rely on `lsof -i | grep codex` or `~/.codex/log/codex-tui.log`: Codex keeps persistent TCP connections to Cloudflare/ChatGPT IPs (e.g. 172.64.0.0/13) for non-inference purposes (the cause was not isolated during testing), and the `provider=OpenAI` lines in the TUI log are not a reliable indicator that inference went to OpenAI — the on-chain numbers can show AntSeed served the request despite that log line.',
+      },
     ],
     troubleshooting: [
       {
         problem: '`OPENAI_BASE_URL` / `OPENAI_API_KEY` are being ignored',
         fix: 'Expected on Codex 0.40+ — it no longer reads OpenAI env vars and only loads providers from `~/.codex/config.toml`. Use the profile shown above and launch with `codex --profile antseed`.',
+      },
+      {
+        problem: 'How can I tell if Codex is actually routing through AntSeed?',
+        fix: 'Check the buyer dashboard at http://localhost:3118 (or `antseed buyer status`) after sending a test prompt. `Reserved` going from $0 to a non-zero value (a channel was opened) and/or `Available` dropping (spend settled) confirms AntSeed served the request. If both stay flat after a real prompt, the profile is not being applied. Do not trust `lsof` connections to Cloudflare IPs or `provider=OpenAI` lines in `~/.codex/log/codex-tui.log` — neither is a reliable routing signal.',
+      },
+      {
+        problem: 'Codex prints `Ignored unsupported project-local config keys … model_provider, model_providers`',
+        fix: 'Provider settings must live in your **user-level** `~/.codex/config.toml`. Codex silently rejects them in a project-local `./.codex/config.toml` and falls back to its default (OpenAI). Move the `[model_providers.antseed]` and `[profiles.antseed]` blocks to `~/.codex/config.toml` and relaunch.',
+      },
+      {
+        problem: 'Declaring the provider on the command line via `-c model_provider=…` / `-c model_providers.antseed=…`',
+        fix: 'Prefer `~/.codex/config.toml` + `--profile antseed`. Declaring the provider via `-c` flags has been observed to apply on `codex resume` but silently revert to OpenAI on a fresh `codex` launch. The config-file path is the only setup we reliably reproduce.',
       },
       {
         problem: 'Streaming stops after the first chunk',


### PR DESCRIPTION
## Summary

Three improvements to the Codex CLI integration page, plus a fix to the older guides page that still showed the broken `OPENAI_BASE_URL` approach.

- Add a routing-verification test step (check the buyer dashboard / `antseed buyer status` after a real prompt to confirm AntSeed actually served it).
- Document that project-local `./.codex/config.toml` silently rejects `model_provider` / `model_providers`. Codex prints a one-line warning and falls back to OpenAI.
- Warn against the `-c model_provider=… -c model_providers.antseed=…` CLI pattern. Worked on `codex resume` in testing, then silently reverted to OpenAI on a fresh launch.
- Replace the broken `export OPENAI_BASE_URL=…` snippet in `docs/guides/using-the-api` with a pointer to `/integrations/codex` (Codex 0.40+ ignores those env vars).

## Files changed

- `apps/website/src/integrations/integrations.ts` — Codex entry: one `note`, one new `test[]` step, three new `troubleshooting[]` entries. Renders via `IntegrationPage.tsx`; the agent-readable `skill.md` regenerates from the same data.
- `apps/website/docs/guides/using-the-api.md` — Codex subsection replaced with pointer to `/integrations/codex`.

## Out of scope

`apps/website/README.md` is stale (claims React Router + Vite + Tailwind; the website is Docusaurus 3.x). Follow-up.

## Test plan

- [x] `pnpm build` in `apps/website/` succeeds.
- [x] New content present in `build/integrations/codex/index.html` and `build/skill.md`.
- [x] Broken snippet gone from `build/docs/guides/using-the-api/index.html`.
- [x] `pnpm typecheck` errors are pre-existing on `main`.