### PR TITLE
fix(desktop): skip stall watchdog during update verify (stuck at 100%)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1027,6 +1027,7 @@ app.whenReady().then(async () => {
   let updateCheckInterval: ReturnType<typeof setInterval> | null = null;
   let downloadStallInterval: ReturnType<typeof setInterval> | null = null;
   let lastDownloadProgressAt: number | null = null;
+  let lastDownloadPercent = 0;
 
   const clearStallWatchdog = () => {
     if (downloadStallInterval) {
@@ -1034,6 +1035,7 @@ app.whenReady().then(async () => {
       downloadStallInterval = null;
     }
     lastDownloadProgressAt = null;
+    lastDownloadPercent = 0;
   };
 
   const startStallWatchdog = () => {
@@ -1041,6 +1043,10 @@ app.whenReady().then(async () => {
     lastDownloadProgressAt = Date.now();
     downloadStallInterval = setInterval(() => {
       if (!pendingUpdateVersion || lastDownloadProgressAt === null) return;
+      // Once bytes are done electron-updater still spends time verifying the
+      // file (sha512 / code-sign) and emits no progress — don't treat that as
+      // a stall, just wait for update-downloaded.
+      if (lastDownloadPercent >= 100) return;
       const idleMs = Date.now() - lastDownloadProgressAt;
       if (idleMs < DOWNLOAD_STALL_TIMEOUT_MS) return;
       console.warn(`[auto-update] download stalled (${Math.round(idleMs / 1000)}s with no progress) — retrying`);
@@ -1061,10 +1067,12 @@ app.whenReady().then(async () => {
   autoUpdater.on('download-progress', (progress) => {
     if (!pendingUpdateVersion) return;
     lastDownloadProgressAt = Date.now();
+    const percent = Math.max(0, Math.min(100, Math.round(progress.percent ?? 0)));
+    lastDownloadPercent = percent;
     getMainWindow()?.webContents.send('app:update-status', {
       status: 'downloading',
       version: pendingUpdateVersion,
-      percent: Math.max(0, Math.min(100, Math.round(progress.percent ?? 0))),
+      percent,
     });
   });
   autoUpdater.on('update-downloaded', (info) => {


### PR DESCRIPTION
## Problem

After #535 landed, users running 0.1.83 saw the auto-update title-bar indicator get stuck on **"Downloading v0.1.83 · 100%"** forever.

Root cause: `electron-updater` emits `download-progress` events while bytes are flowing, but **after the download reaches 100% it still spends time verifying the downloaded file** (sha512 + macOS code-signature check). During that verification phase no progress events are emitted — only `update-downloaded` when it's done.

The 2-minute stall watchdog from #535 didn't know about the verify phase. It saw "no progress events for 2 min", assumed the download was stuck, cleared `pendingUpdateVersion`, and called `autoUpdater.checkForUpdates()` again. That trampled the in-flight verification and the UI never received `update-downloaded`, so it sat at 100% indefinitely.

## Fix

`apps/desktop/src/main/main.ts`:

- Track the last reported percent in `lastDownloadPercent`.
- In the watchdog tick, short-circuit when `lastDownloadPercent >= 100` — at that point bytes are done and we just wait for `update-downloaded`.
- `clearStallWatchdog()` also resets the percent counter.

The watchdog still does its job during the actual bytes-flowing phase, which is the only case it was designed for (network drop, stuck CDN, etc.).

Also bumps `apps/desktop/package.json` from `0.1.83` → `0.1.84` so the next release ships the fix.

## Files

- `apps/desktop/src/main/main.ts`
- `apps/desktop/package.json`

## Out of scope

No protocol / IPC payload changes.
