### PR TITLE
feat(desktop): collapse tool groups and thinking blocks by default

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -351,11 +351,6 @@
 
     .tool-inline {
       overflow: hidden;
-      border-top: 1px solid var(--border);
-    }
-
-    .tool-group-list .tool-inline:first-child {
-      border-top: 0;
     }
 
     .tool-inline-row {
@@ -366,8 +361,8 @@
       display: flex;
       align-items: center;
       gap: 8px;
-      min-height: 24px;
-      padding: 6px 0;
+      min-height: 20px;
+      padding: 2px 0;
       text-align: left;
       cursor: default;
     }
@@ -495,30 +490,26 @@
       animation: tool-spin 0.8s linear infinite;
     }
 
-    /* Thinking blocks */
+    /* Thinking blocks — flat layout matching tool groups */
     .thinking-block {
-      position: relative;
-      margin: 8px 0;
-      border: 1px solid var(--border);
-      border-radius: var(--radius-sm);
+      margin: 4px 0;
     }
 
     .thinking-block-header {
-      position: absolute;
-      top: -8px;
-      left: 8px;
-      display: inline-flex;
-      align-items: center;
-      gap: 4px;
-      padding: 0 6px;
-      background: var(--bg-primary);
+      appearance: none;
       border: 0;
-      cursor: pointer;
-      font-size: 10px;
+      background: transparent;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      padding: 4px 0;
+      font-size: 12px;
+      line-height: 1.4;
       color: var(--text-muted);
-      line-height: 16px;
+      text-align: left;
+      cursor: pointer;
       user-select: none;
-      z-index: 1;
     }
 
     .thinking-block-header:hover {
@@ -526,7 +517,9 @@
     }
 
     .thinking-block-triangle {
-      font-size: 7px;
+      font-size: 9px;
+      line-height: 1;
+      flex-shrink: 0;
       transition: transform 0.15s;
     }
 
@@ -534,13 +527,22 @@
       transform: rotate(90deg);
     }
 
+    .thinking-block-label {
+      flex-shrink: 0;
+    }
+
     .thinking-block-preview {
-      padding: 14px 10px 8px;
-      font-size: 12px;
+      flex: 1;
+      min-width: 0;
+      font-size: 11.5px;
       line-height: 1.4;
       color: var(--text-muted);
-      max-height: calc(14px + 1.4em + 8px);
+      opacity: 0.75;
+      font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+      max-height: 1.4em;
       overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
 
       :global(.thinking-block-preview-md) {
         display: inline;
@@ -568,7 +570,7 @@
 
     .thinking-block-body {
       display: none;
-      padding: 14px 10px 8px;
+      padding: 4px 0 8px;
       font-size: 13px;
       line-height: 1.5;
       color: var(--text-secondary);
@@ -584,8 +586,9 @@
     .thinking-dots {
       display: inline-flex;
       align-items: center;
-      gap: 3px;
+      gap: 4px;
       margin-left: 4px;
+      flex-shrink: 0;
     }
 
     .thinking-dots span {

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -266,41 +266,13 @@
     padding: 0 16px;
 
   :global {
-    /* Tool group */
+    /* Tool group — flat layout in both open and closed states */
     .tool-group {
-      position: relative;
-      margin: 10px 0 12px;
-      border: 1px solid var(--border);
-      border-radius: var(--radius-sm);
-      background: var(--bg-card);
-    }
-
-    .tool-group-header-btn {
-      position: absolute;
-      top: -8px;
-      left: 8px;
-      appearance: none;
-      border: 0;
-      background: var(--bg-primary);
-      display: inline-flex;
-      align-items: center;
-      gap: 4px;
-      padding: 0 6px;
-      font-size: 10px;
-      font-weight: 500;
-      color: var(--text-muted);
-      line-height: 16px;
-      cursor: pointer;
-      user-select: none;
-      z-index: 1;
-    }
-
-    .tool-group-header-btn:hover {
-      color: var(--text-secondary);
+      margin: 4px 0;
     }
 
     .tool-group-chevron {
-      font-size: 7px;
+      font-size: 9px;
       line-height: 1;
       transition: transform 0.15s;
       transform: rotate(0deg);
@@ -310,40 +282,6 @@
 
     .tool-group.open .tool-group-chevron {
       transform: rotate(90deg);
-    }
-
-    .tool-group-label {
-      flex-shrink: 0;
-    }
-
-    .tool-group-preview {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 14px 10px 8px;
-      min-width: 0;
-    }
-
-    .tool-group-preview-text {
-      flex: 1;
-      min-width: 0;
-      font-size: 12px;
-      line-height: 1.4;
-      color: var(--text-muted);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-
-    .tool-group-status {
-      flex-shrink: 0;
-      font-size: 12px;
-      font-weight: 500;
-      padding: 1px 6px;
-      border-radius: 999px;
-      &.running { color: var(--accent-blue);  background: color-mix(in srgb, var(--accent-blue) 14%, transparent); }
-      &.success { color: var(--accent-green); background: color-mix(in srgb, var(--accent-green) 14%, transparent); }
-      &.error   { color: var(--danger);       background: color-mix(in srgb, var(--danger) 14%, transparent); }
     }
 
     /* Collapse animation via CSS grid rows */
@@ -367,8 +305,48 @@
       flex-direction: column;
     }
 
-    .tool-group.open .tool-group-preview {
-      display: none;
+    .tool-group-summary-btn {
+      appearance: none;
+      border: 0;
+      background: transparent;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      padding: 4px 0;
+      font-size: 12px;
+      line-height: 1.4;
+      color: var(--text-muted);
+      text-align: left;
+      cursor: pointer;
+      user-select: none;
+    }
+
+    .tool-group-summary-btn:hover {
+      color: var(--text-secondary);
+    }
+
+    .tool-group-summary-text {
+      flex-shrink: 0;
+      white-space: nowrap;
+    }
+
+    .tool-group-summary-activity {
+      flex: 1;
+      min-width: 0;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      color: var(--text-muted);
+      opacity: 0.75;
+      font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+      font-size: 11.5px;
+    }
+
+    .tool-group-summary-activity::before {
+      content: '—';
+      margin-right: 6px;
+      opacity: 0.6;
     }
 
     .tool-inline {
@@ -389,7 +367,7 @@
       align-items: center;
       gap: 8px;
       min-height: 24px;
-      padding: 10px 10px;
+      padding: 6px 0;
       text-align: left;
       cursor: default;
     }
@@ -402,9 +380,7 @@
       cursor: pointer;
     }
 
-    .tool-inline-row.expandable:hover {
-      background: var(--bg-hover);
-    }
+
 
     .tool-inline-open {
       flex-shrink: 0;

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -89,13 +89,13 @@ function summarizeToolItems(items: ToolRenderItem[]): string {
     `${n} ${n === 1 ? singular : plural}`;
 
   const parts: string[] = [];
-  if (counts.edit > 0)   parts.push(`edited ${phrase(counts.edit,   'file',    'files')}`);
-  if (counts.write > 0)  parts.push(`wrote ${phrase(counts.write,   'file',    'files')}`);
-  if (counts.read > 0)   parts.push(`read ${phrase(counts.read,     'file',    'files')}`);
-  if (counts.search > 0) parts.push(`ran ${phrase(counts.search,    'search',  'searches')}`);
-  if (counts.bash > 0)   parts.push(`executed ${phrase(counts.bash, 'command', 'commands')}`);
-  if (counts.browse > 0) parts.push(`opened ${phrase(counts.browse, 'page',    'pages')}`);
-  if (counts.other > 0)  parts.push(`used ${phrase(counts.other,    'tool',    'tools')}`);
+  if (counts.edit > 0)   parts.push(`Edited ${phrase(counts.edit,   'file',    'files')}`);
+  if (counts.write > 0)  parts.push(`Wrote ${phrase(counts.write,   'file',    'files')}`);
+  if (counts.read > 0)   parts.push(`Read ${phrase(counts.read,     'file',    'files')}`);
+  if (counts.search > 0) parts.push(`Ran ${phrase(counts.search,    'search',  'searches')}`);
+  if (counts.bash > 0)   parts.push(`Executed ${phrase(counts.bash, 'command', 'commands')}`);
+  if (counts.browse > 0) parts.push(`Opened ${phrase(counts.browse, 'page',    'pages')}`);
+  if (counts.other > 0)  parts.push(`Used ${phrase(counts.other,    'tool',    'tools')}`);
 
   if (parts.length === 0) return '';
   if (parts.length === 1) return parts[0];

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -67,6 +67,41 @@ function extractPreviewUrl(name: unknown, input: unknown, output: string): strin
   return urlMatch?.[0];
 }
 
+type VerbBucket = 'edit' | 'read' | 'bash' | 'search' | 'browse' | 'write' | 'other';
+
+function bucketForKind(kind: string): VerbBucket {
+  if (kind === 'edit' || kind === 'multi_edit' || kind === 'apply_patch') return 'edit';
+  if (kind === 'read' || kind === 'read_file' || kind === 'ls' || kind === 'find') return 'read';
+  if (kind === 'bash' || kind === 'shell' || kind === 'run' || kind === 'execute') return 'bash';
+  if (kind === 'grep' || kind === 'search' || kind === 'search_files') return 'search';
+  if (kind === 'web_fetch' || kind === 'open_browser_preview' || kind === 'start_dev_server') return 'browse';
+  if (kind === 'write' || kind === 'write_file') return 'write';
+  return 'other';
+}
+
+function summarizeToolItems(items: ToolRenderItem[]): string {
+  const counts: Record<VerbBucket, number> = {
+    edit: 0, read: 0, bash: 0, search: 0, browse: 0, write: 0, other: 0,
+  };
+  for (const item of items) counts[bucketForKind(item.kind)] += 1;
+
+  const phrase = (n: number, singular: string, plural: string) =>
+    `${n} ${n === 1 ? singular : plural}`;
+
+  const parts: string[] = [];
+  if (counts.edit > 0)   parts.push(`edited ${phrase(counts.edit,   'file',    'files')}`);
+  if (counts.write > 0)  parts.push(`wrote ${phrase(counts.write,   'file',    'files')}`);
+  if (counts.read > 0)   parts.push(`read ${phrase(counts.read,     'file',    'files')}`);
+  if (counts.search > 0) parts.push(`ran ${phrase(counts.search,    'search',  'searches')}`);
+  if (counts.bash > 0)   parts.push(`executed ${phrase(counts.bash, 'command', 'commands')}`);
+  if (counts.browse > 0) parts.push(`opened ${phrase(counts.browse, 'page',    'pages')}`);
+  if (counts.other > 0)  parts.push(`used ${phrase(counts.other,    'tool',    'tools')}`);
+
+  if (parts.length === 0) return '';
+  if (parts.length === 1) return parts[0];
+  return `${parts.slice(0, -1).join(', ')}, ${parts[parts.length - 1]}`;
+}
+
 function buildToolRenderItem(block: ContentBlock, index: number): ToolRenderItem {
   const output = String(block.content || '');
   const diff = extractToolDiff(block);
@@ -350,43 +385,34 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
   const isOpen = manualToggle ?? false;
 
   const groupStatus: 'running' | 'success' | 'error' = anyRunning ? 'running' : anyError ? 'error' : 'success';
-  const groupStatusLabel = anyRunning ? 'Running' : anyError ? 'Error' : 'Done';
-  const label = `Tools (${items.length})`;
-  const runningSummary = items
-    .filter((item) => item.status === 'running')
-    .map((item) => item.label)
-    .join(' / ');
-  const preview = items
-    .slice(0, 3)
-    .map((item) => item.label)
-    .join(' • ');
-  const previewSuffix = items.length > 3 ? ` +${items.length - 3} more` : '';
+  const summary = summarizeToolItems(items);
+  const closedLabel = anyRunning ? `Running ${items.length} ${items.length === 1 ? 'tool' : 'tools'}` : summary;
+  // Current activity hint: while running, show the active tool; otherwise the last one.
+  const activityItem = items.find((it) => it.status === 'running') ?? items[items.length - 1];
+  const activityHint = activityItem?.label ?? '';
+  const toggle = () => setManualToggle((prev) => !(prev ?? false));
 
   return (
     <>
-      <div className={`tool-group${anyRunning ? ' streaming' : ''}${isOpen ? ' open' : ''}`}>
+      <div className={`tool-group${anyRunning ? ' streaming' : ''}${isOpen ? ' open' : ''} status-${groupStatus}`}>
         <button
           type="button"
-          className="tool-group-header-btn"
-          onClick={() => setManualToggle((prev) => !(prev ?? anyRunning))}
+          className="tool-group-summary-btn"
+          onClick={toggle}
         >
           <span className="tool-group-chevron">›</span>
-          <span className="tool-group-label">{label}</span>
+          <span className="tool-group-summary-text">
+            {isOpen ? `Tools (${items.length})` : closedLabel}
+          </span>
+          {!isOpen && activityHint ? (
+            <span className="tool-group-summary-activity">{activityHint}</span>
+          ) : null}
           {anyRunning ? (
             <span className="thinking-dots" aria-hidden="true">
               <span /><span /><span />
             </span>
           ) : null}
         </button>
-        {!isOpen ? (
-          <div className="tool-group-preview">
-            <span className="tool-group-preview-text">
-              {runningSummary || preview}
-              {previewSuffix}
-            </span>
-            <span className={`tool-group-status ${groupStatus}`}>{groupStatusLabel}</span>
-          </div>
-        ) : null}
         <div className={`tool-group-list-wrap${isOpen ? '' : ' collapsed'}`}>
           <div className="tool-group-list-inner">
             <div className="tool-group-list">

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -201,7 +201,7 @@ function StreamingMarkdown({ text }: { text: string }) {
 
 function ThinkingBlockView({ block }: { block: ContentBlock }) {
   const [manualToggle, setManualToggle] = useState<boolean | null>(null);
-  const isOpen = manualToggle ?? true;
+  const isOpen = manualToggle ?? false;
   const thinkingText = String(block.thinking || '');
   const hasThinkingText = thinkingText.trim().length > 0;
 
@@ -223,10 +223,15 @@ function ThinkingBlockView({ block }: { block: ContentBlock }) {
       <button
         type="button"
         className="thinking-block-header"
-        onClick={() => setManualToggle((prev) => !(prev ?? true))}
+        onClick={() => setManualToggle((prev) => !(prev ?? false))}
       >
-        <span className="thinking-block-triangle">▶</span>
-        <span>Internal Thoughts</span>
+        <span className="thinking-block-triangle">›</span>
+        <span className="thinking-block-label">Internal Thoughts</span>
+        {!isOpen && (
+          <span className="thinking-block-preview">
+            <MarkdownContent text={preview} className="thinking-block-preview-md" />
+          </span>
+        )}
         {block.streaming ? (
           <span className="thinking-dots" aria-hidden="true">
             <span />
@@ -235,11 +240,6 @@ function ThinkingBlockView({ block }: { block: ContentBlock }) {
           </span>
         ) : null}
       </button>
-      {!isOpen && (
-        <div className="thinking-block-preview">
-          <MarkdownContent text={preview} className="thinking-block-preview-md" />
-        </div>
-      )}
       <div className="thinking-block-body">
         {hasThinkingText ? (
           block.streaming
@@ -387,9 +387,13 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
   const groupStatus: 'running' | 'success' | 'error' = anyRunning ? 'running' : anyError ? 'error' : 'success';
   const summary = summarizeToolItems(items);
   const closedLabel = anyRunning ? `Running ${items.length} ${items.length === 1 ? 'tool' : 'tools'}` : summary;
-  // Current activity hint: while running, show the active tool; otherwise the last one.
-  const activityItem = items.find((it) => it.status === 'running') ?? items[items.length - 1];
-  const activityHint = activityItem?.label ?? '';
+  // Activity hint: while running show the active tool; otherwise list the
+  // first few tool labels with a "+N more" suffix.
+  const runningItem = items.find((it) => it.status === 'running');
+  const activityHint = runningItem
+    ? runningItem.label
+    : items.slice(0, 3).map((it) => it.label).join(' • ')
+        + (items.length > 3 ? ` +${items.length - 3} more` : '');
   const toggle = () => setManualToggle((prev) => !(prev ?? false));
 
   return (


### PR DESCRIPTION
## Summary

Tool groups and "Internal Thoughts" blocks in the chat view now default to **closed** and share the same flat single-line style. Click the whole row to expand.

## Closed state

```
>  edited 1 file, read 2 files, executed 4 commands  —  Bash (cd /Users/...) • Read (foo.ts) +2 more
```

- Entire row is one button (fully clickable, not just the chevron).
- Left: verb-based summary across the group (`edited N files`, `read N files`, `executed N commands`, `ran N searches`, ...).
- Right: activity hint — while running it's the active tool's label; when finished it's the first 3 tool labels joined with `•` plus a `+N more` suffix (same content as before, rendered inline).
- Tiny animated dots appear while the group is running.

When expanded, the same row stays as the header (label switches to `Tools (N)`) and the existing inline tool list is rendered underneath.

Removed:
- Card border, background, absolute-positioned floating header label.
- Status pill.
- Row dividers between tools.
- Row-hover background.
- Per-tool vertical padding reduced so the list reads tighter.

The "Internal Thoughts" block uses the exact same chevron + label + inline preview + dots layout for consistency, and is also collapsed by default.

## Files

- `apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx`
- `apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss`

## Out of scope

Pure presentational change — no protocol / data-flow / native module work.
