### PR TITLE
feat(contracts): Add emissions v2 upgrade path

### DIFF
--- a/apps/website/docs/guides/payments.md
+++ b/apps/website/docs/guides/payments.md
@@ -111,7 +111,7 @@ antseed seller emissions info
 | AntseedDeposits | `0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2` |
 | AntseedChannels | `0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d` |
 | AntseedStaking | `0x3652E6B22919bd322A25723B94BB207602E5c8e6` |
-| AntseedEmissions | `0x36877fBa8Fa333aa46a1c57b66D132E4995C86b5` |
+| AntseedEmissionsV2 | `0xF13bE52c4A3afC6AE29536f073588d01A0564088` |
 | ANTSToken | `0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263` |
 
 All contracts verified on [BaseScan](https://basescan.org). For testnet (Base Sepolia), set `payments.crypto.chainId` to `base-sepolia` in your config.

--- a/apps/website/docs/protocol/payments.md
+++ b/apps/website/docs/protocol/payments.md
@@ -161,7 +161,7 @@ Contract addresses are built into the CLI for each chain — no manual configura
 | AntseedChannels | `0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d` |
 | AntseedStaking | `0x3652E6B22919bd322A25723B94BB207602E5c8e6` |
 | AntseedStats | `0x15649ff076BFa5e37e24EE3154a00503149954Fd` |
-| AntseedEmissions | `0x36877fBa8Fa333aa46a1c57b66D132E4995C86b5` |
+| AntseedEmissionsV2 | `0xF13bE52c4A3afC6AE29536f073588d01A0564088` |
 | ANTSToken | `0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263` |
 | ERC-8004 IdentityRegistry | `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` |
 

--- a/apps/website/src/pages/ants-token.tsx
+++ b/apps/website/src/pages/ants-token.tsx
@@ -12,7 +12,7 @@ const ANTS_BASESCAN_URL = `https://basescan.org/token/${ANTS_TOKEN_ADDRESS}`;
 const EPOCH_DURATION = 604_800; // 1 week in seconds
 
 // Genesis timestamp from AntseedEmissions contract on Base mainnet (block 44469557)
-// Read via: eth_call genesis() on 0x36877fBa8Fa333aa46a1c57b66D132E4995C86b5
+// Read via: eth_call genesis() on 0xF13bE52c4A3afC6AE29536f073588d01A0564088
 const GENESIS: number = 1775728461; // 2026-04-09T09:54:21Z
 
 function useEpochCountdown() {

--- a/packages/contracts/AntseedEmissionsV2.sol
+++ b/packages/contracts/AntseedEmissionsV2.sol
@@ -1,0 +1,560 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import { IAntseedRegistry } from "./interfaces/IAntseedRegistry.sol";
+import { IAntseedDeposits } from "./interfaces/IAntseedDeposits.sol";
+import { IANTSToken } from "./interfaces/IANTSToken.sol";
+import { IAntseedSellerRewardsPool } from "./interfaces/IAntseedSellerRewardsPool.sol";
+import { IAntseedSellerUnlockPolicy } from "./interfaces/IAntseedSellerUnlockPolicy.sol";
+import { IAntseedPointsPolicy } from "./interfaces/IAntseedPointsPolicy.sol";
+
+interface IAntseedLegacyEmissions {
+    function EPOCH_DURATION() external view returns (uint256);
+    function HALVING_INTERVAL() external view returns (uint256);
+    function INITIAL_EMISSION() external view returns (uint256);
+    function genesis() external view returns (uint256);
+    function currentEpoch() external view returns (uint256);
+
+    function SELLER_SHARE_PCT() external view returns (uint256);
+    function BUYER_SHARE_PCT() external view returns (uint256);
+    function RESERVE_SHARE_PCT() external view returns (uint256);
+    function TEAM_SHARE_PCT() external view returns (uint256);
+    function MAX_SELLER_SHARE_PCT() external view returns (uint256);
+
+    function epochParams(uint256 epoch)
+        external
+        view
+        returns (
+            uint256 sellerSharePct,
+            uint256 buyerSharePct,
+            uint256 reserveSharePct,
+            uint256 teamSharePct,
+            uint256 maxSellerSharePct,
+            bool initialized
+        );
+
+    function epochTotalSellerPoints(uint256 epoch) external view returns (uint256);
+    function epochTotalBuyerPoints(uint256 epoch) external view returns (uint256);
+    function userSellerPoints(address seller, uint256 epoch) external view returns (uint256);
+    function userBuyerPoints(address buyer, uint256 epoch) external view returns (uint256);
+    function sellerEpochClaimed(address seller, uint256 epoch) external view returns (bool);
+    function buyerEpochClaimed(address buyer, uint256 epoch) external view returns (bool);
+}
+
+/**
+ * @title AntseedEmissionsV2
+ * @notice Backward-compatible emissions replacement for the deployed V1 system.
+ *
+ *         V2 keeps the V1 epoch clock by reading V1's genesis and emission
+ *         constants. It can be deployed in the middle of an epoch and combine
+ *         V1 pre-migration points with V2 post-migration points for that same
+ *         migration epoch.
+ *
+ *         New behavior:
+ *           - buyer per-epoch cap, with migration/legacy epochs snapshotted uncapped;
+ *           - seller rewards route to a locked rewards pool unless an on-chain
+ *             unlock policy allows immediate claim;
+ *           - optional pair-aware points policy hook for future buyer/seller
+ *             reputation multipliers without changing this emissions contract.
+ */
+contract AntseedEmissionsV2 is Ownable, Pausable, ReentrancyGuard {
+    // ─── Configuration ───
+    IAntseedRegistry public registry;
+    IAntseedLegacyEmissions public immutable legacyEmissions;
+    IAntseedSellerRewardsPool public sellerRewardsPool;
+    IAntseedSellerUnlockPolicy public sellerUnlockPolicy;
+    IAntseedPointsPolicy public pointsPolicy;
+
+    uint256 public immutable EPOCH_DURATION;
+    uint256 public immutable HALVING_INTERVAL;
+    uint256 public immutable INITIAL_EMISSION;
+    uint256 public immutable genesis;
+    uint256 public immutable MIGRATION_EPOCH;
+
+    uint256 public SELLER_SHARE_PCT;
+    uint256 public BUYER_SHARE_PCT;
+    uint256 public RESERVE_SHARE_PCT;
+    uint256 public TEAM_SHARE_PCT;
+    uint256 public MAX_SELLER_SHARE_PCT;
+    uint256 public MAX_BUYER_SHARE_PCT;
+
+    // ─── Per-Epoch Params (snapshotted on first V2 touch) ───
+    struct EpochParams {
+        uint256 sellerSharePct;
+        uint256 buyerSharePct;
+        uint256 reserveSharePct;
+        uint256 teamSharePct;
+        uint256 maxSellerSharePct;
+        uint256 maxBuyerSharePct;
+        bool initialized;
+    }
+
+    mapping(uint256 => EpochParams) public epochParams;
+
+    // ─── Per-Epoch Totals (V2 post-migration points only) ───
+    mapping(uint256 => uint256) public epochTotalSellerPoints;
+    mapping(uint256 => uint256) public epochTotalBuyerPoints;
+
+    // ─── Per-User State (V2 post-migration points and V2 claims) ───
+    mapping(address => mapping(uint256 => uint256)) public userSellerPoints;
+    mapping(address => mapping(uint256 => uint256)) public userBuyerPoints;
+    mapping(address => mapping(uint256 => bool)) public sellerEpochClaimed;
+    mapping(address => mapping(uint256 => bool)) public buyerEpochClaimed;
+
+    // ─── Reserve & Team ───
+    uint256 public reserveAccumulated;
+    uint256 public teamAccumulated;
+    mapping(uint256 => bool) public epochNonUserAccounted;
+
+    // ─── Events ───
+    event SellerPointsAccrued(address indexed seller, uint256 indexed epoch, uint256 pointsDelta);
+    event BuyerPointsAccrued(address indexed buyer, uint256 indexed epoch, uint256 pointsDelta);
+    event RawSellerPointsAccrued(
+        address indexed seller, uint256 indexed epoch, uint256 rawPoints, uint256 creditedPoints
+    );
+    event RawBuyerPointsAccrued(
+        address indexed buyer, uint256 indexed epoch, uint256 rawPoints, uint256 creditedPoints
+    );
+    event PairPointsAccrued(
+        bytes32 indexed channelId,
+        address indexed buyer,
+        address indexed seller,
+        uint256 epoch,
+        uint256 rawPoints,
+        uint256 creditedSellerPoints,
+        uint256 creditedBuyerPoints
+    );
+    event EmissionsClaimed(address indexed account, address indexed recipient, uint256 amount, uint256[] epochs);
+    event SellerEmissionsLocked(address indexed seller, address indexed pool, uint256 amount, uint256[] epochs);
+    event ReserveFlushed(address indexed destination, uint256 amount);
+    event TeamFlushed(address indexed destination, uint256 amount);
+    event SellerRewardsPoolSet(address indexed pool);
+    event SellerUnlockPolicySet(address indexed policy);
+    event PointsPolicySet(address indexed policy);
+    event MaxSellerSharePctSet(uint256 value);
+    event MaxBuyerSharePctSet(uint256 value);
+
+    // ─── Custom Errors ───
+    error NotAuthorized();
+    error EpochNotFinalized();
+    error InvalidShareSum();
+    error NoProtocolReserve();
+    error NoTeamWallet();
+    error NoReserve();
+    error NoTeamAccumulated();
+    error InvalidAddress();
+    error InvalidValue();
+
+    // ─── Modifiers ───
+    modifier onlyChannels() {
+        if (msg.sender != registry.channels()) revert NotAuthorized();
+        _;
+    }
+
+    constructor(address _registry, address _legacyEmissions, address _sellerRewardsPool)
+        Ownable(msg.sender)
+        ReentrancyGuard()
+    {
+        if (_registry == address(0) || _legacyEmissions == address(0) || _sellerRewardsPool == address(0)) {
+            revert InvalidAddress();
+        }
+
+        registry = IAntseedRegistry(_registry);
+        legacyEmissions = IAntseedLegacyEmissions(_legacyEmissions);
+        sellerRewardsPool = IAntseedSellerRewardsPool(_sellerRewardsPool);
+
+        INITIAL_EMISSION = legacyEmissions.INITIAL_EMISSION();
+        EPOCH_DURATION = legacyEmissions.EPOCH_DURATION();
+        HALVING_INTERVAL = legacyEmissions.HALVING_INTERVAL();
+        genesis = legacyEmissions.genesis();
+        MIGRATION_EPOCH = legacyEmissions.currentEpoch();
+
+        SELLER_SHARE_PCT = legacyEmissions.SELLER_SHARE_PCT();
+        BUYER_SHARE_PCT = legacyEmissions.BUYER_SHARE_PCT();
+        RESERVE_SHARE_PCT = legacyEmissions.RESERVE_SHARE_PCT();
+        TEAM_SHARE_PCT = legacyEmissions.TEAM_SHARE_PCT();
+        MAX_SELLER_SHARE_PCT = legacyEmissions.MAX_SELLER_SHARE_PCT();
+
+        // Migration/legacy epochs are snapshotted uncapped. Future snapshots use this default.
+        MAX_BUYER_SHARE_PCT = 5;
+        for (uint256 i = 0; i <= MIGRATION_EPOCH; i++) {
+            epochParams[i] = _legacyParamsForEpoch(i);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        EPOCH HELPERS
+    // ═══════════════════════════════════════════════════════════════════
+
+    function currentEpoch() public view returns (uint256) {
+        return (block.timestamp - genesis) / EPOCH_DURATION;
+    }
+
+    function getEpochEmission(uint256 epoch) public view returns (uint256) {
+        return INITIAL_EMISSION >> (epoch / HALVING_INTERVAL);
+    }
+
+    function currentEmissionRate() external view returns (uint256) {
+        return getEpochEmission(currentEpoch()) / EPOCH_DURATION;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        POINT ACCRUAL
+    // ═══════════════════════════════════════════════════════════════════
+
+    function accrueSellerPoints(address seller, uint256 pointsDelta) external onlyChannels whenNotPaused {
+        uint256 epoch = currentEpoch();
+        _snapshotEpoch(epoch);
+        userSellerPoints[seller][epoch] += pointsDelta;
+        epochTotalSellerPoints[epoch] += pointsDelta;
+        emit SellerPointsAccrued(seller, epoch, pointsDelta);
+        emit RawSellerPointsAccrued(seller, epoch, pointsDelta, pointsDelta);
+    }
+
+    function accrueBuyerPoints(address buyer, uint256 pointsDelta) external onlyChannels whenNotPaused {
+        uint256 epoch = currentEpoch();
+        _snapshotEpoch(epoch);
+        userBuyerPoints[buyer][epoch] += pointsDelta;
+        epochTotalBuyerPoints[epoch] += pointsDelta;
+        emit BuyerPointsAccrued(buyer, epoch, pointsDelta);
+        emit RawBuyerPointsAccrued(buyer, epoch, pointsDelta, pointsDelta);
+    }
+
+    /// @notice Pair-aware accrual for future Channels versions.
+    /// @dev Current deployed Channels can keep calling the two legacy accrual functions above.
+    function accruePoints(bytes32 channelId, address buyer, address seller, uint256 pointsDelta)
+        external
+        onlyChannels
+        whenNotPaused
+    {
+        uint256 epoch = currentEpoch();
+        (uint256 creditedSellerPoints, uint256 creditedBuyerPoints) =
+            _policyPoints(channelId, buyer, seller, pointsDelta);
+        _snapshotEpoch(epoch);
+
+        userSellerPoints[seller][epoch] += creditedSellerPoints;
+        epochTotalSellerPoints[epoch] += creditedSellerPoints;
+        userBuyerPoints[buyer][epoch] += creditedBuyerPoints;
+        epochTotalBuyerPoints[epoch] += creditedBuyerPoints;
+
+        emit SellerPointsAccrued(seller, epoch, creditedSellerPoints);
+        emit BuyerPointsAccrued(buyer, epoch, creditedBuyerPoints);
+        emit PairPointsAccrued(
+            channelId, buyer, seller, epoch, pointsDelta, creditedSellerPoints, creditedBuyerPoints
+        );
+    }
+
+    function _snapshotEpoch(uint256 epoch) internal {
+        if (!epochParams[epoch].initialized) {
+            epochParams[epoch] = EpochParams({
+                sellerSharePct: SELLER_SHARE_PCT,
+                buyerSharePct: BUYER_SHARE_PCT,
+                reserveSharePct: RESERVE_SHARE_PCT,
+                teamSharePct: TEAM_SHARE_PCT,
+                maxSellerSharePct: MAX_SELLER_SHARE_PCT,
+                maxBuyerSharePct: MAX_BUYER_SHARE_PCT,
+                initialized: true
+            });
+        }
+    }
+
+    function _policyPoints(bytes32 channelId, address buyer, address seller, uint256 rawPoints)
+        internal
+        view
+        returns (uint256 sellerPoints, uint256 buyerPoints)
+    {
+        IAntseedPointsPolicy policy = pointsPolicy;
+        if (address(policy) == address(0)) return (rawPoints, rawPoints);
+        try policy.points(channelId, buyer, seller, rawPoints) returns (
+            uint256 weightedSellerPoints,
+            uint256 weightedBuyerPoints
+        ) {
+            return (weightedSellerPoints, weightedBuyerPoints);
+        } catch {
+            return (rawPoints, rawPoints);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        CLAIMING
+    // ═══════════════════════════════════════════════════════════════════
+
+    function claimSellerEmissions(uint256[] calldata epochs) external nonReentrant whenNotPaused {
+        uint256 _currentEpoch = currentEpoch();
+        uint256 totalReward = 0;
+
+        for (uint256 i = 0; i < epochs.length; i++) {
+            uint256 epoch = epochs[i];
+            if (epoch >= _currentEpoch) revert EpochNotFinalized();
+            if (_sellerEpochClaimed(msg.sender, epoch)) continue;
+
+            uint256 userSP = _combinedUserSellerPoints(msg.sender, epoch);
+            if (userSP == 0) continue;
+
+            uint256 totalSP = _combinedTotalSellerPoints(epoch);
+            if (totalSP == 0) continue;
+
+            sellerEpochClaimed[msg.sender][epoch] = true;
+            _accountReserveAndTeam(epoch);
+
+            EpochParams memory params = epochParams[epoch];
+            uint256 sBudget = (getEpochEmission(epoch) * params.sellerSharePct) / 100;
+            uint256 reward = (userSP * sBudget) / totalSP;
+
+            uint256 maxReward = (sBudget * params.maxSellerSharePct) / 100;
+            if (reward > maxReward) {
+                reserveAccumulated += reward - maxReward;
+                reward = maxReward;
+            }
+
+            totalReward += reward;
+        }
+
+        if (totalReward > 0) {
+            if (_canClaimSellerUnlocked(msg.sender)) {
+                IANTSToken(registry.antsToken()).mint(msg.sender, totalReward);
+                emit EmissionsClaimed(msg.sender, msg.sender, totalReward, epochs);
+            } else {
+                address pool = address(sellerRewardsPool);
+                IANTSToken(registry.antsToken()).mint(pool, totalReward);
+                sellerRewardsPool.recordLockedReward(msg.sender, totalReward);
+                emit SellerEmissionsLocked(msg.sender, pool, totalReward, epochs);
+                emit EmissionsClaimed(msg.sender, pool, totalReward, epochs);
+            }
+        }
+    }
+
+    function claimBuyerEmissions(address buyer, uint256[] calldata epochs) external nonReentrant whenNotPaused {
+        if (IAntseedDeposits(registry.deposits()).getOperator(buyer) != msg.sender) revert NotAuthorized();
+
+        uint256 _currentEpoch = currentEpoch();
+        uint256 totalReward = 0;
+
+        for (uint256 i = 0; i < epochs.length; i++) {
+            uint256 epoch = epochs[i];
+            if (epoch >= _currentEpoch) revert EpochNotFinalized();
+            if (_buyerEpochClaimed(buyer, epoch)) continue;
+
+            uint256 userBP = _combinedUserBuyerPoints(buyer, epoch);
+            if (userBP == 0) continue;
+
+            uint256 totalBP = _combinedTotalBuyerPoints(epoch);
+            if (totalBP == 0) continue;
+
+            buyerEpochClaimed[buyer][epoch] = true;
+            _accountReserveAndTeam(epoch);
+
+            EpochParams memory params = epochParams[epoch];
+            uint256 bBudget = (getEpochEmission(epoch) * params.buyerSharePct) / 100;
+            uint256 reward = (userBP * bBudget) / totalBP;
+
+            uint256 maxReward = (bBudget * params.maxBuyerSharePct) / 100;
+            if (reward > maxReward) {
+                reserveAccumulated += reward - maxReward;
+                reward = maxReward;
+            }
+
+            totalReward += reward;
+        }
+
+        if (totalReward > 0) {
+            IANTSToken(registry.antsToken()).mint(msg.sender, totalReward);
+            emit EmissionsClaimed(buyer, msg.sender, totalReward, epochs);
+        }
+    }
+
+    function pendingEmissions(address account, uint256[] calldata epochs)
+        external
+        view
+        returns (uint256 totalSeller, uint256 totalBuyer)
+    {
+        uint256 _currentEpoch = currentEpoch();
+
+        for (uint256 i = 0; i < epochs.length; i++) {
+            uint256 epoch = epochs[i];
+            if (epoch >= _currentEpoch) continue;
+
+            EpochParams memory params = epochParams[epoch];
+
+            if (!_sellerEpochClaimed(account, epoch)) {
+                uint256 userSP = _combinedUserSellerPoints(account, epoch);
+                uint256 totalSP = _combinedTotalSellerPoints(epoch);
+                if (userSP > 0 && totalSP > 0) {
+                    uint256 sBudget = (getEpochEmission(epoch) * params.sellerSharePct) / 100;
+                    uint256 reward = (userSP * sBudget) / totalSP;
+                    uint256 maxReward = (sBudget * params.maxSellerSharePct) / 100;
+                    totalSeller += reward > maxReward ? maxReward : reward;
+                }
+            }
+
+            if (!_buyerEpochClaimed(account, epoch)) {
+                uint256 userBP = _combinedUserBuyerPoints(account, epoch);
+                uint256 totalBP = _combinedTotalBuyerPoints(epoch);
+                if (userBP > 0 && totalBP > 0) {
+                    uint256 bBudget = (getEpochEmission(epoch) * params.buyerSharePct) / 100;
+                    uint256 reward = (userBP * bBudget) / totalBP;
+                    uint256 maxReward = (bBudget * params.maxBuyerSharePct) / 100;
+                    totalBuyer += reward > maxReward ? maxReward : reward;
+                }
+            }
+        }
+    }
+
+    function _accountReserveAndTeam(uint256 epoch) internal {
+        if (!epochNonUserAccounted[epoch]) {
+            epochNonUserAccounted[epoch] = true;
+
+            // Previous epochs were already accounted in V1. The migration epoch
+            // and all future epochs are accounted in V2.
+            if (epoch >= MIGRATION_EPOCH) {
+                EpochParams memory params = epochParams[epoch];
+                uint256 emission = getEpochEmission(epoch);
+                reserveAccumulated += (emission * params.reserveSharePct) / 100;
+                teamAccumulated += (emission * params.teamSharePct) / 100;
+            }
+        }
+    }
+
+    function _canClaimSellerUnlocked(address seller) internal view returns (bool) {
+        IAntseedSellerUnlockPolicy policy = sellerUnlockPolicy;
+        if (address(policy) == address(0)) return false;
+        try policy.canClaimSellerUnlocked(seller) returns (bool allowed) {
+            return allowed;
+        } catch {
+            return false;
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        LEGACY + V2 STATE HELPERS
+    // ═══════════════════════════════════════════════════════════════════
+
+    function _sellerEpochClaimed(address seller, uint256 epoch) internal view returns (bool) {
+        if (sellerEpochClaimed[seller][epoch]) return true;
+        if (epoch < MIGRATION_EPOCH) return legacyEmissions.sellerEpochClaimed(seller, epoch);
+        return false;
+    }
+
+    function _buyerEpochClaimed(address buyer, uint256 epoch) internal view returns (bool) {
+        if (buyerEpochClaimed[buyer][epoch]) return true;
+        if (epoch < MIGRATION_EPOCH) return legacyEmissions.buyerEpochClaimed(buyer, epoch);
+        return false;
+    }
+
+    function _combinedUserSellerPoints(address seller, uint256 epoch) internal view returns (uint256 points) {
+        points = userSellerPoints[seller][epoch];
+        if (epoch <= MIGRATION_EPOCH) points += legacyEmissions.userSellerPoints(seller, epoch);
+    }
+
+    function _combinedUserBuyerPoints(address buyer, uint256 epoch) internal view returns (uint256 points) {
+        points = userBuyerPoints[buyer][epoch];
+        if (epoch <= MIGRATION_EPOCH) points += legacyEmissions.userBuyerPoints(buyer, epoch);
+    }
+
+    function _combinedTotalSellerPoints(uint256 epoch) internal view returns (uint256 points) {
+        points = epochTotalSellerPoints[epoch];
+        if (epoch <= MIGRATION_EPOCH) points += legacyEmissions.epochTotalSellerPoints(epoch);
+    }
+
+    function _combinedTotalBuyerPoints(uint256 epoch) internal view returns (uint256 points) {
+        points = epochTotalBuyerPoints[epoch];
+        if (epoch <= MIGRATION_EPOCH) points += legacyEmissions.epochTotalBuyerPoints(epoch);
+    }
+
+    function _legacyParamsForEpoch(uint256 epoch) internal view returns (EpochParams memory params) {
+        (
+            params.sellerSharePct,
+            params.buyerSharePct,
+            params.reserveSharePct,
+            params.teamSharePct,
+            params.maxSellerSharePct,
+            params.initialized
+        ) = legacyEmissions.epochParams(epoch);
+        params.maxBuyerSharePct = 100;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        RESERVE
+    // ═══════════════════════════════════════════════════════════════════
+
+    function flushReserve() external onlyOwner nonReentrant {
+        address dest = registry.protocolReserve();
+        if (dest == address(0)) revert NoProtocolReserve();
+        uint256 amount = reserveAccumulated;
+        if (amount == 0) revert NoReserve();
+        reserveAccumulated = 0;
+        IANTSToken(registry.antsToken()).mint(dest, amount);
+        emit ReserveFlushed(dest, amount);
+    }
+
+    function flushTeam() external onlyOwner nonReentrant {
+        address dest = registry.teamWallet();
+        if (dest == address(0)) revert NoTeamWallet();
+        uint256 amount = teamAccumulated;
+        if (amount == 0) revert NoTeamAccumulated();
+        teamAccumulated = 0;
+        IANTSToken(registry.antsToken()).mint(dest, amount);
+        emit TeamFlushed(dest, amount);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        ADMIN FUNCTIONS
+    // ═══════════════════════════════════════════════════════════════════
+
+    function setRegistry(address _registry) external onlyOwner {
+        if (_registry == address(0)) revert InvalidAddress();
+        registry = IAntseedRegistry(_registry);
+    }
+
+    function setSellerRewardsPool(address pool) external onlyOwner {
+        if (pool == address(0)) revert InvalidAddress();
+        sellerRewardsPool = IAntseedSellerRewardsPool(pool);
+        emit SellerRewardsPoolSet(pool);
+    }
+
+    function setSellerUnlockPolicy(address policy) external onlyOwner {
+        sellerUnlockPolicy = IAntseedSellerUnlockPolicy(policy);
+        emit SellerUnlockPolicySet(policy);
+    }
+
+    function setPointsPolicy(address policy) external onlyOwner {
+        pointsPolicy = IAntseedPointsPolicy(policy);
+        emit PointsPolicySet(policy);
+    }
+
+    function setSharePercentages(uint256 sellerPct, uint256 buyerPct, uint256 reservePct, uint256 teamPct)
+        external
+        onlyOwner
+    {
+        if (sellerPct + buyerPct + reservePct + teamPct != 100) revert InvalidShareSum();
+        SELLER_SHARE_PCT = sellerPct;
+        BUYER_SHARE_PCT = buyerPct;
+        RESERVE_SHARE_PCT = reservePct;
+        TEAM_SHARE_PCT = teamPct;
+    }
+
+    function setMaxSellerSharePct(uint256 value) external onlyOwner {
+        if (value > 100) revert InvalidValue();
+        MAX_SELLER_SHARE_PCT = value;
+        emit MaxSellerSharePctSet(value);
+    }
+
+    /// @notice Set buyer cap for future epoch snapshots. Already-snapshotted epochs are unchanged.
+    function setMaxBuyerSharePct(uint256 value) external onlyOwner {
+        if (value > 100) revert InvalidValue();
+        MAX_BUYER_SHARE_PCT = value;
+        emit MaxBuyerSharePctSet(value);
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+}

--- a/packages/contracts/AntseedEmissionsV2.sol
+++ b/packages/contracts/AntseedEmissionsV2.sol
@@ -113,12 +113,6 @@ contract AntseedEmissionsV2 is Ownable, Pausable, ReentrancyGuard {
     // ─── Events ───
     event SellerPointsAccrued(address indexed seller, uint256 indexed epoch, uint256 pointsDelta);
     event BuyerPointsAccrued(address indexed buyer, uint256 indexed epoch, uint256 pointsDelta);
-    event RawSellerPointsAccrued(
-        address indexed seller, uint256 indexed epoch, uint256 rawPoints, uint256 creditedPoints
-    );
-    event RawBuyerPointsAccrued(
-        address indexed buyer, uint256 indexed epoch, uint256 rawPoints, uint256 creditedPoints
-    );
     event PairPointsAccrued(
         bytes32 indexed channelId,
         address indexed buyer,
@@ -212,7 +206,6 @@ contract AntseedEmissionsV2 is Ownable, Pausable, ReentrancyGuard {
         userSellerPoints[seller][epoch] += pointsDelta;
         epochTotalSellerPoints[epoch] += pointsDelta;
         emit SellerPointsAccrued(seller, epoch, pointsDelta);
-        emit RawSellerPointsAccrued(seller, epoch, pointsDelta, pointsDelta);
     }
 
     function accrueBuyerPoints(address buyer, uint256 pointsDelta) external onlyChannels whenNotPaused {
@@ -221,7 +214,6 @@ contract AntseedEmissionsV2 is Ownable, Pausable, ReentrancyGuard {
         userBuyerPoints[buyer][epoch] += pointsDelta;
         epochTotalBuyerPoints[epoch] += pointsDelta;
         emit BuyerPointsAccrued(buyer, epoch, pointsDelta);
-        emit RawBuyerPointsAccrued(buyer, epoch, pointsDelta, pointsDelta);
     }
 
     /// @notice Pair-aware accrual for future Channels versions.

--- a/packages/contracts/AntseedSellerRewardsPool.sol
+++ b/packages/contracts/AntseedSellerRewardsPool.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import { IAntseedRegistry } from "./interfaces/IAntseedRegistry.sol";
+import { IAntseedSellerClaimPolicy } from "./interfaces/IAntseedSellerClaimPolicy.sol";
+
+/**
+ * @title AntseedSellerRewardsPool
+ * @notice Custody pool for seller ANTS emissions that are earned but not yet
+ *         immediately claimable. Emissions mints ANTS to this pool and records
+ *         the per-seller locked balance here.
+ *
+ *         Sellers claim from their own locked balance subject to an optional
+ *         seller claim policy. If no policy is configured, claims are blocked
+ *         until a policy is introduced.
+ */
+contract AntseedSellerRewardsPool is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    IAntseedRegistry public registry;
+    IAntseedSellerClaimPolicy public sellerClaimPolicy;
+
+    mapping(address => uint256) public lockedRewards;
+    uint256 public totalLockedRewards;
+
+    event LockedRewardRecorded(address indexed seller, uint256 amount);
+    event SellerRewardsClaimed(address indexed seller, address indexed recipient, uint256 amount);
+    event RegistrySet(address indexed registry);
+    event SellerClaimPolicySet(address indexed policy);
+
+    error InvalidAddress();
+    error InvalidAmount();
+    error NotEmissionsContract();
+    error NoSellerClaimPolicy();
+    error NothingToClaim();
+
+    modifier onlyEmissions() {
+        if (msg.sender != registry.emissions()) revert NotEmissionsContract();
+        _;
+    }
+
+    constructor(address _registry) Ownable(msg.sender) {
+        if (_registry == address(0)) revert InvalidAddress();
+        registry = IAntseedRegistry(_registry);
+    }
+
+    function recordLockedReward(address seller, uint256 amount) external onlyEmissions {
+        if (seller == address(0)) revert InvalidAddress();
+        if (amount == 0) revert InvalidAmount();
+
+        lockedRewards[seller] += amount;
+        totalLockedRewards += amount;
+
+        emit LockedRewardRecorded(seller, amount);
+    }
+
+    function claim(address recipient) external nonReentrant {
+        if (recipient == address(0)) revert InvalidAddress();
+
+        IAntseedSellerClaimPolicy policy = sellerClaimPolicy;
+        if (address(policy) == address(0)) revert NoSellerClaimPolicy();
+
+        uint256 locked = lockedRewards[msg.sender];
+        uint256 amount = policy.claimableSellerRewards(msg.sender, locked);
+        if (amount > locked) amount = locked;
+        if (amount == 0) revert NothingToClaim();
+
+        lockedRewards[msg.sender] = locked - amount;
+        totalLockedRewards -= amount;
+
+        IERC20(registry.antsToken()).safeTransfer(recipient, amount);
+
+        emit SellerRewardsClaimed(msg.sender, recipient, amount);
+    }
+
+    function setSellerClaimPolicy(address policy) external onlyOwner {
+        sellerClaimPolicy = IAntseedSellerClaimPolicy(policy);
+        emit SellerClaimPolicySet(policy);
+    }
+
+    function setRegistry(address _registry) external onlyOwner {
+        if (_registry == address(0)) revert InvalidAddress();
+        registry = IAntseedRegistry(_registry);
+        emit RegistrySet(_registry);
+    }
+}

--- a/packages/contracts/AntseedSellerUnlockPolicy.sol
+++ b/packages/contracts/AntseedSellerUnlockPolicy.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+import { IAntseedSellerUnlockPolicy } from "./interfaces/IAntseedSellerUnlockPolicy.sol";
+
+/**
+ * @title AntseedSellerUnlockPolicy
+ * @notice Transparent policy used by AntseedEmissionsV2 to decide whether a
+ *         seller's ANTS emissions may be claimed immediately instead of being
+ *         routed into the locked seller rewards pool.
+ *
+ *         Eligibility is explicit per seller/proxy address. Any seller not
+ *         explicitly marked eligible by the owner remains locked by default.
+ */
+contract AntseedSellerUnlockPolicy is IAntseedSellerUnlockPolicy, Ownable {
+    mapping(address => bool) public eligibleSeller;
+
+    event SellerEligibilitySet(address indexed seller, bool eligible);
+
+    error InvalidAddress();
+
+    constructor() Ownable(msg.sender) { }
+
+    function canClaimSellerUnlocked(address seller) external view returns (bool) {
+        return eligibleSeller[seller];
+    }
+
+    function setSellerEligibility(address seller, bool eligible) external onlyOwner {
+        if (seller == address(0)) revert InvalidAddress();
+        eligibleSeller[seller] = eligible;
+        emit SellerEligibilitySet(seller, eligible);
+    }
+}

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -192,7 +192,7 @@ All constants are configurable by the contract owner via dedicated setter functi
 | **AntseedDeposits** | `0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2` |
 | **AntseedChannels** | `0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d` |
 | **AntseedStats** | `0x15649ff076BFa5e37e24EE3154a00503149954Fd` |
-| **AntseedEmissions** | `0x36877fBa8Fa333aa46a1c57b66D132E4995C86b5` |
+| **AntseedEmissionsV2** | `0xF13bE52c4A3afC6AE29536f073588d01A0564088` |
 | **ERC-8004 IdentityRegistry** | `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` (external) |
 
 All verified on [BaseScan](https://basescan.org). Contract addresses are built into `@antseed/node` chain-config — no manual configuration needed when `chainId: "base-mainnet"` is set.

--- a/packages/contracts/interfaces/IAntseedPointsPolicy.sol
+++ b/packages/contracts/interfaces/IAntseedPointsPolicy.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IAntseedPointsPolicy {
+    function points(bytes32 channelId, address buyer, address seller, uint256 rawPoints)
+        external
+        view
+        returns (uint256 sellerPoints, uint256 buyerPoints);
+}

--- a/packages/contracts/interfaces/IAntseedSellerClaimPolicy.sol
+++ b/packages/contracts/interfaces/IAntseedSellerClaimPolicy.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IAntseedSellerClaimPolicy {
+    function claimableSellerRewards(address seller, uint256 lockedAmount) external view returns (uint256 amount);
+}

--- a/packages/contracts/interfaces/IAntseedSellerRewardsPool.sol
+++ b/packages/contracts/interfaces/IAntseedSellerRewardsPool.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IAntseedSellerRewardsPool {
+    function recordLockedReward(address seller, uint256 amount) external;
+}

--- a/packages/contracts/interfaces/IAntseedSellerUnlockPolicy.sol
+++ b/packages/contracts/interfaces/IAntseedSellerUnlockPolicy.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IAntseedSellerUnlockPolicy {
+    function canClaimSellerUnlocked(address seller) external view returns (bool);
+}

--- a/packages/contracts/script/UpgradeEmissionsV2BaseMainnet.s.sol
+++ b/packages/contracts/script/UpgradeEmissionsV2BaseMainnet.s.sol
@@ -27,7 +27,6 @@ interface IANTSTokenAdmin {
  *   ANTSEED_REGISTRY       Deployed AntseedRegistry address.
  *
  * Optional env:
- *   BUYER_CAP_PCT          Defaults to 5 for future epoch snapshots.
  *   SELLER_UNLOCK_POLICY   Existing unlock policy. If unset, this script deploys one.
  *   DIEM_PROXY_SELLER      Optional seller/proxy address to make immediately claimable.
  *   WHITELIST_REWARDS_POOL Defaults to false. Enable later when seller claims should be transferable.
@@ -92,9 +91,7 @@ contract UpgradeEmissionsV2BaseMainnet is Script {
 
         emissionsV2.setSellerUnlockPolicy(policyAddress);
 
-        uint256 buyerCapPct = vm.envOr("BUYER_CAP_PCT", uint256(5));
-        emissionsV2.setMaxBuyerSharePct(buyerCapPct);
-        console.log("Buyer cap pct:        ", buyerCapPct);
+        console.log("Buyer cap pct:        ", emissionsV2.MAX_BUYER_SHARE_PCT());
 
         // Optional explicit registry writes for uniform operational checks.
         ISetRegistry(address(emissionsV2)).setRegistry(registryAddress);

--- a/packages/contracts/script/UpgradeEmissionsV2BaseMainnet.s.sol
+++ b/packages/contracts/script/UpgradeEmissionsV2BaseMainnet.s.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+
+import { AntseedEmissionsV2 } from "../AntseedEmissionsV2.sol";
+import { AntseedSellerRewardsPool } from "../AntseedSellerRewardsPool.sol";
+import { AntseedSellerUnlockPolicy } from "../AntseedSellerUnlockPolicy.sol";
+import { IAntseedRegistry } from "../interfaces/IAntseedRegistry.sol";
+import { ISetRegistry } from "../interfaces/IAntseedWiring.sol";
+
+interface IAntseedRegistryAdmin is IAntseedRegistry {
+    function setEmissions(address emissions) external;
+}
+
+interface IANTSTokenAdmin {
+    function setTransferWhitelist(address account, bool allowed) external;
+}
+
+/**
+ * @title UpgradeEmissionsV2BaseMainnet
+ * @notice Deploys AntseedEmissionsV2 + seller rewards pool while keeping the
+ *         deployed registry, token, channels, deposits, staking, and stats in place.
+ *
+ * Required env:
+ *   DEPLOYER_PRIVATE_KEY   Owner/broadcaster key.
+ *   ANTSEED_REGISTRY       Deployed AntseedRegistry address.
+ *
+ * Optional env:
+ *   BUYER_CAP_PCT          Defaults to 5 for future epoch snapshots.
+ *   SELLER_UNLOCK_POLICY   Existing unlock policy. If unset, this script deploys one.
+ *   DIEM_PROXY_SELLER      Optional seller/proxy address to make immediately claimable.
+ *   WHITELIST_REWARDS_POOL Defaults to true. Allows locked pool releases while ANTS transfers are disabled.
+ *
+ * Usage:
+ *   cd packages/contracts
+ *   source .env
+ *   forge script script/UpgradeEmissionsV2BaseMainnet.s.sol \
+ *     --rpc-url $BASE_MAINNET_RPC_URL \
+ *     --broadcast \
+ *     --verify \
+ *     --etherscan-api-key $BASESCAN_API_KEY \
+ *     --via-ir
+ */
+contract UpgradeEmissionsV2BaseMainnet is Script {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        address registryAddress = vm.envAddress("ANTSEED_REGISTRY");
+
+        IAntseedRegistryAdmin registry = IAntseedRegistryAdmin(registryAddress);
+        address oldEmissions = registry.emissions();
+        require(oldEmissions != address(0), "old emissions not set");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        console.log("=== AntSeed Emissions V2 Upgrade ===");
+        console.log("Deployer:             ", deployer);
+        console.log("Registry:             ", registryAddress);
+        console.log("Old Emissions:        ", oldEmissions);
+        console.log("ANTS Token:           ", registry.antsToken());
+        console.log("");
+
+        AntseedSellerRewardsPool rewardsPool = new AntseedSellerRewardsPool(registryAddress);
+        console.log("SellerRewardsPool:    ", address(rewardsPool));
+
+        bool whitelistRewardsPool = vm.envOr("WHITELIST_REWARDS_POOL", true);
+        if (whitelistRewardsPool) {
+            IANTSTokenAdmin(registry.antsToken()).setTransferWhitelist(address(rewardsPool), true);
+            console.log("Rewards pool whitelisted for ANTS transfers");
+        }
+
+        address policyAddress = vm.envOr("SELLER_UNLOCK_POLICY", address(0));
+        if (policyAddress == address(0)) {
+            AntseedSellerUnlockPolicy policy = new AntseedSellerUnlockPolicy();
+            policyAddress = address(policy);
+            console.log("SellerUnlockPolicy:   ", policyAddress);
+
+            address diemProxySeller = vm.envOr("DIEM_PROXY_SELLER", address(0));
+            if (diemProxySeller != address(0)) {
+                policy.setSellerEligibility(diemProxySeller, true);
+                console.log("Diem proxy seller:    ", diemProxySeller);
+            }
+        } else {
+            console.log("SellerUnlockPolicy:   ", policyAddress);
+        }
+
+        AntseedEmissionsV2 emissionsV2 = new AntseedEmissionsV2(registryAddress, oldEmissions, address(rewardsPool));
+        console.log("EmissionsV2:          ", address(emissionsV2));
+        console.log("Migration epoch:      ", emissionsV2.MIGRATION_EPOCH());
+        console.log("Current epoch:        ", emissionsV2.currentEpoch());
+
+        emissionsV2.setSellerUnlockPolicy(policyAddress);
+
+        uint256 buyerCapPct = vm.envOr("BUYER_CAP_PCT", uint256(5));
+        emissionsV2.setMaxBuyerSharePct(buyerCapPct);
+        console.log("Buyer cap pct:        ", buyerCapPct);
+
+        // Optional explicit registry writes for uniform operational checks.
+        ISetRegistry(address(emissionsV2)).setRegistry(registryAddress);
+        ISetRegistry(address(rewardsPool)).setRegistry(registryAddress);
+
+        // Final cutover: ANTSToken.mint will now accept EmissionsV2 and reject V1.
+        registry.setEmissions(address(emissionsV2));
+
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== Emissions V2 upgrade complete ===");
+        console.log("Update chain config emissions address to:", address(emissionsV2));
+        console.log("Seller rewards pool:                 ", address(rewardsPool));
+        console.log("Seller unlock policy:                ", policyAddress);
+    }
+}

--- a/packages/contracts/script/UpgradeEmissionsV2BaseMainnet.s.sol
+++ b/packages/contracts/script/UpgradeEmissionsV2BaseMainnet.s.sol
@@ -30,7 +30,7 @@ interface IANTSTokenAdmin {
  *   BUYER_CAP_PCT          Defaults to 5 for future epoch snapshots.
  *   SELLER_UNLOCK_POLICY   Existing unlock policy. If unset, this script deploys one.
  *   DIEM_PROXY_SELLER      Optional seller/proxy address to make immediately claimable.
- *   WHITELIST_REWARDS_POOL Defaults to true. Allows locked pool releases while ANTS transfers are disabled.
+ *   WHITELIST_REWARDS_POOL Defaults to false. Enable later when seller claims should be transferable.
  *
  * Usage:
  *   cd packages/contracts
@@ -64,7 +64,7 @@ contract UpgradeEmissionsV2BaseMainnet is Script {
         AntseedSellerRewardsPool rewardsPool = new AntseedSellerRewardsPool(registryAddress);
         console.log("SellerRewardsPool:    ", address(rewardsPool));
 
-        bool whitelistRewardsPool = vm.envOr("WHITELIST_REWARDS_POOL", true);
+        bool whitelistRewardsPool = vm.envOr("WHITELIST_REWARDS_POOL", false);
         if (whitelistRewardsPool) {
             IANTSTokenAdmin(registry.antsToken()).setTransferWhitelist(address(rewardsPool), true);
             console.log("Rewards pool whitelisted for ANTS transfers");

--- a/packages/contracts/test/AntseedChannelsV2Emissions.t.sol
+++ b/packages/contracts/test/AntseedChannelsV2Emissions.t.sol
@@ -1,0 +1,1145 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../AntseedChannels.sol";
+import "../AntseedDeposits.sol";
+import "../AntseedStaking.sol";
+import "../MockERC8004Registry.sol";
+import "../MockUSDC.sol";
+import "../AntseedRegistry.sol";
+import "../AntseedStats.sol";
+import { AntseedEmissions } from "../AntseedEmissions.sol";
+import { AntseedEmissionsV2 } from "../AntseedEmissionsV2.sol";
+import { AntseedSellerRewardsPool } from "../AntseedSellerRewardsPool.sol";
+
+contract AntseedChannelsV2EmissionsTest is Test {
+    MockUSDC public usdc;
+    MockERC8004Registry public identityRegistry;
+    AntseedRegistry public antseedRegistry;
+    AntseedStats public externalStats;
+    AntseedStaking public staking;
+    AntseedDeposits public deposits;
+    AntseedChannels public channels;
+    AntseedEmissions public legacyEmissions;
+    AntseedEmissionsV2 public emissionsV2;
+    AntseedSellerRewardsPool public rewardsPool;
+
+    // Deterministic private keys
+    uint256 constant BUYER_PK = 0xA11CE;
+    uint256 constant SELLER_PK = 0xB0B;
+    uint256 constant RANDOM_PK = 0xDEAD;
+
+    address public buyer;
+    address public seller;
+    address public randomUser;
+    address public protocolReserve = address(0xFEE);
+    address public buyerOperator = address(0xAA);
+
+    // USDC amounts (6 decimals)
+    uint128 constant USDC_100 = 100_000_000;
+    uint128 constant USDC_50 = 50_000_000;
+    uint128 constant USDC_30 = 30_000_000;
+    uint128 constant USDC_60 = 60_000_000;
+    uint128 constant USDC_10 = 10_000_000;
+    uint128 constant USDC_150 = 150_000_000;
+
+    uint256 constant STAKE_AMOUNT = 10_000_000; // MIN_SELLER_STAKE
+
+    // AntSeed EIP-712 typehashes (must match contract)
+    bytes32 constant SPENDING_AUTH_TYPEHASH = keccak256(
+        "SpendingAuth(bytes32 channelId,uint256 cumulativeAmount,bytes32 metadataHash)"
+    );
+    bytes32 constant RESERVE_AUTH_TYPEHASH = keccak256(
+        "ReserveAuth(bytes32 channelId,uint128 maxAmount,uint256 deadline)"
+    );
+
+    function setUp() public {
+        buyer = vm.addr(BUYER_PK);
+        seller = vm.addr(SELLER_PK);
+        randomUser = vm.addr(RANDOM_PK);
+
+        // Deploy contracts
+        usdc = new MockUSDC();
+        identityRegistry = new MockERC8004Registry();
+        antseedRegistry = new AntseedRegistry();
+        staking = new AntseedStaking(address(usdc), address(antseedRegistry));
+        deposits = new AntseedDeposits(address(usdc));
+        channels = new AntseedChannels(address(antseedRegistry));
+        externalStats = new AntseedStats();
+
+        // Wire registry
+        antseedRegistry.setChannels(address(channels));
+        antseedRegistry.setDeposits(address(deposits));
+        antseedRegistry.setStaking(address(staking));
+        antseedRegistry.setIdentityRegistry(address(identityRegistry));
+        antseedRegistry.setProtocolReserve(protocolReserve);
+
+        legacyEmissions = new AntseedEmissions(address(antseedRegistry), 1000 ether, 1 weeks);
+        antseedRegistry.setEmissions(address(legacyEmissions));
+        vm.prank(address(channels));
+        legacyEmissions.accrueSellerPoints(address(0xDEAD), 0);
+        vm.prank(address(channels));
+        legacyEmissions.accrueBuyerPoints(address(0xBEEF), 0);
+        rewardsPool = new AntseedSellerRewardsPool(address(antseedRegistry));
+        emissionsV2 = new AntseedEmissionsV2(address(antseedRegistry), address(legacyEmissions), address(rewardsPool));
+        antseedRegistry.setEmissions(address(emissionsV2));
+
+        // Set registry on contracts that need it
+        deposits.setRegistry(address(antseedRegistry));
+
+        // Raise FIRST_SIGN_CAP for tests that need large reservations
+        channels.setFirstSignCap(500_000_000);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        HELPERS
+    // ═══════════════════════════════════════════════════════════════════
+
+    function createBuyer(uint256 pk, uint256 depositAmount) internal {
+        address addr = vm.addr(pk);
+
+        // Register on MockERC8004Registry
+        vm.prank(addr);
+        identityRegistry.register();
+
+        deposits.setCreditLimitOverride(addr, type(uint256).max);
+
+        // Set operator via EIP-712 signature
+        uint256 nonce = deposits.getOperatorNonce(addr);
+        bytes32 structHash = keccak256(abi.encode(deposits.SET_OPERATOR_TYPEHASH(), buyerOperator, nonce));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", deposits.domainSeparator(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        deposits.setOperator(addr, buyerOperator, nonce, abi.encodePacked(r, s, v));
+
+        // Operator deposits USDC
+        usdc.mint(buyerOperator, depositAmount);
+        vm.startPrank(buyerOperator);
+        usdc.approve(address(deposits), depositAmount);
+        deposits.deposit(addr, depositAmount);
+        vm.stopPrank();
+    }
+
+    function createSeller(uint256 pk) internal {
+        address addr = vm.addr(pk);
+
+        // Register on MockERC8004Registry and stake with agentId
+        vm.prank(addr);
+        uint256 agentId = identityRegistry.register();
+
+        usdc.mint(addr, STAKE_AMOUNT);
+        vm.startPrank(addr);
+        usdc.approve(address(staking), STAKE_AMOUNT);
+        staking.stake(agentId, STAKE_AMOUNT);
+        vm.stopPrank();
+    }
+
+    /**
+     * @dev Sign an AntSeed SpendingAuth (our EIP-712 domain, version "7")
+     */
+    function signSpendingAuth(
+        uint256 pk,
+        bytes32 channelId,
+        uint256 cumulativeAmount,
+        uint256 cumulativeInputTokens,
+        uint256 cumulativeOutputTokens
+    ) internal view returns (bytes memory) {
+        bytes32 metadataHash = keccak256(abi.encode(METADATA_VERSION, cumulativeInputTokens, cumulativeOutputTokens, uint256(0)));
+        bytes32 structHash = keccak256(
+            abi.encode(
+                SPENDING_AUTH_TYPEHASH,
+                channelId,
+                cumulativeAmount,
+                metadataHash
+            )
+        );
+        bytes32 digest = _hashTypedDataChannels(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    /**
+     * @dev Sign an AntSeed ReserveAuth (our EIP-712 domain, version "7")
+     */
+    function signReserveAuth(
+        uint256 pk,
+        bytes32 channelId,
+        uint128 maxAmount,
+        uint256 deadline
+    ) internal view returns (bytes memory) {
+        bytes32 structHash = keccak256(
+            abi.encode(
+                RESERVE_AUTH_TYPEHASH,
+                channelId,
+                maxAmount,
+                deadline
+            )
+        );
+        bytes32 digest = _hashTypedDataChannels(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    uint256 constant METADATA_VERSION = 1;
+
+    function encodeMetadata(
+        uint256 cumulativeInputTokens,
+        uint256 cumulativeOutputTokens
+    ) internal pure returns (bytes memory) {
+        return abi.encode(METADATA_VERSION, cumulativeInputTokens, cumulativeOutputTokens, uint256(0));
+    }
+
+    function _hashTypedDataChannels(bytes32 structHash) internal view returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", channels.domainSeparator(), structHash));
+    }
+
+    function _hashTypedDataDeposits(bytes32 structHash) internal view returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", deposits.domainSeparator(), structHash));
+    }
+
+    /**
+     * @dev Compute the channelId: keccak256(abi.encode(buyer, seller, salt))
+     */
+    function computeChannelId(bytes32 salt) internal view returns (bytes32) {
+        return channels.computeChannelId(buyer, seller, salt);
+    }
+
+    /**
+     * @dev Full reserve helper: creates buyer+seller, computes channelId, signs, reserves.
+     */
+    function doReserve(
+        bytes32 salt,
+        uint128 maxAmount,
+        uint256 buyerDeposit
+    ) internal returns (bytes32 channelId) {
+        createBuyer(BUYER_PK, buyerDeposit);
+        createSeller(SELLER_PK);
+
+        channelId = computeChannelId(salt);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, maxAmount, deadline);
+
+        vm.prank(seller);
+        channels.reserve(buyer, salt, maxAmount, deadline, reserveSig);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                   RESERVE TESTS
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_reserve_newChannel() public {
+        bytes32 salt = keccak256("session-1");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // Assert channel state
+        (
+            address sBuyer,
+            address sSeller,
+            uint128 sDeposit,
+            uint128 sSettled,
+            ,
+            uint256 sDeadline,
+            uint256 sSettledAt,
+            ,
+            AntseedChannels.ChannelStatus sStatus
+        ) = channels.channels(channelId);
+
+        assertEq(sBuyer, buyer);
+        assertEq(sSeller, seller);
+        assertEq(sDeposit, USDC_100);
+        assertEq(sSettled, 0);
+        assertGt(sDeadline, 0);
+        assertEq(sSettledAt, 0);
+        assertTrue(sStatus == AntseedChannels.ChannelStatus.Active);
+
+        // USDC stays in Deposits (locked via reserved)
+        assertEq(usdc.balanceOf(address(channels)), 0);
+        assertEq(usdc.balanceOf(address(deposits)), USDC_100);
+
+        // Assert buyer's Deposits: reserved = maxAmount, available = 0
+        (uint256 available, uint256 reserved,) = deposits.getBuyerBalance(buyer);
+        assertEq(reserved, USDC_100);
+        assertEq(available, 0); // all 100 USDC reserved in Deposits
+    }
+
+    function test_reserve_revert_sellerNotStaked() public {
+        createBuyer(BUYER_PK, USDC_100);
+        // Register seller but don't stake
+        vm.prank(seller);
+        identityRegistry.register();
+
+        bytes32 salt = keccak256("session-1");
+        bytes32 channelId = computeChannelId(salt);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, USDC_50, deadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.SellerNotStaked.selector);
+        channels.reserve(buyer, salt, USDC_50, deadline, reserveSig);
+    }
+
+    function test_reserve_revert_expiredDeadline() public {
+        createBuyer(BUYER_PK, USDC_100);
+        createSeller(SELLER_PK);
+
+        bytes32 salt = keccak256("session-1");
+        bytes32 channelId = computeChannelId(salt);
+        uint256 pastDeadline = block.timestamp - 1;
+
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, USDC_50, pastDeadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.ChannelExpired.selector);
+        channels.reserve(buyer, salt, USDC_50, pastDeadline, reserveSig);
+    }
+
+    function test_reserve_revert_invalidSignature() public {
+        createBuyer(BUYER_PK, USDC_100);
+        createSeller(SELLER_PK);
+
+        bytes32 salt = keccak256("session-1");
+        bytes32 channelId = computeChannelId(salt);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        // Sign with wrong key
+        bytes memory badSig = signReserveAuth(RANDOM_PK, channelId, USDC_50, deadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.InvalidSignature.selector);
+        channels.reserve(buyer, salt, USDC_50, deadline, badSig);
+    }
+
+    function test_reserve_revert_firstSignCapExceeded() public {
+        channels.setFirstSignCap(1_000_000);
+
+        createBuyer(BUYER_PK, USDC_100);
+        createSeller(SELLER_PK);
+
+        uint128 overCap = 1_000_001;
+        bytes32 salt = keccak256("session-1");
+        bytes32 channelId = computeChannelId(salt);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, overCap, deadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.FirstSignCapExceeded.selector);
+        channels.reserve(buyer, salt, overCap, deadline, reserveSig);
+    }
+
+    function test_reserve_revert_channelExists() public {
+        bytes32 salt = keccak256("session-1");
+        bytes32 channelId = doReserve(salt, USDC_50, USDC_100);
+
+        // Try to reserve again with same salt (same channelId)
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, USDC_30, deadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.ChannelExists.selector);
+        channels.reserve(buyer, salt, USDC_30, deadline, reserveSig);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                   CLOSE TESTS (final settle)
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_close_partialAmount() public {
+        bytes32 salt = keccak256("session-close");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        uint128 finalAmount = USDC_60;
+        uint256 inputTokens = 5000;
+        uint256 outputTokens = 2000;
+
+        bytes memory metaSig = signSpendingAuth(BUYER_PK, channelId, finalAmount, inputTokens, outputTokens);
+
+        vm.prank(seller);
+        channels.close(channelId, finalAmount, encodeMetadata(inputTokens, outputTokens), metaSig);
+
+        // Assert channel state
+        (
+            ,
+            ,
+            ,
+            uint128 sSettled,
+            ,
+            ,
+            uint256 sSettledAt,
+            ,
+            AntseedChannels.ChannelStatus sStatus
+        ) = channels.channels(channelId);
+
+        assertTrue(sStatus == AntseedChannels.ChannelStatus.Settled);
+        assertEq(sSettled, USDC_60);
+        assertGt(sSettledAt, 0);
+
+        // Platform fee = 60 * 200 / 10000 = 3 USDC
+        uint256 platformFee = (uint256(USDC_60) * 200) / 10000;
+        uint256 sellerPayout = uint256(USDC_60) - platformFee;
+        assertEq(usdc.balanceOf(seller), sellerPayout);
+
+        // Protocol reserve got the fee
+        assertEq(usdc.balanceOf(protocolReserve), platformFee);
+
+        // Buyer: refund of 40 USDC credited back
+        (uint256 available, uint256 reserved,) = deposits.getBuyerBalance(buyer);
+        assertEq(reserved, 0);
+        assertEq(available, USDC_100 - USDC_100 + (USDC_100 - USDC_60)); // 0 + 40 = 40
+
+        // Stats updated
+        uint256 sellerAgentId = staking.getAgentId(seller);
+        AntseedChannels.AgentStats memory s = channels.getAgentStats(sellerAgentId);
+        assertEq(s.channelCount, 1);
+        assertEq(s.totalVolumeUsdc, USDC_60);
+    }
+
+    function test_close_fullDeposit() public {
+        bytes32 salt = keccak256("session-close-full");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        uint128 finalAmount = USDC_100;
+        bytes memory metaSig = signSpendingAuth(BUYER_PK, channelId, finalAmount, 10000, 5000);
+
+        vm.prank(seller);
+        channels.close(channelId, finalAmount, encodeMetadata(10000, 5000), metaSig);
+
+        (,,,uint128 sSettled,,,,,AntseedChannels.ChannelStatus sStatus) = channels.channels(channelId);
+        assertEq(sSettled, USDC_100);
+        assertTrue(sStatus == AntseedChannels.ChannelStatus.Settled);
+
+        // Buyer should have 0 available (no refund)
+        (uint256 available,,) = deposits.getBuyerBalance(buyer);
+        assertEq(available, 0);
+    }
+
+    function test_close_zeroAmount() public {
+        bytes32 salt = keccak256("session-close-zero");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // Close with 0 — full refund to buyer
+        bytes memory metaSig = signSpendingAuth(BUYER_PK, channelId, 0, 0, 0);
+
+        vm.prank(seller);
+        channels.close(channelId, 0, encodeMetadata(0, 0), metaSig);
+
+        (uint256 available,,) = deposits.getBuyerBalance(buyer);
+        assertEq(available, USDC_100);
+
+        assertEq(usdc.balanceOf(seller), 0);
+    }
+
+    function test_close_revert_notSeller() public {
+        bytes32 salt = keccak256("session-close-auth");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        bytes memory metaSig = signSpendingAuth(BUYER_PK, channelId, USDC_60, 0, 0);
+
+        vm.prank(randomUser);
+        vm.expectRevert(AntseedChannels.NotAuthorized.selector);
+        channels.close(channelId, USDC_60, encodeMetadata(0, 0), metaSig);
+    }
+
+    function test_close_revert_invalidMetadataSignature() public {
+        bytes32 salt = keccak256("session-close-badsig");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // Sign metadata with wrong key
+        bytes memory badMetaSig = signSpendingAuth(RANDOM_PK, channelId, USDC_60, 0, 0);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.InvalidSignature.selector);
+        channels.close(channelId, USDC_60, encodeMetadata(0, 0), badMetaSig);
+    }
+
+    function test_close_revert_doubleClose() public {
+        bytes32 salt = keccak256("session-double-close");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        bytes memory metaSig = signSpendingAuth(BUYER_PK, channelId, USDC_60, 0, 0);
+
+        vm.prank(seller);
+        channels.close(channelId, USDC_60, encodeMetadata(0, 0), metaSig);
+
+        // Try again — channel already Settled
+        bytes memory metaSig2 = signSpendingAuth(BUYER_PK, channelId, USDC_30, 0, 0);
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.ChannelNotActive.selector);
+        channels.close(channelId, USDC_30, encodeMetadata(0, 0), metaSig2);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                   SETTLE TESTS (mid-channel)
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_settle_midChannel() public {
+        bytes32 salt = keccak256("session-settle");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        uint128 amount1 = USDC_30;
+        bytes memory metaSig1 = signSpendingAuth(BUYER_PK, channelId, amount1, 1000, 500);
+
+        vm.prank(seller);
+        channels.settle(channelId, amount1, encodeMetadata(1000, 500), metaSig1);
+
+        // Channel still active
+        (,, uint128 sDeposit, uint128 sSettled,,,,, AntseedChannels.ChannelStatus sStatus) = channels.channels(channelId);
+        assertTrue(sStatus == AntseedChannels.ChannelStatus.Active);
+        assertEq(sDeposit, USDC_100);
+        assertEq(sSettled, USDC_30);
+
+        // Seller payouts credited for first settle
+        uint256 fee1 = (uint256(USDC_30) * 200) / 10000;
+        uint256 payout1 = uint256(USDC_30) - fee1;
+        assertEq(usdc.balanceOf(seller), payout1);
+    }
+
+    function test_settle_thenClose() public {
+        bytes32 salt = keccak256("session-settle-close");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // First settle: 30 USDC
+        uint128 amount1 = USDC_30;
+        bytes memory metaSig1 = signSpendingAuth(BUYER_PK, channelId, amount1, 1000, 500);
+
+        vm.prank(seller);
+        channels.settle(channelId, amount1, encodeMetadata(1000, 500), metaSig1);
+
+        // Then close: final cumulative = 60 USDC
+        uint128 finalAmount = USDC_60;
+        bytes memory metaSig2 = signSpendingAuth(BUYER_PK, channelId, finalAmount, 3000, 1500);
+
+        vm.prank(seller);
+        channels.close(channelId, finalAmount, encodeMetadata(3000, 1500), metaSig2);
+
+        // Channel settled
+        (,,,uint128 sSettled,,,,,AntseedChannels.ChannelStatus sStatus) = channels.channels(channelId);
+        assertTrue(sStatus == AntseedChannels.ChannelStatus.Settled);
+        assertEq(sSettled, USDC_60);
+
+        // Total seller payouts = payout from 30 (settle) + payout from delta 30 (close)
+        // Each delta of 30 has its own fee: 30 * 500/10000 = 1.5 USDC per delta
+        uint256 fee30 = (uint256(USDC_30) * 200) / 10000;
+        uint256 expectedPayouts = (uint256(USDC_30) - fee30) * 2; // two deltas of 30
+        assertEq(usdc.balanceOf(seller), expectedPayouts);
+
+        // Buyer refund = 100 - 60 = 40
+        (uint256 available,,) = deposits.getBuyerBalance(buyer);
+        assertEq(available, USDC_100 - USDC_60);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                   TIMEOUT TESTS
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_requestClose_and_withdraw() public {
+        bytes32 salt = keccak256("session-close-req");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // Operator can request close anytime — no deadline dependency
+        vm.prank(buyerOperator);
+        channels.requestClose(channelId);
+
+        // Can't withdraw yet — need to wait for grace period (15 min)
+        vm.prank(buyerOperator);
+        vm.expectRevert(AntseedChannels.CloseNotReady.selector);
+        channels.withdraw(channelId);
+
+        // Warp past grace period
+        vm.warp(block.timestamp + 15 minutes + 1);
+
+        // Operator can withdraw after grace period
+        vm.prank(buyerOperator);
+        channels.withdraw(channelId);
+
+        // Channel timed out (withdrawn)
+        (,,,,,,,,AntseedChannels.ChannelStatus sStatus) = channels.channels(channelId);
+        assertTrue(sStatus == AntseedChannels.ChannelStatus.TimedOut);
+
+        // Full deposit returned to buyer
+        (uint256 available,,) = deposits.getBuyerBalance(buyer);
+        assertEq(available, USDC_100);
+    }
+
+    function test_requestClose_revert_notBuyer() public {
+        bytes32 salt = keccak256("session-close-auth");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // Seller can't request close
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.NotAuthorized.selector);
+        channels.requestClose(channelId);
+
+        // Random user can't request close
+        vm.prank(randomUser);
+        vm.expectRevert(AntseedChannels.NotAuthorized.selector);
+        channels.requestClose(channelId);
+    }
+
+    function test_requestClose_revert_alreadyRequested() public {
+        bytes32 salt = keccak256("session-close-dup");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        vm.prank(buyerOperator);
+        channels.requestClose(channelId);
+
+        vm.prank(buyerOperator);
+        vm.expectRevert(AntseedChannels.CloseAlreadyRequested.selector);
+        channels.requestClose(channelId);
+    }
+
+    function test_withdraw_revert_notOperator() public {
+        bytes32 salt = keccak256("session-withdraw-auth");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        vm.prank(buyerOperator);
+        channels.requestClose(channelId);
+
+        vm.warp(block.timestamp + 15 minutes + 1);
+
+        // Seller can't withdraw
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.NotAuthorized.selector);
+        channels.withdraw(channelId);
+    }
+
+    function test_withdraw_revert_withoutRequestClose() public {
+        bytes32 salt = keccak256("session-withdraw-no-req");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // withdraw without calling requestClose first
+        vm.prank(buyerOperator);
+        vm.expectRevert(AntseedChannels.CloseNotReady.selector);
+        channels.withdraw(channelId);
+    }
+
+    function test_sellerCanStillCloseDuringGracePeriod() public {
+        bytes32 salt = keccak256("session-grace-settle");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // Operator requests close
+        vm.prank(buyerOperator);
+        channels.requestClose(channelId);
+
+        // Seller can still close with a SpendingAuth during grace period
+        uint128 finalAmount = USDC_60;
+        bytes memory metaSig = signSpendingAuth(BUYER_PK, channelId, finalAmount, 5000, 2000);
+
+        vm.prank(seller);
+        channels.close(channelId, finalAmount, encodeMetadata(5000, 2000), metaSig);
+
+        (,,,uint128 sSettled,,,,,AntseedChannels.ChannelStatus sStatus) = channels.channels(channelId);
+        assertTrue(sStatus == AntseedChannels.ChannelStatus.Settled);
+        assertEq(sSettled, USDC_60);
+
+        // Buyer gets refund of 40 USDC
+        (uint256 available,,) = deposits.getBuyerBalance(buyer);
+        assertEq(available, USDC_100 - USDC_60);
+    }
+
+    function test_sellerCanSettleDuringGracePeriod() public {
+        bytes32 salt = keccak256("session-grace-mid");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // Operator requests close
+        vm.prank(buyerOperator);
+        channels.requestClose(channelId);
+
+        // Seller can still settle mid-channel during grace period
+        uint128 amount = USDC_30;
+        bytes memory metaSig = signSpendingAuth(BUYER_PK, channelId, amount, 1000, 500);
+
+        vm.prank(seller);
+        channels.settle(channelId, amount, encodeMetadata(1000, 500), metaSig);
+
+        (,,, uint128 sSettled,,,,, AntseedChannels.ChannelStatus sStatus) = channels.channels(channelId);
+        assertTrue(sStatus == AntseedChannels.ChannelStatus.Active);
+        assertEq(sSettled, USDC_30);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                   PLATFORM FEE TESTS
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_close_platformFeeCalculation() public {
+        bytes32 salt = keccak256("session-fee");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        uint128 chargeAmount = USDC_60;
+        uint256 expectedPlatformFee = (uint256(chargeAmount) * 200) / 10000; // 3 USDC
+        uint256 expectedSellerPayout = uint256(chargeAmount) - expectedPlatformFee; // 57 USDC
+
+        bytes memory metaSig = signSpendingAuth(BUYER_PK, channelId, chargeAmount, 0, 0);
+
+        vm.prank(seller);
+        channels.close(channelId, chargeAmount, encodeMetadata(0, 0), metaSig);
+
+        assertEq(usdc.balanceOf(seller), expectedSellerPayout);
+        assertEq(usdc.balanceOf(protocolReserve), expectedPlatformFee);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                   STATS TESTS
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_close_statsUpdate() public {
+        bytes32 salt = keccak256("session-rep");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        uint256 inputToks = 7500;
+        uint256 outputToks = 3200;
+
+        bytes memory metaSig = signSpendingAuth(BUYER_PK, channelId, USDC_50, inputToks, outputToks);
+
+        vm.prank(seller);
+        channels.close(channelId, USDC_50, encodeMetadata(inputToks, outputToks), metaSig);
+
+        uint256 sellerAgentId = staking.getAgentId(seller);
+        AntseedChannels.AgentStats memory s = channels.getAgentStats(sellerAgentId);
+        assertEq(s.channelCount, 1);
+        assertEq(s.totalVolumeUsdc, USDC_50);
+    }
+
+    function test_settle_writesExternalMetadataWhenConfiguredAndAuthorized() public {
+        bytes32 salt = keccak256("session-ext-meta");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+        uint256 sellerAgentId = staking.getAgentId(seller);
+
+        antseedRegistry.setStats(address(externalStats));
+        externalStats.setWriter(address(channels), true);
+
+        bytes memory sig1 = signSpendingAuth(BUYER_PK, channelId, USDC_30, 4000, 1500);
+        vm.prank(seller);
+        channels.settle(channelId, USDC_30, encodeMetadata(4000, 1500), sig1);
+
+        IAntseedStats.BuyerMetadataStats memory midStats = externalStats.getBuyerMetadataStats(sellerAgentId, buyer);
+        assertEq(midStats.totalInputTokens, 4000);
+        assertEq(midStats.totalOutputTokens, 1500);
+        assertEq(midStats.totalRequestCount, 0);
+
+        bytes memory sig2 = signSpendingAuth(BUYER_PK, channelId, USDC_60, 9000, 3500);
+        vm.prank(seller);
+        channels.close(channelId, USDC_60, encodeMetadata(9000, 3500), sig2);
+
+        IAntseedStats.BuyerMetadataStats memory stats = externalStats.getBuyerMetadataStats(sellerAgentId, buyer);
+        assertEq(stats.totalInputTokens, 9000);
+        assertEq(stats.totalOutputTokens, 3500);
+        assertEq(stats.totalRequestCount, 0);
+        assertGt(stats.lastUpdatedAt, 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                   ADMIN TESTS
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_setFirstSignCap() public {
+        channels.setFirstSignCap(2_000_000);
+        assertEq(channels.FIRST_SIGN_CAP(), 2_000_000);
+    }
+
+    function test_setPlatformFeeBps() public {
+        channels.setPlatformFeeBps(300);
+        assertEq(channels.PLATFORM_FEE_BPS(), 300);
+    }
+
+    function test_setPlatformFeeBps_revert_aboveMax() public {
+        vm.expectRevert(AntseedChannels.InvalidFee.selector);
+        channels.setPlatformFeeBps(1001);
+    }
+
+    function test_setRegistry() public {
+        AntseedRegistry newReg = new AntseedRegistry();
+        channels.setRegistry(address(newReg));
+        assertEq(address(channels.registry()), address(newReg));
+    }
+
+    function test_setRegistry_revert_zeroAddress() public {
+        vm.expectRevert(AntseedChannels.InvalidAddress.selector);
+        channels.setRegistry(address(0));
+    }
+
+    function test_setRegistry_revert_notOwner() public {
+        vm.prank(randomUser);
+        vm.expectRevert();
+        channels.setRegistry(address(0x1234));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                   PAUSE TESTS
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_pause_blocksReserve() public {
+        createBuyer(BUYER_PK, USDC_100);
+        createSeller(SELLER_PK);
+
+        channels.pause();
+
+        bytes32 salt = keccak256("session-paused");
+        bytes32 channelId = computeChannelId(salt);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, USDC_50, deadline);
+
+        vm.prank(seller);
+        vm.expectRevert();
+        channels.reserve(buyer, salt, USDC_50, deadline, reserveSig);
+    }
+
+    function test_unpause_allowsReserve() public {
+        createBuyer(BUYER_PK, USDC_100);
+        createSeller(SELLER_PK);
+
+        channels.pause();
+        channels.unpause();
+
+        bytes32 salt = keccak256("session-unpaused");
+        bytes32 channelId = computeChannelId(salt);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, USDC_50, deadline);
+
+        vm.prank(seller);
+        channels.reserve(buyer, salt, USDC_50, deadline, reserveSig);
+
+        (,,,,,,,,AntseedChannels.ChannelStatus sStatus) = channels.channels(channelId);
+        assertTrue(sStatus == AntseedChannels.ChannelStatus.Active);
+    }
+
+    function test_pause_revert_notOwner() public {
+        vm.prank(randomUser);
+        vm.expectRevert();
+        channels.pause();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                   TOP UP TESTS
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_topUp_settlesInlineAndLocks() public {
+        bytes32 salt = keccak256("session-topup");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_150);
+
+        // Top up with inline settle of 85 USDC (85% threshold met)
+        uint128 settleAmount = 85_000_000;
+        bytes memory spendingSig = signSpendingAuth(BUYER_PK, channelId, settleAmount, 5000, 2000);
+
+        uint128 newMax = USDC_150;
+        uint256 newDeadline = block.timestamp + 2 hours;
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, newMax, newDeadline);
+
+        vm.prank(seller);
+        channels.topUp(channelId, settleAmount, encodeMetadata(5000, 2000), spendingSig, newMax, newDeadline, reserveSig);
+
+        // Verify channel state updated
+        (,, uint128 sDeposit, uint128 sSettled,,uint256 sDeadline,,,AntseedChannels.ChannelStatus sStatus) = channels.channels(channelId);
+        assertTrue(sStatus == AntseedChannels.ChannelStatus.Active);
+        assertEq(sDeposit, USDC_150);
+        assertEq(sSettled, settleAmount);
+        assertEq(sDeadline, newDeadline);
+
+        // reserved = 100 - 85 (settle freed) + 50 (topUp locked) = 65
+        (, uint256 reserved,) = deposits.getBuyerBalance(buyer);
+        assertEq(reserved, 65_000_000);
+
+        // Seller received 85 USDC minus platform fee directly
+        uint256 platformFee = (uint256(settleAmount) * 200) / 10000;
+        assertEq(usdc.balanceOf(seller), settleAmount - platformFee);
+    }
+
+    function test_topUp_revert_thresholdNotMet() public {
+        bytes32 salt = keccak256("session-topup-fail");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_150);
+
+        // Only settle 50% (50 USDC out of 100) — below 85% threshold
+        uint128 settleAmount = USDC_50;
+        bytes memory spendingSig = signSpendingAuth(BUYER_PK, channelId, settleAmount, 3000, 1000);
+
+        uint128 newMax = USDC_150;
+        uint256 newDeadline = block.timestamp + 2 hours;
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, newMax, newDeadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.TopUpThresholdNotMet.selector);
+        channels.topUp(channelId, settleAmount, encodeMetadata(3000, 1000), spendingSig, newMax, newDeadline, reserveSig);
+    }
+
+    function test_topUp_revert_newAmountNotHigher() public {
+        bytes32 salt = keccak256("session-topup-low");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_150);
+
+        // Settle 90%
+        uint128 settleAmount = 90_000_000;
+        bytes memory spendingSig = signSpendingAuth(BUYER_PK, channelId, settleAmount, 5000, 2000);
+
+        // Try topUp with same ceiling — should revert
+        uint256 newDeadline = block.timestamp + 2 hours;
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, USDC_100, newDeadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.TopUpAmountTooLow.selector);
+        channels.topUp(channelId, settleAmount, encodeMetadata(5000, 2000), spendingSig, USDC_100, newDeadline, reserveSig);
+    }
+
+    function test_topUp_revert_notSeller() public {
+        bytes32 salt = keccak256("session-topup-auth");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_150);
+
+        uint128 settleAmount = 90_000_000;
+        bytes memory spendingSig = signSpendingAuth(BUYER_PK, channelId, settleAmount, 5000, 2000);
+        uint128 newMax = USDC_150;
+        uint256 newDeadline = block.timestamp + 2 hours;
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, newMax, newDeadline);
+
+        vm.prank(randomUser);
+        vm.expectRevert(AntseedChannels.NotAuthorized.selector);
+        channels.topUp(channelId, settleAmount, encodeMetadata(5000, 2000), spendingSig, newMax, newDeadline, reserveSig);
+    }
+
+    function test_topUp_revert_expiredDeadline() public {
+        bytes32 salt = keccak256("session-topup-expired");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_150);
+
+        uint128 settleAmount = 90_000_000;
+        bytes memory spendingSig = signSpendingAuth(BUYER_PK, channelId, settleAmount, 5000, 2000);
+        uint128 newMax = USDC_150;
+        uint256 pastDeadline = block.timestamp - 1;
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, newMax, pastDeadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.ChannelExpired.selector);
+        channels.topUp(channelId, settleAmount, encodeMetadata(5000, 2000), spendingSig, newMax, pastDeadline, reserveSig);
+    }
+
+    function test_topUp_revert_invalidSignature() public {
+        bytes32 salt = keccak256("session-topup-badsig");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_150);
+
+        uint128 settleAmount = 90_000_000;
+        bytes memory spendingSig = signSpendingAuth(BUYER_PK, channelId, settleAmount, 5000, 2000);
+        uint128 newMax = USDC_150;
+        uint256 newDeadline = block.timestamp + 2 hours;
+        bytes memory badSig = signReserveAuth(RANDOM_PK, channelId, newMax, newDeadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.InvalidSignature.selector);
+        channels.topUp(channelId, settleAmount, encodeMetadata(5000, 2000), spendingSig, newMax, newDeadline, badSig);
+    }
+
+    function test_topUp_continueAndClose() public {
+        bytes32 salt = keccak256("session-topup-then-close");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_150);
+
+        // Top up with 90 USDC settle
+        uint128 settleAmount1 = 90_000_000;
+        bytes memory spendingSig1 = signSpendingAuth(BUYER_PK, channelId, settleAmount1, 5000, 2000);
+        uint128 newMax = USDC_150;
+        uint256 newDeadline = block.timestamp + 2 hours;
+        bytes memory reserveSig = signReserveAuth(BUYER_PK, channelId, newMax, newDeadline);
+
+        vm.prank(seller);
+        channels.topUp(channelId, settleAmount1, encodeMetadata(5000, 2000), spendingSig1, newMax, newDeadline, reserveSig);
+
+        // Continue settling up to 120 cumulative
+        uint128 settleAmount2 = 120_000_000;
+        bytes memory settleSig2 = signSpendingAuth(BUYER_PK, channelId, settleAmount2, 8000, 3500);
+        vm.prank(seller);
+        channels.settle(channelId, settleAmount2, encodeMetadata(8000, 3500), settleSig2);
+
+        // Close at 130 cumulative
+        uint128 finalAmount = 130_000_000;
+        bytes memory closeSig = signSpendingAuth(BUYER_PK, channelId, finalAmount, 10000, 4000);
+        vm.prank(seller);
+        channels.close(channelId, finalAmount, encodeMetadata(10000, 4000), closeSig);
+
+        (,,, uint128 sSettledFinal,,,,, AntseedChannels.ChannelStatus sStatusFinal) = channels.channels(channelId);
+        assertTrue(sStatusFinal == AntseedChannels.ChannelStatus.Settled);
+        assertEq(sSettledFinal, 130_000_000);
+
+        // Buyer refund = 150 - 130 = 20 USDC
+        (uint256 available,,) = deposits.getBuyerBalance(buyer);
+        assertEq(available, 20_000_000);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                   DOMAIN SEPARATOR TEST
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_domainSeparator_nonZero() public view {
+        bytes32 ds = channels.domainSeparator();
+        assertTrue(ds != bytes32(0));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                   OPERATOR TESTS
+    // ═══════════════════════════════════════════════════════════════════
+
+    bytes32 constant SET_OPERATOR_TYPEHASH = keccak256(
+        "SetOperator(address operator,uint256 nonce)"
+    );
+
+    function signSetOperator(
+        uint256 buyerPk,
+        address operator,
+        uint256 nonce
+    ) internal view returns (bytes memory) {
+        bytes32 structHash = keccak256(
+            abi.encode(SET_OPERATOR_TYPEHASH, operator, nonce)
+        );
+        bytes32 digest = _hashTypedDataDeposits(structHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(buyerPk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    // NOTE: These are standalone operator tests — they don't use createBuyer/doReserve.
+    // Operator is set via the first deposit() call.
+
+    /// @dev Set operator and deposit for standalone operator tests.
+    function _setOperatorAndDeposit(address op, uint256 buyerPk, uint256 nonce) internal {
+        address addr = vm.addr(buyerPk);
+        bytes memory sig = signSetOperator(buyerPk, op, nonce);
+        deposits.setCreditLimitOverride(addr, type(uint256).max);
+        deposits.setOperator(addr, op, nonce, sig);
+
+        usdc.mint(op, USDC_100);
+        vm.startPrank(op);
+        usdc.approve(address(deposits), USDC_100);
+        deposits.deposit(addr, USDC_100);
+        vm.stopPrank();
+    }
+
+    function test_operatorSetViaDeposit() public {
+        address op = address(0xABCDE1);
+        _setOperatorAndDeposit(op, BUYER_PK, 0);
+        assertEq(deposits.getOperator(buyer), op);
+        assertEq(deposits.getOperatorNonce(buyer), 1);
+    }
+
+    function test_setOperator_revert_wrongNonce() public {
+        address op = address(0xABCDE1);
+        bytes memory sig = signSetOperator(BUYER_PK, op, 1); // nonce should be 0
+
+        vm.expectRevert(AntseedDeposits.InvalidNonce.selector);
+        deposits.setOperator(buyer, op, 1, sig);
+    }
+
+    function test_setOperator_revert_wrongSigner() public {
+        address op = address(0xABCDE1);
+        bytes memory sig = signSetOperator(RANDOM_PK, op, 0); // wrong signer
+
+        vm.expectRevert(AntseedDeposits.InvalidSignature.selector);
+        deposits.setOperator(buyer, op, 0, sig);
+    }
+
+    function test_setOperator_revert_alreadySet() public {
+        _setOperatorAndDeposit(address(0xABCDE2), BUYER_PK, 0);
+
+        address op2 = address(0xABCDE3);
+        bytes memory sig2 = signSetOperator(BUYER_PK, op2, 1);
+        vm.expectRevert(AntseedDeposits.OperatorAlreadySet.selector);
+        deposits.setOperator(buyer, op2, 1, sig2);
+    }
+
+    function test_transferOperator() public {
+        address op1 = address(0xABCDE2);
+        address op2 = address(0xABCDE3);
+        _setOperatorAndDeposit(op1, BUYER_PK, 0);
+
+        vm.prank(op1);
+        deposits.transferOperator(buyer, op2);
+        assertEq(deposits.getOperator(buyer), op2);
+    }
+
+    function test_transferOperator_revoke() public {
+        address op = address(0xABCDE1);
+        _setOperatorAndDeposit(op, BUYER_PK, 0);
+
+        vm.prank(op);
+        deposits.transferOperator(buyer, address(0));
+        assertEq(deposits.getOperator(buyer), address(0));
+    }
+
+    function test_transferOperator_revert_notOperator() public {
+        address op = address(0xABCDE1);
+        _setOperatorAndDeposit(op, BUYER_PK, 0);
+
+        vm.prank(randomUser);
+        vm.expectRevert(AntseedDeposits.NotAuthorized.selector);
+        deposits.transferOperator(buyer, address(0xBEEF));
+
+        vm.prank(buyer);
+        vm.expectRevert(AntseedDeposits.NotAuthorized.selector);
+        deposits.transferOperator(buyer, address(0xBEEF));
+    }
+
+    function test_transferOperator_thenSetAgain() public {
+        address op1 = address(0xABCDE2);
+        address op2 = address(0xABCDE3);
+        _setOperatorAndDeposit(op1, BUYER_PK, 0);
+
+        // Revoke
+        vm.prank(op1);
+        deposits.transferOperator(buyer, address(0));
+
+        // Set new operator (nonce 1)
+        bytes memory sig2 = signSetOperator(BUYER_PK, op2, 1);
+        deposits.setOperator(buyer, op2, 1, sig2);
+        assertEq(deposits.getOperator(buyer), op2);
+    }
+
+    function test_operator_canRequestClose() public {
+        bytes32 salt = keccak256("session-operator-close");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // Operator calls requestClose
+        vm.prank(buyerOperator);
+        channels.requestClose(channelId);
+
+        (,,,,,,,uint256 closeRequestedAt,) = channels.channels(channelId);
+        assertTrue(closeRequestedAt > 0);
+    }
+
+    function test_operator_canWithdraw() public {
+        bytes32 salt = keccak256("session-operator-withdraw");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // Operator requests close
+        vm.prank(buyerOperator);
+        channels.requestClose(channelId);
+
+        // Wait grace period
+        vm.warp(block.timestamp + 15 minutes + 1);
+
+        // Operator withdraws
+        vm.prank(buyerOperator);
+        channels.withdraw(channelId);
+
+        // Funds returned to buyer's deposits balance
+        (uint256 available,,) = deposits.getBuyerBalance(buyer);
+        assertEq(available, USDC_100);
+    }
+
+    function test_operator_revert_randomUserCannotClose() public {
+        bytes32 salt = keccak256("session-operator-random");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // buyerOperator already set via createBuyer
+
+        // Random user cannot close
+        vm.prank(randomUser);
+        vm.expectRevert(AntseedChannels.NotAuthorized.selector);
+        channels.requestClose(channelId);
+    }
+
+    function test_operator_revert_sellerCannotClose() public {
+        bytes32 salt = keccak256("session-operator-seller");
+        bytes32 channelId = doReserve(salt, USDC_100, USDC_100);
+
+        // Seller is not the operator — should not be able to close
+        vm.prank(seller);
+        vm.expectRevert(AntseedChannels.NotAuthorized.selector);
+        channels.requestClose(channelId);
+    }
+
+}

--- a/packages/contracts/test/AntseedEmissionsV2.t.sol
+++ b/packages/contracts/test/AntseedEmissionsV2.t.sol
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { ANTSToken } from "../ANTSToken.sol";
+import { AntseedEmissions } from "../AntseedEmissions.sol";
+import { AntseedEmissionsV2 } from "../AntseedEmissionsV2.sol";
+import { AntseedRegistry } from "../AntseedRegistry.sol";
+import { AntseedSellerRewardsPool } from "../AntseedSellerRewardsPool.sol";
+import { AntseedSellerUnlockPolicy } from "../AntseedSellerUnlockPolicy.sol";
+import { IAntseedPointsPolicy } from "../interfaces/IAntseedPointsPolicy.sol";
+import { IAntseedSellerClaimPolicy } from "../interfaces/IAntseedSellerClaimPolicy.sol";
+
+contract MockPairPointsPolicy is IAntseedPointsPolicy {
+    bytes32 public immutable targetChannelId;
+    address public immutable targetBuyer;
+    address public immutable targetSeller;
+
+    constructor(bytes32 _targetChannelId, address _targetBuyer, address _targetSeller) {
+        targetChannelId = _targetChannelId;
+        targetBuyer = _targetBuyer;
+        targetSeller = _targetSeller;
+    }
+
+    function points(bytes32 channelId, address buyer, address seller, uint256 rawPoints)
+        external
+        view
+        returns (uint256 sellerPoints, uint256 buyerPoints)
+    {
+        if (channelId == targetChannelId && buyer == targetBuyer && seller == targetSeller) {
+            return (rawPoints * 2, rawPoints * 3);
+        }
+        return (rawPoints, rawPoints);
+    }
+}
+
+contract MockSellerClaimPolicy is IAntseedSellerClaimPolicy {
+    mapping(address => uint256) public claimable;
+
+    function setClaimable(address seller, uint256 amount) external {
+        claimable[seller] = amount;
+    }
+
+    function claimableSellerRewards(address seller, uint256 lockedAmount) external view returns (uint256 amount) {
+        amount = claimable[seller];
+        if (amount > lockedAmount) amount = lockedAmount;
+    }
+}
+
+contract MockDepositsForEmissionsV2 {
+    mapping(address => address) private _operators;
+
+    function setOperator(address buyer, address operator) external {
+        _operators[buyer] = operator;
+    }
+
+    function getOperator(address buyer) external view returns (address) {
+        return _operators[buyer];
+    }
+}
+
+contract AntseedEmissionsV2Test is Test {
+    ANTSToken public token;
+    AntseedEmissions public legacy;
+    AntseedEmissionsV2 public v2;
+    AntseedRegistry public antseedRegistry;
+    AntseedSellerRewardsPool public rewardsPool;
+    AntseedSellerUnlockPolicy public unlockPolicy;
+    MockDepositsForEmissionsV2 public mockDeposits;
+
+    address public seller1 = address(0x10);
+    address public seller2 = address(0x20);
+    address public buyer1 = address(0x30);
+    address public buyer2 = address(0x40);
+    address public reserveDest = address(0x50);
+    address public teamWallet = address(0x51);
+    address public operator1 = address(0x60);
+    address public operator2 = address(0x70);
+
+    uint256 constant INITIAL_EMISSION = 1000 ether;
+    uint256 constant EPOCH_DURATION = 1 weeks;
+
+    function setUp() public {
+        vm.warp(1_700_000_000);
+
+        token = new ANTSToken();
+        antseedRegistry = new AntseedRegistry();
+        mockDeposits = new MockDepositsForEmissionsV2();
+
+        antseedRegistry.setChannels(address(this));
+        antseedRegistry.setDeposits(address(mockDeposits));
+        antseedRegistry.setAntsToken(address(token));
+        antseedRegistry.setProtocolReserve(reserveDest);
+        antseedRegistry.setTeamWallet(teamWallet);
+
+        legacy = new AntseedEmissions(address(antseedRegistry), INITIAL_EMISSION, EPOCH_DURATION);
+        antseedRegistry.setEmissions(address(legacy));
+        token.setRegistry(address(antseedRegistry));
+
+        mockDeposits.setOperator(buyer1, operator1);
+        mockDeposits.setOperator(buyer2, operator2);
+    }
+
+    function _deployV2WithoutCutover() internal {
+        rewardsPool = new AntseedSellerRewardsPool(address(antseedRegistry));
+        unlockPolicy = new AntseedSellerUnlockPolicy();
+        v2 = new AntseedEmissionsV2(address(antseedRegistry), address(legacy), address(rewardsPool));
+        v2.setSellerUnlockPolicy(address(unlockPolicy));
+        v2.setMaxBuyerSharePct(5);
+    }
+
+    function _deployV2() internal {
+        _deployV2WithoutCutover();
+        antseedRegistry.setEmissions(address(v2));
+    }
+
+    function _epochList(uint256 epoch) internal pure returns (uint256[] memory) {
+        uint256[] memory epochs = new uint256[](1);
+        epochs[0] = epoch;
+        return epochs;
+    }
+
+    function test_migrationEpochCombinesLegacyAndV2PointsAndLocksSellerReward() public {
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 4 + 1);
+        assertEq(legacy.currentEpoch(), 4);
+
+        legacy.accrueSellerPoints(seller1, 100);
+        legacy.accrueBuyerPoints(buyer1, 100);
+
+        _deployV2();
+        assertEq(v2.MIGRATION_EPOCH(), 4);
+        assertEq(v2.currentEpoch(), 4);
+
+        v2.accrueSellerPoints(seller1, 100);
+        v2.accrueBuyerPoints(buyer1, 100);
+        v2.accrueSellerPoints(seller2, 200);
+        v2.accrueBuyerPoints(buyer2, 200);
+
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 5 + 1);
+
+        vm.prank(seller1);
+        v2.claimSellerEmissions(_epochList(4));
+        vm.prank(operator1);
+        v2.claimBuyerEmissions(buyer1, _epochList(4));
+
+        uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
+        uint256 expectedSeller = (sellerBudget * 200) / 400;
+        assertEq(expectedSeller, (sellerBudget * 50) / 100, "expected to sit at seller cap");
+
+        uint256 buyerBudget = (INITIAL_EMISSION * 20) / 100;
+        uint256 expectedBuyer = (buyerBudget * 200) / 400;
+
+        assertEq(token.balanceOf(seller1), 0, "seller rewards are locked by default");
+        assertEq(token.balanceOf(address(rewardsPool)), expectedSeller);
+        assertEq(rewardsPool.lockedRewards(seller1), expectedSeller);
+        assertEq(token.balanceOf(operator1), expectedBuyer);
+        assertTrue(v2.sellerEpochClaimed(seller1, 4));
+        assertTrue(v2.buyerEpochClaimed(buyer1, 4));
+    }
+
+    function test_legacyPreviousEpochSellerAndBuyerCanBeClaimedThroughV2() public {
+        legacy.accrueSellerPoints(seller1, 100);
+        legacy.accrueBuyerPoints(buyer1, 100);
+
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 4 + 1);
+        _deployV2();
+
+        vm.prank(seller1);
+        v2.claimSellerEmissions(_epochList(0));
+        vm.prank(operator1);
+        v2.claimBuyerEmissions(buyer1, _epochList(0));
+
+        uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
+        uint256 maxSellerReward = (sellerBudget * 50) / 100;
+        uint256 buyerBudget = (INITIAL_EMISSION * 20) / 100;
+
+        assertEq(rewardsPool.lockedRewards(seller1), maxSellerReward);
+        assertEq(token.balanceOf(address(rewardsPool)), maxSellerReward);
+        assertEq(token.balanceOf(operator1), buyerBudget);
+    }
+
+    function test_legacyPreviousEpochCanBeClaimedThroughV2WithoutDuplicatingBaseReserve() public {
+        legacy.accrueSellerPoints(seller1, 1_000_000);
+
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 4 + 1);
+        _deployV2();
+
+        vm.prank(seller1);
+        v2.claimSellerEmissions(_epochList(0));
+
+        uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
+        uint256 maxSellerReward = (sellerBudget * 50) / 100;
+
+        assertEq(rewardsPool.lockedRewards(seller1), maxSellerReward);
+        assertEq(token.balanceOf(address(rewardsPool)), maxSellerReward);
+        assertEq(v2.reserveAccumulated(), sellerBudget - maxSellerReward, "only cap excess moves to V2 reserve");
+    }
+
+    function test_preMigrationSellerRewardsAreLockedByDefault() public {
+        legacy.accrueSellerPoints(seller1, 100);
+
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 4 + 1);
+        _deployV2();
+
+        vm.prank(seller1);
+        v2.claimSellerEmissions(_epochList(0));
+
+        uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
+        uint256 maxSellerReward = (sellerBudget * 50) / 100;
+
+        assertEq(token.balanceOf(seller1), 0);
+        assertEq(rewardsPool.lockedRewards(seller1), maxSellerReward);
+        assertEq(token.balanceOf(address(rewardsPool)), maxSellerReward);
+    }
+
+    function test_legacyClaimedSellerAndBuyerEpochsCannotDoubleClaimThroughV2() public {
+        legacy.accrueSellerPoints(seller1, 100);
+        legacy.accrueBuyerPoints(buyer1, 100);
+
+        vm.warp(legacy.genesis() + EPOCH_DURATION + 1);
+        vm.prank(seller1);
+        legacy.claimSellerEmissions(_epochList(0));
+        vm.prank(operator1);
+        legacy.claimBuyerEmissions(buyer1, _epochList(0));
+
+        uint256 sellerBalanceBefore = token.balanceOf(seller1);
+        uint256 operatorBalanceBefore = token.balanceOf(operator1);
+
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 4 + 1);
+        _deployV2();
+
+        vm.prank(seller1);
+        v2.claimSellerEmissions(_epochList(0));
+        vm.prank(operator1);
+        v2.claimBuyerEmissions(buyer1, _epochList(0));
+
+        assertEq(token.balanceOf(seller1), sellerBalanceBefore);
+        assertEq(token.balanceOf(operator1), operatorBalanceBefore);
+        assertEq(token.balanceOf(address(rewardsPool)), 0);
+        assertEq(rewardsPool.lockedRewards(seller1), 0);
+    }
+
+    function test_buyerCapStartsNextEpochNotMigrationEpoch() public {
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 4 + 1);
+        legacy.accrueBuyerPoints(buyer1, 100);
+        _deployV2();
+
+        v2.accrueBuyerPoints(buyer1, 100);
+
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 5 + 1);
+        vm.prank(operator1);
+        v2.claimBuyerEmissions(buyer1, _epochList(4));
+
+        uint256 buyerBudget = (INITIAL_EMISSION * 20) / 100;
+        assertEq(token.balanceOf(operator1), buyerBudget, "migration epoch keeps legacy no-buyer-cap behavior");
+
+        v2.accrueBuyerPoints(buyer2, 100);
+
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 6 + 1);
+        vm.prank(operator2);
+        v2.claimBuyerEmissions(buyer2, _epochList(5));
+
+        uint256 cappedReward = (buyerBudget * 5) / 100;
+        assertEq(token.balanceOf(operator2), cappedReward, "next epoch applies 5% buyer cap");
+    }
+
+    function test_unlockPolicyAllowsImmediateSellerClaim() public {
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 4 + 1);
+        _deployV2();
+
+        unlockPolicy.setSellerEligibility(seller1, true);
+        v2.accrueSellerPoints(seller1, 100);
+
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 5 + 1);
+
+        vm.prank(seller1);
+        v2.claimSellerEmissions(_epochList(4));
+
+        uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
+        uint256 maxSellerReward = (sellerBudget * 50) / 100;
+
+        assertEq(token.balanceOf(seller1), maxSellerReward);
+        assertEq(token.balanceOf(address(rewardsPool)), 0);
+        assertEq(rewardsPool.lockedRewards(seller1), 0);
+    }
+
+    function test_futurePairAccrualSupportsBuyerSellerPolicy() public {
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 4 + 1);
+        _deployV2();
+
+        bytes32 channelId = keccak256("channel-1");
+        MockPairPointsPolicy policy = new MockPairPointsPolicy(channelId, buyer1, seller1);
+        v2.setPointsPolicy(address(policy));
+
+        v2.accruePoints(channelId, buyer1, seller1, 100);
+
+        assertEq(v2.userSellerPoints(seller1, 4), 200);
+        assertEq(v2.epochTotalSellerPoints(4), 200);
+        assertEq(v2.userBuyerPoints(buyer1, 4), 300);
+        assertEq(v2.epochTotalBuyerPoints(4), 300);
+    }
+
+    function test_legacySeparateAccrualsUseUnknownCounterpartyForPolicy() public {
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 4 + 1);
+        _deployV2();
+
+        MockPairPointsPolicy policy = new MockPairPointsPolicy(keccak256("channel-1"), buyer1, seller1);
+        v2.setPointsPolicy(address(policy));
+
+        v2.accrueSellerPoints(seller1, 100);
+        v2.accrueBuyerPoints(buyer1, 100);
+
+        assertEq(v2.userSellerPoints(seller1, 4), 100);
+        assertEq(v2.userBuyerPoints(buyer1, 4), 100);
+    }
+
+    function test_poolClaim_revert_withoutSellerClaimPolicy() public {
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 4 + 1);
+        _deployV2();
+        v2.accrueSellerPoints(seller1, 100);
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 5 + 1);
+
+        vm.prank(seller1);
+        v2.claimSellerEmissions(_epochList(4));
+
+        vm.prank(seller1);
+        vm.expectRevert(AntseedSellerRewardsPool.NoSellerClaimPolicy.selector);
+        rewardsPool.claim(seller1);
+    }
+
+    function test_poolClaim_transfersPolicyClaimableAmount() public {
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 4 + 1);
+        _deployV2();
+        v2.accrueSellerPoints(seller1, 100);
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 5 + 1);
+
+        vm.prank(seller1);
+        v2.claimSellerEmissions(_epochList(4));
+
+        uint256 locked = rewardsPool.lockedRewards(seller1);
+        MockSellerClaimPolicy claimPolicy = new MockSellerClaimPolicy();
+        uint256 partialClaim = locked / 2;
+        claimPolicy.setClaimable(seller1, partialClaim);
+        rewardsPool.setSellerClaimPolicy(address(claimPolicy));
+        token.setTransferWhitelist(address(rewardsPool), true);
+
+        vm.prank(seller1);
+        rewardsPool.claim(seller1);
+
+        assertEq(token.balanceOf(seller1), partialClaim);
+        assertEq(rewardsPool.lockedRewards(seller1), locked - partialClaim);
+    }
+
+    function test_poolClaim_clampsToLockedAmount() public {
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 4 + 1);
+        _deployV2();
+        v2.accrueSellerPoints(seller1, 100);
+        vm.warp(legacy.genesis() + EPOCH_DURATION * 5 + 1);
+
+        vm.prank(seller1);
+        v2.claimSellerEmissions(_epochList(4));
+
+        uint256 locked = rewardsPool.lockedRewards(seller1);
+        MockSellerClaimPolicy claimPolicy = new MockSellerClaimPolicy();
+        claimPolicy.setClaimable(seller1, locked + 1);
+        rewardsPool.setSellerClaimPolicy(address(claimPolicy));
+        token.setTransferWhitelist(address(rewardsPool), true);
+
+        vm.prank(seller1);
+        rewardsPool.claim(seller1);
+
+        assertEq(token.balanceOf(seller1), locked);
+        assertEq(rewardsPool.lockedRewards(seller1), 0);
+    }
+}

--- a/packages/contracts/test/AntseedEmissionsV2Compatibility.t.sol
+++ b/packages/contracts/test/AntseedEmissionsV2Compatibility.t.sol
@@ -1,0 +1,699 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../ANTSToken.sol";
+import { AntseedEmissions } from "../AntseedEmissions.sol";
+import { AntseedEmissionsV2 } from "../AntseedEmissionsV2.sol";
+import { AntseedRegistry } from "../AntseedRegistry.sol";
+import { AntseedSellerRewardsPool } from "../AntseedSellerRewardsPool.sol";
+
+/// @dev Minimal mock Deposits that only supports getOperator for emission tests.
+contract MockDepositsForEmissions {
+    mapping(address => address) private _operators;
+
+    function setOperator(address buyer, address operator) external {
+        _operators[buyer] = operator;
+    }
+
+    function getOperator(address buyer) external view returns (address) {
+        return _operators[buyer];
+    }
+}
+
+contract MockAllowAllSellerUnlockPolicy {
+    function canClaimSellerUnlocked(address) external pure returns (bool) {
+        return true;
+    }
+}
+
+contract AntseedEmissionsV2CompatibilityTest is Test {
+    ANTSToken public token;
+    AntseedEmissions public legacyEmissions;
+    AntseedEmissionsV2 public emissions;
+    AntseedSellerRewardsPool public rewardsPool;
+    MockAllowAllSellerUnlockPolicy public unlockPolicy;
+    AntseedRegistry public antseedRegistry;
+    MockDepositsForEmissions public mockDeposits;
+
+    address public seller1 = address(0x10);
+    address public seller2 = address(0x20);
+    address public buyer1 = address(0x30);
+    address public buyer2 = address(0x40);
+    address public reserveDest = address(0x50);
+    address public operator1 = address(0x60);
+    address public operator2 = address(0x70);
+
+    uint256 constant INITIAL_EMISSION = 1000 ether;
+    uint256 constant EPOCH_DURATION = 1 weeks;
+
+    function setUp() public {
+        token = new ANTSToken();
+        antseedRegistry = new AntseedRegistry();
+        mockDeposits = new MockDepositsForEmissions();
+        antseedRegistry.setChannels(address(this));
+        antseedRegistry.setDeposits(address(mockDeposits));
+        antseedRegistry.setAntsToken(address(token));
+
+        legacyEmissions = new AntseedEmissions(address(antseedRegistry), INITIAL_EMISSION, EPOCH_DURATION);
+        antseedRegistry.setEmissions(address(legacyEmissions));
+        legacyEmissions.accrueSellerPoints(seller1, 0);
+        legacyEmissions.accrueBuyerPoints(buyer1, 0);
+
+        rewardsPool = new AntseedSellerRewardsPool(address(antseedRegistry));
+        unlockPolicy = new MockAllowAllSellerUnlockPolicy();
+        emissions = new AntseedEmissionsV2(address(antseedRegistry), address(legacyEmissions), address(rewardsPool));
+        emissions.setSellerUnlockPolicy(address(unlockPolicy));
+        emissions.setMaxBuyerSharePct(100);
+
+        antseedRegistry.setEmissions(address(emissions));
+        antseedRegistry.setProtocolReserve(reserveDest);
+        token.setRegistry(address(antseedRegistry));
+
+        // Set operators for buyers
+        mockDeposits.setOperator(buyer1, operator1);
+        mockDeposits.setOperator(buyer2, operator2);
+    }
+
+    // ── Helpers ──
+
+    function _epochList(uint256 epoch) internal pure returns (uint256[] memory) {
+        uint256[] memory epochs = new uint256[](1);
+        epochs[0] = epoch;
+        return epochs;
+    }
+
+    function _epochRange(uint256 from, uint256 to) internal pure returns (uint256[] memory) {
+        uint256[] memory epochs = new uint256[](to - from);
+        for (uint256 i = 0; i < epochs.length; i++) {
+            epochs[i] = from + i;
+        }
+        return epochs;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        INITIAL STATE
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_initialState() public view {
+        assertEq(emissions.currentEpoch(), 0);
+        assertEq(emissions.INITIAL_EMISSION(), INITIAL_EMISSION);
+        assertEq(emissions.EPOCH_DURATION(), EPOCH_DURATION);
+        assertEq(emissions.SELLER_SHARE_PCT(), 50);
+        assertEq(emissions.BUYER_SHARE_PCT(), 20);
+        assertEq(emissions.RESERVE_SHARE_PCT(), 15);
+        assertEq(emissions.TEAM_SHARE_PCT(), 15);
+        assertEq(emissions.MAX_SELLER_SHARE_PCT(), 50);
+        assertEq(emissions.HALVING_INTERVAL(), 104);
+        assertEq(emissions.currentEmissionRate(), INITIAL_EMISSION / EPOCH_DURATION);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        EPOCH DERIVATION
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_currentEpoch_derivedFromTimestamp() public {
+        assertEq(emissions.currentEpoch(), 0);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+        assertEq(emissions.currentEpoch(), 1);
+
+        vm.warp(block.timestamp + EPOCH_DURATION * 9);
+        assertEq(emissions.currentEpoch(), 10);
+    }
+
+    function test_halvingSchedule() public view {
+        assertEq(emissions.getEpochEmission(0), INITIAL_EMISSION);
+        assertEq(emissions.getEpochEmission(103), INITIAL_EMISSION); // last epoch before halving
+        assertEq(emissions.getEpochEmission(104), INITIAL_EMISSION / 2);
+        assertEq(emissions.getEpochEmission(208), INITIAL_EMISSION / 4);
+        assertEq(emissions.getEpochEmission(416), INITIAL_EMISSION / 16);
+    }
+
+    function test_currentEmissionRate_afterHalving() public {
+        vm.warp(block.timestamp + EPOCH_DURATION * 104);
+        uint256 expectedRate = (INITIAL_EMISSION / 2) / EPOCH_DURATION;
+        assertEq(emissions.currentEmissionRate(), expectedRate);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        POINT ACCRUAL
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_accrueSellerPoints() public {
+        emissions.accrueSellerPoints(seller1, 100);
+
+        assertEq(emissions.epochTotalSellerPoints(0), 100);
+        assertEq(emissions.userSellerPoints(seller1, 0), 100);
+    }
+
+    function test_accrueSellerPoints_revert_notChannels() public {
+        vm.prank(seller1);
+        vm.expectRevert(AntseedEmissionsV2.NotAuthorized.selector);
+        emissions.accrueSellerPoints(seller1, 100);
+    }
+
+    function test_accrueBuyerPoints() public {
+        emissions.accrueBuyerPoints(buyer1, 200);
+
+        assertEq(emissions.epochTotalBuyerPoints(0), 200);
+        assertEq(emissions.userBuyerPoints(buyer1, 0), 200);
+    }
+
+    function test_accrueBuyerPoints_revert_notChannels() public {
+        vm.prank(buyer1);
+        vm.expectRevert(AntseedEmissionsV2.NotAuthorized.selector);
+        emissions.accrueBuyerPoints(buyer1, 100);
+    }
+
+    function test_accruePoints_goesToCorrectEpoch() public {
+        emissions.accrueSellerPoints(seller1, 50);
+        assertEq(emissions.userSellerPoints(seller1, 0), 50);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+        emissions.accrueSellerPoints(seller1, 75);
+        assertEq(emissions.userSellerPoints(seller1, 1), 75);
+        // Epoch 0 unchanged
+        assertEq(emissions.userSellerPoints(seller1, 0), 50);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        CLAIMING
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_claimSeller_singleEpoch() public {
+        emissions.accrueSellerPoints(seller1, 100);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
+        uint256 maxPerSeller = (sellerBudget * 50) / 100;
+        uint256 expected = sellerBudget > maxPerSeller ? maxPerSeller : sellerBudget;
+
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochList(0));
+
+        assertEq(token.balanceOf(seller1), expected);
+    }
+
+    function test_claimBuyer_singleEpoch() public {
+        emissions.accrueBuyerPoints(buyer1, 100);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        uint256 expectedBuyerBudget = (INITIAL_EMISSION * 20) / 100;
+
+        // Operator claims on behalf of buyer — tokens go to operator
+        vm.prank(operator1);
+        emissions.claimBuyerEmissions(buyer1, _epochList(0));
+
+        assertEq(token.balanceOf(operator1), expectedBuyerBudget);
+        assertEq(token.balanceOf(buyer1), 0);
+    }
+
+    function test_claimBoth_singleEpoch() public {
+        // seller1 is both seller and buyer — set an operator for seller1 as buyer
+        mockDeposits.setOperator(seller1, operator1);
+        emissions.accrueSellerPoints(seller1, 100);
+        emissions.accrueBuyerPoints(seller1, 100);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        // Seller claims seller rewards directly
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochList(0));
+        assertTrue(token.balanceOf(seller1) > 0);
+
+        // Operator claims buyer rewards — goes to operator, not seller1
+        vm.prank(operator1);
+        emissions.claimBuyerEmissions(seller1, _epochList(0));
+        assertTrue(token.balanceOf(operator1) > 0);
+    }
+
+    function test_claim_revert_currentEpoch() public {
+        emissions.accrueSellerPoints(seller1, 100);
+
+        vm.prank(seller1);
+        vm.expectRevert(AntseedEmissionsV2.EpochNotFinalized.selector);
+        emissions.claimSellerEmissions(_epochList(0));
+    }
+
+    function test_claim_revert_futureEpoch() public {
+        vm.prank(seller1);
+        vm.expectRevert(AntseedEmissionsV2.EpochNotFinalized.selector);
+        emissions.claimSellerEmissions(_epochList(5));
+    }
+
+    function test_claim_duplicateEpochIsIdempotent() public {
+        emissions.accrueSellerPoints(seller1, 100);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        // First claim
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochList(0));
+        uint256 balanceAfterFirst = token.balanceOf(seller1);
+
+        // Second claim of same epoch — should be a no-op (continue), not revert
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochList(0));
+        assertEq(token.balanceOf(seller1), balanceAfterFirst);
+    }
+
+    function test_claim_skipsZeroActivityEpochs() public {
+        emissions.accrueSellerPoints(seller1, 100);
+
+        vm.warp(block.timestamp + EPOCH_DURATION * 3);
+
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochRange(0, 3));
+
+        assertTrue(emissions.sellerEpochClaimed(seller1, 0));
+        assertFalse(emissions.sellerEpochClaimed(seller1, 1));
+        assertFalse(emissions.sellerEpochClaimed(seller1, 2));
+    }
+
+    function test_claim_emptyEpochArray() public {
+        uint256[] memory empty = new uint256[](0);
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(empty);
+        assertEq(token.balanceOf(seller1), 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //               PROPORTIONAL DISTRIBUTION
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_proportionalSellers() public {
+        emissions.accrueSellerPoints(seller1, 300);
+        emissions.accrueSellerPoints(seller2, 100);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
+        uint256 maxPerSeller = (sellerBudget * 50) / 100;
+
+        uint256 raw1 = (300 * sellerBudget) / 400;
+        uint256 raw2 = (100 * sellerBudget) / 400;
+
+        uint256 expected1 = raw1 > maxPerSeller ? maxPerSeller : raw1;
+        uint256 expected2 = raw2 > maxPerSeller ? maxPerSeller : raw2;
+
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochList(0));
+        vm.prank(seller2);
+        emissions.claimSellerEmissions(_epochList(0));
+
+        assertEq(token.balanceOf(seller1), expected1);
+        assertEq(token.balanceOf(seller2), expected2);
+    }
+
+    function test_proportionalBuyers() public {
+        emissions.accrueBuyerPoints(buyer1, 600);
+        emissions.accrueBuyerPoints(buyer2, 400);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        uint256 buyerBudget = (INITIAL_EMISSION * 20) / 100;
+
+        vm.prank(operator1);
+        emissions.claimBuyerEmissions(buyer1, _epochList(0));
+        vm.prank(operator2);
+        emissions.claimBuyerEmissions(buyer2, _epochList(0));
+
+        // Tokens go to operators, not buyers
+        assertEq(token.balanceOf(operator1), (600 * buyerBudget) / 1000);
+        assertEq(token.balanceOf(operator2), (400 * buyerBudget) / 1000);
+        assertEq(token.balanceOf(buyer1), 0);
+        assertEq(token.balanceOf(buyer2), 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //               POINTS EXPIRE — NO CARRY-OVER
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_pointsDontCarryOver() public {
+        uint256 t = block.timestamp;
+        emissions.accrueSellerPoints(seller1, 100);
+
+        t += EPOCH_DURATION;
+        vm.warp(t);
+        emissions.accrueSellerPoints(seller2, 100);
+
+        t += EPOCH_DURATION;
+        vm.warp(t);
+
+        // seller1 has 0 points in epoch 1
+        assertEq(emissions.userSellerPoints(seller1, 1), 0);
+
+        // seller2 gets full epoch 1 seller budget (capped)
+        uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
+        uint256 maxPerSeller = (sellerBudget * 50) / 100;
+        uint256 expected = sellerBudget > maxPerSeller ? maxPerSeller : sellerBudget;
+
+        vm.prank(seller2);
+        emissions.claimSellerEmissions(_epochList(1));
+
+        assertEq(token.balanceOf(seller2), expected);
+    }
+
+    function test_inactiveSellerEarnsNothing() public {
+        emissions.accrueSellerPoints(seller1, 1000);
+
+        vm.warp(block.timestamp + EPOCH_DURATION * 3);
+
+        assertEq(emissions.userSellerPoints(seller1, 1), 0);
+        assertEq(emissions.userSellerPoints(seller1, 2), 0);
+
+        (uint256 pendSeller,) = emissions.pendingEmissions(seller1, _epochList(1));
+        assertEq(pendSeller, 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //               CROSS-EPOCH CLAIMING
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_claimMultipleEpochs() public {
+        uint256 t = block.timestamp;
+        emissions.accrueSellerPoints(seller1, 100);
+
+        t += EPOCH_DURATION;
+        vm.warp(t);
+        emissions.accrueSellerPoints(seller1, 200);
+
+        t += EPOCH_DURATION;
+        vm.warp(t);
+
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochRange(0, 2));
+
+        assertTrue(token.balanceOf(seller1) > 0);
+        assertTrue(emissions.sellerEpochClaimed(seller1, 0));
+        assertTrue(emissions.sellerEpochClaimed(seller1, 1));
+    }
+
+    function test_claimAfterLongAbsence() public {
+        emissions.accrueSellerPoints(seller1, 100);
+
+        vm.warp(block.timestamp + EPOCH_DURATION * 52);
+
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochList(0));
+
+        assertTrue(token.balanceOf(seller1) > 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //               SELLER CAP
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_sellerCap() public {
+        emissions.accrueSellerPoints(seller1, 1_000_000);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
+        uint256 maxPerSeller = (sellerBudget * 50) / 100;
+
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochList(0));
+
+        assertEq(token.balanceOf(seller1), maxPerSeller);
+    }
+
+    function test_sellerCap_excessGoesToReserve() public {
+        emissions.accrueSellerPoints(seller1, 1_000_000);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        uint256 reserveBefore = emissions.reserveAccumulated();
+
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochList(0));
+
+        assertTrue(emissions.reserveAccumulated() > reserveBefore);
+    }
+
+    function test_sellerCap_notTriggeredWithManySellers() public {
+        for (uint256 i = 1; i <= 10; i++) {
+            emissions.accrueSellerPoints(address(uint160(i)), 100);
+        }
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        uint256 sellerBudget = (INITIAL_EMISSION * 50) / 100;
+        uint256 expectedEach = sellerBudget / 10;
+
+        vm.prank(address(uint160(1)));
+        emissions.claimSellerEmissions(_epochList(0));
+
+        assertEq(token.balanceOf(address(uint160(1))), expectedEach);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //               RESERVE
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_reserveAccumulates_onClaim() public {
+        emissions.accrueSellerPoints(seller1, 100);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        assertEq(emissions.reserveAccumulated(), 0);
+
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochList(0));
+
+        // Reserve should have 10% of epoch emission
+        uint256 expectedReserve = (INITIAL_EMISSION * 15) / 100;
+        // Plus any seller cap excess
+        uint256 reserveAmount = emissions.reserveAccumulated();
+        assertTrue(reserveAmount >= expectedReserve);
+    }
+
+    function test_reserveAccumulates_onlyOncePerEpoch() public {
+        // Use 10 sellers so each gets 10% (below 15% cap = no excess)
+        for (uint256 i = 1; i <= 10; i++) {
+            emissions.accrueSellerPoints(address(uint160(i)), 100);
+        }
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        vm.prank(address(uint160(1)));
+        emissions.claimSellerEmissions(_epochList(0));
+        uint256 reserveAfterFirst = emissions.reserveAccumulated();
+
+        vm.prank(address(uint160(2)));
+        emissions.claimSellerEmissions(_epochList(0));
+        uint256 reserveAfterSecond = emissions.reserveAccumulated();
+
+        // Reserve share (10%) added on first claim only
+        uint256 baseReserve = (INITIAL_EMISSION * 15) / 100;
+        assertEq(reserveAfterFirst, baseReserve);
+        // Second claim adds no additional reserve (no cap excess with 10% each)
+        assertEq(reserveAfterSecond, baseReserve);
+    }
+
+    function test_reserveFlush() public {
+        emissions.accrueSellerPoints(seller1, 100);
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochList(0));
+
+        uint256 reserveAmount = emissions.reserveAccumulated();
+        assertTrue(reserveAmount > 0);
+
+        emissions.flushReserve();
+        assertEq(token.balanceOf(reserveDest), reserveAmount);
+        assertEq(emissions.reserveAccumulated(), 0);
+    }
+
+    function test_reserveFlush_revert_zeroBalance() public {
+        vm.expectRevert(AntseedEmissionsV2.NoReserve.selector);
+        emissions.flushReserve();
+    }
+
+    function test_reserveFlush_revert_noProtocolReserve() public {
+        AntseedRegistry reg2 = new AntseedRegistry();
+        reg2.setChannels(address(this));
+        reg2.setAntsToken(address(token));
+        AntseedEmissions legacy2 = new AntseedEmissions(address(reg2), INITIAL_EMISSION, EPOCH_DURATION);
+        AntseedSellerRewardsPool pool2 = new AntseedSellerRewardsPool(address(reg2));
+        AntseedEmissionsV2 em2 = new AntseedEmissionsV2(address(reg2), address(legacy2), address(pool2));
+        reg2.setEmissions(address(em2));
+
+        vm.expectRevert(AntseedEmissionsV2.NoProtocolReserve.selector);
+        em2.flushReserve();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //               PENDING EMISSIONS VIEW
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_pendingEmissions_matchesClaim() public {
+        emissions.accrueSellerPoints(seller1, 500);
+        emissions.accrueBuyerPoints(seller1, 300);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        (uint256 pendSeller, uint256 pendBuyer) = emissions.pendingEmissions(seller1, _epochList(0));
+        assertTrue(pendSeller > 0);
+        assertTrue(pendBuyer > 0);
+
+        // Seller claims seller rewards directly
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochList(0));
+        assertEq(token.balanceOf(seller1), pendSeller);
+
+        // Operator claims buyer rewards for seller1
+        mockDeposits.setOperator(seller1, operator1);
+        vm.prank(operator1);
+        emissions.claimBuyerEmissions(seller1, _epochList(0));
+        assertEq(token.balanceOf(operator1), pendBuyer);
+    }
+
+    function test_pendingEmissions_zeroAfterClaim() public {
+        emissions.accrueSellerPoints(seller1, 100);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        vm.prank(seller1);
+        emissions.claimSellerEmissions(_epochList(0));
+
+        (uint256 pendSeller,) = emissions.pendingEmissions(seller1, _epochList(0));
+        assertEq(pendSeller, 0);
+    }
+
+    function test_pendingEmissions_currentEpochReturnsZero() public {
+        emissions.accrueSellerPoints(seller1, 100);
+
+        (uint256 pendSeller, uint256 pendBuyer) = emissions.pendingEmissions(seller1, _epochList(0));
+        assertEq(pendSeller, 0);
+        assertEq(pendBuyer, 0);
+    }
+
+    function test_pendingEmissions_buyerOnlyEpoch() public {
+        emissions.accrueBuyerPoints(buyer1, 500);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        (uint256 pendSeller, uint256 pendBuyer) = emissions.pendingEmissions(buyer1, _epochList(0));
+        assertEq(pendSeller, 0);
+        assertTrue(pendBuyer > 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //               CONFIG
+    // ═══════════════════════════════════════════════════════════════════
+
+    function test_sharePercentages() public {
+        emissions.setSharePercentages(60, 20, 10, 10);
+        assertEq(emissions.SELLER_SHARE_PCT(), 60);
+        assertEq(emissions.BUYER_SHARE_PCT(), 20);
+        assertEq(emissions.RESERVE_SHARE_PCT(), 10);
+        assertEq(emissions.TEAM_SHARE_PCT(), 10);
+    }
+
+    function test_sharePercentages_revert_invalidSum() public {
+        vm.expectRevert(AntseedEmissionsV2.InvalidShareSum.selector);
+        emissions.setSharePercentages(60, 20, 10, 5);
+    }
+
+    function test_setRegistry_onlyOwner() public {
+        vm.prank(seller1);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", seller1));
+        emissions.setRegistry(address(0x99));
+    }
+
+    function test_setRegistry() public {
+        AntseedRegistry newReg = new AntseedRegistry();
+        newReg.setChannels(address(this));
+        newReg.setAntsToken(address(token));
+        emissions.setRegistry(address(newReg));
+        assertEq(address(emissions.registry()), address(newReg));
+    }
+
+    function test_setRegistry_revert_zeroAddress() public {
+        vm.expectRevert(AntseedEmissionsV2.InvalidAddress.selector);
+        emissions.setRegistry(address(0));
+    }
+
+    function test_setMaxSellerSharePct() public {
+        emissions.setMaxSellerSharePct(20);
+        assertEq(emissions.MAX_SELLER_SHARE_PCT(), 20);
+    }
+
+    function test_setMaxSellerSharePct_allowsZero() public {
+        emissions.setMaxSellerSharePct(0);
+        assertEq(emissions.MAX_SELLER_SHARE_PCT(), 0);
+    }
+
+    function test_setMaxSellerSharePct_revert_over100() public {
+        vm.expectRevert(AntseedEmissionsV2.InvalidValue.selector);
+        emissions.setMaxSellerSharePct(101);
+    }
+
+    function test_constructor_revert_zeroRegistry() public {
+        vm.expectRevert(AntseedEmissionsV2.InvalidAddress.selector);
+        new AntseedEmissionsV2(address(0), address(legacyEmissions), address(rewardsPool));
+    }
+
+    function test_constructor_revert_zeroLegacyEmissions() public {
+        vm.expectRevert(AntseedEmissionsV2.InvalidAddress.selector);
+        new AntseedEmissionsV2(address(antseedRegistry), address(0), address(rewardsPool));
+    }
+
+    function test_constructor_revert_zeroRewardsPool() public {
+        vm.expectRevert(AntseedEmissionsV2.InvalidAddress.selector);
+        new AntseedEmissionsV2(address(antseedRegistry), address(legacyEmissions), address(0));
+    }
+
+    function test_pause_blocksAccrual() public {
+        emissions.pause();
+
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        emissions.accrueSellerPoints(seller1, 100);
+
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        emissions.accrueBuyerPoints(buyer1, 100);
+    }
+
+    function test_pause_blocksClaim() public {
+        emissions.accrueSellerPoints(seller1, 100);
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        emissions.pause();
+
+        vm.prank(seller1);
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        emissions.claimSellerEmissions(_epochList(0));
+    }
+
+    function test_unpause_restoresFunction() public {
+        emissions.pause();
+        emissions.unpause();
+
+        emissions.accrueSellerPoints(seller1, 100);
+        assertEq(emissions.userSellerPoints(seller1, 0), 100);
+    }
+
+    function test_pause_revert_notOwner() public {
+        vm.prank(seller1);
+        vm.expectRevert(abi.encodeWithSignature("OwnableUnauthorizedAccount(address)", seller1));
+        emissions.pause();
+    }
+
+    function test_transferOwnership() public {
+        emissions.transferOwnership(seller1);
+        assertEq(emissions.owner(), seller1);
+
+        AntseedRegistry newRegistry = new AntseedRegistry();
+        newRegistry.setChannels(address(0x99));
+        newRegistry.setAntsToken(address(token));
+
+        vm.prank(seller1);
+        emissions.setRegistry(address(newRegistry));
+        assertEq(address(emissions.registry()), address(newRegistry));
+    }
+}

--- a/packages/contracts/test/AntseedEmissionsV2Integration.t.sol
+++ b/packages/contracts/test/AntseedEmissionsV2Integration.t.sol
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { ANTSToken } from "../ANTSToken.sol";
+import { AntseedChannels } from "../AntseedChannels.sol";
+import { AntseedDeposits } from "../AntseedDeposits.sol";
+import { AntseedEmissions } from "../AntseedEmissions.sol";
+import { AntseedEmissionsV2 } from "../AntseedEmissionsV2.sol";
+import { AntseedRegistry } from "../AntseedRegistry.sol";
+import { AntseedSellerRewardsPool } from "../AntseedSellerRewardsPool.sol";
+import { AntseedSellerUnlockPolicy } from "../AntseedSellerUnlockPolicy.sol";
+import { AntseedStaking } from "../AntseedStaking.sol";
+import { DiemStakingProxy } from "../DiemStakingProxy.sol";
+import { MockERC8004Registry } from "../MockERC8004Registry.sol";
+import { MockUSDC } from "../MockUSDC.sol";
+
+import { MockDiem } from "./mocks/MockDiem.sol";
+
+contract AntseedEmissionsV2IntegrationTest is Test {
+    uint256 constant BUYER_PK = 0xA11CE;
+    uint256 constant SELLER_PK = 0xB0B;
+    uint256 constant OWNER_PK = 0x0A;
+    uint256 constant OPERATOR_PK = 0x0B;
+    uint256 constant ALICE_PK = 0x0C;
+
+    uint256 constant INITIAL_EMISSION = 1000 ether;
+    uint256 constant EPOCH_DURATION = 1 weeks;
+    uint256 constant STAKE_AMOUNT = 10_000_000;
+    uint256 constant METADATA_VERSION = 1;
+
+    bytes32 constant SET_OPERATOR_TYPEHASH = keccak256("SetOperator(address operator,uint256 nonce)");
+    bytes32 constant SPENDING_AUTH_TYPEHASH =
+        keccak256("SpendingAuth(bytes32 channelId,uint256 cumulativeAmount,bytes32 metadataHash)");
+    bytes32 constant RESERVE_AUTH_TYPEHASH =
+        keccak256("ReserveAuth(bytes32 channelId,uint128 maxAmount,uint256 deadline)");
+
+    address buyer;
+    address seller;
+    address buyerOperator = address(0xAA);
+    address protocolReserve = address(0xFEE);
+    address teamWallet = address(0xBEEF);
+    address owner;
+    address operator;
+    address alice;
+
+    MockUSDC usdc;
+    ANTSToken ants;
+    MockERC8004Registry identityRegistry;
+    AntseedRegistry antseedRegistry;
+    AntseedDeposits deposits;
+    AntseedStaking staking;
+    AntseedChannels channels;
+    AntseedEmissions legacyEmissions;
+    AntseedEmissionsV2 emissionsV2;
+    AntseedSellerRewardsPool rewardsPool;
+    AntseedSellerUnlockPolicy unlockPolicy;
+
+    function setUp() public {
+        buyer = vm.addr(BUYER_PK);
+        seller = vm.addr(SELLER_PK);
+        owner = vm.addr(OWNER_PK);
+        operator = vm.addr(OPERATOR_PK);
+        alice = vm.addr(ALICE_PK);
+
+        vm.warp(1_700_000_000);
+
+        usdc = new MockUSDC();
+        ants = new ANTSToken();
+        identityRegistry = new MockERC8004Registry();
+        antseedRegistry = new AntseedRegistry();
+        deposits = new AntseedDeposits(address(usdc));
+        staking = new AntseedStaking(address(usdc), address(antseedRegistry));
+        channels = new AntseedChannels(address(antseedRegistry));
+        legacyEmissions = new AntseedEmissions(address(antseedRegistry), INITIAL_EMISSION, EPOCH_DURATION);
+
+        antseedRegistry.setChannels(address(channels));
+        antseedRegistry.setDeposits(address(deposits));
+        antseedRegistry.setStaking(address(staking));
+        antseedRegistry.setEmissions(address(legacyEmissions));
+        antseedRegistry.setAntsToken(address(ants));
+        antseedRegistry.setIdentityRegistry(address(identityRegistry));
+        antseedRegistry.setProtocolReserve(protocolReserve);
+        antseedRegistry.setTeamWallet(teamWallet);
+
+        deposits.setRegistry(address(antseedRegistry));
+        ants.setRegistry(address(antseedRegistry));
+        channels.setFirstSignCap(10_000_000_000);
+
+        // Mirror the real upgrade condition: deploy V2 during an already-touched legacy epoch.
+        vm.warp(legacyEmissions.genesis() + EPOCH_DURATION * 4 + 1);
+        vm.prank(address(channels));
+        legacyEmissions.accrueSellerPoints(address(0xDEAD), 1);
+        vm.prank(address(channels));
+        legacyEmissions.accrueBuyerPoints(address(0xBEEF), 1);
+
+        rewardsPool = new AntseedSellerRewardsPool(address(antseedRegistry));
+        unlockPolicy = new AntseedSellerUnlockPolicy();
+        emissionsV2 = new AntseedEmissionsV2(address(antseedRegistry), address(legacyEmissions), address(rewardsPool));
+        emissionsV2.setSellerUnlockPolicy(address(unlockPolicy));
+        antseedRegistry.setEmissions(address(emissionsV2));
+    }
+
+    function test_channelsSettlementAccruesIntoEmissionsV2() public {
+        _createBuyer(500e6);
+        _createSeller(seller);
+
+        bytes32 channelId = _reserve(seller, bytes32(uint256(1)), 500e6);
+        _settle(seller, channelId, 300e6);
+
+        assertEq(emissionsV2.userSellerPoints(seller, 4), 300e6);
+        assertEq(emissionsV2.userBuyerPoints(buyer, 4), 300e6);
+
+        vm.warp(legacyEmissions.genesis() + EPOCH_DURATION * 5 + 1);
+
+        vm.prank(seller);
+        emissionsV2.claimSellerEmissions(_epochList(4));
+        assertGt(rewardsPool.lockedRewards(seller), 0, "seller emissions are locked by default");
+
+        vm.prank(buyerOperator);
+        emissionsV2.claimBuyerEmissions(buyer, _epochList(4));
+        assertGt(ants.balanceOf(buyerOperator), 0, "buyer operator receives buyer emissions");
+    }
+
+    function test_diemProxyCanClaimNormallyWhenUnlockPolicyAllowsIt() public {
+        MockDiem diem = new MockDiem(1 days);
+        DiemStakingProxy proxy;
+
+        vm.prank(owner);
+        proxy = new DiemStakingProxy(address(diem), address(usdc), address(antseedRegistry), operator);
+        unlockPolicy.setSellerEligibility(address(proxy), true);
+        ants.setTransferWhitelist(address(proxy), true);
+
+        vm.prank(address(proxy));
+        uint256 proxyAgentId = identityRegistry.register();
+
+        usdc.mint(address(this), STAKE_AMOUNT);
+        usdc.approve(address(staking), STAKE_AMOUNT);
+        staking.stakeFor(address(proxy), proxyAgentId, STAKE_AMOUNT);
+
+        vm.prank(owner);
+        proxy.setMaxTotalStake(0);
+
+        diem.mint(alice, 100e18);
+        vm.startPrank(alice);
+        diem.approve(address(proxy), 100e18);
+        proxy.stake(100e18);
+        vm.stopPrank();
+
+        _createBuyer(1000e6);
+        bytes32 channelId = _reserve(address(proxy), bytes32(uint256(2)), 1000e6);
+
+        bytes memory metadata = _encodeMetadata(500e6, 0);
+        bytes memory sig = _signSpendingAuth(channelId, 500e6, metadata);
+        vm.prank(operator);
+        proxy.settle(channelId, 500e6, metadata, sig);
+
+        vm.warp(legacyEmissions.genesis() + EPOCH_DURATION * 5 + 1);
+
+        uint256 beforeBal = ants.balanceOf(alice);
+        vm.prank(alice);
+        proxy.claimAnts(_rewardEpochs(4, 1));
+
+        assertGt(ants.balanceOf(alice) - beforeBal, 0, "Diem staker receives ANTS through V2");
+    }
+
+    function _createBuyer(uint256 depositAmount) internal {
+        vm.prank(buyer);
+        identityRegistry.register();
+
+        deposits.setCreditLimitOverride(buyer, type(uint256).max);
+
+        uint256 nonce = deposits.getOperatorNonce(buyer);
+        bytes32 structHash = keccak256(abi.encode(SET_OPERATOR_TYPEHASH, buyerOperator, nonce));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", deposits.domainSeparator(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(BUYER_PK, digest);
+        deposits.setOperator(buyer, buyerOperator, nonce, abi.encodePacked(r, s, v));
+
+        usdc.mint(buyerOperator, depositAmount);
+        vm.startPrank(buyerOperator);
+        usdc.approve(address(deposits), depositAmount);
+        deposits.deposit(buyer, depositAmount);
+        vm.stopPrank();
+    }
+
+    function _createSeller(address sellerAddress) internal {
+        vm.prank(sellerAddress);
+        uint256 agentId = identityRegistry.register();
+
+        usdc.mint(sellerAddress, STAKE_AMOUNT);
+        vm.startPrank(sellerAddress);
+        usdc.approve(address(staking), STAKE_AMOUNT);
+        staking.stake(agentId, STAKE_AMOUNT);
+        vm.stopPrank();
+    }
+
+    function _reserve(address sellerAddress, bytes32 salt, uint128 maxAmount) internal returns (bytes32 channelId) {
+        channelId = channels.computeChannelId(buyer, sellerAddress, salt);
+        uint256 deadline = block.timestamp + 1 days;
+        bytes memory reserveSig = _signReserveAuth(channelId, maxAmount, deadline);
+        if (sellerAddress == seller) {
+            vm.prank(sellerAddress);
+            channels.reserve(buyer, salt, maxAmount, deadline, reserveSig);
+        } else {
+            vm.prank(operator);
+            DiemStakingProxy(sellerAddress).reserve(buyer, salt, maxAmount, deadline, reserveSig);
+        }
+    }
+
+    function _settle(address sellerAddress, bytes32 channelId, uint128 cumulativeAmount) internal {
+        bytes memory metadata = _encodeMetadata(cumulativeAmount, 0);
+        bytes memory sig = _signSpendingAuth(channelId, cumulativeAmount, metadata);
+        vm.prank(sellerAddress);
+        channels.settle(channelId, cumulativeAmount, metadata, sig);
+    }
+
+    function _signReserveAuth(bytes32 channelId, uint128 maxAmount, uint256 deadline) internal view returns (bytes memory) {
+        bytes32 structHash = keccak256(abi.encode(RESERVE_AUTH_TYPEHASH, channelId, maxAmount, deadline));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(BUYER_PK, _hashTypedDataChannels(structHash));
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _signSpendingAuth(bytes32 channelId, uint256 cumulativeAmount, bytes memory metadata)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 structHash = keccak256(abi.encode(SPENDING_AUTH_TYPEHASH, channelId, cumulativeAmount, keccak256(metadata)));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(BUYER_PK, _hashTypedDataChannels(structHash));
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _hashTypedDataChannels(bytes32 structHash) internal view returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", channels.domainSeparator(), structHash));
+    }
+
+    function _encodeMetadata(uint256 inputTokens, uint256 outputTokens) internal pure returns (bytes memory) {
+        return abi.encode(METADATA_VERSION, inputTokens, outputTokens, uint256(0));
+    }
+
+    function _epochList(uint256 epoch) internal pure returns (uint256[] memory epochs) {
+        epochs = new uint256[](1);
+        epochs[0] = epoch;
+    }
+
+    function _rewardEpochs(uint32 first, uint32 count) internal pure returns (uint32[] memory epochs) {
+        epochs = new uint32[](count);
+        for (uint32 i = 0; i < count; i++) {
+            epochs[i] = first + i;
+        }
+    }
+}

--- a/packages/contracts/test/DiemStakingProxyV2Emissions.t.sol
+++ b/packages/contracts/test/DiemStakingProxyV2Emissions.t.sol
@@ -1,0 +1,1579 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { MockUSDC } from "../MockUSDC.sol";
+import { MockERC8004Registry } from "../MockERC8004Registry.sol";
+import { ANTSToken } from "../ANTSToken.sol";
+import { AntseedRegistry } from "../AntseedRegistry.sol";
+import { AntseedDeposits } from "../AntseedDeposits.sol";
+import { AntseedStaking } from "../AntseedStaking.sol";
+import { AntseedChannels } from "../AntseedChannels.sol";
+import { AntseedEmissions } from "../AntseedEmissions.sol";
+import { AntseedEmissionsV2 } from "../AntseedEmissionsV2.sol";
+import { AntseedSellerRewardsPool } from "../AntseedSellerRewardsPool.sol";
+import { AntseedSellerUnlockPolicy } from "../AntseedSellerUnlockPolicy.sol";
+import { DiemStakingProxy } from "../DiemStakingProxy.sol";
+import { AntseedSellerDelegation } from "../AntseedSellerDelegation.sol";
+
+import { MockDiem } from "./mocks/MockDiem.sol";
+
+contract DiemStakingProxyV2EmissionsTest is Test {
+    uint256 constant OWNER_PK = 0x0A;
+    uint256 constant OPERATOR_PK = 0x0B;
+    uint256 constant ALICE_PK = 0x0C;
+    uint256 constant BOB_PK = 0x0D;
+    uint256 constant BUYER_PK = 0xA11CE;
+
+    uint256 constant DIEM_COOLDOWN = 1 days;
+    uint256 constant PROXY_STAKE = 10_000_000; // MIN_SELLER_STAKE
+    uint256 constant INITIAL_EMISSION = 1000 ether;
+    uint256 constant EPOCH_DURATION = 1 weeks;
+
+    address owner;
+    address operator;
+    address alice;
+    address bob;
+    address buyer;
+    address buyerOperator = address(0xAA);
+    address protocolReserve = address(0xFEE);
+    address teamWallet = address(0xBEEF);
+
+    MockDiem diem;
+    MockUSDC usdc;
+    ANTSToken ants;
+
+    MockERC8004Registry identityRegistry;
+    AntseedRegistry antseedRegistry;
+    AntseedDeposits deposits;
+    AntseedStaking staking;
+    AntseedChannels channels;
+    AntseedEmissions legacyEmissions;
+    AntseedEmissionsV2 emissions;
+    AntseedSellerRewardsPool rewardsPool;
+    AntseedSellerUnlockPolicy unlockPolicy;
+
+    DiemStakingProxy proxy;
+    uint256 proxyAgentId;
+
+    bytes32 constant SPENDING_AUTH_TYPEHASH =
+        keccak256("SpendingAuth(bytes32 channelId,uint256 cumulativeAmount,bytes32 metadataHash)");
+    bytes32 constant RESERVE_AUTH_TYPEHASH =
+        keccak256("ReserveAuth(bytes32 channelId,uint128 maxAmount,uint256 deadline)");
+    uint256 constant METADATA_VERSION = 1;
+
+    function setUp() public {
+        owner = vm.addr(OWNER_PK);
+        operator = vm.addr(OPERATOR_PK);
+        alice = vm.addr(ALICE_PK);
+        bob = vm.addr(BOB_PK);
+        buyer = vm.addr(BUYER_PK);
+
+        vm.warp(1_700_000_000);
+
+        diem = new MockDiem(DIEM_COOLDOWN);
+        usdc = new MockUSDC();
+        ants = new ANTSToken();
+
+        identityRegistry = new MockERC8004Registry();
+        antseedRegistry = new AntseedRegistry();
+        deposits = new AntseedDeposits(address(usdc));
+        staking = new AntseedStaking(address(usdc), address(antseedRegistry));
+        channels = new AntseedChannels(address(antseedRegistry));
+        legacyEmissions = new AntseedEmissions(address(antseedRegistry), INITIAL_EMISSION, EPOCH_DURATION);
+
+        antseedRegistry.setChannels(address(channels));
+        antseedRegistry.setDeposits(address(deposits));
+        antseedRegistry.setStaking(address(staking));
+        antseedRegistry.setEmissions(address(legacyEmissions));
+        antseedRegistry.setAntsToken(address(ants));
+        antseedRegistry.setIdentityRegistry(address(identityRegistry));
+        antseedRegistry.setProtocolReserve(protocolReserve);
+        antseedRegistry.setTeamWallet(teamWallet);
+
+        deposits.setRegistry(address(antseedRegistry));
+        ants.setRegistry(address(antseedRegistry));
+
+        vm.prank(address(channels));
+        legacyEmissions.accrueSellerPoints(address(0xDEAD), 0);
+        vm.prank(address(channels));
+        legacyEmissions.accrueBuyerPoints(address(0xBEEF), 0);
+        rewardsPool = new AntseedSellerRewardsPool(address(antseedRegistry));
+        unlockPolicy = new AntseedSellerUnlockPolicy();
+        emissions = new AntseedEmissionsV2(address(antseedRegistry), address(legacyEmissions), address(rewardsPool));
+        emissions.setSellerUnlockPolicy(address(unlockPolicy));
+        antseedRegistry.setEmissions(address(emissions));
+
+        channels.setFirstSignCap(10_000_000_000);
+
+        vm.prank(owner);
+        proxy = new DiemStakingProxy(address(diem), address(usdc), address(antseedRegistry), operator);
+        unlockPolicy.setSellerEligibility(address(proxy), true);
+
+        vm.prank(address(proxy));
+        proxyAgentId = identityRegistry.register();
+
+        usdc.mint(address(this), PROXY_STAKE);
+        usdc.approve(address(staking), PROXY_STAKE);
+        staking.stakeFor(address(proxy), proxyAgentId, PROXY_STAKE);
+
+        ants.setTransferWhitelist(address(proxy), true);
+
+        vm.prank(owner);
+        proxy.setMaxTotalStake(0);
+
+        vm.prank(owner);
+        proxy.setMinUnstakeBatchOpenSecs(0);
+    }
+
+    function _stakeAs(address user, uint256 amount) internal {
+        diem.mint(user, amount);
+        vm.startPrank(user);
+        diem.approve(address(proxy), amount);
+        proxy.stake(amount);
+        vm.stopPrank();
+    }
+
+    function _setupBuyer(uint256 depositAmount) internal {
+        vm.prank(buyer);
+        identityRegistry.register();
+
+        deposits.setCreditLimitOverride(buyer, type(uint256).max);
+
+        uint256 nonce = deposits.getOperatorNonce(buyer);
+        bytes32 structHash = keccak256(abi.encode(deposits.SET_OPERATOR_TYPEHASH(), buyerOperator, nonce));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", deposits.domainSeparator(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(BUYER_PK, digest);
+        deposits.setOperator(buyer, buyerOperator, nonce, abi.encodePacked(r, s, v));
+
+        usdc.mint(buyerOperator, depositAmount);
+        vm.startPrank(buyerOperator);
+        usdc.approve(address(deposits), depositAmount);
+        deposits.deposit(buyer, depositAmount);
+        vm.stopPrank();
+    }
+
+    function _hashTypedDataChannels(bytes32 structHash) internal view returns (bytes32) {
+        return keccak256(abi.encodePacked("\x19\x01", channels.domainSeparator(), structHash));
+    }
+
+    function _signReserveAuth(bytes32 channelId, uint128 maxAmount, uint256 deadline)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 structHash = keccak256(abi.encode(RESERVE_AUTH_TYPEHASH, channelId, maxAmount, deadline));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(BUYER_PK, _hashTypedDataChannels(structHash));
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _signSpendingAuth(bytes32 channelId, uint256 cumulativeAmount, bytes memory metadata)
+        internal
+        view
+        returns (bytes memory)
+    {
+        bytes32 structHash =
+            keccak256(abi.encode(SPENDING_AUTH_TYPEHASH, channelId, cumulativeAmount, keccak256(metadata)));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(BUYER_PK, _hashTypedDataChannels(structHash));
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _encodeMetadata(uint256 inputTokens, uint256 outputTokens) internal pure returns (bytes memory) {
+        return abi.encode(METADATA_VERSION, inputTokens, outputTokens, uint256(0));
+    }
+
+    function _rewardEpochs(uint32 first, uint32 count) internal pure returns (uint32[] memory epochs) {
+        epochs = new uint32[](count);
+        for (uint32 i = 0; i < count; i++) {
+            epochs[i] = first + i;
+        }
+    }
+
+    function _reserveViaProxy(bytes32 salt, uint128 maxAmount, uint256 depositAmount)
+        internal
+        returns (bytes32 channelId)
+    {
+        _setupBuyer(depositAmount);
+        channelId = channels.computeChannelId(buyer, address(proxy), salt);
+        bytes memory reserveSig = _signReserveAuth(channelId, maxAmount, block.timestamp + 1 days);
+        vm.prank(operator);
+        proxy.reserve(buyer, salt, maxAmount, block.timestamp + 1 days, reserveSig);
+    }
+
+    function _settleViaProxy(bytes32 channelId, uint128 cumulativeAmount) internal {
+        bytes memory metadata = _encodeMetadata(cumulativeAmount, 0);
+        bytes memory sig = _signSpendingAuth(channelId, cumulativeAmount, metadata);
+        vm.prank(operator);
+        proxy.settle(channelId, cumulativeAmount, metadata, sig);
+    }
+
+    function _closeViaProxy(bytes32 channelId, uint128 finalAmount) internal {
+        bytes memory metadata = _encodeMetadata(finalAmount, 0);
+        bytes memory sig = _signSpendingAuth(channelId, finalAmount, metadata);
+        vm.prank(operator);
+        proxy.close(channelId, finalAmount, metadata, sig);
+    }
+
+    function test_stake_success() public {
+        _stakeAs(alice, 100e18);
+
+        assertEq(proxy.staked(alice), 100e18);
+        assertEq(proxy.totalStaked(), 100e18);
+        (uint256 amountStaked,,) = diem.stakedInfos(address(proxy));
+        assertEq(amountStaked, 100e18);
+    }
+
+    function test_stake_revert_zeroAmount() public {
+        vm.prank(alice);
+        vm.expectRevert(DiemStakingProxy.InvalidAmount.selector);
+        proxy.stake(0);
+    }
+
+    function test_initiateUnstake_queuesAndStopsAccrual() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 100e6, 200e6);
+        _settleViaProxy(channelId, 90e6);
+
+        uint256 earnedBefore = proxy.earnedUsdc(alice);
+        assertGt(earnedBefore, 0);
+
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+
+        assertEq(proxy.staked(alice), 0);
+        assertEq(proxy.totalStaked(), 0);
+
+        uint32 batchId = proxy.currentUnstakeBatch();
+        (uint128 total, uint64 unlockAt, uint32 userCount, bool claimed) = proxy.unstakeBatches(batchId);
+        assertEq(total, 100e18);
+        assertEq(userCount, 1);
+        assertFalse(claimed);
+        assertEq(unlockAt, 0, "no unlockAt until flush");
+        assertEq(proxy.unstakeBatchUserAmount(batchId, alice), 100e18);
+
+        vm.warp(block.timestamp + 5 hours);
+        uint256 earnedAfter = proxy.earnedUsdc(alice);
+        assertEq(earnedAfter, earnedBefore, "no further accrual on queued balance");
+    }
+
+    function test_initiateUnstake_sameEpochAccumulates() public {
+        _stakeAs(alice, 200e18);
+
+        vm.prank(alice);
+        proxy.initiateUnstake(50e18);
+        uint32 batchId = proxy.currentUnstakeBatch();
+
+        vm.warp(block.timestamp + 3 hours);
+        vm.prank(alice);
+        proxy.initiateUnstake(30e18);
+
+        (uint128 total,, uint32 userCount,) = proxy.unstakeBatches(batchId);
+        assertEq(total, 80e18);
+        assertEq(userCount, 1, "same user shouldn't add a second row");
+        assertEq(proxy.unstakeBatchUserAmount(batchId, alice), 80e18);
+    }
+
+    function test_twoUsersSameEpoch_paidInOneClaim() public {
+        _stakeAs(alice, 100e18);
+        _stakeAs(bob, 50e18);
+
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+        uint32 batchId = proxy.currentUnstakeBatch();
+
+        vm.warp(block.timestamp + 6 hours);
+        vm.prank(bob);
+        proxy.initiateUnstake(50e18);
+
+        (uint128 total,, uint32 userCount,) = proxy.unstakeBatches(batchId);
+        assertEq(total, 150e18);
+        assertEq(userCount, 2);
+
+        proxy.flush();
+        assertEq(proxy.currentUnstakeBatch(), batchId + 1, "flush advances currentUnstakeBatch");
+
+        vm.warp(block.timestamp + DIEM_COOLDOWN + 1);
+        proxy.claimUnstakeBatch(batchId);
+
+        assertEq(diem.balanceOf(alice), 100e18);
+        assertEq(diem.balanceOf(bob), 50e18);
+        assertEq(diem.balanceOf(address(proxy)), 0, "proxy direct balance must return to 0");
+    }
+
+    function test_flush_revertsWhenNothingQueued() public {
+        vm.expectRevert(DiemStakingProxy.NothingToFlush.selector);
+        proxy.flush();
+    }
+
+    function test_flush_revertsWhilePriorBatchUnclaimed() public {
+        _stakeAs(alice, 100e18);
+        _stakeAs(bob, 50e18);
+
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+        proxy.flush();
+
+        vm.prank(bob);
+        proxy.initiateUnstake(50e18);
+
+        vm.expectRevert(DiemStakingProxy.PriorUnstakeBatchUnclaimed.selector);
+        proxy.flush();
+    }
+
+    function test_flush_revertsBeforeMinUnstakeBatchOpenSecs() public {
+        vm.prank(owner);
+        proxy.setMinUnstakeBatchOpenSecs(6 hours);
+
+        _stakeAs(alice, 100e18);
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+
+        vm.expectRevert(DiemStakingProxy.UnstakeBatchTooYoung.selector);
+        proxy.flush();
+
+        vm.warp(block.timestamp + 6 hours - 1);
+        vm.expectRevert(DiemStakingProxy.UnstakeBatchTooYoung.selector);
+        proxy.flush();
+
+        vm.warp(block.timestamp + 1);
+        proxy.flush();
+    }
+
+    function test_flush_succeedsImmediatelyWhenBatchFull() public {
+        vm.prank(owner);
+        proxy.setMinUnstakeBatchOpenSecs(6 hours);
+
+        for (uint256 i = 0; i < proxy.MAX_PER_UNSTAKE_BATCH(); i++) {
+            address user = address(uint160(0x1000 + i));
+            _stakeAs(user, 1e18);
+            vm.prank(user);
+            proxy.initiateUnstake(1e18);
+        }
+
+        (,, uint32 userCount,) = proxy.unstakeBatches(proxy.currentUnstakeBatch());
+        assertEq(userCount, proxy.MAX_PER_UNSTAKE_BATCH());
+        proxy.flush();
+    }
+
+    function test_flush_windowMeasuredFromFirstQueuer() public {
+        vm.prank(owner);
+        proxy.setMinUnstakeBatchOpenSecs(6 hours);
+
+        _stakeAs(alice, 50e18);
+        vm.prank(alice);
+        proxy.initiateUnstake(50e18);
+        uint32 firstBatch = proxy.currentUnstakeBatch();
+        vm.warp(block.timestamp + 6 hours);
+        proxy.flush();
+        vm.warp(block.timestamp + DIEM_COOLDOWN + 1);
+        proxy.claimUnstakeBatch(firstBatch);
+
+        vm.warp(block.timestamp + 7 days);
+        assertEq(proxy.currentUnstakeBatchOpenedAt(), 0, "no queuer: clock not started");
+
+        _stakeAs(bob, 50e18);
+        vm.prank(bob);
+        proxy.initiateUnstake(50e18);
+
+        vm.expectRevert(DiemStakingProxy.UnstakeBatchTooYoung.selector);
+        proxy.flush();
+
+        vm.warp(block.timestamp + 6 hours);
+        proxy.flush();
+    }
+
+    function test_flush_windowNotExtendedByLaterQueuers() public {
+        vm.prank(owner);
+        proxy.setMinUnstakeBatchOpenSecs(6 hours);
+
+        _stakeAs(alice, 100e18);
+        _stakeAs(bob, 50e18);
+
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+        uint64 openedAt = proxy.currentUnstakeBatchOpenedAt();
+
+        vm.warp(block.timestamp + 3 hours);
+        vm.prank(bob);
+        proxy.initiateUnstake(50e18);
+        assertEq(proxy.currentUnstakeBatchOpenedAt(), openedAt, "later queuer must not bump clock");
+
+        vm.warp(openedAt + 6 hours);
+        proxy.flush();
+    }
+
+    function test_flushableAt_reflectsWindow() public {
+        vm.prank(owner);
+        proxy.setMinUnstakeBatchOpenSecs(6 hours);
+
+        assertEq(proxy.flushableAt(), 0, "empty batch: zero");
+
+        _stakeAs(alice, 100e18);
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+
+        uint64 openedAt = proxy.currentUnstakeBatchOpenedAt();
+        assertEq(proxy.flushableAt(), openedAt + 6 hours);
+
+        vm.warp(block.timestamp + 6 hours);
+        proxy.flush();
+        assertEq(proxy.flushableAt(), 0, "post-flush empty: zero");
+    }
+
+    function test_setMinUnstakeBatchOpenSecs_onlyOwner() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.setMinUnstakeBatchOpenSecs(1 hours);
+    }
+
+    function test_setMinUnstakeBatchOpenSecs_enforcesUpperBound() public {
+        vm.prank(owner);
+        vm.expectRevert(DiemStakingProxy.MinUnstakeBatchOpenSecsTooLarge.selector);
+        proxy.setMinUnstakeBatchOpenSecs(7 days + 1);
+
+        vm.prank(owner);
+        proxy.setMinUnstakeBatchOpenSecs(7 days);
+        assertEq(proxy.minUnstakeBatchOpenSecs(), 7 days);
+    }
+
+    function test_pause_onlyOwnerAndUnpauseRestoresStake() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.pause();
+
+        vm.prank(owner);
+        proxy.pause();
+
+        diem.mint(alice, 10e18);
+        vm.startPrank(alice);
+        diem.approve(address(proxy), 10e18);
+        vm.expectRevert();
+        proxy.stake(10e18);
+        vm.stopPrank();
+
+        vm.prank(owner);
+        proxy.unpause();
+
+        vm.prank(alice);
+        proxy.stake(10e18);
+        assertEq(proxy.staked(alice), 10e18);
+    }
+
+    function test_pause_blocksUserFacingFlowsButAllowsExitAndSync() public {
+        _stakeAs(alice, 100e18);
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.prank(alice);
+        proxy.initiateUnstake(50e18);
+        uint32 batchId = proxy.currentUnstakeBatch();
+        proxy.flush();
+
+        vm.prank(owner);
+        proxy.pause();
+
+        diem.mint(bob, 1e18);
+        vm.startPrank(bob);
+        diem.approve(address(proxy), 1e18);
+        vm.expectRevert();
+        proxy.stake(1e18);
+        vm.stopPrank();
+
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.initiateUnstake(1e18);
+
+        vm.expectRevert();
+        proxy.flush();
+
+        bytes memory pausedMetadata = _encodeMetadata(600e6, 0);
+        bytes memory pausedSig = _signSpendingAuth(channelId, 600e6, pausedMetadata);
+
+        vm.prank(operator);
+        vm.expectRevert();
+        proxy.settle(channelId, 600e6, pausedMetadata, pausedSig);
+
+        vm.prank(operator);
+        vm.expectRevert();
+        proxy.close(channelId, 600e6, pausedMetadata, pausedSig);
+
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.claimUsdc();
+
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.claimAnts(_rewardEpochs(0, 1));
+
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.catchUpPoints(1);
+
+        vm.warp(block.timestamp + EPOCH_DURATION + 1);
+        proxy.syncRewardEpochs(1);
+        assertEq(proxy.syncedRewardEpoch(), 1, "sync remains available while paused");
+
+        vm.warp(block.timestamp + DIEM_COOLDOWN + 1);
+        uint256 before = diem.balanceOf(alice);
+        proxy.claimUnstakeBatch(batchId);
+        assertEq(diem.balanceOf(alice) - before, 50e18, "exits remain available while paused");
+    }
+
+    function _advanceRewardEpochs(uint256 count) internal {
+        for (uint256 i = 0; i < count; i++) {
+            skip(EPOCH_DURATION + 1);
+            proxy.syncRewardEpochs(1);
+        }
+    }
+
+    function test_catchUpPoints_clearsBacklog() public {
+        _stakeAs(alice, 100e18);
+
+        _advanceRewardEpochs(17);
+        assertEq(proxy.syncedRewardEpoch(), 17);
+        assertEq(proxy.userCurrentEpoch(alice), 0);
+
+        diem.mint(alice, 10e18);
+        vm.startPrank(alice);
+        diem.approve(address(proxy), 10e18);
+        vm.expectRevert(DiemStakingProxy.BacklogTooLarge.selector);
+        proxy.stake(10e18);
+        vm.expectRevert(DiemStakingProxy.BacklogTooLarge.selector);
+        proxy.initiateUnstake(10e18);
+        vm.expectRevert(DiemStakingProxy.BacklogTooLarge.selector);
+        proxy.claimUsdc();
+        vm.stopPrank();
+
+        vm.prank(alice);
+        proxy.catchUpPoints(16);
+        assertEq(proxy.userCurrentEpoch(alice), 16);
+
+        vm.prank(alice);
+        proxy.catchUpPoints(16);
+        assertEq(proxy.userCurrentEpoch(alice), 17);
+
+        vm.prank(alice);
+        proxy.initiateUnstake(10e18);
+    }
+
+    function test_catchUpPoints_settlesUsdc() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        uint256 paidBefore = proxy.userUsdcRewardPerTokenPaid(alice);
+        uint256 storedAfterSettle = proxy.usdcRewardPerTokenStored();
+        assertGt(storedAfterSettle, paidBefore, "settle must bump the global accumulator");
+
+        _advanceRewardEpochs(17);
+
+        vm.prank(alice);
+        proxy.catchUpPoints(16);
+
+        assertEq(
+            proxy.userUsdcRewardPerTokenPaid(alice),
+            proxy.usdcRewardPerTokenStored(),
+            "per-token-paid should be caught up"
+        );
+        assertGt(proxy.usdcRewards(alice), 0, "pending USDC materialised");
+    }
+
+    function test_catchUpPoints_syncsGlobalBacklogInChunks() public {
+        _stakeAs(alice, 100e18);
+
+        skip((EPOCH_DURATION * 17) + 1);
+        assertEq(proxy.syncedRewardEpoch(), 0, "global reward epochs not synced yet");
+
+        vm.prank(alice);
+        proxy.catchUpPoints(16);
+        assertEq(proxy.syncedRewardEpoch(), 16, "bounded sync closes first chunk");
+        assertEq(proxy.userCurrentEpoch(alice), 16, "user catches up to first chunk");
+
+        vm.prank(alice);
+        proxy.catchUpPoints(16);
+        assertEq(proxy.syncedRewardEpoch(), 17, "second call closes remaining finalized epoch");
+        assertEq(proxy.userCurrentEpoch(alice), 17, "user catches up fully");
+    }
+
+    function test_constructor_defaultMinUnstakeBatchOpenSecs() public {
+        vm.prank(owner);
+        DiemStakingProxy fresh = new DiemStakingProxy(address(diem), address(usdc), address(antseedRegistry), operator);
+        assertEq(fresh.minUnstakeBatchOpenSecs(), fresh.ALPHA_MIN_UNSTAKE_BATCH_OPEN_SECS());
+        assertEq(fresh.ALPHA_MIN_UNSTAKE_BATCH_OPEN_SECS(), 1 days);
+    }
+
+    function test_claimUnstakeBatch_revertBeforeCooldown() public {
+        _stakeAs(alice, 100e18);
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+        uint32 batchId = proxy.currentUnstakeBatch();
+        proxy.flush();
+
+        vm.expectRevert(DiemStakingProxy.UnstakeBatchNotReady.selector);
+        proxy.claimUnstakeBatch(batchId);
+    }
+
+    function test_claimUnstakeBatch_revertOnUnflushedBatch() public {
+        _stakeAs(alice, 100e18);
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+        uint32 batchId = proxy.currentUnstakeBatch();
+
+        vm.expectRevert(DiemStakingProxy.UnstakeBatchNotReady.selector);
+        proxy.claimUnstakeBatch(batchId);
+    }
+
+    function test_claimUnstakeBatch_revertOnDoubleClaim() public {
+        _stakeAs(alice, 100e18);
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+        uint32 batchId = proxy.currentUnstakeBatch();
+        proxy.flush();
+
+        vm.warp(block.timestamp + DIEM_COOLDOWN + 1);
+        proxy.claimUnstakeBatch(batchId);
+
+        vm.expectRevert(DiemStakingProxy.UnstakeBatchAlreadyClaimed.selector);
+        proxy.claimUnstakeBatch(batchId);
+    }
+
+    function test_multipleUnstakeBatchesSerialize() public {
+        _stakeAs(alice, 100e18);
+        _stakeAs(bob, 50e18);
+
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+        uint32 firstBatch = proxy.currentUnstakeBatch();
+        proxy.flush();
+
+        vm.prank(bob);
+        proxy.initiateUnstake(50e18);
+        uint32 secondBatch = proxy.currentUnstakeBatch();
+        assertEq(secondBatch, firstBatch + 1);
+
+        skip(DIEM_COOLDOWN + 1);
+        proxy.claimUnstakeBatch(firstBatch);
+
+        proxy.flush();
+        skip(DIEM_COOLDOWN + 1);
+        proxy.claimUnstakeBatch(secondBatch);
+
+        assertEq(diem.balanceOf(alice), 100e18);
+        assertEq(diem.balanceOf(bob), 50e18);
+    }
+
+    function test_donationDoesNotStealOrStrand() public {
+        _stakeAs(alice, 100e18);
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+        uint32 batchId = proxy.currentUnstakeBatch();
+        proxy.flush();
+
+        diem.mint(address(this), 100e18);
+        diem.transfer(address(proxy), 100e18);
+
+        vm.warp(block.timestamp + DIEM_COOLDOWN + 1);
+        proxy.claimUnstakeBatch(batchId);
+
+        assertEq(diem.balanceOf(alice), 100e18, "alice got exactly her stake");
+        assertEq(diem.balanceOf(address(proxy)), 100e18);
+    }
+
+    function test_reserve_forwardsToChannels() public {
+        _setupBuyer(200e6);
+
+        bytes32 salt = bytes32(uint256(1));
+        bytes32 expectedChannelId = channels.computeChannelId(buyer, address(proxy), salt);
+        uint256 deadline = block.timestamp + 1 days;
+        bytes memory reserveSig = _signReserveAuth(expectedChannelId, 100e6, deadline);
+
+        vm.prank(alice);
+        vm.expectRevert(AntseedSellerDelegation.NotOperator.selector);
+        proxy.reserve(buyer, salt, 100e6, deadline, reserveSig);
+
+        vm.prank(operator);
+        proxy.reserve(buyer, salt, 100e6, deadline, reserveSig);
+
+        assertEq(channels.activeChannelCount(address(proxy)), 1);
+    }
+
+    function test_settle_capturesUsdcDeltaAndNotifies() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+
+        uint256 usdcBefore = usdc.balanceOf(address(proxy));
+        uint256 storedBefore = proxy.usdcRewardPerTokenStored();
+        _settleViaProxy(channelId, 500e6);
+        uint256 inflow = usdc.balanceOf(address(proxy)) - usdcBefore;
+
+        assertEq(inflow, 500e6 - (500e6 * 200) / 10000 - ((500e6 - (500e6 * 200) / 10000) * 1000) / 10000);
+
+        uint256 storedAfter = proxy.usdcRewardPerTokenStored();
+        assertGt(storedAfter, storedBefore);
+        assertEq(proxy.earnedUsdc(alice), inflow, "alice (sole staker) earns the full inflow");
+    }
+
+    function test_close_capturesUsdcDeltaAndNotifies() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 500e6, 500e6);
+
+        uint256 usdcBefore = usdc.balanceOf(address(proxy));
+        _closeViaProxy(channelId, 400e6);
+        uint256 inflow = usdc.balanceOf(address(proxy)) - usdcBefore;
+
+        assertEq(inflow, 400e6 - (400e6 * 200) / 10000 - ((400e6 - (400e6 * 200) / 10000) * 1000) / 10000);
+        assertEq(proxy.earnedUsdc(alice), inflow);
+
+        assertEq(channels.activeChannelCount(address(proxy)), 0);
+    }
+
+    function test_operatorFee_takesDefaultUsdcCutFromSettlement() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+
+        uint256 recipientBefore = usdc.balanceOf(operator);
+        uint256 proxyBefore = usdc.balanceOf(address(proxy));
+        _settleViaProxy(channelId, 500e6);
+
+        uint256 protocolNetInflow = 500e6 - (500e6 * 200) / 10000;
+        uint256 operatorFee = (protocolNetInflow * proxy.DEFAULT_OPERATOR_FEE_BPS()) / 10000;
+        uint256 stakerNet = protocolNetInflow - operatorFee;
+
+        assertEq(proxy.operatorFeeBps(), 1000);
+        assertEq(proxy.operatorFeeRecipient(), operator);
+        assertEq(usdc.balanceOf(operator) - recipientBefore, operatorFee);
+        assertEq(usdc.balanceOf(address(proxy)) - proxyBefore, stakerNet);
+        assertEq(proxy.earnedUsdc(alice), stakerNet);
+        assertEq(proxy.totalUsdcReservedForStakers(), stakerNet);
+    }
+
+    function test_setOperatorFee_enforcesMaxAndRecipient() public {
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit AntseedSellerDelegation.OperatorFeeSet(0, address(0));
+        proxy.setOperatorFee(0, address(0));
+
+        vm.prank(owner);
+        vm.expectRevert(AntseedSellerDelegation.InvalidAddress.selector);
+        proxy.setOperatorFee(1, address(0));
+
+        vm.prank(owner);
+        vm.expectRevert(AntseedSellerDelegation.OperatorFeeTooLarge.selector);
+        proxy.setOperatorFee(2001, bob);
+
+        vm.prank(owner);
+        proxy.setOperatorFee(2000, bob);
+        assertEq(proxy.operatorFeeBps(), 2000);
+    }
+
+    function test_operatorFee_takesAntsCutFromEpochPot() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.warp(block.timestamp + EPOCH_DURATION + 1);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 0;
+        (uint256 pendingSeller,) = emissions.pendingEmissions(address(proxy), ids);
+        uint256 operatorFee = (pendingSeller * proxy.DEFAULT_OPERATOR_FEE_BPS()) / 10000;
+        uint256 stakerPot = pendingSeller - operatorFee;
+
+        uint256 aliceBefore = ants.balanceOf(alice);
+        uint256 recipientBefore = ants.balanceOf(operator);
+        vm.prank(alice);
+        proxy.claimAnts(_rewardEpochs(0, 1));
+
+        assertEq(ants.balanceOf(operator) - recipientBefore, operatorFee);
+        assertEq(ants.balanceOf(alice) - aliceBefore, stakerPot);
+        (,, uint256 antsPot,) = proxy.rewardEpochs(0);
+        assertEq(antsPot, stakerPot);
+    }
+
+    function test_topUp_noInflow_noNotify() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 100e6, 300e6);
+        _settleViaProxy(channelId, 90e6);
+
+        uint256 storedBefore = proxy.usdcRewardPerTokenStored();
+        uint256 usdcBefore = usdc.balanceOf(address(proxy));
+
+        uint128 newMax = 200e6;
+        uint256 newDeadline = block.timestamp + 2 days;
+        bytes memory newReserveSig = _signReserveAuth(channelId, newMax, newDeadline);
+        bytes memory metadata = _encodeMetadata(90e6, 0);
+        bytes memory spendingSig = _signSpendingAuth(channelId, 90e6, metadata);
+
+        vm.prank(operator);
+        proxy.topUp(channelId, 90e6, metadata, spendingSig, newMax, newDeadline, newReserveSig);
+
+        assertEq(usdc.balanceOf(address(proxy)), usdcBefore, "no USDC should flow on zero-delta topUp");
+        uint256 storedAfter = proxy.usdcRewardPerTokenStored();
+        assertEq(storedAfter, storedBefore, "rewardPerTokenStored must not change");
+    }
+
+    function test_claimAnts_opensAndFundsRewardEpoch() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.warp(block.timestamp + EPOCH_DURATION + 1);
+
+        uint32 rewardEpochBefore = proxy.syncedRewardEpoch();
+        uint256 antsBefore = ants.balanceOf(alice);
+        vm.prank(alice);
+        proxy.claimAnts(_rewardEpochs(0, 1));
+        uint256 claimed = ants.balanceOf(alice) - antsBefore;
+
+        assertGt(claimed, 0, "emissions should pay ANTS through the proxy");
+        assertEq(proxy.syncedRewardEpoch(), rewardEpochBefore + 1, "reward epoch advanced");
+        (,, uint256 antsPot,) = proxy.rewardEpochs(rewardEpochBefore);
+        assertEq(antsPot, claimed, "epoch pot captures the lazy claim");
+    }
+
+    function test_claimAnts_zeroRevenueEpochDoesNotFundPot() public {
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.warp(block.timestamp + EPOCH_DURATION + 1);
+
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 0;
+        (uint256 pendingSeller,) = emissions.pendingEmissions(address(proxy), ids);
+        assertGt(pendingSeller, 0, "proxy has external seller emissions");
+
+        _stakeAs(alice, 100e18);
+
+        (,, uint256 potBefore, bool fundedBefore) = proxy.rewardEpochs(0);
+        assertEq(potBefore, 0, "zero-revenue epoch has no pot before claim");
+        assertFalse(fundedBefore, "zero-revenue epoch starts unfunded");
+
+        vm.prank(alice);
+        proxy.claimAnts(_rewardEpochs(0, 1));
+
+        (,, uint256 potAfter, bool fundedAfter) = proxy.rewardEpochs(0);
+        assertEq(potAfter, 0, "zero-revenue epoch stays unfunded");
+        assertFalse(fundedAfter, "claim must not strand an undistributable pot");
+        assertEq(ants.balanceOf(address(proxy)), 0, "no ANTS minted into proxy");
+        assertTrue(proxy.userEpochClaimed(alice, 0), "user can advance past empty epoch");
+    }
+
+    function test_claimUsdcAndClaimAnts_paysBothRewards() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.warp(block.timestamp + EPOCH_DURATION + 1);
+        proxy.syncRewardEpochs(1);
+        assertGt(proxy.pendingAntsForEpoch(alice, 0), 0, "pending preview uses emissions pot");
+
+        uint256 usdcBefore = usdc.balanceOf(alice);
+        vm.prank(alice);
+        proxy.claimUsdc();
+        assertGt(usdc.balanceOf(alice) - usdcBefore, 0);
+
+        uint256 antsBefore = ants.balanceOf(alice);
+        vm.prank(alice);
+        proxy.claimAnts(_rewardEpochs(0, 1));
+        assertGt(ants.balanceOf(alice) - antsBefore, 0);
+        (,,, bool funded) = proxy.rewardEpochs(0);
+        assertTrue(funded, "claimAnts lazily funded epoch");
+    }
+
+    function test_claimAnts_lazilySyncsUnsyncedFinalizedEpoch() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.warp(block.timestamp + EPOCH_DURATION + 1);
+        assertEq(proxy.syncedRewardEpoch(), 0, "proxy has not synced the finalized epoch");
+        assertEq(proxy.finalizedRewardEpoch(), 1, "emissions clock finalized epoch 0");
+
+        uint256 antsBefore = ants.balanceOf(alice);
+        vm.prank(alice);
+        proxy.claimAnts(_rewardEpochs(0, 1));
+
+        assertEq(proxy.syncedRewardEpoch(), 1, "claimAnts syncs before claiming");
+        assertGt(ants.balanceOf(alice) - antsBefore, 0, "lazy claim pays finalized epoch");
+    }
+
+    function test_multiStaker_proRataUsdc() public {
+        _stakeAs(alice, 30e18);
+        _stakeAs(bob, 70e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 1000e6);
+
+        uint256 aliceUsdc = proxy.earnedUsdc(alice);
+        uint256 bobUsdc = proxy.earnedUsdc(bob);
+        uint256 totalEarned = aliceUsdc + bobUsdc;
+
+        assertApproxEqAbs(aliceUsdc, (totalEarned * 30) / 100, 1);
+        assertApproxEqAbs(bobUsdc, (totalEarned * 70) / 100, 1);
+    }
+
+    function test_usdcAttribution_followsInflowTiming() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        _stakeAs(bob, 100e18);
+
+        assertGt(proxy.earnedUsdc(alice), 0);
+        assertEq(proxy.earnedUsdc(bob), 0, "late staker must not capture prior inflow");
+    }
+
+    function test_usdcAttribution_unstakeBeforeSettle() public {
+        _stakeAs(alice, 100e18);
+        _stakeAs(bob, 100e18);
+
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        assertEq(proxy.earnedUsdc(alice), 0, "already-unstaked alice earns nothing from later settle");
+        assertGt(proxy.earnedUsdc(bob), 0);
+    }
+
+    function test_antsAttribution_matchesUsdcRevenueShare() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.warp(block.timestamp + EPOCH_DURATION / 2);
+        _stakeAs(bob, 100e18);
+        _settleViaProxy(channelId, 1000e6);
+
+        uint256 aliceUsdc = proxy.earnedUsdc(alice);
+        uint256 bobUsdc = proxy.earnedUsdc(bob);
+        assertApproxEqAbs(aliceUsdc, bobUsdc * 3, 3, "USDC split is 3:1");
+
+        vm.warp(block.timestamp + EPOCH_DURATION / 2 + 1);
+        proxy.syncRewardEpochs(1);
+
+        uint256 aliceAnts = proxy.pendingAntsForEpoch(alice, 0);
+        uint256 bobAnts = proxy.pendingAntsForEpoch(bob, 0);
+        assertGt(bobAnts, 0, "bob earns from the second settlement");
+        assertApproxEqAbs(aliceAnts, bobAnts * 3, 3, "ANTS split matches USDC split");
+    }
+
+    function test_antsAttribution_delayedOperatorClaimDoesNotDilutePastEpoch() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.warp(block.timestamp + EPOCH_DURATION + 1);
+
+        _stakeAs(bob, 100e18);
+
+        assertGt(proxy.pendingAntsForEpoch(alice, 0), 0, "alice earned during epoch 0");
+        assertEq(proxy.pendingAntsForEpoch(bob, 0), 0, "post-epoch staker must not dilute epoch 0");
+    }
+
+    function test_antsAttribution_backloggedClaimsDoNotStrandLaterPots() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 10_000e6, 10_000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        skip(EPOCH_DURATION + 1);
+        _settleViaProxy(channelId, 900e6);
+
+        skip(EPOCH_DURATION + 1);
+
+        uint256 beforeBal = ants.balanceOf(alice);
+        vm.prank(alice);
+        proxy.claimAnts(_rewardEpochs(0, 2));
+        (,, uint256 pot0,) = proxy.rewardEpochs(0);
+        (,, uint256 pot1,) = proxy.rewardEpochs(1);
+        assertGt(pot0, 0, "epoch 0 pot");
+        assertGt(pot1, 0, "epoch 1 pot");
+        assertEq(ants.balanceOf(alice) - beforeBal, pot0 + pot1, "sole staker claims both pots");
+    }
+
+    function test_claimAnts_acceptsExplicitEpochArray() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(7)), 10_000e6, 10_000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        skip(EPOCH_DURATION + 1);
+        _settleViaProxy(channelId, 900e6);
+
+        skip(EPOCH_DURATION + 1);
+        proxy.syncRewardEpochs(2);
+
+        uint256 beforeBal = ants.balanceOf(alice);
+        vm.prank(alice);
+        proxy.claimAnts(_rewardEpochs(1, 1));
+        (,, uint256 pot1,) = proxy.rewardEpochs(1);
+        assertEq(ants.balanceOf(alice) - beforeBal, pot1, "can claim epoch 1 before epoch 0");
+        assertEq(proxy.userLastClaimedEpoch(alice), 0, "cursor waits for epoch 0");
+        assertTrue(proxy.userEpochClaimed(alice, 1), "epoch 1 marked claimed");
+
+        beforeBal = ants.balanceOf(alice);
+        vm.prank(alice);
+        proxy.claimAnts(_rewardEpochs(0, 1));
+        (,, uint256 pot0,) = proxy.rewardEpochs(0);
+        assertEq(ants.balanceOf(alice) - beforeBal, pot0, "epoch 0 remains claimable");
+        assertEq(proxy.userLastClaimedEpoch(alice), 2, "cursor advances across claimed epochs");
+    }
+
+    function test_antsAttribution_unstakePreservesPoints() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.warp(block.timestamp + EPOCH_DURATION / 2);
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+        proxy.flush();
+        vm.warp(block.timestamp + DIEM_COOLDOWN + 1);
+        proxy.claimUnstakeBatch(proxy.oldestUnclaimedUnstakeBatch());
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+        proxy.syncRewardEpochs(1);
+
+        assertGt(proxy.pendingAntsForEpoch(alice, 0), 0, "unstaked user retains points");
+    }
+
+    function test_setOperator_onlyOwner_revertsForNonOwner() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.setOperator(vm.addr(0x99), true);
+    }
+
+    function test_setOperator_addSecondOperator_bothCanCall() public {
+        address secondOp = vm.addr(0x99);
+
+        vm.prank(owner);
+        proxy.setOperator(secondOp, true);
+
+        assertTrue(proxy.isOperator(operator), "original operator still authorized");
+        assertTrue(proxy.isOperator(secondOp), "new operator authorized");
+
+        _setupBuyer(200e6);
+        bytes32 salt = bytes32(uint256(42));
+        bytes32 channelId = channels.computeChannelId(buyer, address(proxy), salt);
+        uint256 deadline = block.timestamp + 1 days;
+        bytes memory reserveSig = _signReserveAuth(channelId, 100e6, deadline);
+
+        vm.prank(secondOp);
+        proxy.reserve(buyer, salt, 100e6, deadline, reserveSig);
+        assertEq(channels.activeChannelCount(address(proxy)), 1);
+    }
+
+    function test_setOperator_removeOperator_revertsAfterRemoval() public {
+        vm.prank(owner);
+        proxy.setOperator(operator, false);
+
+        assertFalse(proxy.isOperator(operator));
+
+        vm.prank(operator);
+        vm.expectRevert(AntseedSellerDelegation.NotOperator.selector);
+        proxy.reserve(buyer, bytes32(0), 100e6, block.timestamp + 1 days, "");
+    }
+
+    function test_setOperator_revertZero() public {
+        vm.prank(owner);
+        vm.expectRevert(AntseedSellerDelegation.InvalidAddress.selector);
+        proxy.setOperator(address(0), true);
+    }
+
+    function test_withdrawAntseedStake_onlyOwner() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.withdrawAntseedStake(alice);
+
+        uint256 before = usdc.balanceOf(alice);
+        vm.prank(owner);
+        vm.expectEmit(true, false, false, true);
+        emit AntseedSellerDelegation.AntseedStakeWithdrawn(alice, PROXY_STAKE);
+        proxy.withdrawAntseedStake(alice);
+        assertEq(usdc.balanceOf(alice) - before, PROXY_STAKE);
+    }
+
+    function test_withdrawAntseedStake_revertZero() public {
+        vm.prank(owner);
+        vm.expectRevert(AntseedSellerDelegation.InvalidAddress.selector);
+        proxy.withdrawAntseedStake(address(0));
+    }
+
+    function test_withdrawAntseedStake_doesNotCreditStakers() public {
+        _stakeAs(alice, 100e18);
+
+        uint256 storedBefore = proxy.usdcRewardPerTokenStored();
+        vm.prank(owner);
+        proxy.withdrawAntseedStake(bob);
+
+        uint256 storedAfter = proxy.usdcRewardPerTokenStored();
+        assertEq(storedAfter, storedBefore, "stake recovery must not be routed to stakers as a reward");
+    }
+
+    function test_isValidSignature_validOwner() public view {
+        bytes32 hash = keccak256("venice-api-key-challenge");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(OWNER_PK, hash);
+        bytes memory sig = abi.encodePacked(r, s, v);
+        assertEq(proxy.isValidSignature(hash, sig), bytes4(0x1626ba7e));
+    }
+
+    function test_isValidSignature_operatorReturnsInvalid() public view {
+        bytes32 hash = keccak256("venice-api-key-challenge");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(OPERATOR_PK, hash);
+        bytes memory sig = abi.encodePacked(r, s, v);
+        assertEq(proxy.isValidSignature(hash, sig), bytes4(0xffffffff));
+    }
+
+    function test_isValidSignature_nonOwnerReturnsInvalid() public view {
+        bytes32 hash = keccak256("venice-api-key-challenge");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ALICE_PK, hash);
+        bytes memory sig = abi.encodePacked(r, s, v);
+        assertEq(proxy.isValidSignature(hash, sig), bytes4(0xffffffff));
+    }
+
+    function test_isValidSignature_afterOwnershipTransferOldSigInvalid() public {
+        bytes32 hash = keccak256("venice-api-key-challenge");
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(OWNER_PK, hash);
+        bytes memory oldSig = abi.encodePacked(r, s, v);
+
+        vm.prank(owner);
+        proxy.transferOwnership(bob);
+
+        assertEq(proxy.isValidSignature(hash, oldSig), bytes4(0xffffffff));
+
+        (uint8 v2, bytes32 r2, bytes32 s2) = vm.sign(BOB_PK, hash);
+        bytes memory newSig = abi.encodePacked(r2, s2, v2);
+        assertEq(proxy.isValidSignature(hash, newSig), bytes4(0x1626ba7e));
+    }
+
+    function test_sweepOrphanUsdc_recoversInflowWithNoStakers() public {
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 500e6, 500e6);
+        _settleViaProxy(channelId, 400e6);
+
+        uint256 trapped = usdc.balanceOf(address(proxy));
+        assertGt(trapped, 0, "USDC sits in proxy since no stakers");
+        assertEq(proxy.totalUsdcReservedForStakers(), 0, "no liability accrued");
+
+        uint256 recipientBefore = usdc.balanceOf(bob);
+        vm.prank(owner);
+        vm.expectEmit(true, false, false, true);
+        emit DiemStakingProxy.OrphanUsdcSwept(bob, trapped);
+        proxy.sweepOrphanUsdc(bob);
+
+        assertEq(usdc.balanceOf(bob) - recipientBefore, trapped);
+        assertEq(usdc.balanceOf(address(proxy)), 0);
+    }
+
+    function test_sweepOrphanUsdc_recoversDirectDonation() public {
+        _stakeAs(alice, 100e18);
+
+        uint256 donation = 123e6;
+        usdc.mint(address(this), donation);
+        usdc.transfer(address(proxy), donation);
+
+        assertEq(proxy.totalUsdcReservedForStakers(), 0);
+
+        vm.prank(owner);
+        proxy.sweepOrphanUsdc(bob);
+        assertEq(usdc.balanceOf(bob), donation);
+    }
+
+    function test_sweepOrphanUsdc_doesNotInvadeStakerLiabilities() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        uint256 reserved = proxy.totalUsdcReservedForStakers();
+        uint256 balance = usdc.balanceOf(address(proxy));
+        assertEq(reserved, balance);
+
+        uint256 recipientBefore = usdc.balanceOf(bob);
+        vm.prank(owner);
+        proxy.sweepOrphanUsdc(bob);
+        assertEq(usdc.balanceOf(bob), recipientBefore, "nothing to sweep");
+        assertEq(usdc.balanceOf(address(proxy)), balance, "balance untouched");
+
+        uint256 aliceBefore = usdc.balanceOf(alice);
+        vm.prank(alice);
+        proxy.claimUsdc();
+        assertEq(usdc.balanceOf(alice) - aliceBefore, reserved);
+    }
+
+    function test_sweepOrphanUsdc_afterPartialClaim() public {
+        _stakeAs(alice, 100e18);
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.prank(alice);
+        proxy.claimUsdc();
+        assertEq(proxy.totalUsdcReservedForStakers(), 0);
+
+        uint256 donation = 7e6;
+        usdc.mint(address(this), donation);
+        usdc.transfer(address(proxy), donation);
+
+        vm.prank(owner);
+        proxy.sweepOrphanUsdc(bob);
+        assertEq(usdc.balanceOf(bob), donation);
+    }
+
+    function test_sweepOrphanUsdc_onlyOwner() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.sweepOrphanUsdc(alice);
+    }
+
+    function test_sweepOrphanUsdc_revertZeroRecipient() public {
+        vm.prank(owner);
+        vm.expectRevert(AntseedSellerDelegation.InvalidAddress.selector);
+        proxy.sweepOrphanUsdc(address(0));
+    }
+
+    function test_maxTotalStake_defaultsToAlphaCap_onFreshDeploy() public {
+        vm.prank(owner);
+        DiemStakingProxy fresh = new DiemStakingProxy(address(diem), address(usdc), address(antseedRegistry), operator);
+        assertEq(fresh.maxTotalStake(), fresh.ALPHA_MAX_TOTAL_STAKE());
+        assertEq(fresh.maxTotalStake(), 10e18);
+    }
+
+    function test_alphaCap_enforcedOnFreshDeploy() public {
+        vm.prank(owner);
+        DiemStakingProxy fresh = new DiemStakingProxy(address(diem), address(usdc), address(antseedRegistry), operator);
+
+        diem.mint(alice, 11e18);
+        vm.startPrank(alice);
+        diem.approve(address(fresh), 11e18);
+        vm.expectRevert(DiemStakingProxy.MaxStakeExceeded.selector);
+        fresh.stake(11e18); // over the 10 DIEM alpha cap
+        fresh.stake(10e18);
+        vm.stopPrank();
+        assertEq(fresh.totalStaked(), 10e18);
+    }
+
+    function test_setMaxTotalStake_onlyOwner() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        proxy.setMaxTotalStake(50e18);
+    }
+
+    function test_setMaxTotalStake_emitsEvent() public {
+        vm.prank(owner);
+        vm.expectEmit(false, false, false, true);
+        emit DiemStakingProxy.MaxTotalStakeSet(50e18);
+        proxy.setMaxTotalStake(50e18);
+        assertEq(proxy.maxTotalStake(), 50e18);
+    }
+
+    function test_stake_revertsWhenCapExceeded() public {
+        vm.prank(owner);
+        proxy.setMaxTotalStake(100e18);
+
+        _stakeAs(alice, 80e18);
+
+        diem.mint(bob, 30e18);
+        vm.startPrank(bob);
+        diem.approve(address(proxy), 30e18);
+        vm.expectRevert(DiemStakingProxy.MaxStakeExceeded.selector);
+        proxy.stake(30e18);
+        vm.stopPrank();
+
+        diem.mint(bob, 20e18);
+        vm.startPrank(bob);
+        diem.approve(address(proxy), 20e18);
+        proxy.stake(20e18);
+        vm.stopPrank();
+        assertEq(proxy.totalStaked(), 100e18);
+    }
+
+    function test_setMaxTotalStake_belowCurrentTotal_doesNotTrapStakers() public {
+        _stakeAs(alice, 100e18);
+        _stakeAs(bob, 100e18);
+        assertEq(proxy.totalStaked(), 200e18);
+
+        vm.prank(owner);
+        proxy.setMaxTotalStake(50e18); // below current totalStaked
+
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+        assertEq(proxy.staked(alice), 0);
+
+        diem.mint(bob, 10e18);
+        vm.startPrank(bob);
+        diem.approve(address(proxy), 10e18);
+        vm.expectRevert(DiemStakingProxy.MaxStakeExceeded.selector);
+        proxy.stake(10e18);
+        vm.stopPrank();
+    }
+
+    function test_maxTotalStake_zeroMeansUnlimited() public {
+        vm.prank(owner);
+        proxy.setMaxTotalStake(0);
+        _stakeAs(alice, 1_000_000e18);
+        assertEq(proxy.totalStaked(), 1_000_000e18);
+    }
+
+    function test_stakerCount_startsAtZero() public view {
+        assertEq(proxy.stakerCount(), 0);
+    }
+
+    function test_stakerCount_incrementsOnFirstStake() public {
+        _stakeAs(alice, 10e18);
+        assertEq(proxy.stakerCount(), 1);
+        _stakeAs(bob, 5e18);
+        assertEq(proxy.stakerCount(), 2);
+    }
+
+    function test_stakerCount_partialStakeDoesNotDoubleCount() public {
+        _stakeAs(alice, 10e18);
+        _stakeAs(alice, 20e18); // top-up, still one distinct staker
+        assertEq(proxy.stakerCount(), 1);
+    }
+
+    function test_stakerCount_decrementsOnFullExitOnly() public {
+        _stakeAs(alice, 100e18);
+        _stakeAs(bob, 50e18);
+        assertEq(proxy.stakerCount(), 2);
+
+        vm.prank(alice);
+        proxy.initiateUnstake(40e18);
+        assertEq(proxy.stakerCount(), 2, "partial unstake doesn't change count");
+
+        vm.prank(alice);
+        proxy.initiateUnstake(60e18);
+        assertEq(proxy.stakerCount(), 1);
+
+        vm.prank(bob);
+        proxy.initiateUnstake(50e18);
+        assertEq(proxy.stakerCount(), 0);
+    }
+
+    function test_stakerCount_restakeAfterFullExitIncrements() public {
+        _stakeAs(alice, 10e18);
+        vm.prank(alice);
+        proxy.initiateUnstake(10e18);
+        assertEq(proxy.stakerCount(), 0);
+
+        _stakeAs(alice, 5e18);
+        assertEq(proxy.stakerCount(), 1, "re-entry counts again");
+    }
+
+    function test_totalUsdcDistributedEver_accumulatesAcrossSettles() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 ch1 = _reserveViaProxy(bytes32(uint256(1)), 500e6, 500e6);
+        _settleViaProxy(ch1, 300e6);
+        uint256 after1 = proxy.totalUsdcDistributedEver();
+        assertGt(after1, 0);
+
+        _closeViaProxy(ch1, 400e6); // +100 delta
+        uint256 after2 = proxy.totalUsdcDistributedEver();
+        assertGt(after2, after1, "increments on every inflow");
+    }
+
+    function test_totalUsdcDistributedEver_neverDecrementsOnClaim() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+        uint256 distributed = proxy.totalUsdcDistributedEver();
+
+        vm.prank(alice);
+        proxy.claimUsdc();
+        assertEq(proxy.totalUsdcDistributedEver(), distributed, "lifetime counter must not decrement");
+    }
+
+    function test_totalUsdcDistributedEver_skipsInflowWithNoStakers() public {
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 500e6, 500e6);
+        _settleViaProxy(channelId, 400e6);
+        assertEq(proxy.totalUsdcDistributedEver(), 0, "no-staker inflow doesn't count as distributed");
+    }
+
+    function test_invariant_usdcClaimsSumToInflows() public {
+        _stakeAs(alice, 40e18);
+        _stakeAs(bob, 60e18);
+
+        bytes32 ch1 = _reserveViaProxy(bytes32(uint256(1)), 10_000e6, 10_000e6);
+
+        uint256 balBefore = usdc.balanceOf(address(proxy));
+        _settleViaProxy(ch1, 3_000e6);
+        _settleViaProxy(ch1, 5_000e6);
+        _closeViaProxy(ch1, 7_000e6);
+        uint256 netInflow = usdc.balanceOf(address(proxy)) - balBefore;
+
+        uint256 aliceBefore = usdc.balanceOf(alice);
+        uint256 bobBefore = usdc.balanceOf(bob);
+        vm.prank(alice);
+        proxy.claimUsdc();
+        vm.prank(bob);
+        proxy.claimUsdc();
+        uint256 paidOut = (usdc.balanceOf(alice) - aliceBefore) + (usdc.balanceOf(bob) - bobBefore);
+
+        assertLe(paidOut, netInflow, "claims must not exceed inflows");
+        assertApproxEqAbs(paidOut, netInflow, 3, "rounding dust bounded by #settles");
+        assertEq(
+            proxy.totalUsdcDistributedEver(), netInflow, "lifetime counter equals full inflow regardless of rounding"
+        );
+    }
+
+    function test_invariant_balanceNeverBelowReserved() public {
+        _stakeAs(alice, 30e18);
+        _stakeAs(bob, 70e18);
+
+        bytes32 ch1 = _reserveViaProxy(bytes32(uint256(1)), 10_000e6, 10_000e6);
+        _settleViaProxy(ch1, 1_000e6);
+        assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
+
+        _settleViaProxy(ch1, 2_500e6);
+        assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
+
+        vm.prank(alice);
+        proxy.claimUsdc();
+        assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
+
+        _closeViaProxy(ch1, 4_000e6);
+        assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
+
+        vm.prank(bob);
+        proxy.claimUsdc();
+        assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
+    }
+
+    function test_invariant_antsClaimsSumToPot() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(1)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        vm.warp(block.timestamp + EPOCH_DURATION / 3);
+        _stakeAs(bob, 50e18);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+
+        uint256 aliceBefore = ants.balanceOf(alice);
+        uint256 bobBefore = ants.balanceOf(bob);
+        vm.prank(alice);
+        proxy.claimAnts(_rewardEpochs(0, 1));
+        vm.prank(bob);
+        proxy.claimAnts(_rewardEpochs(0, 1));
+        (,, uint256 antsPot,) = proxy.rewardEpochs(0);
+        assertGt(antsPot, 0);
+        uint256 paidOut = (ants.balanceOf(alice) - aliceBefore) + (ants.balanceOf(bob) - bobBefore);
+
+        assertLe(paidOut, antsPot, "sum of ANTS claims must not exceed pot");
+        assertApproxEqAbs(paidOut, antsPot, 2, "rounding dust bounded by #claimants");
+    }
+
+    function test_catchUpPoints_openEpochDeferredThenCaptured() public {
+        _stakeAs(alice, 100e18);
+
+        _advanceRewardEpochs(17);
+        vm.prank(alice);
+        proxy.catchUpPoints(16);
+        vm.prank(alice);
+        proxy.catchUpPoints(16); // drains to syncedRewardEpoch = 17
+
+        uint32 openEp = proxy.syncedRewardEpoch();
+        assertEq(openEp, 17);
+        assertEq(proxy.userCurrentEpoch(alice), openEp);
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(99)), 1000e6, 1000e6);
+        _settleViaProxy(channelId, 500e6);
+
+        assertEq(proxy.userPoints(alice, openEp), 0, "open-epoch points deferred");
+
+        vm.prank(alice);
+        proxy.initiateUnstake(1e18);
+        assertGt(proxy.userPoints(alice, openEp), 0, "open-epoch points captured on next interaction");
+    }
+
+    function test_churn_stakeSettleUnstakeRestakeSettle() public {
+        _stakeAs(alice, 100e18);
+
+        bytes32 ch1 = _reserveViaProxy(bytes32(uint256(1)), 10_000e6, 10_000e6);
+        _settleViaProxy(ch1, 1_000e6);
+        uint256 aliceRound1 = proxy.earnedUsdc(alice);
+        assertGt(aliceRound1, 0);
+
+        vm.warp(block.timestamp + 1 hours);
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+
+        _settleViaProxy(ch1, 2_000e6);
+        uint256 orphanBefore = usdc.balanceOf(address(proxy)) - proxy.totalUsdcReservedForStakers();
+        assertGt(orphanBefore, 0, "settle with zero totalStaked is orphaned");
+
+        vm.warp(block.timestamp + 1 hours);
+        _stakeAs(alice, 50e18);
+        _settleViaProxy(ch1, 3_000e6);
+
+        uint256 aliceRound2 = proxy.earnedUsdc(alice) - aliceRound1;
+        assertGt(aliceRound2, 0, "restake earns again");
+
+        assertGe(usdc.balanceOf(address(proxy)), proxy.totalUsdcReservedForStakers());
+    }
+
+    function test_flush_windowAfterImmediateNextQueue() public {
+        vm.prank(owner);
+        proxy.setMinUnstakeBatchOpenSecs(6 hours);
+
+        _stakeAs(alice, 100e18);
+        _stakeAs(bob, 100e18);
+
+        vm.prank(alice);
+        proxy.initiateUnstake(100e18);
+        uint32 firstBatch = proxy.currentUnstakeBatch();
+        vm.warp(block.timestamp + 6 hours);
+        proxy.flush();
+        vm.warp(block.timestamp + DIEM_COOLDOWN + 1);
+        proxy.claimUnstakeBatch(firstBatch);
+
+        vm.prank(bob);
+        proxy.initiateUnstake(100e18);
+
+        vm.expectRevert(DiemStakingProxy.UnstakeBatchTooYoung.selector);
+        proxy.flush();
+
+        vm.warp(block.timestamp + 6 hours);
+        proxy.flush();
+    }
+
+    function test_isValidSignature_malformedSigReturnsInvalid() public {
+        bytes32 hash = keccak256("venice-api-key-challenge");
+        bytes memory bad = hex"deadbeef"; // 4 bytes, not 65
+        assertEq(proxy.isValidSignature(hash, bad), bytes4(0xffffffff));
+    }
+
+    function test_rewardPerToken_precisionAtHighTvl() public {
+        vm.prank(owner);
+        proxy.setMaxTotalStake(0);
+
+        _stakeAs(alice, 5e23);
+        _stakeAs(bob, 5e23);
+
+        uint256 before = proxy.usdcRewardPerTokenStored();
+
+        bytes32 channelId = _reserveViaProxy(bytes32(uint256(123)), 1e6, 1e6);
+        _settleViaProxy(channelId, 1e6);
+
+        uint256 afterStored = proxy.usdcRewardPerTokenStored();
+        assertGt(afterStored, before, "RAY scalar preserves small-inflow precision at 1e24 TVL");
+    }
+}

--- a/packages/node/src/payments/chain-config.ts
+++ b/packages/node/src/payments/chain-config.ts
@@ -48,7 +48,7 @@ const CHAIN_CONFIGS: Record<ChainId, ChainConfig> = {
     depositsContractAddress: '0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2',
     channelsContractAddress: '0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d',
     stakingContractAddress: '0x3652E6B22919bd322A25723B94BB207602E5c8e6',
-    emissionsContractAddress: '0x36877fBa8Fa333aa46a1c57b66D132E4995C86b5',
+    emissionsContractAddress: '0xF13bE52c4A3afC6AE29536f073588d01A0564088',
     antsTokenAddress: '0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263',
     identityRegistryAddress: '0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
     channelsDeployBlock: 44469557,


### PR DESCRIPTION
## Description

Adds AntseedEmissionsV2 and related upgrade scaffolding while preserving compatibility with the legacy emissions deployment. This also expands contract test coverage to run the legacy emissions, channels, and Diem proxy flows against the V2 path and introduces seller-claim-policy-based rewards pool claiming.

## Release Notes

- Added AntseedEmissionsV2 with migration-aware legacy compatibility
- Added V2 test coverage for emissions, channels, and Diem proxy flows
- Added seller claim policy hooks for locked seller rewards

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [ ] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
