### PR TITLE
Align website copy with protocol terms

### DIFF
--- a/apps/website/docs/faq.mdx
+++ b/apps/website/docs/faq.mdx
@@ -40,7 +40,7 @@ export const faqLd = {
       name: 'Who runs the AntSeed network?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: 'No one. The network is decentralized — it runs on the peers that join it. There is no company operating the routing layer. AntSeed (the team) builds the protocol and tools, but does not operate the network or sit between buyers and providers.',
+        text: 'The network runs on the independent peers that join it. AntSeed is open peer-to-peer software; no single hosted service controls every node, provider, model, output, log, or data practice.',
       },
     },
     {
@@ -48,7 +48,7 @@ export const faqLd = {
       name: 'Is my data private on AntSeed?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: "Privacy works in two layers. Layer 1 — network anonymity (default for everyone). Requests go peer-to-peer, like a VPN for AI. Providers never know who you are. Layer 2 — TEE-verified providers, running inside Trusted Execution Environments (Intel TDX, AMD SEV) — hardware enclaves where not even the node operator can read your prompts. Payments settle on-chain so the money trail stays private too.",
+        text: "AntSeed is designed for anonymous access without a central account, platform-issued API key, or centralized chat database. Requests route peer-to-peer, so providers generally see a peer/wallet rather than a platform identity account, and TEE providers can add hardware-backed confidentiality where available. This is not a promise that every piece of data is hidden from every participant: independent providers and supporting infrastructure may process data needed to deliver and settle requests, and public-chain activity remains visible on-chain.",
       },
     },
     {
@@ -64,7 +64,7 @@ export const faqLd = {
       name: 'Does AntSeed log my requests?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: "AntSeed the protocol does not log requests. We don't operate the nodes — providers do. Each provider has their own data handling practices. For guaranteed no-logging, route to a TEE-verified provider.",
+        text: "AntSeed the protocol does not create a central request log, but independent providers, nodes, interfaces, RPC providers, analytics tools, or other infrastructure may log or observe data. Each provider has its own data handling practices. Prefer TEE-verified providers where stronger confidentiality is required.",
       },
     },
     {
@@ -178,7 +178,7 @@ Yes. The full protocol, CLI, and node implementation are open source on [GitHub]
 
 ### Who runs the network?
 
-No one. The network is decentralized — it runs on the peers that join it. There is no company operating the routing layer. AntSeed (the team) builds the protocol and tools, but does not operate the network or sit between buyers and providers.
+The network runs on the independent peers that join it. AntSeed is open peer-to-peer software; no single hosted service controls every node, provider, model, output, log, or data practice.
 
 ---
 
@@ -188,13 +188,13 @@ No one. The network is decentralized — it runs on the peers that join it. Ther
 
 Privacy on AntSeed works in two layers:
 
-**Layer 1 — Network anonymity (everyone gets this by default).** Requests go peer-to-peer, like a VPN for AI. Providers never know who you are — no accounts, no identity, no IP exposed. Your prompts travel directly to the provider with no corporate server in the middle.
+**Layer 1 — Anonymous access (default).** AntSeed is designed for use without a central account, sign-up, or platform-issued API key. Requests route peer-to-peer, so providers generally see a peer/wallet rather than a platform identity account.
 
-**Layer 2 — TEE-verified providers.** These run inside Trusted Execution Environments (Intel TDX, AMD SEV) — hardware enclaves where not even the node operator can read your prompts. This is cryptographic proof, not a policy promise. TEE provider verification is being rolled out in a future release.
+**Layer 2 — TEE-verified providers.** These run inside Trusted Execution Environments (Intel TDX, AMD SEV) — hardware enclaves that can reduce what the node operator can see. This is cryptographic proof, not just a policy promise. TEE provider verification is being rolled out in a future release.
 
-Payments are settled on-chain, so the money trail stays private too.
+AntSeed's privacy model is architectural rather than account-based: users can route requests without a central identity account, platform-issued API key, or centralized chat database, and TEE providers can add hardware-backed confidentiality where available. It is not, however, a promise that every piece of data is hidden from every participant. Independent providers and supporting infrastructure may process data needed to deliver and settle requests, and public-chain activity remains visible on-chain. Users should choose providers and routes appropriate to the sensitivity of their work.
 
-Most users are well-served by Layer 1 alone. Journalists, lawyers, security researchers, and anyone handling sensitive data will want Layer 2.
+Most users are well-served by no-account routing. Journalists, lawyers, security researchers, and anyone handling sensitive data should carefully choose providers and prefer TEE routes where available.
 
 ### Can providers see my prompts?
 
@@ -202,7 +202,7 @@ Standard providers can. TEE-verified providers cannot — the hardware prevents 
 
 ### Does AntSeed log my requests?
 
-AntSeed the protocol does not log requests. We don't operate the nodes — providers do. Each provider has their own data handling practices. For guaranteed no-logging, route to a TEE-verified provider.
+AntSeed the protocol does not create a central request log, but independent providers, nodes, interfaces, RPC providers, analytics tools, or other infrastructure may log or observe data. Each provider has its own data handling practices. Prefer TEE-verified providers where stronger confidentiality is required.
 
 ---
 
@@ -274,7 +274,7 @@ Seller ANTS emissions are currently tracked but routed into a dedicated Provider
 
 ### Where do protocol fees go?
 
-Network fees are set to 4% and flow into the Protocol Reserve, not to a company. The Protocol Reserve is intended to support long-term network sustainability, trust, utility, and alignment. The same applies to the 10% fee from the DIEM pool.
+Network fees are set to 4% and may be directed to ecosystem mechanisms such as reserves, grants, incentives, buy-and-burn, or other community-approved uses. Any DIEM program/operator fee is governed by the separate DIEM Provider Capacity Program rules. No fee use, burn, distribution, token value, or return is promised.
 
 ### Are ANTS incentives guaranteed?
 

--- a/apps/website/docs/lightpaper.md
+++ b/apps/website/docs/lightpaper.md
@@ -25,13 +25,13 @@ The problem compounds with AI agents. An agent can technically switch between AP
 
 ## AntSeed
 
-AntSeed is a communication protocol for peer-to-peer AI services. Anyone can provide AI services, from model inference to specialized agents and routing services, and anyone can consume them, directly, with no company in the middle.
+AntSeed is a communication protocol for peer-to-peer AI services. Anyone can provide AI services, from model inference to specialized agents and routing services, and anyone can consume them directly through open peer-to-peer software. Providers are independent operators that run their own infrastructure, models, policies, and data practices.
 
 The protocol does not care what happens between request and response. It is a neutral transport layer: direct peer-to-peer communication. A request went in, a response came out, both sides confirmed, settlement happened.
 
 ### Two Layers. One Protocol.
 
-**Layer 1: Unstoppable Infrastructure.** Open source. Peer-to-peer. Anonymous. Always on. No login. No central point that can be shut down. Discovery via BitTorrent DHT. Transport via WebRTC. The network routes around failures. To block access to any service, you would need to shut down every individual provider who serves it.
+**Layer 1: Open Peer-to-Peer Infrastructure.** Open source. Peer-to-peer. Anonymous by design. No central account. Discovery via BitTorrent DHT. Transport via WebRTC. The network routes around failures, and independent nodes may continue operating without reliance on a single hosted service. Blocking a service generally requires action against the independent providers who choose to serve it.
 
 **Layer 2: An Open Marketplace for AI Services.** Gasless payments. On-chain stats. Cumulative payment channels. Any provider. Any service. Set your own price. Buyers deposit USDC. Providers settle via cryptographic vouchers. Every settlement is recorded on-chain.
 
@@ -49,9 +49,11 @@ All three expose a standard API. What runs behind it is entirely the provider's 
 
 Decentralization is not the value proposition. Cheap, reliable, uncensorable AI access is. Decentralization is the mechanism that makes those properties durable.
 
-A centralized aggregator can be pressured by upstream providers, shut down by regulators, acquired by a competitor, or disrupted by business failure. When that happens, every customer is affected by one decision from one company. AntSeed has no company in the middle.
+A centralized aggregator can be pressured by upstream providers, shut down by regulators, acquired by a competitor, or disrupted by business failure. When that happens, every customer is affected by one decision from one company. AntSeed removes the centralized routing intermediary between buyers and independent providers.
 
-Buyers are anonymous by default. No account, no sign-up, no identity. Just a wallet. Providers can operate anonymously too, though most will choose to build a public reputation. For providers running in Trusted Execution Environments, not even the provider operator can see the prompts. Privacy is a structural property of the architecture, not a policy promise.
+Buyers are anonymous by default at the application layer: no central account, no sign-up, and no platform-issued API key. Providers can operate pseudonymously too, though most will choose to build a public reputation. For providers running in Trusted Execution Environments, hardware attestation can reduce what the provider operator can see.
+
+AntSeed's privacy model is architectural rather than account-based: users can route requests without a central identity account, platform-issued API key, or centralized chat database, and TEE providers can add hardware-backed confidentiality where available. It is not, however, a promise that every piece of data is hidden from every participant. Independent providers and supporting infrastructure may process data needed to deliver and settle requests, and public-chain activity remains visible on-chain. Users should choose providers and routes appropriate to the sensitivity of their work.
 
 ## Why Now
 
@@ -111,6 +113,14 @@ The buyer never needs gas. All on-chain actions are either seller-initiated (res
 
 **Everyday users.** AntStation brings the open market to non-technical users through chat and co-work interfaces, powered by the same P2P network underneath.
 
-**Privacy-sensitive organizations.** Law firms, healthcare, finance, journalists who cannot use cloud AI due to confidentiality. TEE-verified providers open this market. Privacy is enforced by hardware, not policy.
+**Privacy-sensitive organizations.** Law firms, healthcare, finance, and journalists who cannot use conventional cloud AI may prefer routes with no central account and TEE-verified providers. TEE can improve confidentiality against a provider operator, but users remain responsible for selecting suitable providers and should not assume all prompts, outputs, metadata, wallet activity, or network information are private.
 
 **Users in underserved markets.** Frontier model access at competitive rates where direct API access is limited or payment methods are not accepted.
+
+## Compliance and Risk
+
+AntSeed is open peer-to-peer software. The protocol may remain technically accessible from many jurisdictions, but technical access does not mean legal permission. Users and Providers are solely responsible for sanctions, export-control, AML/CFT, tax, data-protection, AI, consumer-protection, and other legal compliance in their jurisdictions. Interfaces or hosted services may apply restrictions where technically possible or legally required.
+
+AI outputs are generated by independent models and providers. AntSeed does not guarantee that outputs are accurate, lawful, safe, non-infringing, unbiased, confidential, or suitable for any purpose. Users are responsible for reviewing outputs before relying on or sharing them.
+
+Providers are independent third parties. AntSeed contributors, maintainers, ecosystem participants, and support entities do not control every provider, model, node, output, log, or data practice.

--- a/apps/website/docs/protocol/overview.md
+++ b/apps/website/docs/protocol/overview.md
@@ -35,7 +35,7 @@ AntSeed is a fully decentralized protocol for buying and selling AI services dir
 
 **No central server** — discovery, negotiation, metering, payments, and reputation are all handled peer-to-peer. To block access to any service on the network, you would need to shut down every individual provider who serves it.
 
-**Nodes ARE the network** — the network is defined entirely by the set of active nodes. No separate infrastructure to deploy or maintain. The protocol has no off switch.
+**Nodes ARE the network** — the network is defined by the set of active independent nodes. No single hosted service controls every node, provider, model, output, log, or data practice.
 
 **Direct communication** — all interactions happen directly between the two parties involved. Communication is encrypted end-to-end. There is no intermediary server collecting requests.
 
@@ -50,5 +50,5 @@ AntSeed is a fully decentralized protocol for buying and selling AI services dir
 **Agent-to-agent commerce** — autonomous agents hold credits, discover providers by capability, evaluate reputation, consume services, and settle payment without human involvement.
 
 :::info Provider Compliance
-AntSeed is designed for providers who build differentiated services on top of AI APIs — not for raw resale of API keys or subscription credentials. Subscription-based provider plugins are for local testing only. Providers are solely responsible for complying with their upstream API provider's terms of service.
+AntSeed is designed for providers who build differentiated services on top of AI APIs — not for raw resale of API keys or subscription credentials. Subscription-based provider plugins are for local testing only. Providers are independent operators and are solely responsible for their infrastructure, outputs, logs, privacy practices, data handling, security, sanctions/export compliance, tax obligations, applicable AI laws, and upstream API provider terms.
 :::

--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -112,7 +112,7 @@ const config: Config = {
         name: 'AntSeed',
         url: 'https://antseed.com',
         description:
-          'The open market for AI inference. Serve or consume AI peer-to-peer. Pay per request in USDC. Anonymous. Private. No gatekeepers.',
+          'The open market for AI inference. Serve or consume AI peer-to-peer. Pay per request in USDC. Anonymous by design, with independent providers and no central account.',
         applicationCategory: 'DeveloperApplication',
         operatingSystem: 'macOS, Linux, Windows',
         offers: {
@@ -152,15 +152,15 @@ const config: Config = {
     metadata: [
       {name: 'google-site-verification', content: '09pzs5Q9kHdpQSNSBpr0vNh9SMq-T8lzhBgH5Zgm6ug'},
       {name: 'keywords', content: 'AI marketplace, OpenRouter alternative, serving AI inference, consuming AI inference, peer-to-peer AI, decentralized AI inference, anonymous AI, private AI, P2P AI, AI economy'},
-      {name: 'description', content: 'Permissionless peer-to-peer AI inference. Pay per request in USDC. Any model, any provider — no gatekeepers.'},
+      {name: 'description', content: 'Permissionless peer-to-peer AI inference. Pay per request in USDC. Anonymous by design, with independent providers and no central account.'},
       {property: 'og:title', content: 'AntSeed — The open market for AI inference'},
-      {property: 'og:description', content: 'Permissionless peer-to-peer AI inference. Pay per request in USDC. Any model, any provider — no gatekeepers.'},
+      {property: 'og:description', content: 'Permissionless peer-to-peer AI inference. Pay per request in USDC. Anonymous by design, with independent providers and no central account.'},
       {property: 'og:type', content: 'website'},
       {name: 'twitter:card', content: 'summary_large_image'},
       {name: 'twitter:image', content: 'https://antseed.com/og-image.jpg'},
       {property: 'og:image', content: 'https://antseed.com/og-image.jpg'},
       {name: 'twitter:title', content: 'AntSeed — The open market for AI inference'},
-      {name: 'twitter:description', content: 'Permissionless peer-to-peer AI inference. Pay per request in USDC. Any model, any provider — no gatekeepers.'},
+      {name: 'twitter:description', content: 'Permissionless peer-to-peer AI inference. Pay per request in USDC. Anonymous by design, with independent providers and no central account.'},
     ],
     colorMode: {
       defaultMode: 'light',

--- a/apps/website/src/pages/ants-token.tsx
+++ b/apps/website/src/pages/ants-token.tsx
@@ -317,24 +317,25 @@ export default function AntsToken(): JSX.Element {
   return (
     <Layout
       title="ANTS Token | AntSeed"
-      description="ANTS is the coordination and trust asset of the AntSeed network. Hard-capped at 1.04B with automatic halvings."
+      description="ANTS is intended as a utility and coordination token for the AntSeed ecosystem. Holding ANTS does not represent equity, ownership, debt, or a right to payments."
     >
 
       {/* ── HERO ── */}
       <section className={styles.hero}>
         <a href={ANTS_BASESCAN_URL} target="_blank" rel="noopener noreferrer" className={styles.heroKicker}>$ANTS</a>
         <h1 className={styles.heroTitle}>
-          A network owned by<br />
-          <em>the people who use it.</em>
+          A utility token for<br />
+          <em>open AI coordination.</em>
         </h1>
         <div className={styles.heroStatus}>
           <span className={styles.statusDot} />
           <span className={styles.statusText}>Tokens Restricted</span>
         </div>
         <p className={styles.heroSub}>
-          ANTS is designed to become the coordination and trust asset of the AntSeed network.
-          No pre-mine, no insider allocation, no unfair head start, and no company extracting protocol fees.
-          ANTS distribution is meant for real users and providers who help the network grow.
+          ANTS is intended as a utility and coordination token for the AntSeed ecosystem.
+          Holding ANTS does not represent equity, ownership, debt, profit share, revenue share,
+          claim on assets, or any right to receive payments. ANTS distribution is meant for eligible
+          users and providers who help the network grow.
         </p>
         <a
           href="https://x.com/AntSeedAI/status/2053924623935218044"
@@ -442,8 +443,8 @@ export default function AntsToken(): JSX.Element {
           {[
             {pct: '50%', label: 'Provider Pool', desc: 'Seller emissions are tracked and routed into a locked Provider Pool while stronger validation and proof systems are developed.', accent: true},
             {pct: '20%', label: 'Buyers', desc: 'For eligible real usage. Buyer incentives may be capped, filtered, delayed, or excluded for anti-abuse reasons.', accent: false},
-            {pct: '15%', label: 'Protocol Reserve', desc: 'Supports long-term network sustainability, trust, utility, and alignment.', accent: false},
-            {pct: '15%', label: 'Team', desc: 'Vested to core contributors. Aligned with long-term network health.', accent: false},
+            {pct: '15%', label: 'Ecosystem Reserve', desc: 'May support long-term network sustainability, trust, utility, grants, incentives, and alignment. Tokenholders do not own the reserve.', accent: false},
+            {pct: '15%', label: 'Contributors', desc: 'Vested contributor allocation intended to align long-term development and ecosystem health.', accent: false},
           ].map(s => (
             <div key={s.label} className={`${styles.splitCard} ${s.accent ? styles.splitCardAccent : ''}`}>
               <div className={styles.splitPct}>{s.pct}</div>
@@ -458,7 +459,7 @@ export default function AntsToken(): JSX.Element {
       <section className={styles.activity}>
         <div className={styles.activityHeader}>
           <h2>Network activity</h2>
-          <p>Real economic activity backing the token. All settlement happens on Base.</p>
+          <p>Network usage and settlement data from Base. No token value, burn, distribution, or return is promised.</p>
         </div>
 
         <a href={DUNE_URL} target="_blank" rel="noopener noreferrer" className={styles.duneBanner}>
@@ -472,7 +473,7 @@ export default function AntsToken(): JSX.Element {
             <div className={styles.duneBannerText}>
               <div className={styles.duneBannerTitle}>Live on Dune Analytics</div>
               <div className={styles.duneBannerSub}>
-                Volume, channels, fees, staking, and deposits, all from on-chain data.
+                Volume, channels, fees, deposits, and protocol activity, all from on-chain data.
                 Open dashboard →
               </div>
             </div>
@@ -499,8 +500,9 @@ export default function AntsToken(): JSX.Element {
             {label: 'Max supply', value: '1,040,000,000 ANTS'},
             {label: 'Epoch duration', value: '1 week (604,800 seconds)'},
             {label: 'Halving interval', value: 'Every 104 epochs (~2 years)'},
-            {label: 'Network fee', value: '4% of settlement, flowing to the Protocol Reserve — not to a company'},
-            {label: 'DIEM pool fee', value: '10% fee flows to the Protocol Reserve to strengthen the AntSeed ecosystem and ANTS'},
+            {label: 'Network fee', value: '4% of settlement may be directed to ecosystem mechanisms such as reserves, grants, incentives, buy-and-burn, or other community-approved uses'},
+            {label: 'DIEM program fee', value: '10% program/operator fee may be directed according to applicable DIEM Provider Capacity Program rules'},
+            {label: 'Token rights', value: 'ANTS does not represent equity, ownership, debt, profit share, revenue share, claim on assets, or any right to receive payments'},
             {label: 'Provider Pool', value: 'Seller ANTS emissions are tracked but locked pending stronger validation; future claims may be subject to verification or slashing'},
             {label: 'Anti-abuse policy', value: 'Farming, fake volume, sybil behavior, spam, or value extraction may be capped, excluded, delayed, locked, or subject to future slashing'},
             {label: 'Transfers', value: 'Currently restricted'},

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -241,7 +241,7 @@ function EarnAnimation() {
 
 /* ========== FAQ ========== */
 const FAQ_DATA = [
-  {q:'How is this different from OpenRouter?', a:"OpenRouter is a centralized aggregator: it decides which models are listed, reads every request, and holds your earnings until payout. AntSeed removes the aggregator entirely. Requests go peer-to-peer. Payments settle on-chain directly to the provider's wallet. Anyone can provide — no approval needed. The network has no company behind it and no off switch. <a href=\"/vs/openrouter\" style=\"color:#1FD87A;font-weight:500;\">Read the full comparison →</a>"},
+  {q:'How is this different from OpenRouter?', a:"OpenRouter is a centralized aggregator: it decides which models are listed, reads every request, and holds provider payouts until withdrawal. AntSeed removes the aggregator from routing. Requests go peer-to-peer. Payments settle on-chain directly to the provider's wallet. Anyone can provide — no approval needed. Because AntSeed is open peer-to-peer software, independent nodes may continue operating without reliance on a single hosted service. <a href=\"/vs/openrouter\" style=\"color:#1FD87A;font-weight:500;\">Read the full comparison →</a>"},
   {q:'What happens when LLMs become so good that anyone can do anything?', a:"That is exactly what we want. When LLMs become dramatically more capable, costs collapse and more people can run their own capable LLMs on their own hardware. Those people become AntSeed providers. The supply side grows, not shrinks. But \"anyone can do anything\" does not mean everyone delivers the same result. The value is in what you build on top: the skills, the workflows, the domain expertise, the agent orchestration. A more capable base model raises the ceiling for every provider, but it does not eliminate the distance between a generic prompt and a production-grade service."},
   {q:"Isn't this just like P2P file sharing? Netflix killed that.", a:"Netflix and Spotify won because humans are happy to pay a simple subscription for a clean UI. But that logic only applies to humans who care about experience. Agents don't. An agent has no preference for a polished interface, no reason to care about a brand, no inertia keeping it on a familiar platform. It just needs the service, the price, and the reliability. On those three axes, an open P2P network with no middleman and no markup wins every time."},
   {q:'Is AntSeed built for agents specifically?', a:"It works for humans today and is being used by humans now. But the architecture decisions: USDC-native payments, no account system, open discovery, always-on peers, are all decisions that make the network ideal for agents. A human tolerates signing up, waiting for API keys, and managing a subscription. An agent cannot. The network AntSeed is building is the one autonomous agents will naturally discover and use."},
@@ -296,7 +296,7 @@ export default function Home(): JSX.Element {
   return (
     <Layout
       title={siteConfig.tagline}
-      description="The open market for AI inference. Serve or consume AI peer-to-peer. Onchain payments. Verifiable reputation. Anonymous. Private. No gatekeepers."
+      description="The open market for AI inference. Serve or consume AI peer-to-peer. Onchain payments. Verifiable reputation. Anonymous by design, with independent providers and no central account."
       wrapperClassName="homepage-wrapper">
       <Head>
         <script type="application/ld+json">{JSON.stringify(faqLd)}</script>
@@ -336,7 +336,7 @@ export default function Home(): JSX.Element {
               <div className={styles.entryContent}>
                 <span>Chat</span>
                 <h3>AntStation</h3>
-                <p>Sort providers by what you need — video, images, coding, price, privacy — then chat anonymously.</p>
+                <p>Sort providers by what you need — video, images, coding, price, privacy — then chat without creating a central account.</p>
                 <div className={styles.entryBadges}><b>No account</b><b>Desktop app</b></div>
               </div>
               <div className={styles.entryDownloadPair}>
@@ -374,11 +374,11 @@ export default function Home(): JSX.Element {
       <section className={`${styles.audienceSection} ${styles.chatSection}`}>
         <div className={styles.audienceCopy}>
           <span className={styles.kicker}>For chat users</span>
-          <h2>AntStation is the anonymous AI app for the open model market.</h2>
-          <p className={styles.audienceLead}>Open the desktop app, pick a model, chat anonymously, and pay providers in USDC. Providers compete directly, so users get some of the lowest AI prices in the market.</p>
+          <h2>AntStation is the no-account AI app for the open model market.</h2>
+          <p className={styles.audienceLead}>Open the desktop app, pick a model, route through the peer-to-peer network, and pay providers in USDC. AntSeed is designed for anonymous access without a central account, while users remain responsible for what they send to independent providers.</p>
           <div className={styles.conversionGrid}>
-            <div><strong>Anon by default</strong><span>No account wall before you can ask.</span></div>
-            <div><strong>Uncensored market</strong><span>Providers compete; no single policy team controls access.</span></div>
+            <div><strong>Anonymous access</strong><span>No central account wall before you can ask.</span></div>
+            <div><strong>Uncensored market</strong><span>Providers choose their models and policies; users are responsible for lawful use.</span></div>
             <div><strong>Frontier + open source</strong><span>Use the best model for the job, not the one your subscription picked.</span></div>
             <div><strong>Private Providers</strong><span>Prefer TEE providers and direct P2P transport.</span></div>
           </div>

--- a/apps/website/src/pages/providers.tsx
+++ b/apps/website/src/pages/providers.tsx
@@ -7,11 +7,11 @@ import styles from './providers.module.css';
 const FAQ_DATA = [
   {
     q: 'Does the network see my backend, model choice, or routing logic?',
-    a: 'Never. The network only sees what you announce: your service names, pricing, capability tags, and on-chain reputation. Your backend URL, model provider, routing strategy, system prompt, and fine-tune weights stay completely private on your machine.',
+    a: 'The network only sees what you announce: your service names, pricing, capability tags, and on-chain reputation. Your backend URL, model provider, routing strategy, system prompt, and fine-tune weights are intended to remain under your control. You are responsible for securing your own node, credentials, logs, and provider infrastructure.',
   },
   {
     q: 'What provider types can I run?',
-    a: 'Three: Raw Inference (serve a model or proxy an existing API), Routing Service (select providers on behalf of buyers and earn per request), or AI Agent (wrap domain expertise as a named always-on service). A single node can run all three simultaneously at different price tiers.',
+    a: 'Three: Raw Inference (serve a model or proxy an existing API), Routing Service (select providers on behalf of buyers and receive payment per routed request), or AI Agent (wrap domain expertise as a named always-on service). A single node can run all three simultaneously at different price tiers.',
   },
   {
     q: 'Does my node need to run 24/7?',
@@ -64,7 +64,7 @@ export default function Providers(): JSX.Element {
   return (
     <Layout
       title="Become a Provider | AntSeed"
-      description="Build an AntSeed provider that monetizes your AI capability. Your model, your prompt chain, your RAG — none of it is ever exposed. Buyers get results. You get paid."
+      description="Build an AntSeed provider for your AI capability. Providers are independent operators responsible for their own infrastructure, policies, compliance, and data handling."
     >
 
       {/* ── HERO ── */}
@@ -74,7 +74,7 @@ export default function Providers(): JSX.Element {
           <em>No permission needed.</em>
         </h1>
         <p className={styles.heroSub}>
-          Set your price. Announce to the network. Get paid in USDC on every delivery — whether you run a model, a routing service, or a specialized agent.
+          Set your price. Announce to the network. Receive USDC for settled deliveries, depending on demand, availability, successful settlement, and your configuration — whether you run a model, a routing service, or a specialized agent.
         </p>
         <div className={styles.heroCtas}>
           <Link to="/docs/guides/become-a-provider" className={styles.ctaPrimary}>Become a provider →</Link>
@@ -99,7 +99,7 @@ export default function Providers(): JSX.Element {
               </svg>
             </div>
             <h3>Raw Inference</h3>
-            <p>You run a model or proxy an upstream API — Ollama, a fine-tune, a local GPU, OpenAI, Together. Point AntSeed at it with one config entry, announce it to the network, and start earning. Buyers choose you based on price, latency, and on-chain reputation.</p>
+            <p>You run a model or proxy an upstream API — Ollama, a fine-tune, a local GPU, OpenAI, Together. Point AntSeed at it with one config entry and announce it to the network. Buyers choose you based on price, latency, and on-chain reputation; payments depend on demand and successful settlement.</p>
             <ul className={styles.pathList}>
               <li>→ Any model or backend</li>
               <li>→ Set your own price per token</li>
@@ -135,11 +135,11 @@ export default function Providers(): JSX.Element {
               </svg>
             </div>
             <h3>Routing Service</h3>
-            <p>Build specialized routing logic and offer it on the network. Latency-optimized, cost-minimizing, TEE-only, or domain-aware. Earn per request you route without running a single model.</p>
+            <p>Build specialized routing logic and offer it on the network. Latency-optimized, cost-minimizing, TEE-only, or domain-aware. Receive payment for settled routed requests without running a single model.</p>
             <ul className={styles.pathList}>
               <li>→ No model infrastructure required</li>
               <li>→ Latency, cost, TEE, or domain-aware routing</li>
-              <li>→ Earn per request routed</li>
+              <li>→ Payment per settled routed request</li>
             </ul>
             <Link to="/docs/guides/become-a-provider" className={styles.pathLink}>Become a provider →</Link>
           </div>
@@ -161,8 +161,10 @@ export default function Providers(): JSX.Element {
               intended use and may violate your upstream provider's terms of service.
             </p>
             <p>
-              Providers are solely responsible for complying with their upstream
-              API provider's terms.
+              Providers are independent operators and are solely responsible for their models,
+              infrastructure, outputs, logs, privacy practices, data handling,
+              security, sanctions/export compliance, tax obligations, applicable AI laws,
+              and upstream API provider terms.
             </p>
             <p>
               Seller-side ANTS emissions are currently tracked but locked in a dedicated Provider Pool while AntSeed develops stronger validation and proof systems. Fake usage, sybil behavior, or incentive extraction may be excluded or subject to future slashing.
@@ -193,7 +195,7 @@ export default function Providers(): JSX.Element {
             </svg>
           </div>
           <div className={styles.privacyCol}>
-            <div className={styles.privacyColLabel + ' ' + styles.private}>Private — never leaves your node</div>
+            <div className={styles.privacyColLabel + ' ' + styles.private}>Under your control — secure your node</div>
             {['Your backend URL or model provider', 'Your routing logic and selection criteria', 'Your system prompt and guardrails', 'Your RAG sources and knowledge base', 'Your prompt engineering', 'Your fine-tune weights'].map(item => (
               <div key={item} className={styles.privacyRow}>
                 <span className={styles.privacyLock}>🔒</span>
@@ -210,7 +212,7 @@ export default function Providers(): JSX.Element {
           <h2>One JSON file. Full control.</h2>
           <p>
             No code to write. Point AntSeed at an OpenAI-compatible endpoint,
-            set your prices and categories, and start earning.{' '}
+            set your prices and categories, and offer capacity to buyers.{' '}
             <Link to="/docs/guides/become-a-provider">Become a provider →</Link>
           </p>
         </div>
@@ -283,8 +285,8 @@ antseed seller start`}</pre>
 }`}</pre>
             </div>
             <p className={styles.codeNote}>
-              Your backend URL, API key, and routing logic never leave your node.
-              The network only sees the service name, price, and categories.{' '}
+              Your backend URL, API key, and routing logic are intended to remain under your control.
+              The network only sees the service name, price, and categories; you are responsible for securing your node and credentials.{' '}
               <Link to="/docs/config">Full config reference →</Link>
             </p>
           </div>
@@ -336,7 +338,7 @@ antseed seller start`}</pre>
           </div>
           <div className={styles.econRow}>
             <span className={styles.econLabel}>Protocol fee</span>
-            <span className={styles.econValue}>4% — flows to the Protocol Reserve, not to a company</span>
+            <span className={styles.econValue}>4% — may be directed to ecosystem mechanisms such as reserves, grants, incentives, buy-and-burn, or other community-approved uses</span>
           </div>
           <div className={styles.econRow}>
             <span className={styles.econLabel}>Your payout</span>
@@ -396,7 +398,7 @@ antseed seller unstake        # withdraw your stake`}</pre>
         </div>
         <p className={styles.reputationNote}>
           Any buyer can build their own access and routing rules on top of on-chain stats.
-          Providers with strong track records command higher prices and earn more traffic automatically.
+          Providers with strong track records may command higher prices and receive more traffic, depending on buyer and router preferences.
         </p>
       </section>
 
@@ -406,7 +408,7 @@ antseed seller unstake        # withdraw your stake`}</pre>
       {/* ── BOTTOM CTA ── */}
       <section className={styles.bottomCta}>
         <h2>Ready to provide?</h2>
-        <p>Install AntSeed, configure your provider, and start earning.</p>
+        <p>Install AntSeed, configure your provider, and offer AI capacity as an independent operator.</p>
         <div className={styles.bottomCtaBtns}>
           <Link to="/docs/install" className={styles.ctaPrimary}>Get started →</Link>
           <Link to="/docs/guides/become-a-provider" className={styles.ctaSecondary}>Become a provider</Link>

--- a/apps/website/src/pages/vs/openrouter.tsx
+++ b/apps/website/src/pages/vs/openrouter.tsx
@@ -26,17 +26,17 @@ const ROWS: Array<{dim: string; antseed: string; openrouter: string}> = [
   },
   {
     dim: 'Platform fee',
-    antseed: 'No platform cut on inference. Provider sets the price.',
+    antseed: 'Provider sets the price. Network fees may support ecosystem mechanisms.',
     openrouter: 'Platform fee on top of provider pricing.',
   },
   {
     dim: 'Request privacy',
-    antseed: "Prompts go peer-to-peer. The network operator doesn't exist.",
+    antseed: 'Prompts go peer-to-peer without a central platform account. Independent providers and infrastructure may still process or observe data.',
     openrouter: 'Every prompt transits their infrastructure.',
   },
   {
     dim: 'Can be shut down',
-    antseed: 'No central company. No single off switch.',
+    antseed: 'Open peer-to-peer software. Independent nodes may continue without reliance on one hosted service.',
     openrouter: 'Single company can be sued, acquired, or deplatformed.',
   },
   {
@@ -53,7 +53,7 @@ const ROWS: Array<{dim: string; antseed: string; openrouter: string}> = [
 
 const TITLE = 'OpenRouter Alternative: Permissionless P2P AI Inference | AntSeed';
 const DESCRIPTION =
-  'AntSeed is a permissionless, peer-to-peer alternative to OpenRouter. Any provider can join. Requests go direct. Pay per request in USDC — no accounts, no platform fee.';
+  'AntSeed is a permissionless, peer-to-peer alternative to OpenRouter. Any provider can join. Requests go direct. Pay per request in USDC — no central account.';
 
 export default function VsOpenRouter(): JSX.Element {
   return (
@@ -116,7 +116,7 @@ export default function VsOpenRouter(): JSX.Element {
           <h1 className={styles.title}>A permissionless, peer-to-peer alternative to OpenRouter.</h1>
           <p className={styles.subtitle}>
             Same OpenAI-compatible API. Any provider can join. Pay per request in USDC.
-            No accounts, no platform fee, no central operator.
+            No central account, independent providers, open peer-to-peer routing.
           </p>
           <div className={styles.ctaRow}>
             <Link to="/docs/install" className={styles.ctaPrimary}>Install AntSeed</Link>
@@ -146,7 +146,7 @@ export default function VsOpenRouter(): JSX.Element {
             <li>You're building an agent that needs to pay for its own inference.</li>
             <li>You want payments to settle per request, on-chain, with no platform holding funds.</li>
             <li>You want to <Link to="/providers">serve</Link> a model and get paid without applying to a platform.</li>
-            <li>You need a routing layer with no central company behind it.</li>
+            <li>You need open peer-to-peer routing that does not rely on one hosted service.</li>
           </ul>
         </section>
 


### PR DESCRIPTION
## Summary
- Aligns homepage, $ANTS, providers, FAQ, lightpaper, protocol overview, and OpenRouter comparison copy with the updated AntSeed Protocol Terms positioning.
- Keeps “uncensored market” positioning, but clarifies provider choice and user responsibility for lawful use.
- Keeps anonymous/no-account privacy positioning while replacing the overly harsh privacy disclaimer with balanced architecture-based privacy language.
- Softens token, reserve, fee, provider-payment, and provider-privacy claims without changing Terms pages or DIEM app copy.

## Key places to review
- Homepage: `/`, especially AntStation/chat and FAQ copy.
- $ANTS page: `/ants-token`, especially hero, emissions split, network activity, and contract details.
- Providers page: `/providers`, especially provider compliance, privacy/config copy, payment wording, and bottom CTA.
- Lightpaper: `/docs/lightpaper`, especially “Two Layers,” “Why Decentralized,” privacy-sensitive users, and new “Compliance and Risk.”
- FAQ: `/docs/faq`, especially “Who runs the network?”, “Is my data private?”, “Does AntSeed log my requests?”, and “Where do protocol fees go?”
- OpenRouter comparison: `/vs/openrouter`, especially request privacy and shutdown rows.
- Protocol overview: `/docs/overview`, especially Key Principles and Provider Compliance.

## Testing
- Passed in active local website workspace: `cd apps/website && npm run typecheck`.
- In the separate clean PR worktree, `npm run typecheck` currently fails with existing `Cannot find namespace 'JSX'` dependency/type-resolution errors after fresh install. The same source changes typecheck successfully in the active local workspace.
