### PR TITLE
Design assistant chat activity separation

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -647,6 +647,32 @@
 }
 
 /* ===================================================================
+   Assistant activity timeline
+   =================================================================== */
+
+.assistant-work-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 0 12px;
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.assistant-work-label {
+  flex-shrink: 0;
+  font-weight: 500;
+}
+
+.assistant-work-rule {
+  height: 1px;
+  flex: 1;
+  min-width: 24px;
+  background: var(--border-light);
+}
+
+/* ===================================================================
    Bubble meta
    =================================================================== */
 

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -268,31 +268,27 @@
   :global {
     /* Tool group */
     .tool-group {
-      position: relative;
-      margin: 10px 0 12px;
-      border: 1px solid var(--border);
-      border-radius: var(--radius-sm);
-      background: var(--bg-card);
+      margin: 8px 0;
+      color: var(--text-muted);
     }
 
     .tool-group-header-btn {
-      position: absolute;
-      top: -8px;
-      left: 8px;
       appearance: none;
+      width: 100%;
       border: 0;
-      background: var(--bg-primary);
-      display: inline-flex;
+      background: transparent;
+      display: flex;
       align-items: center;
-      gap: 4px;
-      padding: 0 6px;
-      font-size: 10px;
+      gap: 7px;
+      padding: 3px 0;
+      font-family: var(--font-sans);
+      font-size: 12px;
       font-weight: 500;
       color: var(--text-muted);
-      line-height: 16px;
+      line-height: 18px;
       cursor: pointer;
       user-select: none;
-      z-index: 1;
+      text-align: left;
     }
 
     .tool-group-header-btn:hover {
@@ -300,27 +296,47 @@
     }
 
     .tool-group-chevron {
-      font-size: 7px;
+      width: 12px;
+      font-size: 12px;
       line-height: 1;
       transition: transform 0.15s;
       transform: rotate(0deg);
       display: inline-block;
       flex-shrink: 0;
+      opacity: 0.65;
     }
 
     .tool-group.open .tool-group-chevron {
       transform: rotate(90deg);
     }
 
+    .tool-group-icon {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      flex: 0 0 8px;
+      background: var(--text-muted);
+      opacity: 0.7;
+    }
+
+    .tool-group-icon.running { background: var(--accent-blue); }
+    .tool-group-icon.success { background: var(--accent-green); }
+    .tool-group-icon.error { background: var(--danger); }
+
     .tool-group-label {
-      flex-shrink: 0;
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .tool-group-preview {
       display: flex;
       align-items: center;
       gap: 8px;
-      padding: 14px 10px 8px;
+      margin-left: 27px;
+      padding: 0 0 4px;
       min-width: 0;
     }
 
@@ -339,11 +355,11 @@
       flex-shrink: 0;
       font-size: 12px;
       font-weight: 500;
-      padding: 1px 6px;
-      border-radius: 999px;
-      &.running { color: var(--accent-blue);  background: color-mix(in srgb, var(--accent-blue) 14%, transparent); }
-      &.success { color: var(--accent-green); background: color-mix(in srgb, var(--accent-green) 14%, transparent); }
-      &.error   { color: var(--danger);       background: color-mix(in srgb, var(--danger) 14%, transparent); }
+      padding: 0;
+      border-radius: 0;
+      &.running { color: var(--accent-blue); }
+      &.success { color: var(--accent-green); }
+      &.error   { color: var(--danger); }
     }
 
     /* Collapse animation via CSS grid rows */
@@ -365,6 +381,8 @@
     .tool-group-list {
       display: flex;
       flex-direction: column;
+      margin-left: 27px;
+      border-left: 1px solid var(--border-light);
     }
 
     .tool-group.open .tool-group-preview {
@@ -373,7 +391,7 @@
 
     .tool-inline {
       overflow: hidden;
-      border-top: 1px solid var(--border);
+      border-top: 0;
     }
 
     .tool-group-list .tool-inline:first-child {
@@ -387,9 +405,9 @@
       background: none;
       display: flex;
       align-items: center;
-      gap: 8px;
-      min-height: 24px;
-      padding: 10px 10px;
+      gap: 7px;
+      min-height: 22px;
+      padding: 4px 0 4px 10px;
       text-align: left;
       cursor: default;
     }
@@ -469,9 +487,9 @@
       flex: 1;
       min-width: 0;
       font-family: var(--font-sans);
-      font-size: 13px;
+      font-size: 12px;
       font-weight: 500;
-      color: var(--text-primary);
+      color: var(--text-secondary);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -482,8 +500,8 @@
 
     .tool-inline-status {
       flex-shrink: 0;
-      font-size: 12px;
-      font-weight: 600;
+      font-size: 11px;
+      font-weight: 500;
       letter-spacing: 0;
       text-transform: none;
       color: var(--text-muted);
@@ -521,28 +539,24 @@
 
     /* Thinking blocks */
     .thinking-block {
-      position: relative;
       margin: 8px 0;
-      border: 1px solid var(--border);
-      border-radius: var(--radius-sm);
+      color: var(--text-muted);
     }
 
     .thinking-block-header {
-      position: absolute;
-      top: -8px;
-      left: 8px;
       display: inline-flex;
       align-items: center;
-      gap: 4px;
-      padding: 0 6px;
-      background: var(--bg-primary);
+      gap: 7px;
+      padding: 3px 0;
+      background: transparent;
       border: 0;
       cursor: pointer;
-      font-size: 10px;
+      font-family: var(--font-sans);
+      font-size: 12px;
+      font-weight: 500;
       color: var(--text-muted);
-      line-height: 16px;
+      line-height: 18px;
       user-select: none;
-      z-index: 1;
     }
 
     .thinking-block-header:hover {
@@ -550,8 +564,10 @@
     }
 
     .thinking-block-triangle {
-      font-size: 7px;
+      width: 12px;
+      font-size: 12px;
       transition: transform 0.15s;
+      opacity: 0.65;
     }
 
     .thinking-block.open .thinking-block-triangle {
@@ -559,7 +575,9 @@
     }
 
     .thinking-block-preview {
-      padding: 14px 10px 8px;
+      margin-left: 19px;
+      padding: 0 0 4px 10px;
+      border-left: 1px solid var(--border-light);
       font-size: 12px;
       line-height: 1.4;
       color: var(--text-muted);
@@ -592,7 +610,9 @@
 
     .thinking-block-body {
       display: none;
-      padding: 14px 10px 8px;
+      margin-left: 19px;
+      padding: 4px 0 4px 10px;
+      border-left: 1px solid var(--border-light);
       font-size: 13px;
       line-height: 1.5;
       color: var(--text-secondary);

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -546,8 +546,9 @@
     .thinking-block-header {
       display: inline-flex;
       align-items: center;
-      gap: 7px;
-      padding: 3px 0;
+      gap: 6px;
+      margin-left: 19px;
+      padding: 2px 0;
       background: transparent;
       border: 0;
       cursor: pointer;
@@ -581,7 +582,6 @@
       font-size: 12px;
       line-height: 1.4;
       color: var(--text-muted);
-      max-height: calc(14px + 1.4em + 8px);
       overflow: hidden;
 
       :global(.thinking-block-preview-md) {
@@ -604,26 +604,6 @@
       }
     }
 
-    .thinking-block.open .thinking-block-preview {
-      display: none;
-    }
-
-    .thinking-block-body {
-      display: none;
-      margin-left: 19px;
-      padding: 4px 0 4px 10px;
-      border-left: 1px solid var(--border-light);
-      font-size: 13px;
-      line-height: 1.5;
-      color: var(--text-secondary);
-      max-height: 400px;
-      overflow-y: auto;
-      word-break: break-word;
-    }
-
-    .thinking-block.open .thinking-block-body {
-      display: block;
-    }
 
     .thinking-dots {
       display: inline-flex;

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -707,7 +707,27 @@
 
 .assistant-work-label {
   flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border: 1px solid color-mix(in srgb, var(--accent-green) 28%, var(--border-light));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent-green) 8%, transparent);
+  color: var(--text-secondary);
   font-weight: 500;
+}
+
+.assistant-work-hint {
+  flex-shrink: 0;
+  color: var(--text-faint);
+  font-size: 12px;
+  opacity: 0;
+  transition: opacity 0.12s, color 0.12s;
+}
+
+.assistant-work-header:hover .assistant-work-hint {
+  opacity: 1;
+  color: var(--text-muted);
 }
 
 .assistant-work-chevron {

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -690,7 +690,7 @@
   background: transparent;
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 7px;
   margin: 4px 0 12px;
   padding: 0;
   color: var(--text-muted);
@@ -709,25 +709,31 @@
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  padding: 2px 8px;
-  border: 1px solid color-mix(in srgb, var(--accent-green) 28%, var(--border-light));
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--accent-green) 8%, transparent);
+  gap: 7px;
   color: var(--text-secondary);
-  font-weight: 500;
+  font-weight: 600;
+}
+
+.assistant-work-label::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent-green);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-green) 12%, transparent);
 }
 
 .assistant-work-hint {
   flex-shrink: 0;
   color: var(--text-faint);
   font-size: 12px;
-  opacity: 0;
+  opacity: 0.55;
   transition: opacity 0.12s, color 0.12s;
 }
 
 .assistant-work-header:hover .assistant-work-hint {
   opacity: 1;
-  color: var(--text-muted);
+  color: var(--accent-green);
 }
 
 .assistant-work-chevron {

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -268,7 +268,7 @@
   :global {
     /* Tool group */
     .tool-group {
-      margin: 8px 0;
+      margin: 10px 0;
       color: var(--text-muted);
     }
 
@@ -296,8 +296,8 @@
     }
 
     .tool-group-chevron {
-      width: 12px;
-      font-size: 12px;
+      width: 14px;
+      font-size: 14px;
       line-height: 1;
       transition: transform 0.15s;
       transform: rotate(0deg);
@@ -311,10 +311,10 @@
     }
 
     .tool-group-icon {
-      width: 8px;
-      height: 8px;
+      width: 9px;
+      height: 9px;
       border-radius: 50%;
-      flex: 0 0 8px;
+      flex: 0 0 9px;
       background: var(--text-muted);
       opacity: 0.7;
     }
@@ -335,7 +335,7 @@
       display: flex;
       align-items: center;
       gap: 8px;
-      margin-left: 27px;
+      margin-left: 30px;
       padding: 0 0 4px;
       min-width: 0;
     }
@@ -381,7 +381,7 @@
     .tool-group-list {
       display: flex;
       flex-direction: column;
-      margin-left: 27px;
+      margin-left: 30px;
       border-left: 1px solid var(--border-light);
     }
 
@@ -406,14 +406,14 @@
       display: flex;
       align-items: center;
       gap: 7px;
-      min-height: 22px;
-      padding: 4px 0 4px 10px;
+      min-height: 24px;
+      padding: 5px 0 5px 10px;
       text-align: left;
       cursor: default;
     }
 
     .tool-inline-row.has-inline-diff {
-      cursor: default;
+      cursor: pointer;
     }
 
     .tool-inline-row.expandable {
@@ -438,6 +438,55 @@
 
     .tool-inline-row.expandable:hover .tool-inline-open {
       opacity: 0.8;
+    }
+
+    .tool-inline-chevron {
+      width: 12px;
+      flex: 0 0 12px;
+      color: var(--text-muted);
+      font-size: 13px;
+      line-height: 1;
+      opacity: 0.65;
+      transition: transform 0.15s;
+    }
+
+    .tool-inline.open .tool-inline-chevron {
+      transform: rotate(90deg);
+    }
+
+    .tool-inline-detail {
+      margin: 0 0 8px 29px;
+    }
+
+    .tool-inline-output {
+      margin: 4px 0 0;
+      padding: 12px 14px;
+      border-radius: var(--radius-md);
+      background: var(--bg-card);
+      border: 1px solid var(--border-light);
+      color: var(--text-secondary);
+      font-family: var(--font-mono);
+      font-size: 12px;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      overflow-x: auto;
+    }
+
+    .tool-inline-output.error {
+      color: var(--danger);
+      border-color: color-mix(in srgb, var(--danger) 25%, var(--border-light));
+    }
+
+    .tool-inline-open-full {
+      appearance: none;
+      margin-top: 6px;
+      padding: 0;
+      border: 0;
+      background: transparent;
+      color: var(--accent);
+      font: inherit;
+      font-size: 12px;
+      cursor: pointer;
     }
 
     .tool-preview-btn {
@@ -630,14 +679,30 @@
    Assistant activity timeline
    =================================================================== */
 
+.assistant-work-section {
+  margin: 4px 0 14px;
+}
+
 .assistant-work-header {
+  appearance: none;
+  width: 100%;
+  border: 0;
+  background: transparent;
   display: flex;
   align-items: center;
   gap: 8px;
   margin: 4px 0 12px;
+  padding: 0;
   color: var(--text-muted);
+  font-family: var(--font-sans);
   font-size: 13px;
   line-height: 18px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.assistant-work-header:hover {
+  color: var(--text-secondary);
 }
 
 .assistant-work-label {
@@ -645,11 +710,27 @@
   font-weight: 500;
 }
 
+.assistant-work-chevron {
+  flex-shrink: 0;
+  font-size: 16px;
+  line-height: 1;
+  opacity: 0.7;
+  transition: transform 0.15s;
+}
+
+.assistant-work-section-open .assistant-work-chevron {
+  transform: rotate(90deg);
+}
+
 .assistant-work-rule {
   height: 1px;
   flex: 1;
   min-width: 24px;
   background: var(--border-light);
+}
+
+.assistant-work-body {
+  margin-bottom: 12px;
 }
 
 /* ===================================================================

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -573,6 +573,7 @@ function AssistantWorkSection({
         aria-expanded={expanded}
       >
         <span className={styles.assistantWorkLabel}>{getAssistantWorkLabel(message, working)}</span>
+        <span className={styles.assistantWorkHint}>{expanded ? 'Hide work' : 'Show work'}</span>
         <span className={styles.assistantWorkChevron}>›</span>
         {working ? (
           <span className="thinking-dots" aria-hidden="true">

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -243,44 +243,39 @@ function StreamingMarkdown({ text }: { text: string }) {
 }
 
 function ThinkingBlockView({ block }: { block: ContentBlock }) {
-  const [manualToggle, setManualToggle] = useState<boolean | null>(null);
-  const isOpen = manualToggle ?? true;
+  const [expanded, setExpanded] = useState(false);
 
   if (!block.thinking?.trim()) return null;
 
   const thinkingText = String(block.thinking || '');
-  const previewLength = 120;
-  const preview = thinkingText.length > previewLength
+  const previewLength = 220;
+  const hasMore = thinkingText.length > previewLength;
+  const preview = hasMore
     ? `${thinkingText.slice(0, previewLength).trimEnd()}...`
     : thinkingText;
 
   return (
-    <div className={`thinking-block${block.streaming ? ' streaming' : ''}${isOpen ? ' open' : ''}`}>
-      <button
-        type="button"
-        className="thinking-block-header"
-        onClick={() => setManualToggle((prev) => !(prev ?? true))}
-      >
-        <span className="thinking-block-triangle">›</span>
-        <span>Thinking</span>
-        {block.streaming ? (
-          <span className="thinking-dots" aria-hidden="true">
-            <span />
-            <span />
-            <span />
-          </span>
-        ) : null}
-      </button>
-      {!isOpen && (
-        <div className="thinking-block-preview">
-          <MarkdownContent text={preview} className="thinking-block-preview-md" />
-        </div>
-      )}
-      <div className="thinking-block-body">
-        {block.streaming
-          ? <StreamingMarkdown text={thinkingText} />
-          : <MarkdownContent text={thinkingText} className="thinking-block-markdown" />}
+    <div className={`thinking-block${block.streaming ? ' streaming' : ''}${expanded ? ' open' : ''}`}>
+      <div className="thinking-block-preview">
+        <MarkdownContent text={expanded ? thinkingText : preview} className="thinking-block-preview-md" />
       </div>
+      {(hasMore || block.streaming) ? (
+        <button
+          type="button"
+          className="thinking-block-header"
+          onClick={() => setExpanded((prev) => !prev)}
+        >
+          <span>{expanded ? 'Show less' : 'Show more'}</span>
+          <span className="thinking-block-triangle">›</span>
+          {block.streaming ? (
+            <span className="thinking-dots" aria-hidden="true">
+              <span />
+              <span />
+              <span />
+            </span>
+          ) : null}
+        </button>
+      ) : null}
     </div>
   );
 }
@@ -413,8 +408,8 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
   }
   if (anyRunning) wasRunningRef.current = true;
 
-  // Keep finished work compact by default, but open live/running work.
-  const isOpen = manualToggle ?? anyRunning;
+  // Keep work compact by default. Details are there when the user asks.
+  const isOpen = manualToggle ?? false;
 
   const groupStatus: 'running' | 'success' | 'error' = anyRunning ? 'running' : anyError ? 'error' : 'success';
   const groupStatusLabel = anyRunning ? 'Running' : anyError ? 'Error' : 'Done';
@@ -436,7 +431,7 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
         <button
           type="button"
           className="tool-group-header-btn"
-          onClick={() => setManualToggle((prev) => !(prev ?? anyRunning))}
+          onClick={() => setManualToggle((prev) => !(prev ?? false))}
         >
           <span className="tool-group-chevron">›</span>
           <span className={`tool-group-icon ${groupStatus}`} aria-hidden="true" />

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -145,26 +145,10 @@ function getAssistantWorkDuration(message: ChatMessage): string {
   return '';
 }
 
-function AssistantWorkHeader({ message, working, hasActivity }: { message: ChatMessage; working: boolean; hasActivity: boolean }) {
-  if (!working && !hasActivity) return null;
+function getAssistantWorkLabel(message: ChatMessage, working: boolean): string {
   const duration = getAssistantWorkDuration(message);
-  const label = working
-    ? 'Working'
-    : duration
-      ? `Worked for ${duration}`
-      : 'Worked';
-
-  return (
-    <div className={styles.assistantWorkHeader}>
-      <span className={styles.assistantWorkLabel}>{label}</span>
-      {working ? (
-        <span className="thinking-dots" aria-hidden="true">
-          <span /><span /><span />
-        </span>
-      ) : null}
-      <span className={styles.assistantWorkRule} aria-hidden="true" />
-    </div>
-  );
+  if (working) return 'Working';
+  return duration ? `Worked for ${duration}` : 'Worked';
 }
 
 // messagePrefix scopes the key to a specific message so that when
@@ -390,6 +374,73 @@ function ToolModal({ item, onClose }: { item: ToolRenderItem; onClose: () => voi
   );
 }
 
+function ToolInlineItem({ item, onOpenPreview, onOpenModal }: { item: ToolRenderItem; onOpenPreview?: (url: string) => void; onOpenModal: (item: ToolRenderItem) => void }) {
+  const [expanded, setExpanded] = useState(false);
+  const hasInlineDiff = item.kind === 'edit' && item.diff.length > 0;
+  const hasDetail = item.diff.length > 0 || item.output.trim().length > 0;
+
+  const statusNode =
+    hasInlineDiff ? (
+      <span className={`tool-inline-status ${item.status}`}>
+        <span className="diff-additions">+{item.additions}</span>
+        {' / '}
+        <span className="diff-removals">-{item.removals}</span>
+      </span>
+    ) : (
+      <span className={`tool-inline-status ${item.status}`}>
+        {item.kind === 'bash' && item.outputLineCount > 0
+          ? `${item.outputLineCount} lines`
+          : item.status === 'running'
+            ? 'Running'
+            : item.status === 'error'
+              ? 'Error'
+              : 'Done'}
+      </span>
+    );
+
+  return (
+    <div className={`tool-inline${expanded ? ' open' : ''}`}>
+      <button
+        type="button"
+        className={`tool-inline-row${hasDetail ? ' expandable' : ''}${hasInlineDiff ? ' has-inline-diff' : ''}`}
+        onClick={() => hasDetail && setExpanded((prev) => !prev)}
+      >
+        <span className="tool-inline-chevron">›</span>
+        <span className={`tool-inline-dot ${item.status}`} />
+        <span className="tool-inline-label">{item.label}</span>
+        {statusNode}
+      </button>
+      {expanded && hasDetail ? (
+        <div className="tool-inline-detail">
+          {item.diff.length > 0 ? (
+            <ToolDiffInline diff={item.diff} />
+          ) : item.output.trim().length > 0 ? (
+            <pre className={`tool-inline-output${item.status === 'error' ? ' error' : ''}`}>
+              {item.output.length > 6000 ? `${item.output.slice(0, 6000)}\n... (truncated)` : item.output}
+            </pre>
+          ) : null}
+          {item.output.length > 6000 ? (
+            <button type="button" className="tool-inline-open-full" onClick={() => onOpenModal(item)}>
+              Open full output
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+      {item.previewUrl && onOpenPreview && (
+        <button
+          type="button"
+          className="tool-preview-btn"
+          onClick={(e) => { e.stopPropagation(); onOpenPreview(item.previewUrl!); }}
+          title={`Preview ${item.previewUrl}`}
+        >
+          <HugeiconsIcon icon={BrowserIcon} size={12} strokeWidth={1.5} />
+          Preview
+        </button>
+      )}
+    </div>
+  );
+}
+
 function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOpenPreview?: (url: string) => void }) {
   const [manualToggle, setManualToggle] = useState<boolean | null>(null);
   const [modalItem, setModalItem] = useState<ToolRenderItem | null>(null);
@@ -415,15 +466,6 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
   const groupStatusLabel = anyRunning ? 'Running' : anyError ? 'Error' : 'Done';
   const activitySummary = summarizeToolActivity(items);
   const label = activitySummary.label;
-  const runningSummary = items
-    .filter((item) => item.status === 'running')
-    .map((item) => item.label)
-    .join(' / ');
-  const preview = items
-    .slice(0, 3)
-    .map((item) => item.label)
-    .join(' • ');
-  const previewSuffix = items.length > 3 ? ` +${items.length - 3} more` : '';
 
   return (
     <>
@@ -442,70 +484,22 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
             </span>
           ) : null}
         </button>
-        {!isOpen ? (
+        {!isOpen && groupStatus !== 'success' ? (
           <div className="tool-group-preview">
-            <span className="tool-group-preview-text">
-              {runningSummary || preview}
-              {previewSuffix}
-            </span>
-            {groupStatus !== 'success' ? (
-              <span className={`tool-group-status ${groupStatus}`}>{groupStatusLabel}</span>
-            ) : null}
+            <span className={`tool-group-status ${groupStatus}`}>{groupStatusLabel}</span>
           </div>
         ) : null}
         <div className={`tool-group-list-wrap${isOpen ? '' : ' collapsed'}`}>
           <div className="tool-group-list-inner">
             <div className="tool-group-list">
-              {items.map((item) => {
-                const hasInlineDiff = item.kind === 'edit' && item.diff.length > 0;
-                const hasDetail = !hasInlineDiff && (item.diff.length > 0 || item.output.trim().length > 0);
-
-                const statusNode =
-                  hasInlineDiff ? (
-                    <span className={`tool-inline-status ${item.status}`}>
-                      <span className="diff-additions">+{item.additions}</span>
-                      {' / '}
-                      <span className="diff-removals">-{item.removals}</span>
-                    </span>
-                  ) : (
-                    <span className={`tool-inline-status ${item.status}`}>
-                      {item.kind === 'bash' && item.outputLineCount > 0
-                        ? `${item.outputLineCount} lines`
-                        : item.status === 'running'
-                          ? 'Running'
-                          : item.status === 'error'
-                            ? 'Error'
-                            : 'Done'}
-                    </span>
-                  );
-
-                return (
-                  <div key={item.id} className="tool-inline">
-                    <button
-                      type="button"
-                      className={`tool-inline-row${hasDetail ? ' expandable' : ''}${hasInlineDiff ? ' has-inline-diff' : ''}`}
-                      onClick={() => hasDetail && setModalItem(item)}
-                    >
-                      <span className={`tool-inline-dot ${item.status}`} />
-                      <span className="tool-inline-label">{item.label}</span>
-                      {statusNode}
-                      <span className={`tool-inline-open${hasDetail ? '' : ' hidden'}`}>↗</span>
-                    </button>
-                    {item.previewUrl && onOpenPreview && (
-                      <button
-                        type="button"
-                        className="tool-preview-btn"
-                        onClick={(e) => { e.stopPropagation(); onOpenPreview(item.previewUrl!); }}
-                        title={`Preview ${item.previewUrl}`}
-                      >
-                        <HugeiconsIcon icon={BrowserIcon} size={12} strokeWidth={1.5} />
-                        Preview
-                      </button>
-                    )}
-                    {hasInlineDiff ? <ToolDiffInline diff={item.diff} /> : null}
-                  </div>
-                );
-              })}
+              {items.map((item) => (
+                <ToolInlineItem
+                  key={item.id}
+                  item={item}
+                  onOpenPreview={onOpenPreview}
+                  onOpenModal={setModalItem}
+                />
+              ))}
             </div>
           </div>
         </div>
@@ -550,6 +544,62 @@ function renderAssistantBlocks(
 
   flushToolGroup();
   return nodes;
+}
+
+function AssistantWorkSection({
+  message,
+  blocks,
+  working,
+  messagePrefix,
+  onOpenPreview,
+  conversationId,
+}: {
+  message: ChatMessage;
+  blocks: ContentBlock[];
+  working: boolean;
+  messagePrefix: string;
+  onOpenPreview?: (url: string) => void;
+  conversationId?: string;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  if (blocks.length === 0) return null;
+
+  return (
+    <section className={`${styles.assistantWorkSection}${expanded ? ` ${styles.assistantWorkSectionOpen}` : ''}`}>
+      <button
+        type="button"
+        className={styles.assistantWorkHeader}
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+      >
+        <span className={styles.assistantWorkLabel}>{getAssistantWorkLabel(message, working)}</span>
+        <span className={styles.assistantWorkChevron}>›</span>
+        {working ? (
+          <span className="thinking-dots" aria-hidden="true">
+            <span /><span /><span />
+          </span>
+        ) : null}
+        <span className={styles.assistantWorkRule} aria-hidden="true" />
+      </button>
+      {expanded ? (
+        <div className={styles.assistantWorkBody}>
+          {renderAssistantBlocks(blocks, working, `${messagePrefix}-work`, onOpenPreview, conversationId)}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function splitAssistantDisplayBlocks(orderedParts: ReturnType<typeof buildAssistantTurnContent>['orderedParts']): { workBlocks: ContentBlock[]; answerBlocks: ContentBlock[] } {
+  const lastProcessIndex = orderedParts.reduce((lastIndex, part, index) => part.kind === 'process' ? index : lastIndex, -1);
+  if (lastProcessIndex < 0) {
+    return { workBlocks: [], answerBlocks: orderedParts.map((part) => part.block) };
+  }
+
+  return {
+    workBlocks: orderedParts.slice(0, lastProcessIndex + 1).map((part) => part.block),
+    answerBlocks: orderedParts.slice(lastProcessIndex + 1).map((part) => part.block),
+  };
 }
 
 function FileAttachmentBlock({ block, conversationId }: { block: ContentBlock; conversationId?: string }) {
@@ -812,12 +862,18 @@ export function ChatBubble({ message, streaming = false, onOpenPreview, conversa
   const content = useMemo(() => {
     if (message.role === 'assistant') {
       const assistantTurnContent = buildAssistantTurnContent(message.content);
-      const inlineBlocks = assistantTurnContent.orderedParts.map((part) => part.block);
-      const hasActivity = assistantTurnContent.processBlocks.length > 0;
+      const { workBlocks, answerBlocks } = splitAssistantDisplayBlocks(assistantTurnContent.orderedParts);
       return (
         <>
-          <AssistantWorkHeader message={message} working={isStreamingBubble} hasActivity={hasActivity} />
-          {renderAssistantBlocks(inlineBlocks, isStreamingBubble, messagePrefix, onOpenPreview, conversationId)}
+          <AssistantWorkSection
+            message={message}
+            blocks={workBlocks}
+            working={isStreamingBubble}
+            messagePrefix={messagePrefix}
+            onOpenPreview={onOpenPreview}
+            conversationId={conversationId}
+          />
+          {renderAssistantBlocks(answerBlocks, isStreamingBubble, `${messagePrefix}-answer`, onOpenPreview, conversationId)}
         </>
       );
     }

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -127,6 +127,46 @@ function summarizeToolActivity(items: ToolRenderItem[]): ActivitySummary {
   return { label: `Used ${pluralize(items.length, 'tool')}`, verb: 'Used', noun: 'tools' };
 }
 
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '';
+  if (ms < 1000) return '<1s';
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+}
+
+function getAssistantWorkDuration(message: ChatMessage): string {
+  const latencyMs = Number(message.meta?.latencyMs);
+  if (Number.isFinite(latencyMs) && latencyMs > 0) {
+    return formatDuration(latencyMs);
+  }
+  return '';
+}
+
+function AssistantWorkHeader({ message, working, hasActivity }: { message: ChatMessage; working: boolean; hasActivity: boolean }) {
+  if (!working && !hasActivity) return null;
+  const duration = getAssistantWorkDuration(message);
+  const label = working
+    ? 'Working'
+    : duration
+      ? `Worked for ${duration}`
+      : 'Worked';
+
+  return (
+    <div className={styles.assistantWorkHeader}>
+      <span className={styles.assistantWorkLabel}>{label}</span>
+      {working ? (
+        <span className="thinking-dots" aria-hidden="true">
+          <span /><span /><span />
+        </span>
+      ) : null}
+      <span className={styles.assistantWorkRule} aria-hidden="true" />
+    </div>
+  );
+}
+
 // messagePrefix scopes the key to a specific message so that when
 // buildDisplayMessages merges consecutive assistant turns, two text-0 blocks
 // from different turns don't share the same React key.
@@ -413,7 +453,9 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
               {runningSummary || preview}
               {previewSuffix}
             </span>
-            <span className={`tool-group-status ${groupStatus}`}>{groupStatusLabel}</span>
+            {groupStatus !== 'success' ? (
+              <span className={`tool-group-status ${groupStatus}`}>{groupStatusLabel}</span>
+            ) : null}
           </div>
         ) : null}
         <div className={`tool-group-list-wrap${isOpen ? '' : ' collapsed'}`}>
@@ -776,7 +818,13 @@ export function ChatBubble({ message, streaming = false, onOpenPreview, conversa
     if (message.role === 'assistant') {
       const assistantTurnContent = buildAssistantTurnContent(message.content);
       const inlineBlocks = assistantTurnContent.orderedParts.map((part) => part.block);
-      return renderAssistantBlocks(inlineBlocks, isStreamingBubble, messagePrefix, onOpenPreview, conversationId);
+      const hasActivity = assistantTurnContent.processBlocks.length > 0;
+      return (
+        <>
+          <AssistantWorkHeader message={message} working={isStreamingBubble} hasActivity={hasActivity} />
+          {renderAssistantBlocks(inlineBlocks, isStreamingBubble, messagePrefix, onOpenPreview, conversationId)}
+        </>
+      );
     }
 
     if (typeof message.content === 'string') {

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -561,7 +561,7 @@ function AssistantWorkSection({
   onOpenPreview?: (url: string) => void;
   conversationId?: string;
 }) {
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(false);
   if (blocks.length === 0) return null;
 
   return (

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -89,6 +89,43 @@ function buildToolRenderItem(block: ContentBlock, index: number): ToolRenderItem
   };
 }
 
+type ActivitySummary = {
+  label: string;
+  verb: string;
+  noun: string;
+};
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function summarizeToolActivity(items: ToolRenderItem[]): ActivitySummary {
+  const kinds = new Set(items.map((item) => item.kind));
+  if ([...kinds].every((kind) => ['read', 'grep', 'find', 'ls'].includes(kind))) {
+    const reads = items.filter((item) => item.kind === 'read').length;
+    const searches = items.filter((item) => item.kind === 'grep' || item.kind === 'find').length;
+    const lists = items.filter((item) => item.kind === 'ls').length;
+    const bits = [
+      reads > 0 ? pluralize(reads, 'file') : '',
+      searches > 0 ? pluralize(searches, 'search', 'searches') : '',
+      lists > 0 ? pluralize(lists, 'list') : '',
+    ].filter(Boolean);
+    return { label: `Explored ${bits.join(', ') || pluralize(items.length, 'item')}`, verb: 'Explored', noun: 'files' };
+  }
+  if ([...kinds].every((kind) => ['edit', 'write'].includes(kind))) {
+    return { label: `Edited ${pluralize(items.length, 'file')}`, verb: 'Edited', noun: 'files' };
+  }
+  if ([...kinds].every((kind) => kind === 'bash')) {
+    return { label: `Ran ${pluralize(items.length, 'command')}`, verb: 'Ran', noun: 'commands' };
+  }
+  if ([...kinds].every((kind) => ['web_fetch'].includes(kind))) {
+    return { label: `Researched ${pluralize(items.length, 'page')}`, verb: 'Researched', noun: 'pages' };
+  }
+  if ([...kinds].every((kind) => ['open_browser_preview', 'start_dev_server'].includes(kind))) {
+    return { label: `Opened ${pluralize(items.length, 'preview')}`, verb: 'Previewed', noun: 'preview' };
+  }
+  return { label: `Used ${pluralize(items.length, 'tool')}`, verb: 'Used', noun: 'tools' };
+}
 
 // messagePrefix scopes the key to a specific message so that when
 // buildDisplayMessages merges consecutive assistant turns, two text-0 blocks
@@ -184,8 +221,8 @@ function ThinkingBlockView({ block }: { block: ContentBlock }) {
         className="thinking-block-header"
         onClick={() => setManualToggle((prev) => !(prev ?? true))}
       >
-        <span className="thinking-block-triangle">▶</span>
-        <span>Internal Thoughts</span>
+        <span className="thinking-block-triangle">›</span>
+        <span>Thinking</span>
         {block.streaming ? (
           <span className="thinking-dots" aria-hidden="true">
             <span />
@@ -336,12 +373,13 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
   }
   if (anyRunning) wasRunningRef.current = true;
 
-  // Open by default (unless user manually collapsed)
-  const isOpen = manualToggle ?? true;
+  // Keep finished work compact by default, but open live/running work.
+  const isOpen = manualToggle ?? anyRunning;
 
   const groupStatus: 'running' | 'success' | 'error' = anyRunning ? 'running' : anyError ? 'error' : 'success';
   const groupStatusLabel = anyRunning ? 'Running' : anyError ? 'Error' : 'Done';
-  const label = `Tools (${items.length})`;
+  const activitySummary = summarizeToolActivity(items);
+  const label = activitySummary.label;
   const runningSummary = items
     .filter((item) => item.status === 'running')
     .map((item) => item.label)
@@ -361,6 +399,7 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
           onClick={() => setManualToggle((prev) => !(prev ?? anyRunning))}
         >
           <span className="tool-group-chevron">›</span>
+          <span className={`tool-group-icon ${groupStatus}`} aria-hidden="true" />
           <span className="tool-group-label">{label}</span>
           {anyRunning ? (
             <span className="thinking-dots" aria-hidden="true">

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -592,14 +592,9 @@ function AssistantWorkSection({
 }
 
 function splitAssistantDisplayBlocks(orderedParts: ReturnType<typeof buildAssistantTurnContent>['orderedParts']): { workBlocks: ContentBlock[]; answerBlocks: ContentBlock[] } {
-  const lastProcessIndex = orderedParts.reduce((lastIndex, part, index) => part.kind === 'process' ? index : lastIndex, -1);
-  if (lastProcessIndex < 0) {
-    return { workBlocks: [], answerBlocks: orderedParts.map((part) => part.block) };
-  }
-
   return {
-    workBlocks: orderedParts.slice(0, lastProcessIndex + 1).map((part) => part.block),
-    answerBlocks: orderedParts.slice(lastProcessIndex + 1).map((part) => part.block),
+    workBlocks: orderedParts.filter((part) => part.kind === 'process').map((part) => part.block),
+    answerBlocks: orderedParts.filter((part) => part.kind === 'response').map((part) => part.block),
   };
 }
 


### PR DESCRIPTION
## Summary

Adds the first production pass for inline assistant activity in the chat flow.

This builds on the assistant turn activity separation foundation branch and keeps the activity inside the assistant message rather than introducing a sidebar. The goal is a compact, Codex-style hierarchy where the final answer stays readable and the process/tool details are available when the user wants them.

## What changed

- Adds a collapsible `Worked` / `Working` section inside assistant turns.
- Keeps normal assistant text visible in the main response flow.
- Groups tool activity into compact summary rows, such as explored files or ran commands.
- Adds nested expansion for individual tool details and outputs.
- Keeps the work section collapsed by default so the answer stays primary.
- Uses the foundation branch’s final-response copy behavior so copied answers skip progress/update lines.

## Notes

The UI styling here is proposed and does not have to be final exactly as-is. The main goal of this PR is to establish the inline hierarchy and interaction model for assistant activity.

## Validation

- `pnpm --filter=@antseed/desktop exec tsc -p tsconfig.renderer.json --noEmit`
- `git diff --check`
