### PR TITLE
fix(website): use desktop package version in
  JSON-LD softwareVersion

### DIFF
--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -3,6 +3,7 @@ import type {Config, Plugin, PluginModule} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import integrationsPagesPlugin from './plugins/integrations-pages';
 import {integrations as integrationEntries} from './src/integrations/integrations';
+import desktopPkg from '../desktop/package.json';
 
 const statsProxyPlugin: PluginModule = () => ({
   name: 'stats-proxy',
@@ -142,7 +143,7 @@ const config: Config = {
           'Agent-to-agent commerce support',
         ],
         downloadUrl: 'https://github.com/AntSeed/antseed/releases',
-        softwareVersion: '0.1.49',
+        softwareVersion: desktopPkg.version,
         license: 'https://github.com/AntSeed/antseed/blob/main/LICENSE',
       }),
     },


### PR DESCRIPTION
## Summary
- The Docusaurus head-tag JSON-LD block hardcoded `softwareVersion: '0.1.49'` while the desktop workspace currently ships `0.1.86` (per `apps/desktop/package.json`).
- Google Rich Results, app-store-style snippets, and any LLM scraping the site for structured data therefore report a 37-version-stale value.
- The fix imports `apps/desktop/package.json` directly and references `desktopPkg.version` so the literal stays in sync with each desktop release.
- The matching `downloadUrl` already points at `…/releases/latest`, so the actual download was unaffected — only the structured-data field was drifting.

## Reproduction
```
$ grep softwareVersion apps/website/docusaurus.config.ts   # was 0.1.49
$ grep '"version"' apps/desktop/package.json               # 0.1.86
```

## Testing
- `pnpm install` + a website build was **not** run in this clean worktree; native dependencies in the wider monorepo make a from-scratch install heavy.
- The change is 2 lines (one new import, one literal → reference rewrite). The pnpm workspace builds desktop before website per topological order, so the import resolves at config load time.
- Visual / structured-data verification recommended on a maintainer worktree: `apps/website` build should succeed (strict broken-link policy still passes) and the rendered JSON-LD should match `apps/desktop/package.json:version`.
