### PR TITLE
fix(desktop): Stabilize Discover pagination bar width

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
@@ -241,6 +241,7 @@
   gap: 4px;
   flex-wrap: wrap;
   justify-content: flex-end;
+  min-width: 240px;
 }
 
 .page-ellipsis {


### PR DESCRIPTION
Fixes #498.

## Problem

The pagination bar at the bottom of the Discover page shifts horizontally as users navigate between pages. `buildPaginationTokens` in `apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx:332` returns:

- **6 tokens** for edges (`page <= 3` or `page >= totalPages - 2`): `[1, 2, 3, '…', N-1, N]`
- **7 tokens** for middle pages: `[1, '…', p-1, p, p+1, '…', N]`

`.pagination` has no reserved width, so the container resizes with the token count and the bar visibly jumps.

## Fix

One-line CSS change: add `min-width: 240px` to `.pagination` in `apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss`. 240px holds the widest layout (7 tokens × 28px button min-width + 6 × 4px gaps + 2 ellipses + headroom for two-digit page numbers).

## Test plan

- [ ] Open Discover with enough providers to produce 5+ pages
- [ ] Click through pages 1 → 2 → 3 → 4 → 5 → last and back
- [ ] Confirm the pagination bar does not shift horizontally at any boundary
- [ ] Verify behavior at the 520px breakpoint where `.pagination-bar` switches to `align-items: flex-start`

## Disclosure

This PR was drafted with assistance from a Claude Code agent. The change has been reviewed and is being submitted by me (@Augustas11).
