### PR TITLE
fix(desktop): unpin mac arch in electron-builder.yml so per-arch loop works

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -80,15 +80,14 @@ mac:
   entitlements: build/entitlements.mac.plist
   entitlementsInherit: build/entitlements.mac.plist
   notarize: true
+  # NOTE: arch is intentionally NOT pinned here. release-mac.mjs runs
+  # electron-builder once per arch (--x64, then --arm64) so each DMG / zip
+  # is packed with prepare-dist's matching-arch native modules. Pinning
+  # arch in the yaml would cause every invocation to build both archs and
+  # collide on the second pass with "already_exists" upload errors.
   target:
     - target: dmg
-      arch:
-        - arm64
-        - x64
     - target: zip
-      arch:
-        - arm64
-        - x64
 
 dmg:
   title: "${productName} ${version}"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.84",
+  "version": "0.1.85",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/scripts/release-mac.mjs
+++ b/apps/desktop/scripts/release-mac.mjs
@@ -4,12 +4,14 @@
 import { config } from 'dotenv';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { rmSync } from 'node:fs';
 import path from 'node:path';
 
 config();
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const desktopDir = path.resolve(__dirname, '..');
+const releaseDir = path.resolve(desktopDir, 'release');
 
 const electronBuilderBin = path.resolve(desktopDir, '../../node_modules/.bin/electron-builder');
 const prepareDistScript = path.resolve(desktopDir, 'scripts', 'prepare-dist.mjs');
@@ -19,6 +21,10 @@ const publish = process.argv.includes('--no-publish') ? 'never' : 'always';
 for (const arch of ['x64', 'arm64']) {
   console.log(`\n=== [release-mac] arch=${arch} publish=${publish} ===`);
   const env = { ...process.env, ANTSEED_PACK_ARCH: arch };
+
+  // Wipe any prior arch's output so its artifacts can't get re-uploaded
+  // by the next electron-builder run.
+  rmSync(releaseDir, { recursive: true, force: true });
 
   execFileSync(process.execPath, [prepareDistScript], { stdio: 'inherit', cwd: desktopDir, env });
   execFileSync(electronBuilderBin, ['--mac', `--${arch}`, '--publish', publish], { stdio: 'inherit', cwd: desktopDir, env });


### PR DESCRIPTION
## Problem

The mac release job (run [25849319676](https://github.com/AntSeed/antseed/actions/runs/25849319676)) failed at the publish step with:

```
⨯ 422 Unprocessable Entity
{"errors":[{"resource":"ReleaseAsset","code":"already_exists","field":"name"}]}
Error: Command failed: .../electron-builder --mac --arm64 --publish always
```

## Root cause

PR #532 introduced `apps/desktop/scripts/release-mac.mjs`, which runs `electron-builder` once per arch so each DMG gets the matching native binaries from `prepare-dist.mjs`:

```js
for (const arch of ['x64', 'arm64']) {
  // ...
  execFileSync(electronBuilderBin, ['--mac', `--${arch}`, '--publish', publish], ...);
}
```

But `apps/desktop/electron-builder.yml` still pinned both archs inside `mac.target`:

```yaml
mac:
  target:
    - target: dmg
      arch: [arm64, x64]
    - target: zip
      arch: [arm64, x64]
```

When `mac.target[].arch` is set, **electron-builder treats it as authoritative and ignores the `--x64` / `--arm64` CLI flag**. The actual behaviour was:

| Loop pass | Asked for | electron-builder did | Result |
|---|---|---|---|
| 1 | `--x64` | built x64 **and** arm64 | both archs uploaded |
| 2 | `--arm64` | built x64 **and** arm64 again | tried to re-upload arm64 → GitHub 422 `already_exists` → exit 1 |

Two consequences:

1. **CI fails** at publish time because the second pass collides with its own previous uploads.
2. **The arm64 DMG shipped from loop 1 is wrong-arch** — `prepare-dist.mjs` had just installed the x64 `better_sqlite3.node` for that pass, so the arm64 DMG was packed with an x86_64 binary. This is exactly the regression PR #532 was supposed to fix.

## Fix

**`apps/desktop/electron-builder.yml`**

- Drop the explicit `arch:` arrays from the `mac.target` entries so `--x64` / `--arm64` on the CLI fully controls which arch is built. Each `release-mac.mjs` iteration now produces exactly one arch.

**`apps/desktop/scripts/release-mac.mjs`**

- `rmSync(apps/desktop/release/, { recursive: true, force: true })` between iterations so leftover files from the previous arch can't accidentally get re-uploaded.

**`apps/desktop/package.json`**

- `0.1.84` → `0.1.85`.

## Out of scope

- `win` / `linux` targets in `electron-builder.yml` keep their `arch:` arrays — they don't use the per-arch loop (no notarization, no native-module arch trap there yet).

## Verify after merge

Look at the next mac release run logs and confirm:

```
=== [release-mac] arch=x64 publish=always ===
...
  • packaging       platform=darwin arch=x64 ...
  • building        target=DMG arch=x64 ...
  (no arm64 packaging in this pass)

=== [release-mac] arch=arm64 publish=always ===
...
  • packaging       platform=darwin arch=arm64 ...
  • building        target=DMG arch=arm64 ...
  (no x64 packaging in this pass)
```

Each pass should also include the `[prepare-dist] Verified better_sqlite3.node is <arch>` line for the matching arch.
