### PR TITLE
feat(metadata): v2 format with service/model hash (word[4])

### DIFF
--- a/packages/contracts/AntseedChannels.sol
+++ b/packages/contracts/AntseedChannels.sol
@@ -80,6 +80,11 @@ contract AntseedChannels is EIP712, Pausable, Ownable, ReentrancyGuard {
 
     // ─── Events ─────────────────────────────────────────────────────
     event Reserved(bytes32 indexed channelId, address indexed buyer, address indexed seller, uint128 maxAmount);
+    /// @dev `metadata` is ABI-encoded as N × uint256 words.
+    ///      v1 (4 words): [version=1, inputTokens, outputTokens, requestCount]
+    ///      v2 (5 words): [version=2, inputTokens, outputTokens, requestCount, serviceHash]
+    ///      where serviceHash = uint256(keccak256(bytes(serviceName))), zero = unknown.
+    ///      The contract does not decode metadata; it only verifies keccak256(metadata).
     event ChannelSettled(bytes32 indexed channelId, address indexed buyer, address indexed seller, uint128 cumulativeAmount, uint128 delta, uint128 totalSettled, uint256 platformFee, bytes metadata);
     event ChannelClosed(bytes32 indexed channelId, address indexed buyer, address indexed seller, uint128 settledAmount, uint128 refund);
     event ChannelTopUp(bytes32 indexed channelId, address indexed buyer, address indexed seller, uint128 additionalAmount, uint128 newDeposit);

--- a/packages/contracts/test/AntseedChannels.t.sol
+++ b/packages/contracts/test/AntseedChannels.t.sol
@@ -1126,4 +1126,69 @@ contract AntseedChannelsTest is Test {
         channels.requestClose(channelId);
     }
 
+    // ═══════════════════════════════════════════════════════════════════
+    //                   METADATA V2 TESTS
+    // ═══════════════════════════════════════════════════════════════════
+
+    uint256 constant METADATA_VERSION_V2 = 2;
+
+    function encodeMetadataV2(
+        uint256 inputTokens,
+        uint256 outputTokens,
+        bytes32 serviceHash
+    ) internal pure returns (bytes memory) {
+        return abi.encode(METADATA_VERSION_V2, inputTokens, outputTokens, uint256(0), uint256(serviceHash));
+    }
+
+    function signSpendingAuthV2(
+        uint256 pk,
+        bytes32 channelId,
+        uint256 cumulativeAmount,
+        uint256 inputTokens,
+        uint256 outputTokens,
+        bytes32 serviceHash
+    ) internal view returns (bytes memory) {
+        bytes32 metadataHash = keccak256(abi.encode(METADATA_VERSION_V2, inputTokens, outputTokens, uint256(0), uint256(serviceHash)));
+        bytes32 structHash = keccak256(
+            abi.encode(
+                SPENDING_AUTH_TYPEHASH,
+                channelId,
+                cumulativeAmount,
+                metadataHash
+            )
+        );
+        bytes32 digest = _hashTypedDataChannels(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function test_settle_v2MetadataEmitsServiceHash() public {
+        bytes32 salt = keccak256("session-v2-metadata");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        uint128 settleAmount = USDC_60;
+        uint256 inputTokens = 10_000;
+        uint256 outputTokens = 3_000;
+        // serviceHash = keccak256("gpt-4o") as uint256, matching the hashServiceName() logic in signatures.ts
+        bytes32 serviceHash = keccak256(bytes("gpt-4o"));
+
+        bytes memory metadata = encodeMetadataV2(inputTokens, outputTokens, serviceHash);
+        bytes memory sig = signSpendingAuthV2(BUYER_PK, channelId, settleAmount, inputTokens, outputTokens, serviceHash);
+
+        // Expect the ChannelSettled event to carry the v2 metadata bytes verbatim
+        vm.expectEmit(true, true, true, true);
+        emit AntseedChannels.ChannelSettled(channelId, buyer, seller, settleAmount, settleAmount, settleAmount, (uint256(settleAmount) * 200) / 10000, metadata);
+
+        vm.prank(seller);
+        channels.settle(channelId, settleAmount, metadata, sig);
+
+        // Verify the emitted metadata decodes back to our v2 fields
+        (uint256 ver, uint256 inTok, uint256 outTok, , uint256 sHash) =
+            abi.decode(metadata, (uint256, uint256, uint256, uint256, uint256));
+        assertEq(ver, METADATA_VERSION_V2);
+        assertEq(inTok, inputTokens);
+        assertEq(outTok, outputTokens);
+        assertEq(sHash, uint256(serviceHash));
+    }
+
 }

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -14,6 +14,7 @@ import {
   makeChannelsDomain,
   computeMetadataHash,
   encodeMetadata,
+  hashServiceName,
   ZERO_METADATA,
   ZERO_METADATA_HASH,
   computeChannelId,
@@ -90,6 +91,11 @@ export class BuyerPaymentManager {
    *  Used in handleNeedAuth to validate cost with the correct pricing tier
    *  without trusting the seller's claim of which service was used. */
   private readonly _requestService = new Map<string, string>();
+
+  /** sellerPeerId -> most recent service/model name used in this channel.
+   *  Included as serviceHash (word[4]) in v2 metadata so the explorer can
+   *  recover the model from the ChannelSettled event. */
+  private readonly _currentService = new Map<string, string>();
 
   /** sellerPeerId -> full pricing map (defaults + per-service overrides from peer metadata / 402) */
   private readonly _sessionPricing = new Map<string, { defaults: ServicePricing; services: Record<string, ServicePricing> }>();
@@ -180,6 +186,7 @@ export class BuyerPaymentManager {
     this._confirmedPeers.delete(sellerPeerId);
     this._rejectedPeers.delete(sellerPeerId);
     this._responseTokenTotals.delete(sellerPeerId);
+    this._currentService.delete(sellerPeerId);
   }
 
   getActiveSession(sellerPeerId: string): StoredChannel | null {
@@ -717,10 +724,13 @@ export class BuyerPaymentManager {
 
     // Update cumulative metadata
     const prev = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
+    if (responseStats.service) this._currentService.set(sellerPeerId, responseStats.service);
+    const currentService = this._currentService.get(sellerPeerId);
     const newMeta: SpendingAuthMetadata = {
       cumulativeInputTokens: prev.cumulativeInputTokens + estimatedInputTokens,
       cumulativeOutputTokens: prev.cumulativeOutputTokens + estimatedOutputTokens,
       cumulativeRequestCount: prev.cumulativeRequestCount + 1n,
+      ...(currentService != null ? { serviceHash: hashServiceName(currentService) } : {}),
     };
     this._metadata.set(sellerPeerId, newMeta);
 
@@ -883,10 +893,13 @@ export class BuyerPaymentManager {
     // on-chain metadata stays consistent even when older sellers omit token
     // fields; absent token fields contribute 0 to the running totals.
     const prevMeta = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
+    if (buyerService) this._currentService.set(sellerPeerId, buyerService);
+    const currentService = this._currentService.get(sellerPeerId);
     const newMeta: SpendingAuthMetadata = {
       cumulativeInputTokens: prevMeta.cumulativeInputTokens + BigInt(payload.inputTokens ?? '0'),
       cumulativeOutputTokens: prevMeta.cumulativeOutputTokens + BigInt(payload.outputTokens ?? '0'),
       cumulativeRequestCount: prevMeta.cumulativeRequestCount + 1n,
+      ...(currentService != null ? { serviceHash: hashServiceName(currentService) } : {}),
     };
     this._metadata.set(sellerPeerId, newMeta);
 

--- a/packages/node/src/payments/evm/signatures.ts
+++ b/packages/node/src/payments/evm/signatures.ts
@@ -1,4 +1,4 @@
-import { type AbstractSigner, type TypedDataDomain, AbiCoder, keccak256 } from 'ethers';
+import { type AbstractSigner, type TypedDataDomain, AbiCoder, keccak256, toUtf8Bytes } from 'ethers';
 
 // =========================================================================
 // EIP-712 Types — AntSeed SpendingAuth (cumulative payment authorization)
@@ -50,26 +50,82 @@ export interface SetOperatorMessage {
 
 // =========================================================================
 // Metadata encoding
+//
+// v1 layout (4 × uint256):
+//   word[0] = 1                           (version)
+//   word[1] = cumulativeInputTokens
+//   word[2] = cumulativeOutputTokens
+//   word[3] = cumulativeRequestCount
+//
+// v2 layout (5 × uint256):
+//   word[0] = 2                           (version)
+//   word[1] = cumulativeInputTokens
+//   word[2] = cumulativeOutputTokens
+//   word[3] = cumulativeRequestCount
+//   word[4] = keccak256(abi.encodePacked(serviceName)) — bytes32 cast to uint256
+//             Zero if the service name is unknown.
+//
+// Indexers can derive the human-readable model name by reversing the hash
+// against the known service catalog in provider_directory.
 // =========================================================================
 
 export interface SpendingAuthMetadata {
   cumulativeInputTokens: bigint;
   cumulativeOutputTokens: bigint;
   cumulativeRequestCount: bigint;
+  /** keccak256 of the UTF-8 service/model name, cast to uint256. Zero = unknown. */
+  serviceHash?: bigint;
 }
 
-export const METADATA_VERSION = 1n;
+export const METADATA_VERSION_V1 = 1n;
+export const METADATA_VERSION_V2 = 2n;
+
+/** @deprecated Use METADATA_VERSION_V2. Kept for consumers that reference the old name. */
+export const METADATA_VERSION = METADATA_VERSION_V1;
+
+/** Compute the keccak256 service hash from a UTF-8 service name string. */
+export function hashServiceName(serviceName: string): bigint {
+  return BigInt(keccak256(toUtf8Bytes(serviceName)));
+}
 
 export function encodeMetadata(metadata: SpendingAuthMetadata): string {
   const coder = AbiCoder.defaultAbiCoder();
+  if (metadata.serviceHash != null && metadata.serviceHash !== 0n) {
+    return coder.encode(
+      ['uint256', 'uint256', 'uint256', 'uint256', 'uint256'],
+      [METADATA_VERSION_V2, metadata.cumulativeInputTokens, metadata.cumulativeOutputTokens, metadata.cumulativeRequestCount, metadata.serviceHash],
+    );
+  }
   return coder.encode(
     ['uint256', 'uint256', 'uint256', 'uint256'],
-    [METADATA_VERSION, metadata.cumulativeInputTokens, metadata.cumulativeOutputTokens, metadata.cumulativeRequestCount],
+    [METADATA_VERSION_V1, metadata.cumulativeInputTokens, metadata.cumulativeOutputTokens, metadata.cumulativeRequestCount],
   );
 }
 
 export function computeMetadataHash(metadata: SpendingAuthMetadata): string {
   return keccak256(encodeMetadata(metadata));
+}
+
+/** Decode a hex-encoded metadata blob emitted by a ChannelSettled event. */
+export function decodeMetadata(hex: string): SpendingAuthMetadata & { version: number } | null {
+  const raw = hex.startsWith('0x') ? hex.slice(2) : hex;
+  if (raw.length < 64 * 4) return null;
+  const word = (i: number): bigint => BigInt('0x' + raw.slice(i * 64, (i + 1) * 64));
+  try {
+    const version = Number(word(0));
+    const base = {
+      version,
+      cumulativeInputTokens: word(1),
+      cumulativeOutputTokens: word(2),
+      cumulativeRequestCount: word(3),
+    };
+    if (version >= 2 && raw.length >= 64 * 5) {
+      return { ...base, serviceHash: word(4) };
+    }
+    return base;
+  } catch {
+    return null;
+  }
 }
 
 export const ZERO_METADATA: SpendingAuthMetadata = {


### PR DESCRIPTION
## Problem

The `ChannelSettled` event carries no model/service information. The metadata field (`bytes`) currently ABI-encodes 4 × uint256:

```
[version=1, inputTokens, outputTokens, requestCount]
```

This makes it impossible for explorer/indexer tooling to answer "which model was used?" for a given settled channel, since model selection is an off-chain routing decision.

## Solution — Metadata v2

Add a fifth word: `serviceHash = uint256(keccak256(utf8(serviceName)))`, with `version = 2` as a discriminant. The encoding stays backward-compatible: v1 decoders that read 4 words continue to work; v2 decoders check `word[0]` and conditionally read `word[4]`.

```
v1 (4 words): [1, inputTokens, outputTokens, requestCount]
v2 (5 words): [2, inputTokens, outputTokens, requestCount, keccak256(serviceName)]
```

Zero serviceHash means "unknown" (backward-compat with callers that omit it).

## Changes

### `packages/node/src/payments/evm/signatures.ts`
- Add `serviceHash?: bigint` to `SpendingAuthMetadata`
- Add `hashServiceName(name: string): bigint` helper — `uint256(keccak256(toUtf8Bytes(name)))`
- `encodeMetadata`: emits v2 (5 words) when `serviceHash` is present and non-zero; falls back to v1 (4 words) otherwise
- Add `decodeMetadata` helper for the explorer to consume
- Keep `METADATA_VERSION` alias for backward-compat consumers

### `packages/node/src/payments/buyer-payment-manager.ts`
- Add `_currentService: Map<string, string>` (sellerPeerId → latest service slug)
- `signPerRequestAuth`: when `responseStats.service` is set, update `_currentService` and include `serviceHash` in metadata
- `handleNeedAuth`: when `buyerService` is resolved from `_requestService`, update `_currentService` and include `serviceHash` in metadata
- `cleanupSession`: clear `_currentService` on session teardown

### `packages/contracts/AntseedChannels.sol`
- NatSpec on `ChannelSettled` event documenting v2 layout — no ABI or logic changes (contract already accepts arbitrary `bytes calldata metadata` and only verifies `keccak256(metadata)`)

### `packages/contracts/test/AntseedChannels.t.sol`
- `test_settle_v2MetadataEmitsServiceHash`: reserve a channel, settle with v2 metadata carrying `keccak256("gpt-4o")`, assert `ChannelSettled` emits the full v2 bytes, assert decoded fields match

## Why no contract code change?

The `AntseedChannels` contract treats `metadata` as an opaque `bytes calldata` blob. It hashes it for EIP-712 verification and emits the raw bytes — no decoding. The 5-word v2 payload hashes correctly without any Solidity change.

## Migration path

- **New buyers** using updated `@antseed/node` will emit v2 metadata on every signed auth once a service slug is known for that channel
- **Old buyers** (v1) continue to work — contract is unchanged, explorers/indexers that read 4 words are unaffected
- **Explorer backfill**: impossible for historical events (no model in v1 data); only new post-deploy events will carry `serviceHash`

## Test plan
- [ ] `forge test --match-test test_settle_v2MetadataEmitsServiceHash` passes
- [ ] Existing `AntseedChannels.t.sol` tests unaffected (v1 encoding path unchanged)
- [ ] TypeScript: `encodeMetadata({ ..., serviceHash: hashServiceName('my-model') })` produces 5-word ABI encoding
- [ ] TypeScript: `encodeMetadata({ ... })` (no serviceHash) produces identical 4-word v1 output as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)