### PR TITLE
fix(contracts): Support legacy emissions in portal

### DIFF
--- a/apps/payments/src/routes.ts
+++ b/apps/payments/src/routes.ts
@@ -82,6 +82,20 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
     return emissionsClient;
   }
 
+  let legacyEmissionsClient: EmissionsClient | null = null;
+  function getLegacyEmissionsClient(): EmissionsClient | null {
+    if (!ctx.chainConfig.legacyEmissionsContractAddress) return null;
+    if (!legacyEmissionsClient) {
+      legacyEmissionsClient = new EmissionsClient({
+        rpcUrl: ctx.cryptoConfig.rpcUrl,
+        ...(ctx.cryptoConfig.fallbackRpcUrls ? { fallbackRpcUrls: ctx.cryptoConfig.fallbackRpcUrls } : {}),
+        contractAddress: ctx.chainConfig.legacyEmissionsContractAddress,
+        evmChainId: ctx.chainConfig.evmChainId,
+      });
+    }
+    return legacyEmissionsClient;
+  }
+
   let antsTokenClient: ANTSTokenClient | null = null;
   function getAntsTokenClient(): ANTSTokenClient | null {
     // ANTSToken address is typically fetched via the registry, but for v1 we
@@ -274,10 +288,12 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
       const current = info.epoch;
       const startEpoch = Math.max(0, current - (scanN - 1));
       const epochList = Array.from({ length: current - startEpoch + 1 }, (_, i) => startEpoch + i);
+      const legacyClient = getLegacyEmissionsClient();
+      const migrationEpoch = legacyClient ? await retryRead(() => client.getMigrationEpoch()) : null;
 
       const rows = await Promise.all(
         epochList.map(async (epoch) => {
-          const [pending, userSP, userBP, sellerClaimed, buyerClaimed, totalSP, totalBP, epEmission] = await Promise.all([
+          const [pending, v2UserSP, v2UserBP, v2SellerClaimed, v2BuyerClaimed, v2TotalSP, v2TotalBP, epEmission] = await Promise.all([
             retryRead(() => client.pendingEmissions(address, [epoch])),
             retryRead(() => client.userSellerPoints(address, epoch)),
             retryRead(() => client.userBuyerPoints(address, epoch)),
@@ -287,6 +303,38 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
             retryRead(() => client.epochTotalBuyerPoints(epoch)),
             retryRead(() => client.getEpochEmission(epoch)),
           ]);
+
+          let userSP = v2UserSP;
+          let userBP = v2UserBP;
+          let totalSP = v2TotalSP;
+          let totalBP = v2TotalBP;
+          let sellerClaimed = v2SellerClaimed;
+          let buyerClaimed = v2BuyerClaimed;
+
+          if (legacyClient && migrationEpoch !== null) {
+            if (epoch <= migrationEpoch) {
+              const [legacyUserSP, legacyUserBP, legacyTotalSP, legacyTotalBP] = await Promise.all([
+                retryRead(() => legacyClient.userSellerPoints(address, epoch)),
+                retryRead(() => legacyClient.userBuyerPoints(address, epoch)),
+                retryRead(() => legacyClient.epochTotalSellerPoints(epoch)),
+                retryRead(() => legacyClient.epochTotalBuyerPoints(epoch)),
+              ]);
+              userSP += legacyUserSP;
+              userBP += legacyUserBP;
+              totalSP += legacyTotalSP;
+              totalBP += legacyTotalBP;
+            }
+
+            if (epoch < migrationEpoch) {
+              const [legacySellerClaimed, legacyBuyerClaimed] = await Promise.all([
+                retryRead(() => legacyClient.sellerEpochClaimed(address, epoch)),
+                retryRead(() => legacyClient.buyerEpochClaimed(address, epoch)),
+              ]);
+              sellerClaimed = legacySellerClaimed;
+              buyerClaimed = legacyBuyerClaimed;
+            }
+          }
+
           return {
             epoch,
             epochEmission: epEmission.toString(),

--- a/packages/node/src/payments/chain-config.ts
+++ b/packages/node/src/payments/chain-config.ts
@@ -17,6 +17,7 @@ export interface ChainConfig {
   usdcContractAddress: string;
   identityRegistryAddress?: string;
   emissionsContractAddress?: string;
+  legacyEmissionsContractAddress?: string;
   antsTokenAddress?: string;
   subPoolContractAddress?: string;
   /** Block when Channels contract was deployed. Floor for event log scans. */
@@ -49,6 +50,7 @@ const CHAIN_CONFIGS: Record<ChainId, ChainConfig> = {
     channelsContractAddress: '0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d',
     stakingContractAddress: '0x3652E6B22919bd322A25723B94BB207602E5c8e6',
     emissionsContractAddress: '0xF13bE52c4A3afC6AE29536f073588d01A0564088',
+    legacyEmissionsContractAddress: '0x36877fBa8Fa333aa46a1c57b66D132E4995C86b5',
     antsTokenAddress: '0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263',
     identityRegistryAddress: '0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
     channelsDeployBlock: 44469557,
@@ -108,6 +110,7 @@ export function resolveChainConfig(overrides?: {
   usdcContractAddress?: string;
   identityRegistryAddress?: string;
   emissionsContractAddress?: string;
+  legacyEmissionsContractAddress?: string;
   antsTokenAddress?: string;
   subPoolContractAddress?: string;
 }): ChainConfig {
@@ -128,6 +131,7 @@ export function resolveChainConfig(overrides?: {
     ...(overrides?.usdcContractAddress ? { usdcContractAddress: overrides.usdcContractAddress } : {}),
     ...(overrides?.identityRegistryAddress ? { identityRegistryAddress: overrides.identityRegistryAddress } : {}),
     ...(overrides?.emissionsContractAddress ? { emissionsContractAddress: overrides.emissionsContractAddress } : {}),
+    ...(overrides?.legacyEmissionsContractAddress ? { legacyEmissionsContractAddress: overrides.legacyEmissionsContractAddress } : {}),
     ...(overrides?.antsTokenAddress ? { antsTokenAddress: overrides.antsTokenAddress } : {}),
     ...(overrides?.subPoolContractAddress ? { subPoolContractAddress: overrides.subPoolContractAddress } : {}),
   };

--- a/packages/node/src/payments/evm/emissions-client.ts
+++ b/packages/node/src/payments/evm/emissions-client.ts
@@ -26,6 +26,7 @@ const EMISSIONS_ABI = [
   'function EPOCH_DURATION() external view returns (uint256)',
   'function INITIAL_EMISSION() external view returns (uint256)',
   'function HALVING_INTERVAL() external view returns (uint256)',
+  'function MIGRATION_EPOCH() external view returns (uint256)',
   'function SELLER_SHARE_PCT() external view returns (uint256)',
   'function BUYER_SHARE_PCT() external view returns (uint256)',
   'function RESERVE_SHARE_PCT() external view returns (uint256)',
@@ -88,6 +89,12 @@ export class EmissionsClient extends BaseEvmClient {
   async getHalvingInterval(): Promise<number> {
     const contract = new Contract(this._contractAddress, EMISSIONS_ABI, this._provider);
     const v = await contract.getFunction('HALVING_INTERVAL')();
+    return Number(v);
+  }
+
+  async getMigrationEpoch(): Promise<number> {
+    const contract = new Contract(this._contractAddress, EMISSIONS_ABI, this._provider);
+    const v = await contract.getFunction('MIGRATION_EPOCH')();
     return Number(v);
   }
 


### PR DESCRIPTION
## Description

Adds legacy emissions support to the payments portal backend so historical epoch rows reflect combined legacy and V2 emissions data. This fixes the emissions table for migrated deployments by merging legacy points and using the correct pre-migration claim flags.

## Release Notes

- Fixed the payments portal emissions history for migrated deployments by merging legacy and V2 epoch data
- Restored accurate claimed and claimable status for pre-migration emissions epochs

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
