### PR TITLE
fix(desktop): pack per-arch native binaries for macOS releases

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -30,8 +30,8 @@
     "start:debug": "cross-env ANTSEED_DESKTOP_DEBUG=1 electron . --debug-runtime",
     "prepare-dist": "node ./scripts/prepare-dist.mjs",
     "dist": "npm run build && npm run prepare-dist && electron-builder",
-    "dist:mac": "npm run build && npm run prepare-dist && electron-builder --mac",
-    "release:mac": "npm run build && npm run prepare-dist && node scripts/release-mac.mjs",
+    "dist:mac": "npm run build && node scripts/release-mac.mjs --no-publish",
+    "release:mac": "npm run build && node scripts/release-mac.mjs",
     "dist:win": "npm run build && npm run prepare-dist && electron-builder --win",
     "release:win": "npm run build && npm run prepare-dist && node scripts/release-win.mjs",
     "dist:linux": "npm run build && npm run prepare-dist && electron-builder --linux"

--- a/apps/desktop/scripts/prepare-dist.mjs
+++ b/apps/desktop/scripts/prepare-dist.mjs
@@ -126,26 +126,38 @@ const electronPkg = JSON.parse(
 const electronVersion = electronPkg.version;
 const betterSqlite3Dir = path.resolve(appDir, '..', '..', 'node_modules', 'better-sqlite3');
 
-// Install the prebuild for the current arch — electron-builder handles
-// cross-arch builds by running the pack step separately for each arch,
-// and better-sqlite3 prebuilds are arch-specific.
-//
-// Resolve prebuild-install's JS entry from better-sqlite3's own deps and
-// invoke it via `node` rather than via `npx`: on Windows `npx` is `npx.cmd`
-// which execFileSync can't run without a shell, and shelling out complicates
-// argument escaping. process.execPath works identically on all platforms.
+// Honors ANTSEED_PACK_ARCH so release scripts can pack arm64 + x64 separately
+// without each DMG inheriting the build host's native binary.
+const targetArch = process.env.ANTSEED_PACK_ARCH || process.arch;
+if (!['x64', 'arm64'].includes(targetArch)) {
+  throw new Error(`[prepare-dist] Unsupported ANTSEED_PACK_ARCH=${targetArch}`);
+}
+
 const prebuildInstallEntry = createRequire(
   path.join(betterSqlite3Dir, 'package.json'),
 ).resolve('prebuild-install/bin.js');
-console.log(`[prepare-dist] Installing better-sqlite3 prebuild for Electron ${electronVersion} (${process.arch})...`);
+console.log(`[prepare-dist] Installing better-sqlite3 prebuild for Electron ${electronVersion} (${targetArch})...`);
 execFileSync(process.execPath, [
   prebuildInstallEntry,
   '--runtime', 'electron',
   '--target', electronVersion,
-  '--arch', process.arch,
+  '--arch', targetArch,
   '--verbose',
 ], { cwd: betterSqlite3Dir, stdio: 'inherit' });
-console.log('[prepare-dist] Native module prebuild installed for Electron.');
+
+if (process.platform === 'darwin') {
+  const nodeFile = path.join(betterSqlite3Dir, 'build', 'Release', 'better_sqlite3.node');
+  if (existsSync(nodeFile)) {
+    const desc = execFileSync('file', [nodeFile], { encoding: 'utf8' });
+    const expected = targetArch === 'arm64' ? 'arm64' : 'x86_64';
+    if (!desc.includes(expected)) {
+      throw new Error(
+        `[prepare-dist] better_sqlite3.node arch mismatch — expected ${expected}, got: ${desc.trim()}`,
+      );
+    }
+    console.log(`[prepare-dist] Verified better_sqlite3.node is ${expected}`);
+  }
+}
 
 // --- 4. Bundle full transitive runtime deps of @antseed/node ---
 // The desktop app must be repairable from its own bundle even on machines that

--- a/apps/desktop/scripts/release-mac.mjs
+++ b/apps/desktop/scripts/release-mac.mjs
@@ -1,22 +1,25 @@
-// Loads .env and spawns electron-builder --mac --publish always.
-// Used by the release:mac script so pnpm can resolve electron-builder
-// from the workspace root node_modules.
+// Runs prepare-dist + electron-builder once per arch so each DMG contains
+// the matching arch's native binaries.
 
 import { config } from 'dotenv';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
-config(); // loads apps/desktop/.env (APPLE_* and GH_TOKEN)
+config();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const desktopDir = path.resolve(__dirname, '..');
 
-// electron-builder is hoisted to workspace root node_modules by pnpm
-const binPath = path.resolve(desktopDir, '../../node_modules/.bin/electron-builder');
+const electronBuilderBin = path.resolve(desktopDir, '../../node_modules/.bin/electron-builder');
+const prepareDistScript = path.resolve(desktopDir, 'scripts', 'prepare-dist.mjs');
 
-execFileSync(binPath, ['--mac', '--publish', 'always'], {
-  stdio: 'inherit',
-  env: process.env,
-  cwd: desktopDir,
-});
+const publish = process.argv.includes('--no-publish') ? 'never' : 'always';
+
+for (const arch of ['x64', 'arm64']) {
+  console.log(`\n=== [release-mac] arch=${arch} publish=${publish} ===`);
+  const env = { ...process.env, ANTSEED_PACK_ARCH: arch };
+
+  execFileSync(process.execPath, [prepareDistScript], { stdio: 'inherit', cwd: desktopDir, env });
+  execFileSync(electronBuilderBin, ['--mac', `--${arch}`, '--publish', publish], { stdio: 'inherit', cwd: desktopDir, env });
+}


### PR DESCRIPTION
## Problem

Intel Mac users hit this on every `/v1/chat/completions` request:

```
[Node] ChannelStore unavailable: dlopen(.../better-sqlite3/build/Release/better_sqlite3.node):
  (mach-o file, but is an incompatible architecture
   (have (arm64), need (x86_64h)))
```

`ChannelStore` fails to initialize → buyer can't open/fund a payment channel → seller responds 402 `payment_required` to every request. Deposits sit unused.

## Root cause

`apps/desktop/electron-builder.yml` packs `arm64` + `x64` Mac DMGs in one invocation with `npmRebuild: false`. The only step that places a prebuilt `better_sqlite3.node` into `node_modules/` before pack is `prepare-dist.mjs`, and it hard-coded `--arch process.arch`. So whichever arch the CI runner has (arm64 on `macos-14`) is what got copied into **both** DMGs.

Result: the Intel DMG shipped an arm64 `better_sqlite3.node`.

## Fix

- `prepare-dist.mjs` now honors `ANTSEED_PACK_ARCH` when calling `prebuild-install`, and verifies the resulting `.node` matches the requested arch on macOS via `file(1)` before pack.
- `release-mac.mjs` loops `x64` + `arm64`, re-running `prepare-dist` and `electron-builder` per arch so each DMG gets its own matching native binary. Supports `--no-publish` for dry runs.
- `package.json` routes `dist:mac` and `release:mac` through `release-mac.mjs` so both paths get the per-arch flow.
- `.github/workflows/release-desktop.yml` needs no changes — it already calls `npm run dist:mac` / `release:mac`.

## Verification

After the next release build, the Intel DMG's `better_sqlite3.node` should report:

```
$ file "AntSeed Desktop.app/Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
... Mach-O 64-bit bundle x86_64
```

instead of arm64. `ChannelStore initialized (buyer)` should appear in logs on Intel Macs, and chat completions should stream instead of 402-ing.