### PR TITLE
Add chat scroll to latest button

### DIFF
--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -884,7 +884,7 @@ export function initChatModule({
   function scrollChatToBottom(): void {
     const container = document.querySelector<HTMLElement>('[data-chat-scroll]');
     if (!container) return;
-    const threshold = 100;
+    const threshold = 40;
     const distanceFromBottom =
       container.scrollHeight - container.scrollTop - container.clientHeight;
     if (distanceFromBottom < threshold) {

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
@@ -294,6 +294,59 @@
   padding: 40px 16px;
 }
 
+.scroll-to-latest-button {
+  position: absolute;
+  left: 50%;
+  bottom: 104px;
+  transform: translateX(-50%);
+  z-index: 12;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 12px;
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg-card) 92%, transparent);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  color: var(--text-secondary);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  cursor: pointer;
+  backdrop-filter: blur(10px);
+  transition: color 0.15s, border-color 0.15s, background 0.15s, transform 0.15s, box-shadow 0.15s;
+
+  &:hover {
+    color: var(--accent-green);
+    border-color: color-mix(in srgb, var(--accent-green) 45%, var(--border-light));
+    background: color-mix(in srgb, var(--accent-green) 8%, var(--bg-card));
+    transform: translateX(-50%) translateY(-1px);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.16);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent-green);
+    outline-offset: 2px;
+  }
+}
+
+.scroll-to-latest-icon {
+  transform: rotate(180deg);
+}
+
+.scroll-to-latest-button-new {
+  border-color: color-mix(in srgb, var(--accent-green) 36%, var(--border-light));
+}
+
+.scroll-to-latest-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-green);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-green) 14%, transparent);
+}
+
 /* ===================================================================
    Chat input area
    =================================================================== */

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
@@ -302,27 +302,25 @@
   z-index: 12;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 7px 12px;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
   border: 1px solid var(--border-light);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--bg-card) 92%, transparent);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-  color: var(--text-secondary);
-  font: inherit;
-  font-size: 12px;
-  font-weight: 500;
-  line-height: 1;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--bg-card) 94%, transparent);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
+  color: var(--text-muted);
   cursor: pointer;
   backdrop-filter: blur(10px);
   transition: color 0.15s, border-color 0.15s, background 0.15s, transform 0.15s, box-shadow 0.15s;
 
   &:hover {
     color: var(--accent-green);
-    border-color: color-mix(in srgb, var(--accent-green) 45%, var(--border-light));
-    background: color-mix(in srgb, var(--accent-green) 8%, var(--bg-card));
+    border-color: color-mix(in srgb, var(--accent-green) 38%, var(--border-light));
+    background: color-mix(in srgb, var(--accent-green) 7%, var(--bg-card));
     transform: translateX(-50%) translateY(-1px);
-    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.16);
+    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.16);
   }
 
   &:focus-visible {
@@ -336,10 +334,13 @@
 }
 
 .scroll-to-latest-button-new {
-  border-color: color-mix(in srgb, var(--accent-green) 36%, var(--border-light));
+  border-color: color-mix(in srgb, var(--accent-green) 32%, var(--border-light));
 }
 
 .scroll-to-latest-dot {
+  position: absolute;
+  top: 5px;
+  right: 5px;
   width: 6px;
   height: 6px;
   border-radius: 50%;

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -40,6 +40,11 @@ const DEFAULT_PREVIEW_FRACTION = 0.5;
 const MAX_ATTACHMENTS = 5;
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 const MAX_TOTAL_ATTACHMENT_BYTES = 50 * 1024 * 1024;
+const NEAR_BOTTOM_PX = 40;
+
+function isNearScrollBottom(el: HTMLElement): boolean {
+  return el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
+}
 
 function getMessageContentKey(content: unknown): string {
   if (typeof content === 'string') {
@@ -160,6 +165,8 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   };
   const [pendingQueue, setPendingQueue] = useState<PendingDraft[]>([]);
   const [previewAttachment, setPreviewAttachment] = useState<ViewerAttachment | null>(null);
+  const [isNearBottom, setIsNearBottom] = useState(true);
+  const [hasNewActivityWhileScrolledUp, setHasNewActivityWhileScrolledUp] = useState(false);
   const [tooltipDismissed, setTooltipDismissed] = useState<boolean>(() => {
     if (typeof window === 'undefined') return true;
     return window.localStorage.getItem(SWITCH_TOOLTIP_DISMISSED_KEY) === 'true';
@@ -195,23 +202,30 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     }
   }, [previewUrl, previewRequestId]);
 
-  // Track whether the user has scrolled away from the bottom
+  // Track whether the user has scrolled away from the bottom.
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     const handleScroll = () => {
-      const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+      const atBottom = isNearScrollBottom(el);
       isUserScrolledUp.current = !atBottom;
+      setIsNearBottom(atBottom);
+      if (atBottom) {
+        setHasNewActivityWhileScrolledUp(false);
+      }
     };
+    handleScroll();
     el.addEventListener('scroll', handleScroll, { passive: true });
     return () => el.removeEventListener('scroll', handleScroll);
   }, []);
 
-  const scrollChatToBottom = useCallback(() => {
+  const scrollChatToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
     const el = scrollRef.current;
     if (!el) return;
-    el.scrollTop = el.scrollHeight;
+    el.scrollTo({ top: el.scrollHeight, behavior });
     isUserScrolledUp.current = false;
+    setIsNearBottom(true);
+    setHasNewActivityWhileScrolledUp(false);
   }, []);
 
   // Opening/reopening a conversation should land on the latest message, not the
@@ -232,14 +246,18 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
 
     isUserScrolledUp.current = false;
     scrollChatToBottom();
-    const frame = requestAnimationFrame(scrollChatToBottom);
+    const frame = requestAnimationFrame(() => scrollChatToBottom());
     return () => cancelAnimationFrame(frame);
   }, [active, snap.chatActiveConversation, scrollChatToBottom]);
 
   // Keep the view pinned to the bottom while the user is already at the bottom.
   useEffect(() => {
     const el = scrollRef.current;
-    if (!el || isUserScrolledUp.current) {
+    if (!el) {
+      return;
+    }
+    if (isUserScrolledUp.current) {
+      setHasNewActivityWhileScrolledUp(true);
       return;
     }
 
@@ -659,11 +677,16 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     bridge?.sendBrowserPreviewElementSelected?.(info);
   }, []);
 
+  const handleScrollToLatest = useCallback(() => {
+    scrollChatToBottom('smooth');
+  }, [scrollChatToBottom]);
+
   const showWelcome =
     snap.chatConversationsLoaded &&
     !snap.chatActiveConversation &&
     visibleMessages.length === 0 &&
     !snap.chatStreamingMessage;
+  const showScrollToLatest = !showWelcome && !isNearBottom;
 
   const workspacePath = snap.chatWorkspacePath || snap.chatWorkspaceDefaultPath;
   const workspaceLabel = getPathEnding(workspacePath);
@@ -848,6 +871,19 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
             />
           </div>
 
+          {showScrollToLatest ? (
+            <button
+              type="button"
+              className={`${styles.scrollToLatestButton}${hasNewActivityWhileScrolledUp ? ` ${styles.scrollToLatestButtonNew}` : ''}`}
+              onClick={handleScrollToLatest}
+              aria-label="Scroll to latest message"
+              title="Scroll to latest message"
+            >
+              <HugeiconsIcon icon={ArrowUp02Icon} size={14} strokeWidth={2} className={styles.scrollToLatestIcon} />
+              <span>Latest</span>
+              {hasNewActivityWhileScrolledUp ? <span className={styles.scrollToLatestDot} aria-hidden="true" /> : null}
+            </button>
+          ) : null}
 
           <div className={styles.chatInputArea}>
             {snap.chatError && <div className={styles.chatError}>{snap.chatError}</div>}

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -879,8 +879,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
               aria-label="Scroll to latest message"
               title="Scroll to latest message"
             >
-              <HugeiconsIcon icon={ArrowUp02Icon} size={14} strokeWidth={2} className={styles.scrollToLatestIcon} />
-              <span>Latest</span>
+              <HugeiconsIcon icon={ArrowUp02Icon} size={16} strokeWidth={2} className={styles.scrollToLatestIcon} />
               {hasNewActivityWhileScrolledUp ? <span className={styles.scrollToLatestDot} aria-hidden="true" /> : null}
             </button>
           ) : null}


### PR DESCRIPTION
## Summary

Closes #499.

Adds a floating `Latest` button in the desktop chat when the user scrolls away from the newest messages.

## What changed

- Reuses the existing near-bottom detection in `ChatView` and exposes it as UI state.
- Shows a floating `Latest` button when the user scrolls up.
- Clicking the button smoothly scrolls back to the newest message / bottom.
- Clears the button state when the user returns to the bottom.
- Adds a subtle new-activity dot when content arrives while the user is scrolled up.
- Aligns the streaming scroll threshold with the chat view threshold so streaming updates do not fight the button behavior.

## Notes

The visual treatment is proposed and does not have to be final exactly as-is.

## Validation

- `pnpm --filter=@antseed/desktop exec tsc -p tsconfig.renderer.json --noEmit`
- `git diff --check`
