### PR TITLE
fix(desktop): Polish credits dropdown

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.86",
+  "version": "0.1.87",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/renderer/ui/components/TitleBar.tsx
+++ b/apps/desktop/src/renderer/ui/components/TitleBar.tsx
@@ -170,7 +170,7 @@ export function TitleBar() {
               </div>
               <div className={styles.creditsDropdownActions}>
                 <button className={styles.creditsDropdownManageBtn} onClick={handleManageCredits}>
-                  Manage
+                  Portal
                 </button>
                 <button className={styles.creditsDropdownAddBtn} onClick={handleDepositCredits}>
                   Deposit

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -212,10 +212,11 @@ function ThinkingBlockView({ block, highlightQuery, activeHighlight }: { block: 
   if (!hasThinkingText && !block.streaming) return null;
 
   const previewLength = 120;
+  const normalizedThinkingPreview = thinkingText.replace(/\s+/g, ' ').trim();
   const preview = hasThinkingText
-    ? (thinkingText.length > previewLength
-        ? `${thinkingText.slice(0, previewLength).trimEnd()}...`
-        : thinkingText)
+    ? (normalizedThinkingPreview.length > previewLength
+        ? `${normalizedThinkingPreview.slice(0, previewLength).trimEnd()}...`
+        : normalizedThinkingPreview)
     : 'Thinking...';
 
   return (


### PR DESCRIPTION
## Description

Updates the desktop credits dropdown so the wallet action is labeled Portal instead of Manage. Also adds spacing after collapsed thinking previews and bumps the desktop app version to 0.1.87.

## Release Notes

- Renamed the credits dropdown wallet action from Manage to Portal
- Added spacing after collapsed internal thoughts previews
- Bumped AntSeed Desktop to v0.1.87

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [ ] Lint and unit tests pass locally with my changes

Note: Local renderer typecheck could not run because the current shell is using Node.js v14.18.0, while pnpm requires at least Node.js v16.14.