### PR TITLE
fix(desktop): Group chat activity rows

### DIFF
--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1573,11 +1573,15 @@ export function initChatModule({
     setStreamingMessage(null);
     activeConversation = null;
     uiState.chatDeleteVisible = false;
-    uiState.chatInputDisabled = false;
-    uiState.chatSendDisabled = false;
-    uiState.chatAbortVisible = false;
     uiState.chatConversationTitle = 'New Chat';
     uiState.chatError = null;
+    // Re-derive sending flags from the (now null) active conversation so that
+    // the thinking indicator does not leak in from whichever chat the user was
+    // previously viewing while it was still streaming. Without this, the
+    // stale chatSending=true / chatSendingConversationId values would make
+    // ChatView's activeConversationIsSending fall back to chatSending and
+    // render the WalkingAnt inside the empty new-chat screen.
+    syncActiveConversationSendingState();
     updateThreadMeta(null);
     notifyUiStateChanged();
   }

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -581,8 +581,22 @@
       display: none;
     }
 
+    .thinking-block-body-wrap {
+      display: grid;
+      grid-template-rows: 1fr;
+      transition: grid-template-rows 0.22s ease;
+    }
+
+    .thinking-block-body-wrap.collapsed {
+      grid-template-rows: 0fr;
+    }
+
+    .thinking-block-body-inner {
+      overflow: hidden;
+      min-height: 0;
+    }
+
     .thinking-block-body {
-      display: none;
       padding: 4px 0 8px;
       font-size: 13px;
       line-height: 1.5;
@@ -590,10 +604,6 @@
       max-height: 400px;
       overflow-y: auto;
       word-break: break-word;
-    }
-
-    .thinking-block.open .thinking-block-body {
-      display: block;
     }
 
     .thinking-dots {

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -240,14 +240,18 @@ function ThinkingBlockView({ block, highlightQuery, activeHighlight }: { block: 
           </span>
         ) : null}
       </button>
-      <div className="thinking-block-body">
-        {hasThinkingText ? (
-          block.streaming
-            ? <StreamingMarkdown text={thinkingText} highlightQuery={highlightQuery} activeHighlight={activeHighlight} />
-            : <MarkdownContent text={thinkingText} className="thinking-block-markdown" highlightQuery={highlightQuery} activeHighlight={activeHighlight} />
-        ) : (
-          <div className="chat-bubble-content streaming-cursor">Thinking...</div>
-        )}
+      <div className={`thinking-block-body-wrap${isOpen ? '' : ' collapsed'}`}>
+        <div className="thinking-block-body-inner">
+          <div className="thinking-block-body">
+            {hasThinkingText ? (
+              block.streaming
+                ? <StreamingMarkdown text={thinkingText} highlightQuery={highlightQuery} activeHighlight={activeHighlight} />
+                : <MarkdownContent text={thinkingText} className="thinking-block-markdown" highlightQuery={highlightQuery} activeHighlight={activeHighlight} />
+            ) : (
+              <div className="chat-bubble-content streaming-cursor">Thinking...</div>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );
@@ -481,6 +485,24 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
   );
 }
 
+function isRenderableThinkingBlock(block: ContentBlock): boolean {
+  return Boolean(block.streaming) || String(block.thinking || '').trim().length > 0;
+}
+
+function mergeThinkingBlocks(blocks: ContentBlock[]): ContentBlock {
+  const first = blocks[0] ?? { type: 'thinking' };
+  return {
+    ...first,
+    type: 'thinking',
+    renderKey: String(first.renderKey || first.id || first.tool_use_id || 'thinking-group'),
+    thinking: blocks
+      .map((block) => String(block.thinking || '').trim())
+      .filter(Boolean)
+      .join('\n\n'),
+    streaming: blocks.some((block) => block.streaming),
+  };
+}
+
 function renderAssistantBlocks(
   blocks: ContentBlock[],
   streaming = false,
@@ -492,6 +514,23 @@ function renderAssistantBlocks(
 ): ReactNode[] {
   const nodes: ReactNode[] = [];
   let toolGroup: ContentBlock[] = [];
+  let thinkingGroup: ContentBlock[] = [];
+
+  const flushThinkingGroup = (): void => {
+    if (thinkingGroup.length === 0) return;
+    const first = thinkingGroup[0];
+    const index = blocks.indexOf(first);
+    nodes.push(renderBlock(
+      mergeThinkingBlocks(thinkingGroup),
+      index >= 0 ? index : nodes.length,
+      streaming,
+      messagePrefix,
+      conversationId,
+      highlightQuery,
+      activeHighlight,
+    ));
+    thinkingGroup = [];
+  };
 
   const flushToolGroup = (): void => {
     if (toolGroup.length === 0) return;
@@ -505,16 +544,30 @@ function renderAssistantBlocks(
     toolGroup = [];
   };
 
+  const flushGroups = (): void => {
+    flushToolGroup();
+    flushThinkingGroup();
+  };
+
   blocks.forEach((block, index) => {
     if (block.type === 'tool_use') {
+      flushThinkingGroup();
       toolGroup.push(block);
       return;
     }
-    flushToolGroup();
+
+    if (block.type === 'thinking') {
+      if (!isRenderableThinkingBlock(block)) return;
+      flushToolGroup();
+      thinkingGroup.push(block);
+      return;
+    }
+
+    flushGroups();
     nodes.push(renderBlock(block, index, streaming, messagePrefix, conversationId, highlightQuery, activeHighlight));
   });
 
-  flushToolGroup();
+  flushGroups();
   return nodes;
 }
 


### PR DESCRIPTION
## Description

Improves Desktop chat activity rendering by grouping consecutive tool rows and consecutive Internal Thoughts rows more cleanly.
Also makes Internal Thoughts expand/collapse with the same smooth transition as tool groups, and prevents stale sending state from leaking into a new empty chat screen.

## Release Notes

- Improved Desktop chat activity display so consecutive tools and reasoning rows are grouped more cleanly
- Fixed the new-chat screen so stale thinking indicators from another active chat do not appear

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
