### PR TITLE
feat(cli): Add seller Base RPC override

### DIFF
--- a/apps/cli/.env.example
+++ b/apps/cli/.env.example
@@ -14,6 +14,8 @@ VITE_ANTSEED_DEBUG=0
 # ANTSEED_ENV_FILE=.env
 
 # Settlement runtime (requires config.payments.crypto in config.json)
+# Recommended for production sellers: use a dedicated Base JSON-RPC endpoint.
+# ANTSEED_BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/...
 # ANTSEED_ENABLE_SETTLEMENT=true
 # ANTSEED_SETTLEMENT_IDLE_MS=30000
 # ANTSEED_DEFAULT_ESCROW_USDC=1

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -56,6 +56,8 @@ Once your config file exists, the usual seller flow is just:
 ```bash
 export OPENAI_API_KEY=sk-...
 export ANTSEED_IDENTITY_HEX=<your-identity-key>
+# Recommended for production sellers: use a dedicated Base RPC endpoint
+export ANTSEED_BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/<key>
 antseed seller start
 ```
 
@@ -208,8 +210,11 @@ Runtime-only overrides (do not write your config file):
 
 ```bash
 antseed seller start --provider anthropic --input-usd-per-million 10 --cached-input-usd-per-million 5 --output-usd-per-million 30
+antseed seller start --base-rpc-url https://base-mainnet.infura.io/v3/<key>
 antseed buyer start --max-input-usd-per-million 20 --max-cached-input-usd-per-million 10 --max-output-usd-per-million 60
 ```
+
+For production sellers, prefer a dedicated Base JSON-RPC endpoint over public defaults. You can set it durably with `payments.crypto.rpcUrl`, at runtime with `ANTSEED_BASE_RPC_URL`, or for one run with `antseed seller start --base-rpc-url <url>`.
 
 ### Session overrides (live, while proxy is running)
 
@@ -304,6 +309,7 @@ Use `base-sepolia` for testing with MockUSDC.
 
 ### Runtime Controls
 
+- `ANTSEED_BASE_RPC_URL=<url>` — custom Base JSON-RPC endpoint for seller on-chain operations (recommended for production)
 - `ANTSEED_SETTLEMENT_IDLE_MS=600000` — idle time before settling a session (default: 10 minutes)
 - `ANTSEED_DEFAULT_DEPOSIT_USDC=1` — default lock amount per session
 - `ANTSEED_IDENTITY_HEX=<hex>` — inject identity via env (supports 0x prefix)

--- a/apps/cli/src/cli/commands/seller/start.test.ts
+++ b/apps/cli/src/cli/commands/seller/start.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { createDefaultConfig } from '../../../config/defaults.js';
 import { resolveEffectiveSellerConfig } from '../../../config/effective.js';
+import { requireCryptoConfig, resolveBaseRpcUrlOverride } from '../../payment-utils.js';
 import {
   assertSellerPrerequisites,
   buildSellerRuntimeOverridesFromFlags,
@@ -242,6 +243,38 @@ test('parseOptionalPositiveIntegerEnv accepts positive integer env values', () =
   assert.equal(parseOptionalPositiveIntegerEnv('0'), undefined);
   assert.equal(parseOptionalPositiveIntegerEnv('123abc'), undefined);
   assert.equal(parseOptionalPositiveIntegerEnv('not-a-number'), undefined);
+});
+
+test('resolveBaseRpcUrlOverride uses flag before ANTSEED_BASE_RPC_URL', () => {
+  const env = {
+    ANTSEED_BASE_RPC_URL: 'https://env-rpc.example',
+  } as NodeJS.ProcessEnv;
+
+  assert.equal(
+    resolveBaseRpcUrlOverride({ flagValue: 'https://flag-rpc.example', env }),
+    'https://flag-rpc.example',
+  );
+  assert.equal(
+    resolveBaseRpcUrlOverride({ env }),
+    'https://env-rpc.example',
+  );
+});
+
+test('requireCryptoConfig applies ANTSEED_BASE_RPC_URL over config rpcUrl', () => {
+  const config = createDefaultConfig();
+  config.payments.crypto = {
+    chainId: 'base-mainnet',
+    rpcUrl: 'https://configured-rpc.example',
+    depositsContractAddress: '0x0000000000000000000000000000000000000001',
+    channelsContractAddress: '0x0000000000000000000000000000000000000002',
+    usdcContractAddress: '0x0000000000000000000000000000000000000003',
+  };
+
+  const crypto = requireCryptoConfig(config, {
+    env: { ANTSEED_BASE_RPC_URL: 'https://env-rpc.example' } as NodeJS.ProcessEnv,
+  });
+
+  assert.equal(crypto.rpcUrl, 'https://env-rpc.example');
 });
 
 test('selectSellerProviderNames defaults to all configured providers', () => {

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -9,8 +9,10 @@ import { AntseedNode, type Provider, resolveChainConfig, loadOrCreateIdentity } 
 import type { PaymentConfig } from '@antseed/node/payments'
 import { checkSellerReadiness, DEFAULT_MIN_SETTLE_DELTA_STR } from '@antseed/node/payments'
 import {
+  ANTSEED_BASE_RPC_URL_ENV,
   createIdentityClient,
   createStakingClient,
+  resolveBaseRpcUrlOverride,
 } from '../../payment-utils.js'
 import type { AntseedConfig } from '../../../config/types.js'
 import { parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery'
@@ -64,6 +66,7 @@ export async function assertSellerPrerequisites(input: {
   paymentsEnabled: boolean
   runtimePricingOverride: boolean
   skipChainChecks: boolean
+  baseRpcUrlOverride?: string
 }): Promise<void> {
   const {
     dataDir,
@@ -73,6 +76,7 @@ export async function assertSellerPrerequisites(input: {
     paymentsEnabled,
     runtimePricingOverride,
     skipChainChecks,
+    baseRpcUrlOverride,
   } = input
 
   const failures: Array<{ title: string; detail: string; command?: string }> = []
@@ -104,8 +108,8 @@ export async function assertSellerPrerequisites(input: {
   if (paymentsEnabled && config.payments.crypto && !skipChainChecks) {
     try {
       const identity = await loadOrCreateIdentity(dataDir)
-      const identityClient = createIdentityClient(config)
-      const stakingClient = createStakingClient(config)
+      const identityClient = createIdentityClient(config, { rpcUrl: baseRpcUrlOverride })
+      const stakingClient = createStakingClient(config, { rpcUrl: baseRpcUrlOverride })
       const sellerContract = config.payments.sellerContract?.address
       const checks = await checkSellerReadiness(identity, identityClient, stakingClient, sellerContract)
       for (const check of checks) {
@@ -306,10 +310,21 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
     .option('--dht-port <number>', 'UDP port for DHT (default: 6881)', parseInt)
     .option('--signaling-port <number>', 'TCP port for P2P signaling (default: 6882)', parseInt)
     .option('--min-settle-delta <usdc>', 'minimum unsettled delta (USDC decimal, e.g. 0.002) before idle settle submits a tx')
+    .option('--base-rpc-url <url>', `runtime-only Base JSON-RPC URL override (also ${ANTSEED_BASE_RPC_URL_ENV})`)
     .option('--skip-prereq-check', 'skip pre-flight checks (services configured, on-chain registration + stake). Use only for local testing.')
     .action(async (options) => {
       const globalOpts = getGlobalOptions(sellerCmd)
       const config = await loadConfig(globalOpts.config)
+      let baseRpcUrlOverride: string | undefined
+      try {
+        baseRpcUrlOverride = resolveBaseRpcUrlOverride({
+          flagValue: options.baseRpcUrl as string | undefined,
+        })
+      } catch (err) {
+        console.error(chalk.red(`Error: ${(err as Error).message}`))
+        process.exit(1)
+      }
+
       const runtimeOverrides = buildSellerRuntimeOverridesFromFlags({
         reserve: options.reserve as number | undefined,
         inputUsdPerMillion: options.inputUsdPerMillion as number | undefined,
@@ -390,10 +405,15 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
       if (preferredMethod === 'crypto') {
         const cc = resolveChainConfig({
           chainId: config.payments.crypto?.chainId,
-          rpcUrl: config.payments.crypto?.rpcUrl,
+          rpcUrl: baseRpcUrlOverride ?? config.payments.crypto?.rpcUrl,
+          fallbackRpcUrls: config.payments.crypto?.fallbackRpcUrls,
           depositsContractAddress: config.payments.crypto?.depositsContractAddress,
           channelsContractAddress: config.payments.crypto?.channelsContractAddress,
+          stakingContractAddress: config.payments.crypto?.stakingContractAddress,
           usdcContractAddress: config.payments.crypto?.usdcContractAddress,
+          identityRegistryAddress: config.payments.crypto?.identityRegistryAddress,
+          emissionsContractAddress: config.payments.crypto?.emissionsContractAddress,
+          subPoolContractAddress: config.payments.crypto?.subPoolContractAddress,
         })
         const defaultLockAmountUSDCBaseUnits = toUSDCBaseUnits(
           config.payments.crypto?.defaultLockAmountUSDC ?? defaultDepositAmountUSDC,
@@ -441,6 +461,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
           paymentsEnabled,
           runtimePricingOverride: forcePricingOverride,
           skipChainChecks: Boolean(options.skipPrereqCheck),
+          baseRpcUrlOverride,
         })
       } catch {
         process.exit(1)
@@ -488,6 +509,10 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
       }
       const minBudgetPerRequest = config.payments.minBudgetPerRequest ?? '10000'
       console.log(chalk.dim(`  min budget per request: ${minBudgetPerRequest} base units`))
+      if (paymentConfig?.crypto?.rpcUrl) {
+        const rpcSource = baseRpcUrlOverride ? 'runtime override' : 'config/default'
+        console.log(chalk.dim(`  Base RPC URL: ${paymentConfig.crypto.rpcUrl} (${rpcSource})`))
+      }
       // CLI flag (decimal USDC) overrides config JSON (base-unit string).
       const minSettleDeltaFlag = options.minSettleDelta as string | undefined
       const minSettleDelta = minSettleDeltaFlag !== undefined

--- a/apps/cli/src/cli/payment-utils.ts
+++ b/apps/cli/src/cli/payment-utils.ts
@@ -1,5 +1,4 @@
 import { join } from 'node:path';
-import type { AntseedConfig } from '../config/types.js';
 import {
   DepositsClient,
   ChannelsClient,
@@ -14,6 +13,51 @@ import {
   ChannelStore,
 } from '@antseed/node/payments';
 import type { Identity } from '@antseed/node';
+import type { AntseedConfig } from '../config/types.js';
+
+export const ANTSEED_BASE_RPC_URL_ENV = 'ANTSEED_BASE_RPC_URL';
+
+export interface RpcUrlOverrideInput {
+  /** Runtime-only CLI flag value. Wins over environment variables. */
+  flagValue?: string;
+  /** Environment to read from. Defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface CryptoConfigOverrides {
+  /** Runtime-only RPC URL override. Wins over environment variables and config.json. */
+  rpcUrl?: string;
+  /** Environment to read ANTSEED_BASE_RPC_URL from. Defaults to process.env. */
+  env?: NodeJS.ProcessEnv;
+}
+
+function normalizeRpcUrl(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`${ANTSEED_BASE_RPC_URL_ENV} must be a valid http(s) URL`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`${ANTSEED_BASE_RPC_URL_ENV} must use http:// or https://`);
+  }
+
+  return trimmed;
+}
+
+/**
+ * Resolve the runtime Base JSON-RPC URL override used by seller infrastructure.
+ * Precedence: CLI flag > ANTSEED_BASE_RPC_URL env var > config/defaults.
+ */
+export function resolveBaseRpcUrlOverride(input: RpcUrlOverrideInput = {}): string | undefined {
+  return normalizeRpcUrl(
+    input.flagValue ?? (input.env ?? process.env)[ANTSEED_BASE_RPC_URL_ENV],
+  );
+}
 
 /** Format ANTS token amounts (18 decimals) to human-readable string. */
 export function formatAnts(baseUnits: bigint): string {
@@ -60,16 +104,27 @@ export async function loadCryptoContext(dataDir: string): Promise<CryptoContext>
  * Validate that crypto payment config is present and return it.
  * Exits with error if not configured.
  */
-export function requireCryptoConfig(config: AntseedConfig): NonNullable<AntseedConfig['payments']['crypto']> & { evmChainId: number } {
+export function requireCryptoConfig(
+  config: AntseedConfig,
+  overrides: CryptoConfigOverrides = {},
+): NonNullable<AntseedConfig['payments']['crypto']> & { evmChainId: number } {
   const crypto = config.payments?.crypto;
   if (!crypto) {
     throw new Error('No crypto payment configuration found. Configure payments.crypto in your config file.');
   }
-  // Merge with chain-config defaults so commands work with just chainId
-  const resolved = resolveChainConfig(crypto);
+
+  const rpcUrlOverride = normalizeRpcUrl(overrides.rpcUrl)
+    ?? resolveBaseRpcUrlOverride({ env: overrides.env });
+
+  // Merge with chain-config defaults so commands work with just chainId.
+  // Runtime RPC overrides intentionally win over config.json and built-ins.
+  const resolved = resolveChainConfig({
+    ...crypto,
+    ...(rpcUrlOverride ? { rpcUrl: rpcUrlOverride } : {}),
+  });
   return {
     ...crypto,
-    rpcUrl: crypto.rpcUrl || resolved.rpcUrl,
+    rpcUrl: rpcUrlOverride || crypto.rpcUrl || resolved.rpcUrl,
     ...(resolved.fallbackRpcUrls && resolved.fallbackRpcUrls.length > 0
       ? { fallbackRpcUrls: resolved.fallbackRpcUrls }
       : {}),
@@ -92,8 +147,8 @@ function fallbackClientOpts(crypto: ReturnType<typeof requireCryptoConfig>) {
 /**
  * Create a DepositsClient from the CLI config.
  */
-export function createDepositsClient(config: AntseedConfig): DepositsClient {
-  const crypto = requireCryptoConfig(config);
+export function createDepositsClient(config: AntseedConfig, overrides?: CryptoConfigOverrides): DepositsClient {
+  const crypto = requireCryptoConfig(config, overrides);
   return new DepositsClient({
     rpcUrl: crypto.rpcUrl,
     ...fallbackClientOpts(crypto),
@@ -106,8 +161,8 @@ export function createDepositsClient(config: AntseedConfig): DepositsClient {
 /**
  * Create a ChannelsClient from the CLI config.
  */
-export function createChannelsClient(config: AntseedConfig): ChannelsClient {
-  const crypto = requireCryptoConfig(config);
+export function createChannelsClient(config: AntseedConfig, overrides?: CryptoConfigOverrides): ChannelsClient {
+  const crypto = requireCryptoConfig(config, overrides);
   return new ChannelsClient({
     rpcUrl: crypto.rpcUrl,
     ...fallbackClientOpts(crypto),
@@ -119,8 +174,8 @@ export function createChannelsClient(config: AntseedConfig): ChannelsClient {
 /**
  * Create an IdentityClient from the CLI config.
  */
-export function createIdentityClient(config: AntseedConfig): IdentityClient {
-  const crypto = requireCryptoConfig(config);
+export function createIdentityClient(config: AntseedConfig, overrides?: CryptoConfigOverrides): IdentityClient {
+  const crypto = requireCryptoConfig(config, overrides);
   if (!crypto.identityRegistryAddress) {
     throw new Error('No identity registry address configured. Set payments.crypto.identityRegistryAddress in your config file.');
   }
@@ -135,8 +190,8 @@ export function createIdentityClient(config: AntseedConfig): IdentityClient {
 /**
  * Create a StakingClient from the CLI config.
  */
-export function createStakingClient(config: AntseedConfig): StakingClient {
-  const crypto = requireCryptoConfig(config);
+export function createStakingClient(config: AntseedConfig, overrides?: CryptoConfigOverrides): StakingClient {
+  const crypto = requireCryptoConfig(config, overrides);
   if (!crypto.stakingContractAddress) {
     throw new Error('No staking contract address configured. Set payments.crypto.stakingContractAddress in your config file.');
   }
@@ -152,8 +207,8 @@ export function createStakingClient(config: AntseedConfig): StakingClient {
 /**
  * Create an EmissionsClient from the CLI config.
  */
-export function createEmissionsClient(config: AntseedConfig): EmissionsClient {
-  const crypto = requireCryptoConfig(config);
+export function createEmissionsClient(config: AntseedConfig, overrides?: CryptoConfigOverrides): EmissionsClient {
+  const crypto = requireCryptoConfig(config, overrides);
   if (!crypto.emissionsContractAddress) {
     throw new Error('No emissions contract address configured. Set payments.crypto.emissionsContractAddress in your config file.');
   }
@@ -168,8 +223,8 @@ export function createEmissionsClient(config: AntseedConfig): EmissionsClient {
 /**
  * Create a SubPoolClient from the CLI config.
  */
-export function createSubPoolClient(config: AntseedConfig): SubPoolClient {
-  const crypto = requireCryptoConfig(config);
+export function createSubPoolClient(config: AntseedConfig, overrides?: CryptoConfigOverrides): SubPoolClient {
+  const crypto = requireCryptoConfig(config, overrides);
   if (!crypto.subPoolContractAddress) {
     throw new Error('No subscription pool contract address configured. Set payments.crypto.subPoolContractAddress in your config file.');
   }

--- a/apps/website/docs/cli/commands.md
+++ b/apps/website/docs/cli/commands.md
@@ -21,6 +21,8 @@ In normal use, you configure the node once with `antseed seller setup` or `antse
 
 ```bash title="provider"
 antseed seller start                  Start providing AI services
+antseed seller start --base-rpc-url <url>
+                                      Use a custom Base RPC URL for this run
 antseed seller register               Register peer identity on-chain (ERC-8004)
 antseed seller stake <amount>         Stake USDC as a provider (min $10)
 antseed seller unstake                Withdraw staked USDC

--- a/apps/website/docs/cli/flags.md
+++ b/apps/website/docs/cli/flags.md
@@ -16,6 +16,16 @@ hide_title: true
 --help                   Show help
 ```
 
+## Seller Start Flags
+
+`antseed seller start` also supports runtime-only overrides for seller operations:
+
+```bash title="seller start"
+--base-rpc-url <url>    Base JSON-RPC endpoint for seller on-chain operations
+```
+
+The same value can be supplied with `ANTSEED_BASE_RPC_URL`. Precedence is: flag, environment variable, `payments.crypto.rpcUrl`, built-in default.
+
 ## Metrics Flags
 
 `antseed metrics serve` also supports:
@@ -40,6 +50,7 @@ See [Metrics](/docs/guides/metrics) for details.
 | `ANTSEED_ENV_FILE` | Override env file path for runtime env loading |
 | ~~`ANTSEED_ALLOWED_SERVICES`~~ | Removed as a user-facing env var. The set of announced services is now derived from the keys under `seller.providers[name].services` in `config.json`. The CLI still injects the env var for plugins internally. |
 | `ANTSEED_ENABLE_SETTLEMENT` | Enable on-chain settlement (`true`/`false`) |
+| `ANTSEED_BASE_RPC_URL` | Base JSON-RPC endpoint override for seller on-chain operations |
 | `ANTSEED_SETTLEMENT_IDLE_MS` | Settlement idle timeout in milliseconds |
 | `ANTSEED_DEFAULT_SESSION_USDC` | Default session authorization amount in USDC |
 | `ANTSEED_AUTO_FUND_DEPOSIT` | Auto-fund deposit on session start (`true`/`false`) |

--- a/apps/website/docs/getting-started/configuration.md
+++ b/apps/website/docs/getting-started/configuration.md
@@ -62,6 +62,7 @@ Use `config.json` for durable node behavior. Use env vars for secrets and tempor
 | `baseUrl` for OpenAI-compatible providers | `ANTSEED_IDENTITY_HEX` |
 | Service list and categories | `ANTSEED_DEBUG=1` |
 | Pricing defaults and per-service pricing | One-off runtime overrides in deployment scripts |
+| `payments.crypto.rpcUrl` for durable RPC config | `ANTSEED_BASE_RPC_URL` for deployment-specific Base RPC endpoints |
 | Buyer proxy port | |
 | Bootstrap nodes | |
 
@@ -310,13 +311,36 @@ For production servers, pass the key from a secrets manager:
 export ANTSEED_IDENTITY_HEX="$(vault kv get -field=key secret/antseed/identity)"
 ```
 
+## Base RPC URL
+
+Sellers should configure a dedicated Base JSON-RPC endpoint for production deployments. Public defaults are fine for testing, but provider RPCs (Alchemy, Infura, QuickNode, self-hosted nodes, etc.) are more reliable for seller registration, staking, reserve, settle, and close transactions.
+
+Use `payments.crypto.rpcUrl` for durable config:
+
+```bash
+antseed config set payments.crypto.rpcUrl "https://base-mainnet.g.alchemy.com/v2/<key>"
+```
+
+Or use runtime overrides when you do not want to edit `config.json`:
+
+```bash
+export ANTSEED_BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/<key>
+antseed seller start
+
+# one-off process override
+antseed seller start --base-rpc-url https://base-mainnet.infura.io/v3/<key>
+```
+
+Precedence is: CLI flag, then `ANTSEED_BASE_RPC_URL`, then `payments.crypto.rpcUrl`, then built-in Base defaults.
+
 ## Runtime Environment Variables
 
-Only secrets and global toggles are set via env vars — everything else is in `config.json`.
+Only secrets, global toggles, and deployment-specific runtime overrides are set via env vars — everything else is in `config.json`.
 
 | Variable | Description |
 |---|---|
 | `ANTSEED_IDENTITY_HEX` | Identity private key (64 hex chars, optional 0x prefix) |
+| `ANTSEED_BASE_RPC_URL` | Runtime Base JSON-RPC endpoint override for seller on-chain operations |
 | `ANTHROPIC_API_KEY` | Upstream Anthropic API key (used by the `anthropic` provider plugin) |
 | `OPENAI_API_KEY` | Upstream OpenAI-compatible API key (used by the `openai` provider plugin) |
 | `ANTSEED_SETTLEMENT_IDLE_MS` | Idle time before settling a session (default: 600000 / 10 min) |

--- a/apps/website/docs/guides/become-a-provider.md
+++ b/apps/website/docs/guides/become-a-provider.md
@@ -110,7 +110,32 @@ export ANTSEED_IDENTITY_HEX=<your-64-char-hex-private-key>
 Use a dedicated key for your provider node. Generate one with any EVM wallet tool. The corresponding address is where you'll receive USDC earnings.
 :::
 
-## 4. Fund Your Wallet
+## 4. Recommended: Set a Custom Base RPC URL
+
+Production sellers should use their own Base JSON-RPC endpoint instead of relying on public defaults. Public RPCs are useful for testing, but they can be rate limited, slow during traffic spikes, or unavailable when your node needs to reserve, settle, register, or stake on-chain.
+
+Set the standard environment variable in your deployment shell:
+
+```bash
+export ANTSEED_BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/<key>
+antseed seller start
+```
+
+You can also pass it for a one-off seller run:
+
+```bash
+antseed seller start --base-rpc-url https://base-mainnet.infura.io/v3/<key>
+```
+
+For durable config-file based deployments, store it under `payments.crypto.rpcUrl`:
+
+```bash
+antseed config set payments.crypto.rpcUrl "https://base-mainnet.g.alchemy.com/v2/<key>"
+```
+
+Runtime precedence is: `--base-rpc-url` flag, then `ANTSEED_BASE_RPC_URL`, then `payments.crypto.rpcUrl`, then AntSeed's built-in Base defaults.
+
+## 5. Fund Your Wallet
 
 Your wallet address needs:
 - **ETH** for gas fees (register, stake, settle transactions)
@@ -122,7 +147,7 @@ Send both to the EVM address derived from your identity key. You can find your a
 antseed seller status
 ```
 
-## 5. Register and Stake
+## 6. Register and Stake
 
 ```bash
 # Register your identity on-chain (ERC-8004)
@@ -135,7 +160,7 @@ antseed seller stake 10
 antseed seller status
 ```
 
-## 6. Add Your Services
+## 7. Add Your Services
 
 Everything you announce on the network lives in `config.json` under `seller.providers[name].services[id]`. One block per upstream provider plugin, one entry per service. The `add-service` command builds this for you:
 
@@ -177,7 +202,7 @@ You only have to do this once per service. To see what you've configured:
 antseed config seller show
 ```
 
-## 7. Set Your API Key and Start Selling
+## 8. Set Your API Key and Start Selling
 
 Upstream credentials stay in environment variables. Your provider shape, service list, pricing, and `baseUrl` stay in `config.json`.
 
@@ -204,7 +229,7 @@ Runtime overrides for a one-off session (without editing `config.json`):
 antseed seller start --provider anthropic --input-usd-per-million 3 --output-usd-per-million 15
 ```
 
-## 8. Verify
+## 9. Verify
 
 Once running, your node is discoverable on the network:
 

--- a/apps/website/docs/guides/payments.md
+++ b/apps/website/docs/guides/payments.md
@@ -76,6 +76,17 @@ Settlement happens:
 - **On budget exhaustion** — when a session's reserved amount is used up
 - **On disconnect** — when a buyer disconnects
 
+### Base RPC Endpoint
+
+Production providers should use a dedicated Base JSON-RPC endpoint so reserve, settle, close, register, and stake calls are not dependent on public RPC rate limits.
+
+```bash
+export ANTSEED_BASE_RPC_URL=https://base-mainnet.g.alchemy.com/v2/<key>
+antseed seller start
+```
+
+For a one-off run, use `antseed seller start --base-rpc-url <url>`. For durable config, set `payments.crypto.rpcUrl` in `~/.antseed/config.json`.
+
 ### Staking
 
 Providers must stake a minimum of $10 USDC to participate:


### PR DESCRIPTION
## Description

Adds a runtime Base RPC override path for seller operations via `antseed seller start --base-rpc-url` and the `ANTSEED_BASE_RPC_URL` environment variable. The override is applied consistently to seller startup payment config, prereq chain checks, and shared CLI payment clients with HTTP(S) URL validation.

Updates seller onboarding, payment, CLI, and configuration documentation to recommend dedicated Base RPC endpoints for production sellers.

## Release Notes

- Added `antseed seller start --base-rpc-url <url>` for custom Base RPC endpoints
- Added `ANTSEED_BASE_RPC_URL` support for seller on-chain operations
- Documented custom Base RPC setup for production sellers

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Closes #365