### PR TITLE
fix(payments): close zombie channels

### DIFF
--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -74,8 +74,15 @@ export class SellerPaymentManager {
     /** On-chain seller address: proxy when behind a facade, wallet otherwise. */
     seller: string;
   }> | null = null;
-  /** In-memory cache of active buyer peerIds for fast has-session checks. */
+  /**
+   * In-memory cache of buyer peerIds with an active payment session. Hydrated
+   * sessions are included for existing hasSession() semantics; `_hydratedChannelIds`
+   * lets timeout cleanup distinguish restart-only zero-auth zombies.
+   */
   private readonly _activeBuyers = new Set<string>();
+
+  /** Channels restored from disk before the buyer has proven it reconnected. */
+  private readonly _hydratedChannelIds = new Set<string>();
   /** Per-buyer mutex to prevent concurrent handleSpendingAuth for the same buyer. */
   private readonly _buyerLocks = new Map<string, Promise<void>>();
 
@@ -148,6 +155,7 @@ export class SellerPaymentManager {
     const activeChannels = this._channelStore.getActiveChannels('seller');
     for (const channel of activeChannels) {
       this._activeBuyers.add(channel.peerId);
+      this._hydratedChannelIds.add(channel.sessionId);
       this._acceptedCumulative.set(channel.sessionId, BigInt(channel.authMax));
       this._spent.set(channel.sessionId, BigInt(channel.tokensDelivered));
       // Hydrate reserveMax from previousConsumption (repurposed field)
@@ -231,6 +239,7 @@ export class SellerPaymentManager {
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
     this._closingChannels.delete(channelId);
+    this._hydratedChannelIds.delete(channelId);
     this._reserveMax.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
     this._releaseAcceptedWaiters(channelId);
@@ -488,6 +497,7 @@ export class SellerPaymentManager {
         );
 
         // Update tracking
+        this._hydratedChannelIds.delete(channelId);
         this._reserveMax.set(channelId, newMaxAmount);
         const session = this._channelStore.getChannel(channelId);
         if (session) {
@@ -547,6 +557,7 @@ export class SellerPaymentManager {
         }
 
         // Update tracking
+        this._hydratedChannelIds.delete(channelId);
         this._acceptedCumulative.set(channelId, cumulativeAmount);
         this._latestAuth.set(channelId, {
           spendingAuthSig: payload.spendingAuthSig,
@@ -663,6 +674,7 @@ export class SellerPaymentManager {
     latestAuth: LatestAuth,
   ): void {
     this._channelStore.upsertChannel(session);
+    this._hydratedChannelIds.delete(session.sessionId);
     this._acceptedCumulative.set(session.sessionId, cumulativeAmount);
     this._reserveMax.set(session.sessionId, reserveMaxAmount);
     this._spent.set(session.sessionId, spent);
@@ -721,6 +733,8 @@ export class SellerPaymentManager {
       debugWarn(`[SellerPayment] validateAndAcceptAuth: cumulative decreased from ${existingCumulative} to ${newCumulative}`);
       return false;
     }
+
+    this._hydratedChannelIds.delete(channelId);
 
     // Update if strictly greater
     if (newCumulative > existingCumulative) {
@@ -889,6 +903,7 @@ export class SellerPaymentManager {
     this._closeRetryCount.delete(channelId);
     this._closingChannels.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
+    this._hydratedChannelIds.delete(channelId);
     this._releaseAcceptedWaiters(channelId);
     this._activeBuyers.delete(buyerPeerId);
   }
@@ -947,8 +962,13 @@ export class SellerPaymentManager {
           continue;
         }
 
+        const buyerDisconnected = !this._activeBuyers.has(channel.peerId);
+        const hydratedZeroAuthExpired = accepted === 0n
+          && this._hydratedChannelIds.has(channel.sessionId)
+          && nowSecs > channel.deadline;
+
         // If we have auths and the buyer is disconnected, try to close
-        if (accepted > 0n && !this._activeBuyers.has(channel.peerId)) {
+        if (accepted > 0n && buyerDisconnected) {
           debugLog(`[SellerPayment] Channel ${channel.sessionId.slice(0, 18)}... buyer disconnected — attempting close`);
           await this.settleSession(channel.peerId);
           continue;
@@ -957,8 +977,10 @@ export class SellerPaymentManager {
         // on-chain settled amount. The contract skips signature verification
         // when finalAmount == settled, so this safely cleans up zombie
         // channels without claiming any unproven spend.
-        if (accepted === 0n && !this._activeBuyers.has(channel.peerId) && nowSecs > channel.deadline) {
+        if (accepted === 0n && (buyerDisconnected || hydratedZeroAuthExpired) && nowSecs > channel.deadline) {
           if (onChainState.status !== 'active') {
+            // 'unknown' means the RPC returned partial data. Evict locally
+            // rather than risking a close() against an ambiguous channel.
             this._evictStaleChannel(channel.sessionId, channel.peerId, 'no auths, past deadline, on-chain status unknown', 'timeout');
             continue;
           }
@@ -1097,6 +1119,7 @@ export class SellerPaymentManager {
     this._closingChannels.delete(channelId);
     this._reserveMax.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
+    this._hydratedChannelIds.delete(channelId);
     this._releaseAcceptedWaiters(channelId);
 
     // Find and remove buyer from active set

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -438,10 +438,10 @@ export class SellerPaymentManager {
           reserveMaxAmount,
           0n,
           {
-          spendingAuthSig: '',
-          cumulativeAmount: 0n,
-          metadataHash: payload.metadataHash,
-          metadata: payload.metadata,
+            spendingAuthSig: '',
+            cumulativeAmount: 0n,
+            metadataHash: payload.metadataHash,
+            metadata: payload.metadata,
           },
         );
 
@@ -922,10 +922,12 @@ export class SellerPaymentManager {
 
   /**
    * Check for stale sessions and attempt to close them.
-   * The seller can only close() with a valid SpendingAuth — it cannot
-   * requestClose or withdraw (those are buyer-only on-chain).
-   * If the seller has no auths, the session remains open until the buyer
-   * calls requestClose → withdraw on-chain.
+   * - Channels with a buyer SpendingAuth go through `settleSession()`.
+   * - Zombie channels (buyer gone, no auth, deadline elapsed) can be closed
+   *   on-chain with `finalAmount == channel.settled`, which intentionally
+   *   skips SpendingAuth verification and lets the seller release the lock,
+   *   decrement activeChannelCount, and advance channel stats without buyer
+   *   cooperation.
    * Called periodically and on startup for recovery.
    */
   async checkTimeouts(): Promise<void> {
@@ -949,16 +951,55 @@ export class SellerPaymentManager {
         if (accepted > 0n && !this._activeBuyers.has(channel.peerId)) {
           debugLog(`[SellerPayment] Channel ${channel.sessionId.slice(0, 18)}... buyer disconnected — attempting close`);
           await this.settleSession(channel.peerId);
+          continue;
         }
-        // If no auths and buyer disconnected, nothing the seller can do on-chain.
-        // The buyer must call requestClose → withdraw. We just clean up locally
-        // after a reasonable period (e.g. deadline passed).
+        // No auths, buyer gone, deadline elapsed: close with the current
+        // on-chain settled amount. The contract skips signature verification
+        // when finalAmount == settled, so this safely cleans up zombie
+        // channels without claiming any unproven spend.
         if (accepted === 0n && !this._activeBuyers.has(channel.peerId) && nowSecs > channel.deadline) {
-          this._evictStaleChannel(channel.sessionId, channel.peerId, 'no auths, past deadline', 'timeout');
+          if (onChainState.status !== 'active') {
+            this._evictStaleChannel(channel.sessionId, channel.peerId, 'no auths, past deadline, on-chain status unknown', 'timeout');
+            continue;
+          }
+          await this._closeWithoutAuth(channel.sessionId, channel.peerId, onChainState.channel.settled);
         }
       } catch (err) {
         debugWarn(`[SellerPayment] Failed to process channel ${channel.sessionId.slice(0, 18)}...: ${err instanceof Error ? err.message : err}`);
       }
+    }
+  }
+
+  /**
+   * Close a zombie channel (buyer gone, no signed auth) using the current
+   * on-chain settled cumulative as finalAmount. This intentionally settles no
+   * additional spend, but still marks the channel closed and releases the
+   * remaining reserved deposit back to the buyer.
+   */
+  private async _closeWithoutAuth(channelId: string, peerId: string, onChainSettled: bigint): Promise<void> {
+    if (this._closingChannels.has(channelId)) {
+      debugLog(`[SellerPayment] Close already in flight for ${channelId.slice(0, 18)}... — skipping zombie close`);
+      return;
+    }
+
+    const retries = this._closeRetryCount.get(channelId) ?? 0;
+    if (retries >= SellerPaymentManager.MAX_CLOSE_RETRIES) {
+      debugWarn(`[SellerPayment] Zombie close failed ${retries} times for ${channelId.slice(0, 18)}... — falling back to local eviction`);
+      this._evictStaleChannel(channelId, peerId, 'no auths, past deadline, close retries exhausted', 'timeout');
+      return;
+    }
+
+    this._closingChannels.add(channelId);
+    debugLog(`[SellerPayment] Closing zombie channel ${channelId.slice(0, 18)}... finalAmount=${onChainSettled} (attempt ${retries + 1}/${SellerPaymentManager.MAX_CLOSE_RETRIES})`);
+    try {
+      await this._channelsClient.close(this._signer, channelId, onChainSettled, '0x', '0x');
+      this._closeRetryCount.delete(channelId);
+      this._evictStaleChannel(channelId, peerId, 'zombie closed on-chain', 'settled');
+    } catch (err) {
+      this._closeRetryCount.set(channelId, retries + 1);
+      debugWarn(`[SellerPayment] Zombie close failed (attempt ${retries + 1}): ${err instanceof Error ? err.message : err}`);
+    } finally {
+      this._closingChannels.delete(channelId);
     }
   }
 

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -248,6 +248,37 @@ export class SellerPaymentManager {
   }
 
   /**
+   * Restore a persisted SpendingAuth after in-memory cleanup. This prevents the
+   * timeout checker from mistaking an active channel with a durable signed auth
+   * for a zero-auth zombie and closing it at the already-settled amount.
+   */
+  private _restorePersistedSpendingAuth(channel: StoredChannel): bigint | null {
+    const persistedCumulative = BigInt(channel.authMax || '0');
+    if (persistedCumulative <= 0n || !channel.latestSpendingAuthSig) {
+      return null;
+    }
+
+    this._acceptedCumulative.set(channel.sessionId, persistedCumulative);
+    this._latestAuth.set(channel.sessionId, {
+      spendingAuthSig: channel.latestSpendingAuthSig,
+      cumulativeAmount: persistedCumulative,
+      metadataHash: '',
+      metadata: channel.latestMetadata ?? '',
+    });
+    this._spent.set(channel.sessionId, BigInt(channel.tokensDelivered || '0'));
+
+    const storedReserveMax = BigInt(channel.previousConsumption || '0');
+    if (storedReserveMax > 0n) {
+      this._reserveMax.set(channel.sessionId, storedReserveMax);
+    }
+
+    this._hydratedChannelIds.delete(channel.sessionId);
+    this._notifyAcceptedUpdate(channel.sessionId, persistedCumulative);
+    debugLog(`[SellerPayment] Restored persisted SpendingAuth for ${channel.sessionId.slice(0, 18)}... cumulative=${persistedCumulative}`);
+    return persistedCumulative;
+  }
+
+  /**
    * Block until `acceptedCumulative(channelId)` reaches `target`, or `timeoutMs`
    * elapses. Returns true if the target was reached, false on timeout. Used by
    * the request handler to wait out the buyer's NeedAuth → SpendingAuth round
@@ -950,7 +981,10 @@ export class SellerPaymentManager {
     const activeChannels = this._channelStore.getActiveChannels('seller');
 
     for (const channel of activeChannels) {
-      const accepted = this._acceptedCumulative.get(channel.sessionId) ?? 0n;
+      let accepted = this._acceptedCumulative.get(channel.sessionId) ?? 0n;
+      if (accepted === 0n) {
+        accepted = this._restorePersistedSpendingAuth(channel) ?? accepted;
+      }
 
       try {
         // Validate on-chain state — evict if channel no longer exists

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -580,6 +580,130 @@ describe('SellerPaymentManager', () => {
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
   });
 
+  it('checkTimeouts closes hydrated zombie channels after restart', async () => {
+    const channelId = makeChannelId(71);
+    const reserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+      deadline: Math.floor(Date.now() / 1000) - 1,
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reserve, mux);
+
+    const restarted = new SellerPaymentManager(sellerIdentity, {
+      rpcUrl: 'http://127.0.0.1:8545',
+      channelsContractAddress: CONTRACT_ADDR,
+      chainId: CHAIN_ID,
+      dataDir: tempDir,
+    }, store);
+    vi.spyOn(restarted.channelsClient, 'getSession').mockResolvedValue(
+      makeOnChainChannel(buyerIdentity, sellerIdentity, {
+        deposit: 1_000_000n,
+        settled: 0n,
+        status: 1,
+      }),
+    );
+    vi.spyOn(restarted.channelsClient, 'close').mockResolvedValue('0xclose-hash');
+
+    expect(restarted.hasSession(buyerIdentity.peerId)).toBe(true);
+
+    await restarted.checkTimeouts();
+
+    expect(restarted.channelsClient.close).toHaveBeenCalledOnce();
+    const closeArgs = (restarted.channelsClient.close as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(closeArgs[1]).toBe(channelId);
+    expect(closeArgs[2]).toBe(0n);
+    expect(store.getChannel(channelId)!.status).toBe('settled');
+    expect(restarted.hasSession(buyerIdentity.peerId)).toBe(false);
+  });
+
+  it('checkTimeouts retries zombie close failures without local eviction', async () => {
+    const channelId = makeChannelId(72);
+    const reserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+      deadline: Math.floor(Date.now() / 1000) - 1,
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reserve, mux);
+    manager.onBuyerDisconnect(buyerIdentity.peerId);
+
+    vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(
+      makeOnChainChannel(buyerIdentity, sellerIdentity, {
+        deposit: 1_000_000n,
+        settled: 0n,
+        status: 1,
+      }),
+    );
+    vi.spyOn(manager.channelsClient, 'close').mockRejectedValue(new Error('estimate failed'));
+
+    await manager.checkTimeouts();
+
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    expect(store.getChannel(channelId)!.status).toBe('active');
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
+  });
+
+  it('checkTimeouts evicts zombie channels after close retries are exhausted', async () => {
+    const channelId = makeChannelId(73);
+    const reserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+      deadline: Math.floor(Date.now() / 1000) - 1,
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reserve, mux);
+    manager.onBuyerDisconnect(buyerIdentity.peerId);
+
+    vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(
+      makeOnChainChannel(buyerIdentity, sellerIdentity, {
+        deposit: 1_000_000n,
+        settled: 0n,
+        status: 1,
+      }),
+    );
+    vi.spyOn(manager.channelsClient, 'close').mockRejectedValue(new Error('estimate failed'));
+
+    await manager.checkTimeouts();
+    await manager.checkTimeouts();
+    await manager.checkTimeouts();
+    await manager.checkTimeouts();
+
+    expect(manager.channelsClient.close).toHaveBeenCalledTimes(3);
+    expect(store.getChannel(channelId)!.status).toBe('timeout');
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
+  });
+
+  it('checkTimeouts deduplicates concurrent zombie close attempts', async () => {
+    const channelId = makeChannelId(74);
+    const reserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+      deadline: Math.floor(Date.now() / 1000) - 1,
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reserve, mux);
+    manager.onBuyerDisconnect(buyerIdentity.peerId);
+
+    vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(
+      makeOnChainChannel(buyerIdentity, sellerIdentity, {
+        deposit: 1_000_000n,
+        settled: 0n,
+        status: 1,
+      }),
+    );
+    let resolveClose!: (value: string) => void;
+    const closePromise = new Promise<string>((resolve) => { resolveClose = resolve; });
+    vi.spyOn(manager.channelsClient, 'close').mockReturnValue(closePromise);
+
+    const first = manager.checkTimeouts();
+    while ((manager.channelsClient.close as ReturnType<typeof vi.fn>).mock.calls.length === 0) {
+      await new Promise<void>((r) => setImmediate(r));
+    }
+    const second = manager.checkTimeouts();
+
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    resolveClose('0xclose-hash');
+    await Promise.all([first, second]);
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+  });
+
   it('test_getPaymentRequirements: returns payment requirements payload', () => {
     const req = manager.getPaymentRequirements('test-req-1');
     expect(req).not.toBeNull();

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -550,6 +550,36 @@ describe('SellerPaymentManager', () => {
     expect(manager.hasSession('nonexistent-peer')).toBe(false);
   });
 
+  it('checkTimeouts closes zombie channels on-chain without a SpendingAuth', async () => {
+    const channelId = makeChannelId(70);
+    const reserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+      deadline: Math.floor(Date.now() / 1000) - 1,
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reserve, mux);
+    manager.onBuyerDisconnect(buyerIdentity.peerId);
+
+    vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(
+      makeOnChainChannel(buyerIdentity, sellerIdentity, {
+        deposit: 1_000_000n,
+        settled: 0n,
+        status: 1,
+      }),
+    );
+
+    await manager.checkTimeouts();
+
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    const closeArgs = (manager.channelsClient.close as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(closeArgs[1]).toBe(channelId);
+    expect(closeArgs[2]).toBe(0n);
+    expect(closeArgs[3]).toBe('0x');
+    expect(closeArgs[4]).toBe('0x');
+    expect(store.getChannel(channelId)!.status).toBe('settled');
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
+  });
+
   it('test_getPaymentRequirements: returns payment requirements payload', () => {
     const req = manager.getPaymentRequirements('test-req-1');
     expect(req).not.toBeNull();

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -550,6 +550,57 @@ describe('SellerPaymentManager', () => {
     expect(manager.hasSession('nonexistent-peer')).toBe(false);
   });
 
+  it('checkTimeouts restores persisted SpendingAuth before zombie close fallback', async () => {
+    const channelId = makeChannelId(69);
+    const reserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+      deadline: Math.floor(Date.now() / 1000) - 1,
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reserve, mux);
+
+    const auth = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 300_000n,
+      cumulativeInputTokens: 10n,
+      cumulativeOutputTokens: 20n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, auth, mux);
+    manager.recordSpend(channelId, 300_000n);
+
+    const closeSpy = manager.channelsClient.close as ReturnType<typeof vi.fn>;
+    closeSpy.mockRejectedValueOnce(new Error('estimate failed')).mockResolvedValue('0xclose-hash');
+
+    manager.onBuyerDisconnect(buyerIdentity.peerId);
+    while (closeSpy.mock.calls.length === 0) {
+      await new Promise<void>((r) => setImmediate(r));
+    }
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(store.getChannel(channelId)!.status).toBe('active');
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
+    expect(manager.getAcceptedCumulative(channelId)).toBe(0n);
+
+    vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(
+      makeOnChainChannel(buyerIdentity, sellerIdentity, {
+        deposit: 1_000_000n,
+        settled: 0n,
+        status: 1,
+      }),
+    );
+
+    await manager.checkTimeouts();
+
+    expect(closeSpy).toHaveBeenCalledTimes(2);
+    const retryArgs = closeSpy.mock.calls[1]!;
+    expect(retryArgs[1]).toBe(channelId);
+    expect(retryArgs[2]).toBe(300_000n);
+    expect(retryArgs[3]).toBe(auth.metadata);
+    expect(retryArgs[4]).toBe(auth.spendingAuthSig);
+    expect(store.getChannel(channelId)!.status).toBe('settled');
+    expect(store.getChannel(channelId)!.settledAmount).toBe('300000');
+  });
+
   it('checkTimeouts closes zombie channels on-chain without a SpendingAuth', async () => {
     const channelId = makeChannelId(70);
     const reserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {


### PR DESCRIPTION
## Description

Closes seller-side zombie payment channels on-chain when the buyer has disconnected, no SpendingAuth exists, and the channel deadline has elapsed. The seller uses the current on-chain settled amount with empty metadata/signature, which matches the contract path that skips signature verification when no additional spend is being claimed.

## Release Notes

- Fixed stale seller payment channels so disconnected zero-auth sessions can be closed on-chain and release reserved funds.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Tested with: pnpm -C packages/node test seller-payment-manager.test.ts