### PR TITLE
fix(payments): resolve topUp race condition causing premature channel closure

### DIFF
--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -28,9 +28,11 @@ import { estimateCostFromBytes, computeCostUsdc, type ServicePricing } from './p
 
 /** Default tolerance: accept seller claims up to 1.4x buyer's estimate. */
 const DEFAULT_COST_TOLERANCE = 1.4;
-/** Fraction of reserve ceiling at which to signal a top-up is needed. */
-/** Must match or exceed contract's TOP_UP_SETTLED_THRESHOLD_BPS (85%). */
-const DEFAULT_TOPUP_THRESHOLD = 0.85;
+/** Fraction of reserve ceiling at which to signal a top-up is needed.
+ *  Trigger well before the contract's TOP_UP_SETTLED_THRESHOLD_BPS (85%)
+ *  so that by the time the seller calls topUp() on-chain, enough has been
+ *  settled to pass the threshold check. */
+const DEFAULT_TOPUP_THRESHOLD = 0.65;
 
 export interface BuyerPaymentConfig {
   rpcUrl: string;
@@ -297,13 +299,20 @@ export class BuyerPaymentManager {
       ? targetCumulative
       : minAdvance;
 
-    if (requestedAmount > maxSignable && maxSignable >= ceiling) {
-      await this.topUpReserve(sellerPeerId, paymentMux);
-      maxSignable = this._maxSignable(sellerPeerId);
-    }
+    const extendNeedsTopUp = requestedAmount > maxSignable && maxSignable >= ceiling;
 
+    // Cap at current ceiling — if topUp is needed we send the SpendingAuth first
+    // so the seller has a high-enough settle amount for the on-chain topUp threshold.
     const nextCumulative = requestedAmount < maxSignable ? requestedAmount : maxSignable;
     if (nextCumulative <= currentCumulative) {
+      // Nothing to sign at current ceiling — try topUp anyway for next round
+      if (extendNeedsTopUp) {
+        try {
+          await this.topUpReserve(sellerPeerId, paymentMux);
+        } catch (err) {
+          debugWarn(`[BuyerPayment] extendCurrentSpendingAuth: topUpReserve failed: ${err instanceof Error ? err.message : err}`);
+        }
+      }
       debugWarn(
         `[BuyerPayment] Cannot extend active session for ${sellerPeerId.slice(0, 12)}... ` +
         `(current=${currentCumulative} maxSignable=${maxSignable} target=${targetCumulative ?? 'n/a'})`,
@@ -336,6 +345,16 @@ export class BuyerPaymentManager {
       metadata: encodedMetadata,
       spendingAuthSig,
     });
+
+    // Send topUp AFTER the SpendingAuth so the seller processes the higher
+    // cumulative first, meeting the on-chain settle threshold for topUp.
+    if (extendNeedsTopUp) {
+      try {
+        await this.topUpReserve(sellerPeerId, paymentMux);
+      } catch (err) {
+        debugWarn(`[BuyerPayment] extendCurrentSpendingAuth: topUpReserve failed: ${err instanceof Error ? err.message : err}`);
+      }
+    }
 
     return session.sessionId;
   }
@@ -855,22 +874,36 @@ export class BuyerPaymentManager {
     // This prevents a malicious seller from claiming a small cost but requesting the full reserve.
     let maxSignable = this._maxSignable(sellerPeerId);
     const ceiling = this._getCeiling(sellerPeerId);
-    if (requiredCumulativeAmount > maxSignable && maxSignable >= ceiling) {
-      try {
-        await this.topUpReserve(sellerPeerId, paymentMux);
-      } catch (err) {
-        debugWarn(`[BuyerPayment] NeedAuth: topUpReserve failed: ${err instanceof Error ? err.message : err}`);
-      }
-      maxSignable = this._maxSignable(sellerPeerId);
-    }
-    if (maxSignable <= currentCumulative) {
+    const needsTopUp = requiredCumulativeAmount > maxSignable && maxSignable >= ceiling;
+    if (maxSignable <= currentCumulative && !needsTopUp) {
       debugWarn(
         `[BuyerPayment] NeedAuth: maxSignable=${maxSignable} <= currentCumulative=${currentCumulative} — overdraft limit reached`,
       );
       return;
     }
 
-    const effectiveAmount = requiredCumulativeAmount < maxSignable ? requiredCumulativeAmount : maxSignable;
+    // When a topUp is needed, first sign at the current ceiling so the seller
+    // has a high-enough settled amount to pass the on-chain TopUpThresholdNotMet
+    // check (contract requires 85% of deposit to be settleable before topUp).
+    // We cap at the old ceiling here; the topUp is sent AFTER so the seller
+    // processes the SpendingAuth first, then the topUp with adequate settle amount.
+    const effectiveAmount = needsTopUp
+      ? (maxSignable > currentCumulative ? maxSignable : currentCumulative)
+      : (requiredCumulativeAmount < maxSignable ? requiredCumulativeAmount : maxSignable);
+    if (effectiveAmount <= currentCumulative) {
+      // Nothing to sign — trigger topUp anyway to extend ceiling for next round
+      if (needsTopUp) {
+        try {
+          await this.topUpReserve(sellerPeerId, paymentMux);
+        } catch (err) {
+          debugWarn(`[BuyerPayment] NeedAuth: topUpReserve failed: ${err instanceof Error ? err.message : err}`);
+        }
+      }
+      debugWarn(
+        `[BuyerPayment] NeedAuth: effectiveAmount=${effectiveAmount} <= currentCumulative=${currentCumulative} — cannot advance`,
+      );
+      return;
+    }
 
     debugLog(`[BuyerPayment] NeedAuth: channel=${session.sessionId.slice(0, 18)}... required=${requiredCumulativeAmount} effective=${effectiveAmount}`);
 
@@ -919,6 +952,18 @@ export class BuyerPaymentManager {
       debugLog(`[BuyerPayment] NeedAuth responded: new cumulativeAmount=${effectiveAmount}`);
     } catch {
       debugLog(`[BuyerPayment] NeedAuth: connection closed before SpendingAuth could be sent`);
+    }
+
+    // Send topUp AFTER the SpendingAuth so the seller processes the higher
+    // cumulative first — this ensures the on-chain settle amount meets the
+    // contract's TopUpThresholdNotMet requirement (85% of deposit must be
+    // settleable before topUp is allowed).
+    if (needsTopUp) {
+      try {
+        await this.topUpReserve(sellerPeerId, paymentMux);
+      } catch (err) {
+        debugWarn(`[BuyerPayment] NeedAuth: topUpReserve failed: ${err instanceof Error ? err.message : err}`);
+      }
     }
   }
 

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -258,37 +258,7 @@ export class BuyerPaymentManager {
 
     const currentCumulative = this._cumulativeAmount.get(sellerPeerId) ?? BigInt(session.authMax);
     let maxSignable = this._maxSignable(sellerPeerId);
-
-    // Overdraft-window unblock: when the buyer has already signed up to
-    // `verified + maxPerRequest` and the seller returned 402 because `spent`
-    // caught up, advance `verifiedCost` to the current signed cumulative so
-    // the window reopens. The buyer has already committed to pay
-    // `currentCumulative` via the signed SpendingAuth, so the seller can
-    // already claim that much on-chain — advancing verified to match doesn't
-    // expose new funds, it just reclaims overdraft headroom.
-    //
-    // SECURITY: the trust anchor here is `currentCumulative`, NOT the
-    // seller-supplied `targetCumulative`. A malicious seller could set
-    // `requiredCumulativeAmount` in the 402 body to the full reserve ceiling
-    // (pretending it spent that much) in an attempt to drain the channel in
-    // one signature. We defend by only ever using `targetCumulative` as a
-    // *destination hint* bounded by `maxSignable = verifiedCost +
-    // maxPerRequestUsdc`. Per-request cost validation still happens
-    // tolerance-checked in `handleNeedAuth`; nothing in the 402 body feeds
-    // `verifiedCost`. The worst a seller can extract per 402 round trip is
-    // one `maxPerRequestUsdc` window beyond what the buyer already signed —
-    // identical to the non-catchup trust model before this PR.
-    if (maxSignable <= currentCumulative) {
-      const previousVerified = this._verifiedCost.get(sellerPeerId) ?? 0n;
-      if (currentCumulative > previousVerified) {
-        this._verifiedCost.set(sellerPeerId, currentCumulative);
-        maxSignable = this._maxSignable(sellerPeerId);
-        debugLog(
-          `[BuyerPayment] extendCurrentSpendingAuth: advanced verifiedCost ${previousVerified} → ${currentCumulative} ` +
-          `to unblock overdraft window for ${sellerPeerId.slice(0, 12)}...`,
-        );
-      }
-    }
+    maxSignable = this._reopenOverdraftWindowIfCollapsed(sellerPeerId, currentCumulative, maxSignable, 'extendCurrentSpendingAuth');
 
     const ceiling = this._getCeiling(sellerPeerId);
     // Prefer the seller-supplied target when present — a raw
@@ -299,19 +269,12 @@ export class BuyerPaymentManager {
       ? targetCumulative
       : minAdvance;
 
-    const extendNeedsTopUp = requestedAmount > maxSignable && maxSignable >= ceiling;
-
-    // Cap at current ceiling — if topUp is needed we send the SpendingAuth first
-    // so the seller has a high-enough settle amount for the on-chain topUp threshold.
     const nextCumulative = requestedAmount < maxSignable ? requestedAmount : maxSignable;
+    const extendNeedsTopUp = this._needsCeilingAdvance(requestedAmount, maxSignable, ceiling);
     if (nextCumulative <= currentCumulative) {
       // Nothing to sign at current ceiling — try topUp anyway for next round
       if (extendNeedsTopUp) {
-        try {
-          await this.topUpReserve(sellerPeerId, paymentMux);
-        } catch (err) {
-          debugWarn(`[BuyerPayment] extendCurrentSpendingAuth: topUpReserve failed: ${err instanceof Error ? err.message : err}`);
-        }
+        await this._topUpAfterSpendAuthBestEffort(sellerPeerId, paymentMux, 'extendCurrentSpendingAuth');
       }
       debugWarn(
         `[BuyerPayment] Cannot extend active session for ${sellerPeerId.slice(0, 12)}... ` +
@@ -321,39 +284,12 @@ export class BuyerPaymentManager {
     }
 
     const currentMeta = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
-    const metadataHashHex = computeMetadataHash(currentMeta);
-    const encodedMetadata = encodeMetadata(currentMeta);
-
-    const metadataMsg: SpendingAuthMessage = {
-      channelId: session.sessionId,
-      cumulativeAmount: nextCumulative,
-      metadataHash: metadataHashHex,
-    };
-    const spendingAuthSig = await signSpendingAuth(this._signer, this._channelsDomain, metadataMsg);
-
-    this._cumulativeAmount.set(sellerPeerId, nextCumulative);
-    this._channelStore.upsertChannel({
-      ...session,
-      authMax: nextCumulative.toString(),
-      updatedAt: Date.now(),
-    });
-
-    paymentMux.sendSpendingAuth({
-      channelId: session.sessionId,
-      cumulativeAmount: nextCumulative.toString(),
-      metadataHash: metadataHashHex,
-      metadata: encodedMetadata,
-      spendingAuthSig,
-    });
+    await this._sendUpdatedSpendingAuth(session, sellerPeerId, nextCumulative, currentMeta, paymentMux);
 
     // Send topUp AFTER the SpendingAuth so the seller processes the higher
     // cumulative first, meeting the on-chain settle threshold for topUp.
     if (extendNeedsTopUp) {
-      try {
-        await this.topUpReserve(sellerPeerId, paymentMux);
-      } catch (err) {
-        debugWarn(`[BuyerPayment] extendCurrentSpendingAuth: topUpReserve failed: ${err instanceof Error ? err.message : err}`);
-      }
+      await this._topUpAfterSpendAuthBestEffort(sellerPeerId, paymentMux, 'extendCurrentSpendingAuth');
     }
 
     return session.sessionId;
@@ -393,6 +329,89 @@ export class BuyerPaymentManager {
     });
 
     return session.sessionId;
+  }
+
+  private _reopenOverdraftWindowIfCollapsed(
+    sellerPeerId: string,
+    currentCumulative: bigint,
+    maxSignable: bigint,
+    context: 'extendCurrentSpendingAuth' | 'handleNeedAuth',
+  ): bigint {
+    // Overdraft-window unblock: when the buyer has already signed up to
+    // `verified + maxPerRequest` and the seller returned 402 because `spent`
+    // caught up, advance `verifiedCost` to the current signed cumulative so
+    // the window reopens. The buyer has already committed to pay
+    // `currentCumulative` via the signed SpendingAuth, so the seller can
+    // already claim that much on-chain — advancing verified to match doesn't
+    // expose new funds, it just reclaims overdraft headroom.
+    //
+    // SECURITY: the trust anchor here is `currentCumulative`, NOT any
+    // seller-supplied target. A malicious seller could overstate required
+    // spend in a 402 / NeedAuth path in an attempt to drain the reserve. We
+    // defend by only advancing verifiedCost to the amount the buyer has
+    // already signed. Seller-provided values remain destination hints bounded
+    // by `verifiedCost + maxPerRequestUsdc` and are never used to mint new
+    // trust directly.
+    if (maxSignable > currentCumulative) return maxSignable;
+
+    const previousVerified = this._verifiedCost.get(sellerPeerId) ?? 0n;
+    if (currentCumulative <= previousVerified) return maxSignable;
+
+    this._verifiedCost.set(sellerPeerId, currentCumulative);
+    const reopened = this._maxSignable(sellerPeerId);
+    debugLog(
+      `[BuyerPayment] ${context}: advanced verifiedCost ${previousVerified} → ${currentCumulative} ` +
+      `to unblock overdraft window for ${sellerPeerId.slice(0, 12)}...`,
+    );
+    return reopened;
+  }
+
+  private _needsCeilingAdvance(requestedAmount: bigint, maxSignable: bigint, ceiling: bigint): boolean {
+    return requestedAmount > maxSignable && maxSignable >= ceiling;
+  }
+
+  private async _sendUpdatedSpendingAuth(
+    session: StoredChannel,
+    sellerPeerId: string,
+    cumulativeAmount: bigint,
+    metadata: SpendingAuthMetadata,
+    paymentMux: PaymentMux,
+  ): Promise<void> {
+    const metadataHashHex = computeMetadataHash(metadata);
+    const encodedMetadata = encodeMetadata(metadata);
+    const metadataMsg: SpendingAuthMessage = {
+      channelId: session.sessionId,
+      cumulativeAmount,
+      metadataHash: metadataHashHex,
+    };
+    const spendingAuthSig = await signSpendingAuth(this._signer, this._channelsDomain, metadataMsg);
+
+    this._cumulativeAmount.set(sellerPeerId, cumulativeAmount);
+    this._channelStore.upsertChannel({
+      ...session,
+      authMax: cumulativeAmount.toString(),
+      updatedAt: Date.now(),
+    });
+
+    paymentMux.sendSpendingAuth({
+      channelId: session.sessionId,
+      cumulativeAmount: cumulativeAmount.toString(),
+      metadataHash: metadataHashHex,
+      metadata: encodedMetadata,
+      spendingAuthSig,
+    });
+  }
+
+  private async _topUpAfterSpendAuthBestEffort(
+    sellerPeerId: string,
+    paymentMux: PaymentMux,
+    context: 'extendCurrentSpendingAuth' | 'handleNeedAuth',
+  ): Promise<void> {
+    try {
+      await this.topUpReserve(sellerPeerId, paymentMux);
+    } catch (err) {
+      debugWarn(`[BuyerPayment] ${context}: topUpReserve failed: ${err instanceof Error ? err.message : err}`);
+    }
   }
 
   // ── Spending Authorization ────────────────────────────────────
@@ -874,12 +893,16 @@ export class BuyerPaymentManager {
     // This prevents a malicious seller from claiming a small cost but requesting the full reserve.
     let maxSignable = this._maxSignable(sellerPeerId);
     const ceiling = this._getCeiling(sellerPeerId);
-    const needsTopUp = requiredCumulativeAmount > maxSignable && maxSignable >= ceiling;
+    let needsTopUp = this._needsCeilingAdvance(requiredCumulativeAmount, maxSignable, ceiling);
     if (maxSignable <= currentCumulative && !needsTopUp) {
-      debugWarn(
-        `[BuyerPayment] NeedAuth: maxSignable=${maxSignable} <= currentCumulative=${currentCumulative} — overdraft limit reached`,
-      );
-      return;
+      maxSignable = this._reopenOverdraftWindowIfCollapsed(sellerPeerId, currentCumulative, maxSignable, 'handleNeedAuth');
+      needsTopUp = this._needsCeilingAdvance(requiredCumulativeAmount, maxSignable, ceiling);
+      if (maxSignable <= currentCumulative && !needsTopUp) {
+        debugWarn(
+          `[BuyerPayment] NeedAuth: maxSignable=${maxSignable} <= currentCumulative=${currentCumulative} — overdraft limit reached`,
+        );
+        return;
+      }
     }
 
     // When a topUp is needed, first sign at the current ceiling so the seller
@@ -893,11 +916,7 @@ export class BuyerPaymentManager {
     if (effectiveAmount <= currentCumulative) {
       // Nothing to sign — trigger topUp anyway to extend ceiling for next round
       if (needsTopUp) {
-        try {
-          await this.topUpReserve(sellerPeerId, paymentMux);
-        } catch (err) {
-          debugWarn(`[BuyerPayment] NeedAuth: topUpReserve failed: ${err instanceof Error ? err.message : err}`);
-        }
+        await this._topUpAfterSpendAuthBestEffort(sellerPeerId, paymentMux, 'handleNeedAuth');
       }
       debugWarn(
         `[BuyerPayment] NeedAuth: effectiveAmount=${effectiveAmount} <= currentCumulative=${currentCumulative} — cannot advance`,
@@ -906,9 +925,6 @@ export class BuyerPaymentManager {
     }
 
     debugLog(`[BuyerPayment] NeedAuth: channel=${session.sessionId.slice(0, 18)}... required=${requiredCumulativeAmount} effective=${effectiveAmount}`);
-
-    // Update cumulative amount
-    this._cumulativeAmount.set(sellerPeerId, effectiveAmount);
 
     // Advance cumulative metadata. requestCount always increments so the
     // on-chain metadata stays consistent even when older sellers omit token
@@ -921,34 +937,9 @@ export class BuyerPaymentManager {
     };
     this._metadata.set(sellerPeerId, newMeta);
 
-    // Sign SpendingAuth with the effective amount and updated metadata
-    const metadataHashHex = computeMetadataHash(newMeta);
-    const encodedMetadata = encodeMetadata(newMeta);
-
-    const channelsDomain = this._channelsDomain;
-    const metadataMsg: SpendingAuthMessage = {
-      channelId: session.sessionId,
-      cumulativeAmount: effectiveAmount,
-      metadataHash: metadataHashHex,
-    };
-    const spendingAuthSig = await signSpendingAuth(this._signer, channelsDomain, metadataMsg);
-
-    // Persist updated values
-    this._channelStore.upsertChannel({
-      ...session,
-      authMax: effectiveAmount.toString(),
-      updatedAt: Date.now(),
-    });
-
     // Send via PaymentMux
     try {
-      paymentMux.sendSpendingAuth({
-        channelId: session.sessionId,
-        cumulativeAmount: effectiveAmount.toString(),
-        metadataHash: metadataHashHex,
-        metadata: encodedMetadata,
-        spendingAuthSig,
-      });
+      await this._sendUpdatedSpendingAuth(session, sellerPeerId, effectiveAmount, newMeta, paymentMux);
       debugLog(`[BuyerPayment] NeedAuth responded: new cumulativeAmount=${effectiveAmount}`);
     } catch {
       debugLog(`[BuyerPayment] NeedAuth: connection closed before SpendingAuth could be sent`);
@@ -959,11 +950,7 @@ export class BuyerPaymentManager {
     // contract's TopUpThresholdNotMet requirement (85% of deposit must be
     // settleable before topUp is allowed).
     if (needsTopUp) {
-      try {
-        await this.topUpReserve(sellerPeerId, paymentMux);
-      } catch (err) {
-        debugWarn(`[BuyerPayment] NeedAuth: topUpReserve failed: ${err instanceof Error ? err.message : err}`);
-      }
+      await this._topUpAfterSpendAuthBestEffort(sellerPeerId, paymentMux, 'handleNeedAuth');
     }
   }
 

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -1132,6 +1132,7 @@ export class SellerPaymentManager {
     this._closeRetryCount.delete(channelId);
     this._closingChannels.delete(channelId);
     this._reserveMax.delete(channelId);
+    this._pendingTopUp.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
     this._releaseAcceptedWaiters(channelId);
 

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -104,6 +104,10 @@ export class SellerPaymentManager {
   /** channelId -> number of failed close() attempts. In-memory only; resets on node restart. */
   private readonly _closeRetryCount = new Map<string, number>();
 
+  /** channelId -> deferred topUp params when on-chain topUp failed (e.g. TopUpThresholdNotMet).
+   *  Retried after the next SpendingAuth raises the settle amount high enough. */
+  private readonly _pendingTopUp = new Map<string, { newMaxAmount: bigint; deadline: number; reserveAuthSig: string }>();
+
   /** channelIds with an in-flight close() tx/estimate. Prevents duplicate close submissions. */
   private readonly _closingChannels = new Set<string>();
 
@@ -232,6 +236,7 @@ export class SellerPaymentManager {
     this._closeRetryCount.delete(channelId);
     this._closingChannels.delete(channelId);
     this._reserveMax.delete(channelId);
+    this._pendingTopUp.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
     this._releaseAcceptedWaiters(channelId);
     this._activeBuyers.delete(peerId);
@@ -476,28 +481,44 @@ export class SellerPaymentManager {
         // Call topUp() on-chain — includes settle of current cumulative spend
         const { amount: settleAmount, metadata: settleMetadata, sig: settleSig } = this._getSettleParams(channelId);
         debugLog(`[SellerPayment] Top-up verified: channel=${channelId.slice(0, 18)}... ceiling ${currentReserveMax} → ${newMaxAmount} (settling cumulative=${settleAmount})`);
-        await this._channelsClient.topUp(
-          this._signer,
-          channelId,
-          settleAmount,
-          settleMetadata,
-          settleSig,
-          newMaxAmount,
-          BigInt(topUpDeadline),
-          payload.spendingAuthSig,
-        );
+        try {
+          await this._channelsClient.topUp(
+            this._signer,
+            channelId,
+            settleAmount,
+            settleMetadata,
+            settleSig,
+            newMaxAmount,
+            BigInt(topUpDeadline),
+            payload.spendingAuthSig,
+          );
 
-        // Update tracking
-        this._reserveMax.set(channelId, newMaxAmount);
-        const session = this._channelStore.getChannel(channelId);
-        if (session) {
-          session.previousConsumption = newMaxAmount.toString(); // repurposed: stores reserveMax
-          session.deadline = topUpDeadline;
-          session.updatedAt = Date.now();
-          this._channelStore.upsertChannel(session);
+          // Update tracking
+          this._reserveMax.set(channelId, newMaxAmount);
+          const session = this._channelStore.getChannel(channelId);
+          if (session) {
+            session.previousConsumption = newMaxAmount.toString(); // repurposed: stores reserveMax
+            session.deadline = topUpDeadline;
+            session.updatedAt = Date.now();
+            this._channelStore.upsertChannel(session);
+          }
+
+          debugLog(`[SellerPayment] Top-up completed: channel=${channelId.slice(0, 18)}... new ceiling=${newMaxAmount}`);
+        } catch (topUpErr) {
+          // On-chain topUp can fail (e.g. TopUpThresholdNotMet if not enough
+          // has been settled yet). Store the pending top-up so it can be
+          // retried after a subsequent SpendingAuth raises the settle amount.
+          debugWarn(
+            `[SellerPayment] Top-up on-chain failed: channel=${channelId.slice(0, 18)}... ` +
+            `error=${topUpErr instanceof Error ? topUpErr.message : topUpErr} — ` +
+            `deferring topUp (will retry after next SpendingAuth)`,
+          );
+          this._pendingTopUp.set(channelId, {
+            newMaxAmount,
+            deadline: topUpDeadline,
+            reserveAuthSig: payload.spendingAuthSig,
+          });
         }
-
-        debugLog(`[SellerPayment] Top-up completed: channel=${channelId.slice(0, 18)}... new ceiling=${newMaxAmount}`);
         return 'accepted';
       } else {
         // ── Subsequent SpendingAuth: verify SpendingAuth signature ──
@@ -537,11 +558,18 @@ export class SellerPaymentManager {
 
         // Reject if cumulative exceeds on-chain deposit — the contract would revert
         // and we'd lose the last valid auth signature that close() could use.
+        // Exception: if there's a pending topUp that would raise the ceiling high
+        // enough, accept the SpendingAuth (the topUp will be retried after).
         const currentReserveMax = this._reserveMax.get(channelId) ?? 0n;
-        if (currentReserveMax > 0n && cumulativeAmount > currentReserveMax) {
+        const pendingTopUpForCheck = this._pendingTopUp.get(channelId);
+        const effectiveMax = pendingTopUpForCheck
+          ? (pendingTopUpForCheck.newMaxAmount > currentReserveMax ? pendingTopUpForCheck.newMaxAmount : currentReserveMax)
+          : currentReserveMax;
+        if (effectiveMax > 0n && cumulativeAmount > effectiveMax) {
           debugWarn(
             `[SellerPayment] Rejecting SpendingAuth exceeding deposit ceiling: ` +
-            `cumulative=${cumulativeAmount} > reserveMax=${currentReserveMax} channel=${channelId.slice(0, 18)}...`,
+            `cumulative=${cumulativeAmount} > reserveMax=${currentReserveMax}` +
+            `${pendingTopUpForCheck ? ` (pending topUp to ${pendingTopUpForCheck.newMaxAmount})` : ''} channel=${channelId.slice(0, 18)}...`,
           );
           return 'rejected';
         }
@@ -568,6 +596,43 @@ export class SellerPaymentManager {
         }
 
         debugLog(`[SellerPayment] Budget updated: channel=${channelId.slice(0, 18)}... cumulative=${cumulativeAmount}`);
+
+        // Retry any deferred topUp now that we have a higher settle amount
+        const pendingTopUp = this._pendingTopUp.get(channelId);
+        if (pendingTopUp) {
+          this._pendingTopUp.delete(channelId);
+          const { amount: retrySettleAmount, metadata: retryMetadata, sig: retrySig } = this._getSettleParams(channelId);
+          debugLog(`[SellerPayment] Retrying deferred topUp: channel=${channelId.slice(0, 18)}... settling=${retrySettleAmount} newMax=${pendingTopUp.newMaxAmount}`);
+          try {
+            await this._channelsClient.topUp(
+              this._signer,
+              channelId,
+              retrySettleAmount,
+              retryMetadata,
+              retrySig,
+              pendingTopUp.newMaxAmount,
+              BigInt(pendingTopUp.deadline),
+              pendingTopUp.reserveAuthSig,
+            );
+            this._reserveMax.set(channelId, pendingTopUp.newMaxAmount);
+            const topUpSession = this._channelStore.getChannel(channelId);
+            if (topUpSession) {
+              topUpSession.previousConsumption = pendingTopUp.newMaxAmount.toString();
+              topUpSession.deadline = pendingTopUp.deadline;
+              topUpSession.updatedAt = Date.now();
+              this._channelStore.upsertChannel(topUpSession);
+            }
+            debugLog(`[SellerPayment] Deferred topUp succeeded: channel=${channelId.slice(0, 18)}... new ceiling=${pendingTopUp.newMaxAmount}`);
+          } catch (retryErr) {
+            debugWarn(
+              `[SellerPayment] Deferred topUp retry failed: channel=${channelId.slice(0, 18)}... ` +
+              `error=${retryErr instanceof Error ? retryErr.message : retryErr}`,
+            );
+            // Re-queue for next attempt
+            this._pendingTopUp.set(channelId, pendingTopUp);
+          }
+        }
+
         return 'accepted';
       }
     } catch (err) {
@@ -986,6 +1051,18 @@ export class SellerPaymentManager {
   /** Get the on-chain reserve budget ceiling for a session. */
   getReserveMax(sessionId: string): bigint {
     return this._reserveMax.get(sessionId) ?? 0n;
+  }
+
+  /** Get the effective reserve max, considering pending (not-yet-on-chain) topUps. */
+  getEffectiveReserveMax(sessionId: string): bigint {
+    const onChain = this._reserveMax.get(sessionId) ?? 0n;
+    const pending = this._pendingTopUp.get(sessionId);
+    return pending && pending.newMaxAmount > onChain ? pending.newMaxAmount : onChain;
+  }
+
+  /** Whether a topUp is pending (on-chain call deferred). */
+  hasPendingTopUp(sessionId: string): boolean {
+    return this._pendingTopUp.has(sessionId);
   }
 
   private static readonly DEFAULT_SUGGESTED_AMOUNT = 1_000_000n; // $1.00 — matches contract FIRST_SIGN_CAP and buyer default

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -105,7 +105,10 @@ export class SellerPaymentManager {
   private readonly _closeRetryCount = new Map<string, number>();
 
   /** channelId -> deferred topUp params when on-chain topUp failed (e.g. TopUpThresholdNotMet).
-   *  Retried after the next SpendingAuth raises the settle amount high enough. */
+   *  Retried after the next SpendingAuth raises the settle amount high enough.
+   *  Latest / largest top-up intent wins: if multiple deferred ReserveAuths arrive
+   *  before a retry succeeds, we keep the most recent higher ceiling because it
+   *  subsumes the older request. */
   private readonly _pendingTopUp = new Map<string, { newMaxAmount: bigint; deadline: number; reserveAuthSig: string }>();
 
   /** channelIds with an in-flight close() tx/estimate. Prevents duplicate close submissions. */

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -174,7 +174,10 @@ export class SellerRequestHandler {
           }
           let accepted = spm.getAcceptedCumulative(session.sessionId);
           const spent = spm.getCumulativeSpend(session.sessionId);
-          const reserveMax = spm.getReserveMax(session.sessionId);
+          // Use the effective ceiling (includes pending topUp that hasn't
+          // confirmed on-chain yet) so we don't prematurely declare the
+          // channel exhausted while a topUp is in progress.
+          const reserveMax = spm.getEffectiveReserveMax(session.sessionId);
           // If spend has caught up and there is no headroom left in the reserve,
           // stop serving before accepting any additional request cost.
           const isAtExactSpendLimit = spent > 0n && spent === accepted && reserveMax > 0n && accepted >= reserveMax;

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -30,6 +30,8 @@ export interface SellerRequestHandlerDeps {
 
 /** Debounce interval for metadata refresh after load changes. */
 const METADATA_REFRESH_DEBOUNCE_MS = 200;
+/** Time to wait for a catch-up SpendingAuth before returning 402. */
+const DEFAULT_CATCH_UP_WAIT_MS = 5_000;
 /**
  * Handles all seller-side request processing: provider matching, execution,
  * cost tracking, payment auth checks, and load management.
@@ -192,8 +194,7 @@ export class SellerRequestHandler {
             // operation this wait is a no-op; under pipelined requests (a new
             // request dispatched before the prior NeedAuth → SpendingAuth has
             // completed) it hides the round-trip latency from the buyer.
-            const CATCH_UP_WAIT_MS = 5_000;
-            const caughtUp = await spm.awaitAcceptedAtLeast(session.sessionId, spent, CATCH_UP_WAIT_MS);
+            const caughtUp = await spm.awaitAcceptedAtLeast(session.sessionId, spent, DEFAULT_CATCH_UP_WAIT_MS);
             accepted = spm.getAcceptedCumulative(session.sessionId);
             if (caughtUp && spent <= accepted) {
               debugLog(`[SellerHandler] Caught up before 402 for ${buyerPeerId.slice(0, 12)}... (spent=${spent} accepted=${accepted})`);

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -512,7 +512,7 @@ describe('BuyerPaymentManager', () => {
     expect(mux.sentSpendingAuths.length).toBeGreaterThanOrEqual(1);
   });
 
-  it('handleNeedAuth tops up reserve when the ceiling blocks the required amount', async () => {
+  it('handleNeedAuth sends spending auth before reserve top-up when the ceiling blocks the required amount', async () => {
     store.close();
     store = new ChannelStore(tempDir);
     manager = new BuyerPaymentManager(
@@ -525,8 +525,6 @@ describe('BuyerPaymentManager', () => {
     const sellerPeerId = fakePeerId('seller-needauth-topup');
     const channelId = await manager.authorizeSpending(sellerPeerId, mux, 100_000n, TEST_PRICING);
 
-    // Increase verified cost so the overdraft model can sign above the current ceiling
-    // once the reserve is topped up.
     manager.recordResponseBytes(sellerPeerId, SAMPLE_INPUT, SAMPLE_OUTPUT);
     mux.sentSpendingAuths.length = 0;
 
@@ -538,10 +536,12 @@ describe('BuyerPaymentManager', () => {
     }, mux);
 
     expect(mux.sentSpendingAuths.length).toBe(2);
-    const reserveTopUp = mux.sentSpendingAuths[0] as Record<string, unknown>;
-    const updatedBudget = mux.sentSpendingAuths[1] as Record<string, unknown>;
+    const updatedBudget = mux.sentSpendingAuths[0] as Record<string, unknown>;
+    const reserveTopUp = mux.sentSpendingAuths[1] as Record<string, unknown>;
+    expect(updatedBudget.cumulativeAmount).toBe('100000');
+    expect(updatedBudget.reserveMaxAmount).toBeUndefined();
+    expect(reserveTopUp.cumulativeAmount).toBe('100000');
     expect(reserveTopUp.reserveMaxAmount).toBe('200000');
-    expect(updatedBudget.cumulativeAmount).toBe('100001');
   });
 
   it('handleNeedAuth allows more after verified cost increases', async () => {
@@ -668,6 +668,43 @@ describe('BuyerPaymentManager', () => {
   });
 
   // ── Reserve top-up ─────────────────────────────────────────────
+
+  it('extendCurrentSpendingAuth sends spending auth before reserve top-up when extending past the current ceiling', async () => {
+    store.close();
+    store = new ChannelStore(tempDir);
+    manager = new BuyerPaymentManager(
+      identity,
+      makeConfig(tempDir, { maxReserveAmountUsdc: 100_000n, maxPerRequestUsdc: 100_000n }),
+      store,
+    );
+    manager.setSigner(Wallet.createRandom());
+    mux = createMockPaymentMux();
+
+    const sellerPeerId = fakePeerId('seller-extend-topup-order');
+    const channelId = await manager.authorizeSpending(sellerPeerId, mux, 100_000n, TEST_PRICING);
+    manager.handleAuthAck(sellerPeerId, { channelId });
+
+    const reserveOnlyCost = 100_000n - SAMPLE_ESTIMATE.cost;
+    await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requiredCumulativeAmount: reserveOnlyCost.toString(),
+      currentAcceptedCumulative: '0',
+      deposit: '1000000',
+      lastRequestCost: reserveOnlyCost.toString(),
+    }, mux);
+
+    manager.recordResponseBytes(sellerPeerId, SAMPLE_INPUT, SAMPLE_OUTPUT);
+    mux.sentSpendingAuths.length = 0;
+    await manager.extendCurrentSpendingAuth(sellerPeerId, 1n, mux, 100_001n);
+
+    expect(mux.sentSpendingAuths).toHaveLength(2);
+    const spendingFirst = mux.sentSpendingAuths[0] as Record<string, unknown>;
+    const reserveSecond = mux.sentSpendingAuths[1] as Record<string, unknown>;
+    expect(spendingFirst.cumulativeAmount).toBe('100000');
+    expect(spendingFirst.reserveMaxAmount).toBeUndefined();
+    expect(reserveSecond.cumulativeAmount).toBe('100000');
+    expect(reserveSecond.reserveMaxAmount).toBe('200000');
+  });
 
   it('topUpReserve sends new ReserveAuth with increased ceiling', async () => {
     const sellerPeerId = fakePeerId('seller-topup-rsv');

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -544,6 +544,49 @@ describe('BuyerPaymentManager', () => {
     expect(reserveTopUp.reserveMaxAmount).toBe('200000');
   });
 
+  it('handleNeedAuth still sends spending auth first for high-price models that exhaust a small per-request budget', async () => {
+    const expensivePricing = { inputUsdPerMillion: 10, outputUsdPerMillion: 100 };
+
+    store.close();
+    store = new ChannelStore(tempDir);
+    manager = new BuyerPaymentManager(
+      identity,
+      makeConfig(tempDir, { maxReserveAmountUsdc: 1_000_000n, maxPerRequestUsdc: 500_000n }),
+      store,
+    );
+    manager.setSigner(Wallet.createRandom());
+    mux = createMockPaymentMux();
+
+    const sellerPeerId = fakePeerId('seller-needauth-expensive-topup');
+    const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n, expensivePricing);
+
+    // Simulate a very expensive first response: verified cost jumps close to the
+    // reserve ceiling, and the seller asks for just above that ceiling. The buyer
+    // must still sign at the current ceiling first, then top up.
+    (manager as unknown as { _verifiedCost: Map<string, bigint> })._verifiedCost.set(sellerPeerId, 950_000n);
+    mux.sentSpendingAuths.length = 0;
+
+    await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requiredCumulativeAmount: '1100000',
+      currentAcceptedCumulative: '950000',
+      deposit: '1000000',
+      lastRequestCost: '950000',
+      inputTokens: '50000',
+      freshInputTokens: '50000',
+      outputTokens: '4500',
+      cachedInputTokens: '0',
+    }, mux);
+
+    expect(mux.sentSpendingAuths).toHaveLength(2);
+    const spendingFirst = mux.sentSpendingAuths[0] as Record<string, unknown>;
+    const reserveSecond = mux.sentSpendingAuths[1] as Record<string, unknown>;
+    expect(spendingFirst.cumulativeAmount).toBe('1000000');
+    expect(spendingFirst.reserveMaxAmount).toBeUndefined();
+    expect(reserveSecond.cumulativeAmount).toBe('1000000');
+    expect(reserveSecond.reserveMaxAmount).toBe('2000000');
+  });
+
   it('handleNeedAuth allows more after verified cost increases', async () => {
     const sellerPeerId = fakePeerId('seller-needauth-v');
     const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -587,6 +587,59 @@ describe('BuyerPaymentManager', () => {
     expect(reserveSecond.reserveMaxAmount).toBe('2000000');
   });
 
+  it('keeps expensive concurrent NeedAuth waves monotonic under multiple conversations on one channel', async () => {
+    const expensivePricing = { inputUsdPerMillion: 10, outputUsdPerMillion: 100 };
+
+    store.close();
+    store = new ChannelStore(tempDir);
+    manager = new BuyerPaymentManager(
+      identity,
+      makeConfig(tempDir, { maxReserveAmountUsdc: 1_000_000n, maxPerRequestUsdc: 500_000n }),
+      store,
+    );
+    manager.setSigner(Wallet.createRandom());
+    mux = createMockPaymentMux();
+
+    const sellerPeerId = fakePeerId('seller-concurrent-expensive-conversations');
+    const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n, expensivePricing);
+
+    (manager as unknown as { _verifiedCost: Map<string, bigint> })._verifiedCost.set(sellerPeerId, 950_000n);
+    mux.sentSpendingAuths.length = 0;
+
+    const payload = {
+      channelId,
+      requiredCumulativeAmount: '1100000',
+      currentAcceptedCumulative: '950000',
+      deposit: '1000000',
+      lastRequestCost: '950000',
+      inputTokens: '50000',
+      freshInputTokens: '50000',
+      outputTokens: '4500',
+      cachedInputTokens: '0',
+    } as const;
+
+    await Promise.all([
+      manager.handleNeedAuth(sellerPeerId, payload, mux),
+      manager.handleNeedAuth(sellerPeerId, payload, mux),
+      manager.handleNeedAuth(sellerPeerId, payload, mux),
+      manager.handleNeedAuth(sellerPeerId, payload, mux),
+      manager.handleNeedAuth(sellerPeerId, payload, mux),
+    ]);
+
+    const cumulatives = mux.sentSpendingAuths
+      .map((message) => message as Record<string, unknown>)
+      .map((message) => BigInt(message.cumulativeAmount as string));
+    const reserveRaises = mux.sentSpendingAuths
+      .map((message) => message as Record<string, unknown>)
+      .filter((message) => message.reserveMaxAmount != null)
+      .map((message) => BigInt(message.reserveMaxAmount as string));
+
+    expect(cumulatives.every((value) => value >= 1_000_000n)).toBe(true);
+    expect(reserveRaises.every((value) => value >= 2_000_000n)).toBe(true);
+    expect(manager.getCumulativeAmount(sellerPeerId)).toBe(1_000_000n);
+    expect(manager.getReserveCeiling(sellerPeerId)).toBeGreaterThanOrEqual(2_000_000n);
+  });
+
   it('handleNeedAuth allows more after verified cost increases', async () => {
     const sellerPeerId = fakePeerId('seller-needauth-v');
     const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -33,12 +33,27 @@ function makeProvider(inputUsdPerMillion: number, outputUsdPerMillion: number, o
   };
 }
 
+function makeSpmMock(overrides: Record<string, unknown> = {}): any {
+  return {
+    hasSession: () => true,
+    getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '1000000' }),
+    recordSpend: vi.fn(),
+    getCumulativeSpend: () => 0n,
+    getAcceptedCumulative: () => 0n,
+    getReserveMax: () => 1_000_000n,
+    getEffectiveReserveMax() {
+      return this.getReserveMax();
+    },
+    getPaymentRequirements: () => ({ minBudgetPerRequest: '10000', suggestedAmount: '1000000' }),
+    waitForPendingAuths: async () => {},
+    awaitAcceptedAtLeast: async () => false,
+    settleSession: vi.fn(async () => {}),
+    ...overrides,
+  };
+}
+
 describe('SellerRequestHandler payment pricing selection', () => {
   it('routes GET /v1/models to the local handler even when a query string is appended', async () => {
-    // Codex CLI calls `GET /v1/models?client_version=…` at startup. The
-    // local-models fast path used to compare `request.path === "/v1/models"`,
-    // which fails once a query string is present, so the request fell through
-    // to the model-matching branch and 400'd.
     const provider = makeProvider(1, 1, {
       name: 'openai',
       services: ['gpt-5.4', 'gpt-5.5'],
@@ -53,15 +68,8 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = {
-      send(frame: Uint8Array) {
-        sentFrames.push(frame);
-      },
-    } as any;
-    const paymentMux = {
-      sendNeedAuth: vi.fn(),
-      sendPaymentRequired: vi.fn(),
-    } as any;
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired: vi.fn() } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
     await mux.handleFrame({
@@ -100,11 +108,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = {
-      send(frame: Uint8Array) {
-        sentFrames.push(frame);
-      },
-    } as any;
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
     const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired: vi.fn() } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -160,28 +164,18 @@ describe('SellerRequestHandler payment pricing selection', () => {
         'content-type': 'application/json',
         'x-antseed-provider': 'openai',
       },
-      body: new TextEncoder().encode(JSON.stringify({
-        model: 'local-test',
-      })),
+      body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })),
     };
 
     const matched = handler.matchProvider(request);
-    const pricing = matched
-      ? handler.resolveProviderPricing(matched, request)
-      : undefined;
+    const pricing = matched ? handler.resolveProviderPricing(matched, request) : undefined;
 
     expect(matched?.name).toBe('openai');
-    expect(pricing).toEqual({
-      inputUsdPerMillion: 0.05,
-      outputUsdPerMillion: 0.1,
-    });
+    expect(pricing).toEqual({ inputUsdPerMillion: 0.05, outputUsdPerMillion: 0.1 });
   });
 
   it('does not add a paid auth headroom for zero-cost responses', async () => {
-    const provider = makeProvider(0, 0, {
-      name: 'free-tier',
-      services: ['local-test'],
-    });
+    const provider = makeProvider(0, 0, { name: 'free-tier', services: ['local-test'] });
     provider.handleRequest = vi.fn(async (req) => ({
       requestId: req.requestId,
       statusCode: 200,
@@ -198,16 +192,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     const sendNeedAuth = vi.fn();
     const handler = new SellerRequestHandler({
       providers: [provider],
-      sellerPaymentManager: {
-        hasSession: () => true,
-        getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '1000000' }),
-        recordSpend: vi.fn(),
-        getCumulativeSpend: () => 0n,
-        getAcceptedCumulative: () => 0n,
-        getReserveMax: () => 1_000_000n,
-        getPaymentRequirements: () => ({ minBudgetPerRequest: '0', suggestedAmount: '0' }),
-        waitForPendingAuths: async () => {},
-      } as any,
+      sellerPaymentManager: makeSpmMock({ getPaymentRequirements: () => ({ minBudgetPerRequest: '0', suggestedAmount: '0' }) }),
       sessionTracker: null,
       channelsClient: {} as any,
       announcer: null,
@@ -215,40 +200,15 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = {
-      send(frame: Uint8Array) {
-        sentFrames.push(frame);
-      },
-    } as any;
-    const paymentMux = {
-      sendNeedAuth,
-      sendPaymentRequired: vi.fn(),
-    } as any;
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth, sendPaymentRequired: vi.fn() } as any;
 
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
-
-    const request: SerializedHttpRequest = {
-      requestId: 'req-zero-cost',
-      method: 'POST',
-      path: '/v1/chat/completions',
-      headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })),
-    };
-
-    await mux.handleFrame({
-      type: MessageType.HttpRequest,
-      messageId: 1,
-      payload: encodeHttpRequest(request),
-    });
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-zero-cost', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })) }) });
 
     expect(sentFrames.length).toBeGreaterThan(0);
     expect(sendNeedAuth).toHaveBeenCalledOnce();
-    expect(sendNeedAuth).toHaveBeenCalledWith(expect.objectContaining({
-      requestId: request.requestId,
-      lastRequestCost: '0',
-      currentAcceptedCumulative: '0',
-      requiredCumulativeAmount: '0',
-    }));
+    expect(sendNeedAuth).toHaveBeenCalledWith(expect.objectContaining({ requestId: 'req-zero-cost', lastRequestCost: '0', currentAcceptedCumulative: '0', requiredCumulativeAmount: '0' }));
   });
 
   it('uses cumulative spend as NeedAuth required amount without double-counting the latest request', async () => {
@@ -256,45 +216,23 @@ describe('SellerRequestHandler payment pricing selection', () => {
       name: 'openai-responses',
       services: ['gpt-5.3-codex-spark'],
       servicePricing: {
-        'gpt-5.3-codex-spark': {
-          inputUsdPerMillion: 5,
-          outputUsdPerMillion: 30,
-          cachedInputUsdPerMillion: 1,
-        },
+        'gpt-5.3-codex-spark': { inputUsdPerMillion: 5, outputUsdPerMillion: 30, cachedInputUsdPerMillion: 1 },
       },
     });
     provider.handleRequest = vi.fn(async (req) => ({
       requestId: req.requestId,
       statusCode: 200,
       headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({
-        usage: {
-          prompt_tokens: 30426,
-          completion_tokens: 108,
-          prompt_tokens_details: { cached_tokens: 1920 },
-        },
-      })),
+      body: new TextEncoder().encode(JSON.stringify({ usage: { prompt_tokens: 30426, completion_tokens: 108, prompt_tokens_details: { cached_tokens: 1920 } } })),
     }));
 
     const costUsdc = 147_690n;
     let cumulativeSpend = 0n;
     const sendNeedAuth = vi.fn();
-    const recordSpend = vi.fn((_sessionId: string, cost: bigint) => {
-      cumulativeSpend += cost;
-    });
+    const recordSpend = vi.fn((_sessionId: string, cost: bigint) => { cumulativeSpend += cost; });
     const handler = new SellerRequestHandler({
       providers: [provider],
-      sellerPaymentManager: {
-        hasSession: () => true,
-        getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '1000000' }),
-        recordSpend,
-        getCumulativeSpend: () => cumulativeSpend,
-        getAcceptedCumulative: () => 0n,
-        getReserveMax: () => 1_000_000n,
-        getPaymentRequirements: () => ({ minBudgetPerRequest: '10000', suggestedAmount: '1000000' }),
-        waitForPendingAuths: async () => {},
-        awaitAcceptedAtLeast: async () => true,
-      } as any,
+      sellerPaymentManager: makeSpmMock({ recordSpend, getCumulativeSpend: () => cumulativeSpend, awaitAcceptedAtLeast: async () => true }),
       sessionTracker: null,
       channelsClient: {} as any,
       announcer: null,
@@ -302,44 +240,16 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = {
-      send(frame: Uint8Array) {
-        sentFrames.push(frame);
-      },
-    } as any;
-    const paymentMux = {
-      sendNeedAuth,
-      sendPaymentRequired: vi.fn(),
-    } as any;
-
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth, sendPaymentRequired: vi.fn() } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
-    const request: SerializedHttpRequest = {
-      requestId: 'req-codex-cost',
-      method: 'POST',
-      path: '/v1/responses',
-      headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({ model: 'gpt-5.3-codex-spark' })),
-    };
-
-    await mux.handleFrame({
-      type: MessageType.HttpRequest,
-      messageId: 1,
-      payload: encodeHttpRequest(request),
-    });
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-codex-cost', method: 'POST', path: '/v1/responses', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'gpt-5.3-codex-spark' })) }) });
 
     expect(sentFrames.length).toBeGreaterThan(0);
     expect(recordSpend).toHaveBeenCalledWith('session-1', costUsdc);
     expect(sendNeedAuth).toHaveBeenCalledOnce();
-    expect(sendNeedAuth).toHaveBeenCalledWith(expect.objectContaining({
-      requestId: request.requestId,
-      lastRequestCost: costUsdc.toString(),
-      requiredCumulativeAmount: costUsdc.toString(),
-      inputTokens: '30426',
-      cachedInputTokens: '1920',
-      freshInputTokens: '28506',
-      outputTokens: '108',
-    }));
+    expect(sendNeedAuth).toHaveBeenCalledWith(expect.objectContaining({ requestId: 'req-codex-cost', lastRequestCost: costUsdc.toString(), requiredCumulativeAmount: costUsdc.toString(), inputTokens: '30426', cachedInputTokens: '1920', freshInputTokens: '28506', outputTokens: '108' }));
   });
 
   it('keeps post-response NeedAuth below the reserve ceiling when cumulative spend is still covered', async () => {
@@ -347,24 +257,14 @@ describe('SellerRequestHandler payment pricing selection', () => {
       name: 'openai-responses',
       services: ['gpt-5.3-codex-spark'],
       servicePricing: {
-        'gpt-5.3-codex-spark': {
-          inputUsdPerMillion: 5,
-          outputUsdPerMillion: 30,
-          cachedInputUsdPerMillion: 1,
-        },
+        'gpt-5.3-codex-spark': { inputUsdPerMillion: 5, outputUsdPerMillion: 30, cachedInputUsdPerMillion: 1 },
       },
     });
     provider.handleRequest = vi.fn(async (req) => ({
       requestId: req.requestId,
       statusCode: 200,
       headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({
-        usage: {
-          prompt_tokens: 32048,
-          completion_tokens: 136,
-          prompt_tokens_details: { cached_tokens: 1920 },
-        },
-      })),
+      body: new TextEncoder().encode(JSON.stringify({ usage: { prompt_tokens: 32048, completion_tokens: 136, prompt_tokens_details: { cached_tokens: 1920 } } })),
     }));
 
     const existingSpend = 835_714n;
@@ -375,19 +275,15 @@ describe('SellerRequestHandler payment pricing selection', () => {
     const sendNeedAuth = vi.fn();
     const handler = new SellerRequestHandler({
       providers: [provider],
-      sellerPaymentManager: {
-        hasSession: () => true,
+      sellerPaymentManager: makeSpmMock({
         getChannelByPeer: () => ({ sessionId: 'session-1', authMax: reserveMax.toString() }),
-        recordSpend: vi.fn((_sessionId: string, cost: bigint) => {
-          cumulativeSpend += cost;
-        }),
+        recordSpend: vi.fn((_sessionId: string, cost: bigint) => { cumulativeSpend += cost; }),
         getCumulativeSpend: () => cumulativeSpend,
         getAcceptedCumulative: () => existingSpend + 1n,
         getReserveMax: () => reserveMax,
         getPaymentRequirements: () => ({ minBudgetPerRequest: '10000', suggestedAmount: reserveMax.toString() }),
-        waitForPendingAuths: async () => {},
         awaitAcceptedAtLeast: async () => true,
-      } as any,
+      }),
       sessionTracker: null,
       channelsClient: {} as any,
       announcer: null,
@@ -395,61 +291,26 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = {
-      send(frame: Uint8Array) {
-        sentFrames.push(frame);
-      },
-    } as any;
-    const paymentMux = {
-      sendNeedAuth,
-      sendPaymentRequired: vi.fn(),
-    } as any;
-
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth, sendPaymentRequired: vi.fn() } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
-    await mux.handleFrame({
-      type: MessageType.HttpRequest,
-      messageId: 1,
-      payload: encodeHttpRequest({
-        requestId: 'req-near-reserve',
-        method: 'POST',
-        path: '/v1/responses',
-        headers: { 'content-type': 'application/json' },
-        body: new TextEncoder().encode(JSON.stringify({ model: 'gpt-5.3-codex-spark' })),
-      }),
-    });
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-near-reserve', method: 'POST', path: '/v1/responses', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'gpt-5.3-codex-spark' })) }) });
 
     expect(cumulativeAfterRequest).toBeLessThan(reserveMax);
-    expect(sendNeedAuth).toHaveBeenCalledWith(expect.objectContaining({
-      lastRequestCost: costUsdc.toString(),
-      requiredCumulativeAmount: cumulativeAfterRequest.toString(),
-    }));
+    expect(sendNeedAuth).toHaveBeenCalledWith(expect.objectContaining({ lastRequestCost: costUsdc.toString(), requiredCumulativeAmount: cumulativeAfterRequest.toString() }));
     expect(BigInt(sendNeedAuth.mock.calls[0]![0].requiredCumulativeAmount)).toBeLessThanOrEqual(reserveMax);
   });
 
   it('skips the 402 / ReserveAuth handshake when the service is free', async () => {
-    const provider = makeProvider(0, 0, {
-      name: 'free-tier',
-      services: ['local-test'],
-    });
-    provider.handleRequest = vi.fn(async (req) => ({
-      requestId: req.requestId,
-      statusCode: 200,
-      headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({ ok: true })),
-    }));
+    const provider = makeProvider(0, 0, { name: 'free-tier', services: ['local-test'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
 
     const sendPaymentRequired = vi.fn();
     const sendNeedAuth = vi.fn();
     const handler = new SellerRequestHandler({
       providers: [provider],
-      // No active session — this is the "first request" condition that
-      // previously triggered 402 → ReserveAuth → on-chain reserve().
-      sellerPaymentManager: {
-        hasSession: () => false,
-        getChannelByPeer: () => undefined,
-        getPaymentRequirements: () => ({ minBudgetPerRequest: '0', suggestedAmount: '0' }),
-      } as any,
+      sellerPaymentManager: makeSpmMock({ hasSession: () => false, getChannelByPeer: () => undefined, getPaymentRequirements: () => ({ minBudgetPerRequest: '0', suggestedAmount: '0' }) }),
       sessionTracker: null,
       channelsClient: {} as any,
       announcer: null,
@@ -457,74 +318,30 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = {
-      send(frame: Uint8Array) {
-        sentFrames.push(frame);
-      },
-    } as any;
-    const paymentMux = {
-      sendNeedAuth,
-      sendPaymentRequired,
-    } as any;
-
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
-    const request: SerializedHttpRequest = {
-      requestId: 'req-free-service',
-      method: 'POST',
-      path: '/v1/chat/completions',
-      headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })),
-    };
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-free-service', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })) }) });
 
-    await mux.handleFrame({
-      type: MessageType.HttpRequest,
-      messageId: 1,
-      payload: encodeHttpRequest(request),
-    });
-
-    // Provider handled the request — not blocked by payment handshake.
     expect(provider.handleRequest).toHaveBeenCalledOnce();
-    // No 402, no PaymentRequired, no NeedAuth — free services bypass the
-    // channel handshake entirely so the seller never calls reserve().
     expect(sendPaymentRequired).not.toHaveBeenCalled();
     expect(sendNeedAuth).not.toHaveBeenCalled();
-
-    const responseFrames = sentFrames
-      .map((f) => decodeFrame(f))
-      .filter((d) => d?.message.type === MessageType.HttpResponse);
+    const responseFrames = sentFrames.map((f) => decodeFrame(f)).filter((d) => d?.message.type === MessageType.HttpResponse);
     expect(responseFrames).toHaveLength(1);
     const response = decodeHttpResponse(responseFrames[0]!.message.payload);
     expect(response.statusCode).toBe(200);
   });
 
   it('continues serving when delivered spend exactly matches the last accepted auth', async () => {
-    const provider = makeProvider(1, 1, {
-      name: 'paid-tier',
-      services: ['local-test'],
-    });
-    provider.handleRequest = vi.fn(async (req) => ({
-      requestId: req.requestId,
-      statusCode: 200,
-      headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({ ok: true })),
-    }));
+    const provider = makeProvider(1, 1, { name: 'paid-tier', services: ['local-test'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
 
     const sendPaymentRequired = vi.fn();
     const sendNeedAuth = vi.fn();
     const handler = new SellerRequestHandler({
       providers: [provider],
-      sellerPaymentManager: {
-        hasSession: () => true,
-        getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '1000000' }),
-        recordSpend: vi.fn(),
-        getCumulativeSpend: () => 2_184n,
-        getAcceptedCumulative: () => 2_184n,
-        getReserveMax: () => 1_000_000n,
-        getPaymentRequirements: () => ({ minBudgetPerRequest: '50000', suggestedAmount: '1000000' }),
-        waitForPendingAuths: async () => {},
-        awaitAcceptedAtLeast: async () => false,
-      } as any,
+      sellerPaymentManager: makeSpmMock({ getCumulativeSpend: () => 2_184n, getAcceptedCumulative: () => 2_184n }),
       sessionTracker: null,
       channelsClient: {} as any,
       announcer: null,
@@ -532,70 +349,30 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = {
-      send(frame: Uint8Array) {
-        sentFrames.push(frame);
-      },
-    } as any;
-    const paymentMux = {
-      sendNeedAuth,
-      sendPaymentRequired,
-    } as any;
-
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
-    await mux.handleFrame({
-      type: MessageType.HttpRequest,
-      messageId: 1,
-      payload: encodeHttpRequest({
-        requestId: 'req-exactly-covered',
-        method: 'POST',
-        path: '/v1/chat/completions',
-        headers: { 'content-type': 'application/json' },
-        body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })),
-      }),
-    });
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-exactly-covered', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })) }) });
 
     expect(provider.handleRequest).toHaveBeenCalledOnce();
     expect(sendPaymentRequired).not.toHaveBeenCalled();
     expect(sendNeedAuth).toHaveBeenCalledOnce();
-
-    const responseFrames = sentFrames
-      .map((f) => decodeFrame(f))
-      .filter((d) => d?.message.type === MessageType.HttpResponse);
+    const responseFrames = sentFrames.map((f) => decodeFrame(f)).filter((d) => d?.message.type === MessageType.HttpResponse);
     expect(responseFrames).toHaveLength(1);
     const response = decodeHttpResponse(responseFrames[0]!.message.payload);
     expect(response.statusCode).toBe(200);
   });
 
   it('stops serving when delivered spend is already at the reserve ceiling', async () => {
-    const provider = makeProvider(1, 1, {
-      name: 'paid-tier',
-      services: ['local-test'],
-    });
-    provider.handleRequest = vi.fn(async (req) => ({
-      requestId: req.requestId,
-      statusCode: 200,
-      headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({ ok: true })),
-    }));
+    const provider = makeProvider(1, 1, { name: 'paid-tier', services: ['local-test'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
 
     const settleSession = vi.fn(async () => {});
     const sendPaymentRequired = vi.fn();
     const handler = new SellerRequestHandler({
       providers: [provider],
-      sellerPaymentManager: {
-        hasSession: () => true,
-        getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '1000000' }),
-        recordSpend: vi.fn(),
-        getCumulativeSpend: () => 1_000_000n,
-        getAcceptedCumulative: () => 1_000_000n,
-        getReserveMax: () => 1_000_000n,
-        getPaymentRequirements: () => ({ minBudgetPerRequest: '50000', suggestedAmount: '1000000' }),
-        waitForPendingAuths: async () => {},
-        awaitAcceptedAtLeast: async () => false,
-        settleSession,
-      } as any,
+      sellerPaymentManager: makeSpmMock({ getCumulativeSpend: () => 1_000_000n, getAcceptedCumulative: () => 1_000_000n, settleSession }),
       sessionTracker: null,
       channelsClient: {} as any,
       announcer: null,
@@ -603,29 +380,11 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = {
-      send(frame: Uint8Array) {
-        sentFrames.push(frame);
-      },
-    } as any;
-    const paymentMux = {
-      sendNeedAuth: vi.fn(),
-      sendPaymentRequired,
-    } as any;
-
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
-    await mux.handleFrame({
-      type: MessageType.HttpRequest,
-      messageId: 1,
-      payload: encodeHttpRequest({
-        requestId: 'req-ceiling',
-        method: 'POST',
-        path: '/v1/chat/completions',
-        headers: { 'content-type': 'application/json' },
-        body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })),
-      }),
-    });
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-ceiling', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })) }) });
 
     expect(provider.handleRequest).not.toHaveBeenCalled();
     expect(sendPaymentRequired).toHaveBeenCalledOnce();
@@ -633,39 +392,17 @@ describe('SellerRequestHandler payment pricing selection', () => {
     const response = decodeHttpResponse(decodeFrame(sentFrames[0]!)!.message.payload);
     const body = JSON.parse(new TextDecoder().decode(response.body));
     expect(response.statusCode).toBe(402);
-    expect(body).toMatchObject({
-      code: PAYMENT_CODE_CHANNEL_EXHAUSTED,
-      requiredCumulativeAmount: '1000000',
-      reserveMaxAmount: '1000000',
-    });
+    expect(body).toMatchObject({ code: PAYMENT_CODE_CHANNEL_EXHAUSTED, requiredCumulativeAmount: '1000000', reserveMaxAmount: '1000000' });
   });
 
   it('stops serving once delivered spend is ahead of the last accepted auth', async () => {
-    const provider = makeProvider(1, 1, {
-      name: 'paid-tier',
-      services: ['local-test'],
-    });
-    provider.handleRequest = vi.fn(async (req) => ({
-      requestId: req.requestId,
-      statusCode: 200,
-      headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({ ok: true })),
-    }));
+    const provider = makeProvider(1, 1, { name: 'paid-tier', services: ['local-test'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
 
     const sendPaymentRequired = vi.fn();
     const handler = new SellerRequestHandler({
       providers: [provider],
-      sellerPaymentManager: {
-        hasSession: () => true,
-        getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '1000000' }),
-        recordSpend: vi.fn(),
-        getCumulativeSpend: () => 2_184n,
-        getAcceptedCumulative: () => 0n,
-        getReserveMax: () => 1_000_000n,
-        getPaymentRequirements: () => ({ minBudgetPerRequest: '50000', suggestedAmount: '1000000' }),
-        waitForPendingAuths: async () => {},
-        awaitAcceptedAtLeast: async () => false,
-      } as any,
+      sellerPaymentManager: makeSpmMock({ getCumulativeSpend: () => 2_184n, getAcceptedCumulative: () => 0n }),
       sessionTracker: null,
       channelsClient: {} as any,
       announcer: null,
@@ -673,36 +410,15 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = {
-      send(frame: Uint8Array) {
-        sentFrames.push(frame);
-      },
-    } as any;
-    const paymentMux = {
-      sendNeedAuth: vi.fn(),
-      sendPaymentRequired,
-    } as any;
-
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
-    const request: SerializedHttpRequest = {
-      requestId: 'req-exhausted-budget',
-      method: 'POST',
-      path: '/v1/chat/completions',
-      headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })),
-    };
-
-    await mux.handleFrame({
-      type: MessageType.HttpRequest,
-      messageId: 1,
-      payload: encodeHttpRequest(request),
-    });
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-exhausted-budget', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })) }) });
 
     expect(provider.handleRequest).not.toHaveBeenCalled();
     expect(sendPaymentRequired).toHaveBeenCalledOnce();
     expect(sentFrames).toHaveLength(1);
-
     const decoded = decodeFrame(sentFrames[0]!);
     expect(decoded?.message.type).toBe(MessageType.HttpResponse);
     const response = decodeHttpResponse(decoded!.message.payload);
@@ -710,34 +426,20 @@ describe('SellerRequestHandler payment pricing selection', () => {
   });
 
   it('closes and flags the channel when unsigned delivered spend exceeds the reserve ceiling', async () => {
-    const provider = makeProvider(1, 1, {
-      name: 'paid-tier',
-      services: ['local-test'],
-    });
-    provider.handleRequest = vi.fn(async (req) => ({
-      requestId: req.requestId,
-      statusCode: 200,
-      headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({ ok: true })),
-    }));
+    const provider = makeProvider(1, 1, { name: 'paid-tier', services: ['local-test'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
 
     const sendPaymentRequired = vi.fn();
     const sendNeedAuth = vi.fn();
     const settleSession = vi.fn(async () => {});
     const handler = new SellerRequestHandler({
       providers: [provider],
-      sellerPaymentManager: {
-        hasSession: () => true,
+      sellerPaymentManager: makeSpmMock({
         getChannelByPeer: () => ({ sessionId: 'session-1', authMax: '950001' }),
-        recordSpend: vi.fn(),
         getCumulativeSpend: () => 1_000_001n,
         getAcceptedCumulative: () => 950_001n,
-        getReserveMax: () => 1_000_000n,
-        getPaymentRequirements: () => ({ minBudgetPerRequest: '50000', suggestedAmount: '1000000' }),
-        waitForPendingAuths: async () => {},
-        awaitAcceptedAtLeast: async () => false,
         settleSession,
-      } as any,
+      }),
       sessionTracker: null,
       channelsClient: {} as any,
       announcer: null,
@@ -745,53 +447,57 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = {
-      send(frame: Uint8Array) {
-        sentFrames.push(frame);
-      },
-    } as any;
-    const paymentMux = {
-      sendNeedAuth,
-      sendPaymentRequired,
-    } as any;
-
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
-    const request: SerializedHttpRequest = {
-      requestId: 'req-near-ceiling',
-      method: 'POST',
-      path: '/v1/chat/completions',
-      headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })),
-    };
-
-    await mux.handleFrame({
-      type: MessageType.HttpRequest,
-      messageId: 1,
-      payload: encodeHttpRequest(request),
-    });
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-near-ceiling', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })) }) });
 
     expect(provider.handleRequest).not.toHaveBeenCalled();
     expect(sendNeedAuth).not.toHaveBeenCalled();
     expect(settleSession).toHaveBeenCalledOnce();
     expect(settleSession.mock.calls[0]?.[0]).toBe('b'.repeat(40));
     expect(settleSession.mock.calls[0]?.[1]?.settleOnly).not.toBe(true);
-
-    expect(sendPaymentRequired).toHaveBeenCalledWith(expect.objectContaining({
-      code: PAYMENT_CODE_CHANNEL_EXHAUSTED,
-      requiredCumulativeAmount: '1000001',
-      reserveMaxAmount: '1000000',
-    }));
-
+    expect(sendPaymentRequired).toHaveBeenCalledWith(expect.objectContaining({ code: PAYMENT_CODE_CHANNEL_EXHAUSTED, requiredCumulativeAmount: '1000001', reserveMaxAmount: '1000000' }));
     const decoded = decodeFrame(sentFrames[0]!);
     expect(decoded?.message.type).toBe(MessageType.HttpResponse);
     const response = decodeHttpResponse(decoded!.message.payload);
     expect(response.statusCode).toBe(402);
     const body = JSON.parse(new TextDecoder().decode(response.body));
-    expect(body).toMatchObject({
-      code: PAYMENT_CODE_CHANNEL_EXHAUSTED,
-      requiredCumulativeAmount: '1000001',
-      reserveMaxAmount: '1000000',
+    expect(body).toMatchObject({ code: PAYMENT_CODE_CHANNEL_EXHAUSTED, requiredCumulativeAmount: '1000001', reserveMaxAmount: '1000000' });
+  });
+
+  it('continues serving when spend reached the on-chain ceiling but a higher topUp is pending', async () => {
+    const provider = makeProvider(1, 1, { name: 'paid-tier', services: ['local-test'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
+
+    const sendPaymentRequired = vi.fn();
+    const sendNeedAuth = vi.fn();
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: makeSpmMock({
+        getCumulativeSpend: () => 1_000_000n,
+        getAcceptedCumulative: () => 1_000_000n,
+        getReserveMax: () => 1_000_000n,
+        getEffectiveReserveMax: () => 2_000_000n,
+      }),
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
     });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-pending-topup', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })) }) });
+
+    expect(provider.handleRequest).toHaveBeenCalledOnce();
+    expect(sendPaymentRequired).not.toHaveBeenCalled();
+    expect(sendNeedAuth).toHaveBeenCalledOnce();
+    const response = decodeHttpResponse(decodeFrame(sentFrames[0]!)!.message.payload);
+    expect(response.statusCode).toBe(200);
   });
 });

--- a/packages/node/tests/seller-close-requested.test.ts
+++ b/packages/node/tests/seller-close-requested.test.ts
@@ -211,6 +211,27 @@ describe('SellerPaymentManager — CloseRequested handling', () => {
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
   });
 
+  it('drops pending top-up state after CloseRequested cleanup', async () => {
+    const channelId = makeChannelId(4);
+    await setupActiveChannel(manager, buyerIdentity, mux, channelId, 900_000n, 900_000n);
+
+    vi.spyOn(manager.channelsClient, 'topUp').mockRejectedValue(new Error('TopUpThresholdNotMet'));
+
+    const topUp = await buildSpendingAuth(buyerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '20000000',
+      salt: '0x' + '09'.repeat(32),
+    });
+    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp, mux)).toBe('accepted');
+    expect(manager.hasPendingTopUp(channelId)).toBe(true);
+
+    await manager.handleCloseRequested(channelId);
+
+    expect(manager.hasPendingTopUp(channelId)).toBe(false);
+    expect(manager.getEffectiveReserveMax(channelId)).toBe(0n);
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
+  });
+
   it('ignores CloseRequested for unknown channels', async () => {
     const unknownChannelId = makeChannelId(99);
 

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -193,15 +193,12 @@ describe('SellerPaymentManager', () => {
   it('waitForPendingAuths drains queued SpendingAuths while an on-chain top-up is in flight', async () => {
     const channelId = makeChannelId(99);
 
-    // Initial reserve with ceiling 1_000_000.
     const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
       isReserve: true,
       reserveMaxAmount: '1000000',
     });
     await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
 
-    // Advance cumulative to 900_000 and record matching spend so the channel is
-    // right at the edge of budget exhaustion.
     const auth900k = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
       cumulativeAmount: 900_000n,
       reserveMaxAmount: '1000000',
@@ -211,8 +208,6 @@ describe('SellerPaymentManager', () => {
     expect(manager.getAcceptedCumulative(channelId)).toBe(900_000n);
     expect(manager.getCumulativeSpend(channelId)).toBe(900_000n);
 
-    // Make topUp() block until we release it so we can observe the window
-    // where the per-buyer mutex holds queued SpendingAuths.
     let releaseTopUp!: () => void;
     const topUpBlocker = new Promise<void>((resolve) => { releaseTopUp = resolve; });
     const topUpSpy = vi.spyOn(manager.channelsClient, 'topUp').mockImplementation(async () => {
@@ -220,7 +215,6 @@ describe('SellerPaymentManager', () => {
       return '0xtopup-hash';
     });
 
-    // Top-up auth (new ceiling 2_000_000) — this fires the blocking topUp() call.
     const topUpPayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
       isReserve: true,
       reserveMaxAmount: '2000000',
@@ -228,13 +222,10 @@ describe('SellerPaymentManager', () => {
     });
     const topUpPromise = manager.handleSpendingAuth(buyerIdentity.peerId, topUpPayload, mux);
 
-    // Wait until the handler is parked inside the topUp() call.
     while (topUpSpy.mock.calls.length === 0) {
       await new Promise<void>((r) => setImmediate(r));
     }
 
-    // Queue a follow-up SpendingAuth above the old ceiling. This should sit
-    // behind the top-up in the per-buyer mutex until the top-up unblocks.
     const followUpPayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
       cumulativeAmount: 1_500_000n,
       reserveMaxAmount: '2000000',
@@ -242,11 +233,8 @@ describe('SellerPaymentManager', () => {
     const followUpPromise = manager.handleSpendingAuth(buyerIdentity.peerId, followUpPayload, mux);
     await new Promise<void>((r) => setImmediate(r));
 
-    // The follow-up is queued — accepted cumulative is still stale at 900_000,
-    // which is the racing state where a request handler would return 402.
     expect(manager.getAcceptedCumulative(channelId)).toBe(900_000n);
 
-    // waitForPendingAuths must not resolve while the top-up is still in flight.
     let waitResolved = false;
     const waitPromise = manager
       .waitForPendingAuths(buyerIdentity.peerId)
@@ -254,14 +242,91 @@ describe('SellerPaymentManager', () => {
     await new Promise<void>((r) => setImmediate(r));
     expect(waitResolved).toBe(false);
 
-    // Release the top-up. The queued follow-up now applies and waitForPendingAuths resolves.
     releaseTopUp();
     await Promise.all([topUpPromise, followUpPromise, waitPromise]);
 
     expect(waitResolved).toBe(true);
     expect(manager.getAcceptedCumulative(channelId)).toBe(1_500_000n);
-    // A budget check after draining sees the advanced cumulative — no bogus 402.
     expect(manager.getCumulativeSpend(channelId) >= manager.getAcceptedCumulative(channelId)).toBe(false);
+  });
+
+  it('tracks the largest pending top-up ceiling while retries are deferred', async () => {
+    const channelId = makeChannelId(100);
+
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    const auth900k = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 900_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, auth900k, mux);
+    manager.recordSpend(channelId, 900_000n);
+
+    const topUpSpy = vi.spyOn(manager.channelsClient, 'topUp')
+      .mockRejectedValue(new Error('TopUpThresholdNotMet'));
+
+    const topUp2m = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '2000000',
+      salt: '0x' + '02'.repeat(32),
+    });
+    const topUp3m = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '3000000',
+      salt: '0x' + '03'.repeat(32),
+    });
+
+    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp2m, mux)).toBe('accepted');
+    expect(manager.hasPendingTopUp(channelId)).toBe(true);
+    expect(manager.getEffectiveReserveMax(channelId)).toBe(2_000_000n);
+
+    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp3m, mux)).toBe('accepted');
+    expect(manager.hasPendingTopUp(channelId)).toBe(true);
+    expect(manager.getEffectiveReserveMax(channelId)).toBe(3_000_000n);
+    expect(manager.getReserveMax(channelId)).toBe(1_000_000n);
+    expect(topUpSpy).toHaveBeenCalledTimes(2);
+    expect(topUpSpy.mock.calls[1]?.[5]).toBe(3_000_000n);
+  });
+
+  it('serializes a burst of concurrent SpendingAuth updates and ends at the latest cumulative amount', async () => {
+    const channelId = makeChannelId(101);
+
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '3000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    const cumulatives = [
+      1_100_000n,
+      1_200_000n,
+      1_300_000n,
+      1_400_000n,
+      1_500_000n,
+      1_600_000n,
+      1_700_000n,
+      1_800_000n,
+      1_900_000n,
+      2_000_000n,
+    ];
+
+    const payloads = await Promise.all(cumulatives.map((amount) =>
+      buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+        cumulativeAmount: amount,
+        reserveMaxAmount: '3000000',
+      })
+    ));
+
+    const results = await Promise.all(payloads.map((payload) =>
+      manager.handleSpendingAuth(buyerIdentity.peerId, payload, mux)
+    ));
+
+    expect(results.every((result) => result === 'accepted')).toBe(true);
+    expect(manager.getAcceptedCumulative(channelId)).toBe(2_000_000n);
   });
 
   it('recovers an active on-chain channel when local seller session is missing', async () => {

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -329,6 +329,43 @@ describe('SellerPaymentManager', () => {
     expect(manager.getAcceptedCumulative(channelId)).toBe(2_000_000n);
   });
 
+  it('validateAndAcceptAuth respects a pending top-up ceiling before the on-chain reserve max is updated', async () => {
+    const channelId = makeChannelId(102);
+
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    const auth900k = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 900_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, auth900k, mux);
+    manager.recordSpend(channelId, 900_000n);
+
+    vi.spyOn(manager.channelsClient, 'topUp').mockRejectedValue(new Error('TopUpThresholdNotMet'));
+
+    const topUp2m = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '2000000',
+      salt: '0x' + '04'.repeat(32),
+    });
+    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp2m, mux)).toBe('accepted');
+    expect(manager.hasPendingTopUp(channelId)).toBe(true);
+    expect(manager.getReserveMax(channelId)).toBe(1_000_000n);
+    expect(manager.getEffectiveReserveMax(channelId)).toBe(2_000_000n);
+
+    const followUp = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 1_500_000n,
+      reserveMaxAmount: '2000000',
+    });
+
+    expect(await manager.validateAndAcceptAuth(buyerIdentity.peerId, followUp)).toBe(true);
+    expect(manager.getAcceptedCumulative(channelId)).toBe(1_500_000n);
+  });
+
   it('recovers an active on-chain channel when local seller session is missing', async () => {
     const channelId = makeChannelId(21);
     vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue({


### PR DESCRIPTION
## Problem

Channels are being prematurely closed and undercharging buyers due to an on-chain `topUp()` race condition.

### Root Cause

The smart contract's `topUp()` requires **85% of the current deposit to be settled** before allowing a top-up (`TopUpThresholdNotMet` error `0x1ea4506b`). The buyer was sending the topUp ReserveAuth **before** the SpendingAuth that would bring the seller's accepted cumulative high enough to meet this threshold.

### Failure Sequence (from logs)

1. Seller sends NeedAuth with `required=1,081,743` (exceeds ceiling of 1,000,000)
2. Buyer sends topUp ReserveAuth first (ceiling 1M → 2M)
3. Buyer sends SpendingAuth for 1,081,743 second
4. Seller processes topUp → calls `topUp()` on-chain with `settleAmount=734,455`
5. **Contract reverts**: `734,455 < 850,000` (85% of 1M) → `TopUpThresholdNotMet`
6. SpendingAuth for 1,081,743 rejected (exceeds unchanged `reserveMax=1,000,000`)
7. Channel declared exhausted → closed at 734,455 instead of actual spend of 1,081,743

## Fix

### Buyer side (`buyer-payment-manager.ts`)
- **Send SpendingAuth BEFORE topUp**: In `handleNeedAuth` and `extendCurrentSpendingAuth`, sign at the current ceiling first (giving seller enough to settle), then send topUp ReserveAuth
- **Lower proactive threshold**: 85% → 65% to trigger topUp earlier with deferred retry as safety net

### Seller side (`seller-payment-manager.ts`)
- **Graceful topUp failure**: When on-chain `topUp()` fails, defer it instead of crashing the flow; retry after the next SpendingAuth raises the settle amount
- **Pending topUp awareness**: Accept SpendingAuths within the pending topUp ceiling (not just current on-chain ceiling)

### Request handler (`seller-request-handler.ts`)
- Use `getEffectiveReserveMax()` (includes pending topUp) when checking exhaustion to prevent premature channel closure while topUp is being retried