### PR TITLE
Redirect DIEM terms path to live terms page

### DIFF
--- a/apps/website/static/terms/diem-provider-capacity-program/index.html
+++ b/apps/website/static/terms/diem-provider-capacity-program/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DIEM Provider Capacity Program Terms | AntSeed</title>
+    <link rel="canonical" href="https://diem.antseed.com/terms-of-service.html" />
+    <meta http-equiv="refresh" content="0; url=https://diem.antseed.com/terms-of-service.html" />
+    <style>
+      body {
+        margin: 0;
+        padding: 64px 24px;
+        background: #f8f6ef;
+        color: #101820;
+        font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      main { max-width: 720px; margin: 0 auto; }
+      a { color: #0a8f4a; font-weight: 700; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>DIEM Provider Capacity Program Terms</h1>
+      <p>
+        Redirecting to the DIEM Provider Capacity Program Terms at
+        <a href="https://diem.antseed.com/terms-of-service.html">diem.antseed.com/terms-of-service.html</a>.
+      </p>
+      <p>If you are not redirected automatically, use the link above.</p>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a static redirect page at `/terms/diem-provider-capacity-program/`.
- Redirects the old/expected DIEM terms URL on `antseed.com` to the live DIEM terms page: `https://diem.antseed.com/terms-of-service.html`.
- This keeps existing or cached DIEM terms links from landing on a 404.

## Notes
- Latest `apps/diem-staking` source on `main` already points `DIEM_TERMS_URL` to `https://diem.antseed.com/terms-of-service.html` in both `Layout.tsx` and `StakeCard.tsx`.

## Testing
- Not run; this is a static HTML redirect only.
