### PR TITLE
fix(desktop): Show Sybil flags in Discover

### DIFF
--- a/apps/desktop/src/renderer/modules/chat.discover-rows.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.discover-rows.test.ts
@@ -20,6 +20,21 @@ test('normalizeDiscoverRow populates all numeric defaults to 0 / null', () => {
   assert.equal(row!.stakeUsdc, '0');
   assert.equal(row!.cachedInputUsdPerMillion, null);
   assert.equal(row!.onChainReputationScore, null);
+  assert.equal(row!.onChainSybilRisk, null);
+  assert.deepEqual(row!.onChainSybilFlags, []);
+});
+
+/* Regression: Discover must carry buyer.state.json Sybil metadata through to the UI. */
+test('normalizeDiscoverRow preserves on-chain sybil risk and string flags', () => {
+  const row = normalizeDiscoverRow({
+    peerId: 'abc123',
+    serviceId: 'gpt-5',
+    onChainSybilRisk: 0.12,
+    onChainSybilFlags: ['narrow_custom', null, 'subfloor_ticket'],
+  });
+  assert.ok(row);
+  assert.equal(row!.onChainSybilRisk, 0.12);
+  assert.deepEqual(row!.onChainSybilFlags, ['narrow_custom', 'subfloor_ticket']);
 });
 
 test('projectRowsToChatServiceOptions dedupes by (provider, service, peer)', () => {

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -77,8 +77,12 @@ function formatSybilFlag(flag: string): string {
   return SYBIL_FLAG_LABELS[flag] ?? flag.replace(/_/g, ' ');
 }
 
+function sybilHasSignals(item: { sybilFlags: string[] }): boolean {
+  return item.sybilFlags.length > 0;
+}
+
 function sybilIsAlarming(item: { sybilRisk: number | null; sybilFlags: string[] }): boolean {
-  return item.sybilFlags.length > 0
+  return sybilHasSignals(item)
     && typeof item.sybilRisk === 'number'
     && item.sybilRisk >= SYBIL_WARN_THRESHOLD;
 }
@@ -752,7 +756,7 @@ function Card({
                 <span>Settled volume: {formatVolumeUsdc(item.volumeUsdc)} USDC.</span>
                 <span>{formatCompact(item.channelCount)} settled session{item.channelCount === 1 ? '' : 's'}.</span>
                 <span>Avg channel value: {reputationTooltip.avgChannelUsdc} USDC.</span>
-                {sybilIsAlarming(item) && (
+                {sybilHasSignals(item) && (
                   <span>
                     ⚠ Sybil risk signals: {item.sybilFlags.map(formatSybilFlag).join(', ')}.
                   </span>
@@ -762,9 +766,11 @@ function Card({
             </span>
           </div>
         </div>
-        <div className={`${styles.cardStats}${lowReputation ? ` ${styles.cardStatsWarning}` : ''}`}>
+        <div className={`${styles.cardStats}${lowReputation || sybilHasSignals(item) ? ` ${styles.cardStatsWarning}` : ''}`}>
           {sybilIsAlarming(item) ? (
             <span>⚠ Suspected wash activity: {item.sybilFlags.map(formatSybilFlag).join(', ')}</span>
+          ) : sybilHasSignals(item) ? (
+            <span>⚠ Sybil risk signals: {item.sybilFlags.map(formatSybilFlag).join(', ')}</span>
           ) : lowReputation ? (
             <span>Low reputation: limited on-chain history</span>
           ) : (


### PR DESCRIPTION
## Description

Shows on-chain Sybil risk signals on Desktop Discover cards whenever the buyer state contains `onChainSybilFlags`.
Previously, flags were only visible when the numeric Sybil risk crossed the warning threshold, which hid lower-risk signals that were present in `buyer.state.json`.

## Release Notes

- Fixed Desktop Discover cards so available on-chain Sybil risk signals are visible to users

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
