### PR TITLE
Docs/emissions v2 update

### DIFF
--- a/apps/website/docs/protocol/payments.md
+++ b/apps/website/docs/protocol/payments.md
@@ -128,15 +128,26 @@ USDC on Base. 6 decimal places. All on-chain amounts are in USDC atomic units (1
 ## Smart Contracts
 
 ```text title="contract architecture"
-AntseedRegistry       Central address book for all protocol contracts
-AntseedStaking        Seller staking (holds stake USDC, binds to ERC-8004 agentId)
-AntseedDeposits       Buyer deposits, seller payouts (holds buyer USDC)
-AntseedChannels       Payment channel lifecycle (swappable, holds NO USDC)
-AntseedEmissions      ANTS token emissions (USDC volume-based incentives)
-ANTSToken             ANTS ERC-20 token (1.04B max supply)
+AntseedRegistry            Central address book for all protocol contracts
+AntseedStaking             Seller staking (holds stake USDC, binds to ERC-8004 agentId)
+AntseedDeposits            Buyer deposits, seller payouts (holds buyer USDC)
+AntseedChannels            Payment channel lifecycle (swappable, holds NO USDC)
+AntseedEmissionsV2         ANTS token emissions (backward-compatible replacement)
+AntseedSellerRewardsPool   Locked ANTS reserves for sellers pending unlock
+AntseedSellerUnlockPolicy  On-chain policy controlling when sellers can claim
+AntseedEmissions (legacy)  Original emissions contract — depleted since epoch 4
+ANTSToken                  ANTS ERC-20 token (1.04B max supply)
 ```
 
-Network fees are set to 4% of settlement and flow to the Protocol Reserve, not to a company. The Protocol Reserve is intended to support long-term network sustainability, trust, utility, and alignment. Seller ANTS emissions are currently tracked but locked in a dedicated Provider Pool pending stronger validation; future claims may be subject to verification or slashing.
+Network fees are set to 4% of settlement and flow to the Protocol Reserve, not to a company. The Protocol Reserve is intended to support long-term network sustainability, trust, utility, and alignment.
+
+### Emissions
+
+`AntseedEmissionsV2` replaced the original `AntseedEmissions` contract at epoch 4. It is backward-compatible: historical points from epochs 1–4 remain claimable through V2, while all new points accrue in V2's own ledger.
+
+**For sellers:** ANTS rewards from finalized epochs are minted to a locked rewards pool (`AntseedSellerRewardsPool`) by default. Sellers can only claim unlocked tokens when the on-chain `AntseedSellerUnlockPolicy` allows it — typically after stake/activity criteria are met. This replaces the earlier "locked in a dedicated Provider Pool pending validation" state with a transparent, contract-enforced policy.
+
+**For buyers:** Buyer emissions are claimable via an operator address through `claimBuyerEmissions`.
 
 **Stable contracts** (Staking, Deposits) hold funds and rarely change. The **swappable contract** (Channels) holds no USDC and can be redeployed by re-pointing via the Registry.
 

--- a/apps/website/docs/protocol/payments.md
+++ b/apps/website/docs/protocol/payments.md
@@ -145,6 +145,8 @@ Network fees are set to 4% of settlement and flow to the Protocol Reserve, not t
 
 `AntseedEmissionsV2` replaced the original `AntseedEmissions` contract at epoch 4. It is backward-compatible: historical points from epochs 1–4 remain claimable through V2, while all new points accrue in V2's own ledger.
 
+Each epoch's ANTS are split: 50% to sellers, 20% to buyers, 15% to the Protocol Reserve, and 15% to the team.
+
 **For sellers:** ANTS rewards from finalized epochs are minted to a locked rewards pool (`AntseedSellerRewardsPool`) by default. Sellers can only claim unlocked tokens when the on-chain `AntseedSellerUnlockPolicy` allows it — typically after stake/activity criteria are met. This replaces the earlier "locked in a dedicated Provider Pool pending validation" state with a transparent, contract-enforced policy.
 
 **For buyers:** Buyer emissions are claimable via an operator address through `claimBuyerEmissions`.

--- a/apps/website/docs/protocol/payments.md
+++ b/apps/website/docs/protocol/payments.md
@@ -147,7 +147,7 @@ Network fees are set to 4% of settlement and flow to the Protocol Reserve, not t
 
 Each epoch's ANTS are split: 50% to sellers, 20% to buyers, 15% to the Protocol Reserve, and 15% to the team.
 
-**For sellers:** ANTS rewards from finalized epochs are minted to a locked rewards pool (`AntseedSellerRewardsPool`) by default. Sellers can only claim unlocked tokens when the on-chain `AntseedSellerUnlockPolicy` allows it — typically after stake/activity criteria are met. This replaces the earlier "locked in a dedicated Provider Pool pending validation" state with a transparent, contract-enforced policy.
+**For sellers:** ANTS rewards from finalized epochs are minted to a locked rewards pool (`AntseedSellerRewardsPool`) by default. Sellers can only claim unlocked tokens when the on-chain `AntseedSellerUnlockPolicy` allows it — typically after stake/activity criteria are met.
 
 **For buyers:** Buyer emissions are claimable via an operator address through `claimBuyerEmissions`.
 

--- a/docs/protocol/diem-proxy.md
+++ b/docs/protocol/diem-proxy.md
@@ -31,7 +31,7 @@ The on-chain seller changes from "peerId's derived EVM address" to "the proxy co
        ▼ reserve/topUp/        ▼ operatorClaimEmissions  ▼ getReward()
          settle/close            (epochs[])               (by user)
        ┌─────────────┐       ┌──────────────────┐       ┌──────────────────┐
-       │ AntseedCh-  │       │ AntseedEmissions │       │ USDC / ANTS      │
+        │ AntseedCh-  │       │AntseedEmissionsV2│       │ USDC / ANTS      │
        │ annels      │       │                  │       │ safeTransfer     │
        └──────┬──────┘       └────────┬─────────┘       └──────────────────┘
               │                       │
@@ -168,7 +168,7 @@ Prerequisites: Base mainnet (or Sepolia); owner EOA with ETH for gas; operator E
    - `_usdc`: Base USDC (mainnet: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`)
    - `_ants`: AntSeed ANTS token address (check `packages/node/chain-config.json`)
    - `_channels`: real `AntseedChannels` address (not the proxy itself)
-   - `_emissions`: `AntseedEmissions` address
+   - `_emissions`: `AntseedEmissionsV2` address
    - `_antseedStaking`: `AntseedStaking` address (needed so the owner can later recover the seller stake via `withdrawAntseedStake`)
    - `_operator`: the operator EOA (= the peer identity wallet address)
    - `_usdcRewardsDuration`: `86400` (1 day)
@@ -176,7 +176,7 @@ Prerequisites: Base mainnet (or Sepolia); owner EOA with ETH for gas; operator E
 
 2. **(Optional) transfer ownership to a multisig** via `Ownable.transferOwnership`. Distributes operator-rotation risk across N signers.
 
-3. **Register an ERC-8004 agentId** for the proxy address. Call `IdentityRegistry.register(<proxyAddress>)` (or whatever the deployed registry's signature is) — this is a separate tx targeting the ERC-8004 contract, not the proxy. The returned `agentId` is used by `AntseedStaking` and `AntseedEmissions` to identify the proxy as a seller.
+3. **Register an ERC-8004 agentId** for the proxy address. Call `IdentityRegistry.register(<proxyAddress>)` (or whatever the deployed registry's signature is) — this is a separate tx targeting the ERC-8004 contract, not the proxy. The returned `agentId` is used by `AntseedStaking` and `AntseedEmissionsV2` to identify the proxy as a seller.
 
 4. **Stake minimum on `AntseedStaking`** so the proxy can call `reserve()`:
    - Owner approves USDC to `AntseedStaking` for at least `MIN_SELLER_STAKE`.

--- a/docs/protocol/diem-proxy.md
+++ b/docs/protocol/diem-proxy.md
@@ -31,7 +31,7 @@ The on-chain seller changes from "peerId's derived EVM address" to "the proxy co
        ▼ reserve/topUp/        ▼ operatorClaimEmissions  ▼ getReward()
          settle/close            (epochs[])               (by user)
        ┌─────────────┐       ┌──────────────────┐       ┌──────────────────┐
-        │ AntseedCh-  │       │AntseedEmissionsV2│       │ USDC / ANTS      │
+       │ AntseedCh-  │       │AntseedEmissionsV2│       │ USDC / ANTS      │
        │ annels      │       │                  │       │ safeTransfer     │
        └──────┬──────┘       └────────┬─────────┘       └──────────────────┘
               │                       │

--- a/docs/protocol/spec/04-payments.md
+++ b/docs/protocol/spec/04-payments.md
@@ -153,69 +153,94 @@ ERC-20 on Base. No pre-mine. No initial supply. All ANTS distributed through ver
 
 **Phase 1 (current):** Non-transferable. `transfer()` and `transferFrom()` revert. Participants earn and claim but cannot trade. Owner calls `enableTransfers()` (one-way toggle) when the network matures.
 
-Mint authority restricted to `AntseedEmissions` contract (`setEmissionsContract()` — one-time setter).
+Mint authority restricted to `AntseedEmissionsV2` contract (`setEmissionsContract()` — one-time setter).
 
-### Emission Schedule
+### AntseedEmissionsV2
 
-- Epoch emission: `e_e = e_0 / 2^(e/h)` — halving every ~6 months
-- Epoch duration: configurable (default 1 week, 26 epochs per halving interval)
-- `advanceEpoch()` callable by anyone when epoch duration has passed
+Deployed upgrade of the original `AntseedEmissions`. Backward-compatible with V1 by reading V1's genesis, epoch constants, and combining V1 + V2 points for the migration epoch and all earlier epochs.
 
-### Emission Split
+- **Base mainnet address:** `0xF13bE52c4A3afC6AE29536f073588d01A0564088`
+- **Genesis:** copied from V1 (`legacyEmissions.genesis()`)
+- **Epoch duration / halving interval:** copied from V1
+
+#### Epochs
+
+Epochs advance automatically via block timestamp:
+
+```
+currentEpoch = (block.timestamp - genesis) / EPOCH_DURATION
+```
+
+No manual `advanceEpoch()` is required. Epoch parameters (share percentages and per-epoch caps) are snapshotted on first V2 touch of each epoch and remain immutable for that epoch.
+
+#### Emission Split (per-epoch snapshot)
 
 | Bucket | Default | Purpose |
 |---|---|---|
 | Seller share | 65% | Rewards proven delivery |
 | Buyer share | 25% | Rewards network usage and feedback |
 | Reserve share | 10% | Future use (subscription pool staking, liquidity) |
+| Team share | 0% | Protocol team |
 
-Reserve accumulates in the emissions contract until `setReserveDestination(address)` is called.
+#### Points Accrual
 
-### Points System
+During `settle()` / `close()`, `AntseedChannels` calls one of:
 
-**Seller points** (accumulated on each `settle()` call):
-```
-sellerPointsDelta = E(P) * V(P) * feedbackMultiplier(P)
+- `accrueSellerPoints(seller, pointsDelta)`
+- `accrueBuyerPoints(buyer, pointsDelta)`
+- `accruePoints(channelId, buyer, seller, pointsDelta)` — optional pair-aware hook for future channels
 
-where:
-  E(P) = min(Q(P), k * S(P))            ← stake-capped qualified proven signs
-  V(P) = qualified token volume           ← real tokens delivered in this settlement
-  feedbackMultiplier(P) =                 ← from ERC-8004 buyer feedback
-    0.5x   if avgFeedback < -50
-    0.75x  if avgFeedback < 0
-    1.0x   if no feedback
-    1.25x  if avgFeedback > 50
-    1.5x   if avgFeedback > 80
-```
+For epochs `<= MIGRATION_EPOCH`, V1 points are combined with V2 points on claim. For later epochs, only V2 points are used.
 
-**Buyer points** (accumulated on each proven session sign + feedback):
-```
-buyerPointsDelta = usagePoints + feedbackPoints + diversityBonus
+#### Points Policy Hook
 
-where:
-  usagePoints    = provenBuyVolume                   ← tokens in this proven sign
-  feedbackPoints = FEEDBACK_WEIGHT per submission     ← flat bonus for on-chain feedback
-  diversityBonus = usagePoints * min(uniqueSellers / BASE_DIVERSITY, MAX_DIVERSITY_MULT)
-```
+An optional `IAntseedPointsPolicy` can be set by owner. If set and its `points()` call succeeds, it returns weighted seller/buyer points. If not set, or if the call reverts, raw points are used.
 
-### Gas-Efficient Distribution (Synthetix Reward-Per-Point)
+#### Per-Epoch Pro-Rata Distribution
 
-No loops. O(1) per interaction. Global accumulator tracks reward-per-point:
+Claiming computes rewards per finalized epoch:
 
 ```
-// On every settle() — O(1):
-rewardPerPointStored += (currentEmissionRate * timeSinceLastUpdate) / totalNetworkPoints;
-seller.pendingReward += seller.points * (rewardPerPointStored - seller.rewardPerPointPaid);
-seller.rewardPerPointPaid = rewardPerPointStored;
-seller.points += pointsDelta;
-totalNetworkPoints += pointsDelta;
+sellerBudget = epochEmission * sellerSharePct / 100
+sellerReward = (userSellerPoints / epochTotalSellerPoints) * sellerBudget
+
+buyerBudget  = epochEmission * buyerSharePct / 100
+buyerReward  = (userBuyerPoints / epochTotalBuyerPoints) * buyerBudget
 ```
 
-Same pattern for buyers with a separate accumulator (`buyerRewardPerPointStored`).
+#### Per-Epoch Caps
 
-**Claiming** (`claimEmissions()`): mints accrued ANTS to caller. 15% per-seller cap enforced — excess redistributed to reserve.
+- **Seller cap:** `maxSellerSharePct` (default historically ~15% of the seller bucket). Excess redirected to reserve.
+- **Buyer cap:** `maxBuyerSharePct` (default 5% of the buyer bucket). Excess redirected to reserve.
 
-**Epoch advancement** (`advanceEpoch()`): callable by anyone. Flushes current epoch accrual, computes new emission rate, updates `epochStart`.
+#### Seller Claiming
+
+Sellers call `claimSellerEmissions(epochs[])` for finalized epochs.
+
+If `sellerUnlockPolicy.canClaimSellerUnlocked(seller)` returns true, ANTS are minted directly to the seller.
+
+If the policy returns false (or is not set), ANTS are minted to `AntseedSellerRewardsPool` and recorded as locked for that seller. They remain locked until the unlock policy later allows release.
+
+#### Buyer Claiming
+
+Anyone can call `claimBuyerEmissions(buyer, epochs[])` provided `msg.sender == Deposits.getOperator(buyer)`. Reward is minted to `msg.sender`.
+
+#### Reserve & Team
+
+Reserve and team shares accumulate in the contract until flushed by owner:
+
+- `flushReserve()` — mints accumulated reserve ANTS to `registry.protocolReserve()`
+- `flushTeam()` — mints accumulated team ANTS to `registry.teamWallet()`
+
+### Legacy V1 Backward Compatibility
+
+`AntseedEmissionsV2` reads the legacy `AntseedEmissions` contract for:
+
+- `genesis`, `EPOCH_DURATION`, `HALVING_INTERVAL`, `INITIAL_EMISSION`
+- Claimed state for epochs `< MIGRATION_EPOCH`
+- User points and total points for epochs `<= MIGRATION_EPOCH`
+
+This ensures sellers and buyers do not lose historical points during the upgrade.
 
 ## 9. Subscription Pool
 
@@ -232,14 +257,16 @@ Separate contract (`AntseedSubPool`) managing subscription-based access. Evolves
 ## 10. Contract Architecture
 
 ```
-ANTSToken (ERC-20)        ── mint restricted to AntseedEmissions
-AntseedDeposits           ── buyer USDC deposits, holds ALL buyer USDC
-AntseedChannels           ── Reserve→Settle/Close lifecycle (holds NO USDC, swappable)
-AntseedStaking            ── seller stake bound to ERC-8004 agentId
-AntseedStats              ── factual per-agent session metrics
-AntseedEmissions          ── USDC volume-based epoch emissions
-AntseedSubPool            ── subscription tiers, daily budgets, revenue distribution
-MockERC8004Registry       ── local testing only (mainnet: deployed ERC-8004)
+ANTSToken (ERC-20)              ── mint restricted to AntseedEmissionsV2
+AntseedDeposits                 ── buyer USDC deposits, holds ALL buyer USDC
+AntseedChannels                 ── Reserve→Settle/Close lifecycle (holds NO USDC, swappable)
+AntseedStaking                  ── seller stake bound to ERC-8004 agentId
+AntseedStats                    ── factual per-agent session metrics
+AntseedEmissionsV2              ── USDC volume-based epoch emissions (backward-compatible with V1)
+AntseedSellerRewardsPool        ── holds locked ANTS for sellers pending unlock policy
+AntseedSellerUnlockPolicy       ── on-chain policy determining if seller can claim unlocked
+AntseedSubPool                  ── subscription tiers, daily budgets, revenue distribution
+MockERC8004Registry             ── local testing only (mainnet: deployed ERC-8004)
 ```
 
 Contracts reference each other by address (set at deployment, updateable by owner). No inheritance between contracts — only interface calls.
@@ -248,9 +275,9 @@ Contracts reference each other by address (set at deployment, updateable by owne
 - `AntseedChannels` calls `AntseedDeposits.lockForChannel()` on reserve
 - `AntseedChannels` calls `AntseedDeposits.chargeAndCreditPayouts()` on settle/close
 - `AntseedChannels` calls `AntseedStats.updateStats()` on settle/close
-- `AntseedChannels` calls `AntseedEmissions.accrueSellerPoints()` / `accrueBuyerPoints()` on settle/close
+- `AntseedChannels` calls `AntseedEmissionsV2.accrueSellerPoints()` / `accrueBuyerPoints()` on settle/close
 - `AntseedChannels` reads from `AntseedStaking` (seller stake verification)
-- `AntseedEmissions` calls `ANTSToken.mint()` on claim
+- `AntseedEmissionsV2` calls `ANTSToken.mint()` on claim
 
 ## 11. P2P Messages
 

--- a/docs/protocol/spec/04-payments.md
+++ b/docs/protocol/spec/04-payments.md
@@ -215,7 +215,7 @@ buyerReward  = (userBuyerPoints / epochTotalBuyerPoints) * buyerBudget
 
 #### Per-Epoch Caps
 
-- **Seller cap:** `maxSellerSharePct` (default historically ~15% of the seller bucket). Excess redirected to reserve.
+- **Seller cap:** `maxSellerSharePct` (default 50% of the seller bucket). Excess redirected to reserve.
 - **Buyer cap:** `maxBuyerSharePct` (default 5% of the buyer bucket). Excess redirected to reserve.
 
 #### Seller Claiming

--- a/docs/protocol/spec/04-payments.md
+++ b/docs/protocol/spec/04-payments.md
@@ -173,6 +173,11 @@ currentEpoch = (block.timestamp - genesis) / EPOCH_DURATION
 
 No manual `advanceEpoch()` is required. Epoch parameters (share percentages and per-epoch caps) are snapshotted on first V2 touch of each epoch and remain immutable for that epoch.
 
+#### Emission Schedule
+
+- Epoch emission: `e_e = e_0 / 2^(epoch / HALVING_INTERVAL)` — halving every ~6 months
+- Epoch duration: configurable (default 1 week, 26 epochs per halving interval)
+
 #### Emission Split (per-epoch snapshot)
 
 | Bucket | Default | Purpose |

--- a/docs/protocol/spec/04-payments.md
+++ b/docs/protocol/spec/04-payments.md
@@ -182,10 +182,10 @@ No manual `advanceEpoch()` is required. Epoch parameters (share percentages and 
 
 | Bucket | Default | Purpose |
 |---|---|---|
-| Seller share | 65% | Rewards proven delivery |
-| Buyer share | 25% | Rewards network usage and feedback |
-| Reserve share | 10% | Future use (subscription pool staking, liquidity) |
-| Team share | 0% | Protocol team |
+| Seller share | 50% | Proven delivery (locked rewards pool until unlocked) |
+| Buyer share | 20% | Rewards network usage and feedback |
+| Reserve share | 15% | Protocol Reserve (network sustainability, liquidity) |
+| Team share | 15% | Protocol team |
 
 #### Points Accrual
 


### PR DESCRIPTION
## What

Update payment protocol documentation to reflect the current `AntseedEmissionsV2` contract deployed at migration epoch 4, replacing the legacy `AntseedEmissions` (now depleted).

### Changes by file

**`docs/protocol/spec/04-payments.md`**
- Rewrote Section 8 (Emission Distribution) to document `AntseedEmissionsV2` mechanics:
  - V2 backward compatibility with V1 points through epoch 4
  - Automatic epoch advancement via block timestamp
  - Emission schedule: `e_e = e_0 / 2^(epoch / HALVING_INTERVAL)`
  - Corrected split: **Seller 50% / Buyers 20% / Reserve 15% / Team 15%** (fixes stale 65/25/10/0 table)
  - Points accrual via `accrueSellerPoints` / `accrueBuyerPoints` / `accruePoints`
  - Optional `IAntseedPointsPolicy` hook
  - Per-epoch pro-rata distribution and seller/buyer caps (`maxSellerSharePct`, `maxBuyerSharePct`)
  - Seller claiming: locked rewards pool (`AntseedSellerRewardsPool`) with `AntseedSellerUnlockPolicy`
  - Buyer claiming via operator (`claimBuyerEmissions`)
  - Reserve & Team flush functions (`flushReserve`, `flushTeam`)
- Updated Section 10 (Contract Architecture) to include new V2 contracts
- Updated interaction flow references to V2

**`docs/protocol/diem-proxy.md`**
- Updated architecture diagram and deployment runbook references from `AntseedEmissions` to `AntseedEmissionsV2`

**`apps/website/docs/protocol/payments.md`**
- Updated Smart Contracts table to list V2, rewards pool, unlock policy, and legacy V1
- Added Emissions subsection:
  - V2 replacement at epoch 4 with backward compatibility
  - Emission split (50/20/15/15)
  - Seller/buyer claim mechanics

## Why

The protocol spec and website docs still described the legacy `AntseedEmissions` V1 contract (65/25/10 split, gas-accumulator claim, `advanceEpoch`, etc.), which was replaced by `AntseedEmissionsV2` after migration epoch 4. The V2 contract has different mechanics (locked rewards pool, unlock policy, pro-rata distribution, different emission split). The old docs were misleading for developers reading the contract source and users checking the website.

## Testing

- Verified `pnpm run build` passes in the `apps/website` workspace
- Verified `AntseedEmissionsV2.sol` source matches documented behavior (automated epochs, legacy combine logic, locked pool claiming)
- Double-checked contract address and migration epoch number against on-chain data

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run test` passes
- [ ] Breaking changes documented