### PR TITLE
fix(config): Add seller setup defaults

### DIFF
--- a/apps/cli/src/cli/commands/buyer/withdraw.ts
+++ b/apps/cli/src/cli/commands/buyer/withdraw.ts
@@ -3,11 +3,7 @@ import chalk from 'chalk';
 import ora from 'ora';
 import { getGlobalOptions } from '../types.js';
 import { loadConfig } from '../../../config/loader.js';
-import {
-  loadOrCreateIdentity,
-  DepositsClient,
-  resolveChainConfig,
-} from '@antseed/node';
+import { loadCryptoContext, createDepositsClient } from '../../payment-utils.js';
 
 export function registerBuyerWithdrawCommand(buyerCmd: Command): void {
   buyerCmd
@@ -31,18 +27,8 @@ export function registerBuyerWithdrawCommand(buyerCmd: Command): void {
       }
 
       const amountBaseUnits = BigInt(Math.round(amountFloat * 1_000_000));
-      const identity = await loadOrCreateIdentity(globalOpts.dataDir);
-      const wallet = identity.wallet;
-      const address = identity.wallet.address;
-
-      const resolvedChain = resolveChainConfig({ chainId: payments.crypto.chainId });
-      const depositsClient = new DepositsClient({
-        rpcUrl: payments.crypto.rpcUrl,
-        ...(payments.crypto.fallbackRpcUrls ? { fallbackRpcUrls: payments.crypto.fallbackRpcUrls } : {}),
-        contractAddress: payments.crypto.depositsContractAddress,
-        usdcAddress: payments.crypto.usdcContractAddress,
-        evmChainId: resolvedChain.evmChainId,
-      });
+      const { wallet, address } = await loadCryptoContext(globalOpts.dataDir);
+      const depositsClient = createDepositsClient(config);
 
       console.log(chalk.dim(`Wallet: ${address}`));
       console.log(chalk.dim(`Amount: ${amountFloat} USDC (${amountBaseUnits} base units)`));

--- a/apps/cli/src/cli/commands/seller/setup.test.ts
+++ b/apps/cli/src/cli/commands/seller/setup.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { createDefaultConfig } from '../../../config/defaults.js';
 import { resolvePluginPackage } from '../../../plugins/registry.js';
-import { buildSellerSetupProviderEntry, getSellerSetupCredentialHint } from './setup.js';
+import { applySellerSetupRpcUrl, buildSellerSetupProviderEntry, getSellerSetupCredentialHint } from './setup.js';
 
 test('resolvePluginPackage resolves trusted plugin aliases', () => {
   assert.equal(resolvePluginPackage('openai'), '@antseed/provider-openai');
@@ -32,4 +33,26 @@ test('buildSellerSetupProviderEntry builds seller provider config shape', () => 
 test('getSellerSetupCredentialHint matches the selected plugin', () => {
   assert.equal(getSellerSetupCredentialHint('anthropic'), 'export ANTHROPIC_API_KEY=<key>');
   assert.equal(getSellerSetupCredentialHint('local-llm'), 'start your local LLM runtime (no API key required)');
+});
+
+test('applySellerSetupRpcUrl stores valid custom RPC URLs, ignores blanks, and clears with dash', () => {
+  const config = createDefaultConfig();
+
+  applySellerSetupRpcUrl(config, '  ');
+  assert.equal(config.payments.crypto?.rpcUrl, undefined);
+
+  applySellerSetupRpcUrl(config, 'https://base.example/rpc');
+  assert.equal(config.payments.crypto?.chainId, 'base-mainnet');
+  assert.equal(config.payments.crypto?.rpcUrl, 'https://base.example/rpc');
+
+  applySellerSetupRpcUrl(config, '-');
+  assert.equal(config.payments.crypto?.chainId, 'base-mainnet');
+  assert.equal(config.payments.crypto?.rpcUrl, undefined);
+});
+
+test('applySellerSetupRpcUrl rejects invalid custom RPC URLs', () => {
+  const config = createDefaultConfig();
+
+  assert.throws(() => applySellerSetupRpcUrl(config, 'not-a-url'), /valid http\(s\) URL/);
+  assert.throws(() => applySellerSetupRpcUrl(config, 'ftp://base.example'), /http:\/\/ or https:\/\//);
 });

--- a/apps/cli/src/cli/commands/seller/setup.ts
+++ b/apps/cli/src/cli/commands/seller/setup.ts
@@ -6,11 +6,12 @@ import { loadOrCreateIdentity } from '@antseed/node';
 import { checkSellerReadiness } from '@antseed/node/payments';
 import { getGlobalOptions } from '../types.js';
 import { loadConfig, saveConfig } from '../../../config/loader.js';
+import { ensureDerivedIdentityDisplayName } from '../../../config/identity-display-name.js';
 import { assertValidConfig } from '../../../config/validation.js';
 import { TRUSTED_PLUGINS } from '../../../plugins/registry.js';
 import { installPlugin } from '../../../plugins/manager.js';
-import type { SellerProviderConfig, SellerServiceConfig } from '../../../config/types.js';
-import { createIdentityClient, createStakingClient } from '../../payment-utils.js';
+import type { AntseedConfig, SellerProviderConfig, SellerServiceConfig } from '../../../config/types.js';
+import { createIdentityClient, createStakingClient, normalizeHttpRpcUrl } from '../../payment-utils.js';
 
 export function buildSellerSetupProviderEntry(input: {
   plugin: string;
@@ -33,6 +34,19 @@ export function buildSellerSetupProviderEntry(input: {
         }
       : {}),
   };
+}
+
+export function applySellerSetupRpcUrl(config: AntseedConfig, input: string): void {
+  const value = input.trim();
+  if (!value) return;
+
+  config.payments.crypto = config.payments.crypto ?? { chainId: 'base-mainnet' };
+  if (value === '-') {
+    delete config.payments.crypto.rpcUrl;
+    return;
+  }
+
+  config.payments.crypto.rpcUrl = normalizeHttpRpcUrl(value, 'Base RPC URL');
 }
 
 async function printReadinessCheck(dataDir: string, configPath: string): Promise<void> {
@@ -83,10 +97,28 @@ export function registerSellerSetupCommand(sellerCmd: Command): void {
     .action(async () => {
       const globalOpts = getGlobalOptions(sellerCmd);
       const config = await loadConfig(globalOpts.config);
+      await ensureDerivedIdentityDisplayName({
+        config,
+        configPath: globalOpts.config,
+        dataDir: globalOpts.dataDir,
+      });
       const rl = createInterface({ input: process.stdin, output: process.stdout });
 
       try {
         console.log(chalk.bold('\nAntSeed Seller Setup\n'));
+
+        const currentRpcUrl = config.payments.crypto?.rpcUrl;
+        const rpcPrompt = currentRpcUrl
+          ? `Custom Base network RPC URL [${currentRpcUrl}] (blank to keep, "-" to clear): `
+          : 'Custom Base network RPC URL (optional, leave empty for default): ';
+        const rpcUrlInput = await rl.question(rpcPrompt);
+        try {
+          applySellerSetupRpcUrl(config, rpcUrlInput);
+        } catch (err) {
+          console.error(chalk.red(`\nError: ${(err as Error).message}`));
+          return;
+        }
+        console.log('');
 
         const providers = TRUSTED_PLUGINS.filter((plugin) => plugin.type === 'provider');
         console.log(chalk.bold('Available provider plugins:\n'));

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -20,6 +20,7 @@ import { setupShutdownHandler } from '../../shutdown.js'
 import { loadProviderPlugin, buildPluginConfig, getPackageVersions } from '../../../plugins/loader.js'
 import { ensurePluginsUpToDate } from '../../../plugins/drift.js'
 import { resolveEffectiveSellerConfig, type SellerRuntimeOverrides } from '../../../config/effective.js'
+import { ensureDerivedIdentityDisplayName } from '../../../config/identity-display-name.js'
 import type { SellerCLIConfig } from '../../../config/types.js'
 import { AntAgentProvider, loadAntAgent, type AntAgentDefinition } from '@antseed/ant-agent'
 import { resolvePluginPackage } from '../../../plugins/registry.js'
@@ -315,6 +316,11 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
     .action(async (options) => {
       const globalOpts = getGlobalOptions(sellerCmd)
       const config = await loadConfig(globalOpts.config)
+      await ensureDerivedIdentityDisplayName({
+        config,
+        configPath: globalOpts.config,
+        dataDir: globalOpts.dataDir,
+      })
       let baseRpcUrlOverride: string | undefined
       try {
         baseRpcUrlOverride = resolveBaseRpcUrlOverride({

--- a/apps/cli/src/cli/payment-utils.ts
+++ b/apps/cli/src/cli/payment-utils.ts
@@ -31,7 +31,7 @@ export interface CryptoConfigOverrides {
   env?: NodeJS.ProcessEnv;
 }
 
-function normalizeRpcUrl(value: string | undefined): string | undefined {
+export function normalizeHttpRpcUrl(value: string | undefined, label = ANTSEED_BASE_RPC_URL_ENV): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
 
@@ -39,14 +39,18 @@ function normalizeRpcUrl(value: string | undefined): string | undefined {
   try {
     parsed = new URL(trimmed);
   } catch {
-    throw new Error(`${ANTSEED_BASE_RPC_URL_ENV} must be a valid http(s) URL`);
+    throw new Error(`${label} must be a valid http(s) URL`);
   }
 
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    throw new Error(`${ANTSEED_BASE_RPC_URL_ENV} must use http:// or https://`);
+    throw new Error(`${label} must use http:// or https://`);
   }
 
   return trimmed;
+}
+
+function normalizeRpcUrl(value: string | undefined): string | undefined {
+  return normalizeHttpRpcUrl(value, ANTSEED_BASE_RPC_URL_ENV);
 }
 
 /**
@@ -90,6 +94,18 @@ export interface CryptoContext {
   address: string;
 }
 
+type ResolvedCryptoConfig = NonNullable<AntseedConfig['payments']['crypto']> & {
+  rpcUrl: string;
+  depositsContractAddress: string;
+  channelsContractAddress: string;
+  usdcContractAddress: string;
+  stakingContractAddress?: string;
+  identityRegistryAddress?: string;
+  emissionsContractAddress?: string;
+  subPoolContractAddress?: string;
+  evmChainId: number;
+};
+
 /**
  * Load identity and derive EVM wallet + address. Shared across all payment commands.
  */
@@ -107,7 +123,7 @@ export async function loadCryptoContext(dataDir: string): Promise<CryptoContext>
 export function requireCryptoConfig(
   config: AntseedConfig,
   overrides: CryptoConfigOverrides = {},
-): NonNullable<AntseedConfig['payments']['crypto']> & { evmChainId: number } {
+): ResolvedCryptoConfig {
   const crypto = config.payments?.crypto;
   if (!crypto) {
     throw new Error('No crypto payment configuration found. Configure payments.crypto in your config file.');

--- a/apps/cli/src/config/defaults.ts
+++ b/apps/cli/src/config/defaults.ts
@@ -6,6 +6,8 @@ import type { AntseedConfig } from './types.js';
 export function createDefaultConfig(): AntseedConfig {
   return {
     identity: {
+      // Replaced with a deterministic peer-derived name when the CLI creates
+      // or loads an identity (for example, `antseed seller setup/start`).
       displayName: 'Antseed Node',
     },
     seller: {
@@ -27,6 +29,9 @@ export function createDefaultConfig(): AntseedConfig {
     payments: {
       preferredMethod: 'crypto',
       platformFeeRate: 0.05,
+      crypto: {
+        chainId: 'base-mainnet',
+      },
     },
     network: {
       bootstrapNodes: [],

--- a/apps/cli/src/config/identity-display-name.ts
+++ b/apps/cli/src/config/identity-display-name.ts
@@ -1,0 +1,55 @@
+import { loadOrCreateIdentity } from '@antseed/node';
+import type { AntseedConfig } from './types.js';
+import { saveConfig } from './loader.js';
+
+// Lowercased because shouldDeriveDisplayName normalizes before lookup.
+const LEGACY_DEFAULT_DISPLAY_NAMES = new Set([
+  'antseed node',
+]);
+
+const ADJECTIVES = [
+  'amber', 'arctic', 'brisk', 'bright', 'cosmic', 'crimson', 'electric', 'ember',
+  'frost', 'golden', 'lunar', 'midnight', 'neon', 'opal', 'quiet', 'radial',
+  'solar', 'tidal', 'velvet', 'violet',
+] as const;
+
+const NOUNS = [
+  'badger', 'falcon', 'fox', 'heron', 'lynx', 'manta', 'otter', 'panda',
+  'raven', 'sparrow', 'tiger', 'wolf', 'wren', 'yak', 'orca', 'gecko',
+  'ibis', 'marten', 'puma', 'swift',
+] as const;
+
+function hexNumber(hex: string, fallback: number): number {
+  const parsed = Number.parseInt(hex, 16);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function deriveDisplayNameFromPeerId(peerId: string): string {
+  const normalized = peerId.trim().toLowerCase().replace(/^0x/, '').replace(/[^0-9a-f]/g, '');
+  const seed = normalized.padEnd(12, '0');
+  const adjective = ADJECTIVES[hexNumber(seed.slice(0, 4), 0) % ADJECTIVES.length];
+  const noun = NOUNS[hexNumber(seed.slice(4, 8), 0) % NOUNS.length];
+  const suffix = seed.slice(-4);
+  return `antseed-${adjective}-${noun}-${suffix}`;
+}
+
+export function shouldDeriveDisplayName(displayName: string | undefined): boolean {
+  const normalized = displayName?.trim().toLowerCase();
+  return !normalized || LEGACY_DEFAULT_DISPLAY_NAMES.has(normalized);
+}
+
+export async function ensureDerivedIdentityDisplayName(input: {
+  config: AntseedConfig;
+  configPath: string;
+  dataDir: string;
+}): Promise<string> {
+  if (!shouldDeriveDisplayName(input.config.identity.displayName)) {
+    return input.config.identity.displayName.trim();
+  }
+
+  const identity = await loadOrCreateIdentity(input.dataDir);
+  const displayName = deriveDisplayNameFromPeerId(identity.peerId);
+  input.config.identity.displayName = displayName;
+  await saveConfig(input.configPath, input.config);
+  return displayName;
+}

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -4,6 +4,8 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { loadConfig } from './loader.js';
+import { createDefaultConfig } from './defaults.js';
+import { deriveDisplayNameFromPeerId, shouldDeriveDisplayName } from './identity-display-name.js';
 
 async function withTempConfig(contents: string, fn: (configPath: string) => Promise<void>): Promise<void> {
   const dir = await mkdtemp(join(tmpdir(), 'antseed-cli-config-'));
@@ -15,6 +17,22 @@ async function withTempConfig(contents: string, fn: (configPath: string) => Prom
     await rm(dir, { recursive: true, force: true });
   }
 }
+
+test('deriveDisplayNameFromPeerId returns deterministic peer-specific names', () => {
+  const peerId = '1234567890abcdef1234567890abcdef12345678';
+
+  assert.equal(deriveDisplayNameFromPeerId(peerId), deriveDisplayNameFromPeerId(peerId));
+  assert.match(deriveDisplayNameFromPeerId(peerId), /^antseed-[a-z]+-[a-z]+-[0-9a-f]{4}$/);
+  assert.notEqual(deriveDisplayNameFromPeerId(peerId), deriveDisplayNameFromPeerId('abcdef1234567890abcdef1234567890abcdef12'));
+  assert.equal(shouldDeriveDisplayName('Antseed Node'), true);
+  assert.equal(shouldDeriveDisplayName('custom seller'), false);
+});
+
+test('createDefaultConfig includes a Base mainnet crypto payment default', () => {
+  const config = createDefaultConfig();
+
+  assert.deepEqual(config.payments.crypto, { chainId: 'base-mainnet' });
+});
 
 test('loadConfig reads nested seller.providers[name].services[id] shape', async () => {
   await withTempConfig(

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -145,18 +145,18 @@ export interface PaymentsCLIConfig {
   crypto?: {
     /** Chain identifier */
     chainId: 'base-local' | 'base-sepolia' | 'base-mainnet';
-    /** Base JSON-RPC URL (e.g. http://127.0.0.1:8545 for local anvil) */
-    rpcUrl: string;
+    /** Base JSON-RPC URL override (e.g. http://127.0.0.1:8545 for local anvil) */
+    rpcUrl?: string;
     /** Additional RPC endpoints tried in order via ethers FallbackProvider. */
     fallbackRpcUrls?: string[];
-    /** Deployed AntseedDeposits contract address */
-    depositsContractAddress: string;
-    /** Deployed AntseedChannels contract address */
-    channelsContractAddress: string;
+    /** Deployed AntseedDeposits contract address override */
+    depositsContractAddress?: string;
+    /** Deployed AntseedChannels contract address override */
+    channelsContractAddress?: string;
     /** Deployed AntseedStaking contract address */
     stakingContractAddress?: string;
-    /** USDC token contract address */
-    usdcContractAddress: string;
+    /** USDC token contract address override */
+    usdcContractAddress?: string;
     /** Deployed AntseedIdentity (ERC-8004 registry) contract address */
     identityRegistryAddress?: string;
     /** Deployed AntseedEmissions contract address */


### PR DESCRIPTION
## Description

Adds a minimal default Base mainnet crypto payment config (`payments.crypto.chainId`) so fresh seller configs can run readiness checks without requiring users to manually create the payment block. Chain RPC and contract addresses continue to resolve from the built-in chain registry unless explicitly overridden.

Seller setup now asks for an optional custom Base network RPC URL and stores it in `payments.crypto.rpcUrl` when provided. It also replaces the generic default seller display name with a deterministic peer-derived name when `antseed seller setup` or `antseed seller start` loads the seller identity.

Related issues: #266 for seller readiness validation context, #365 for custom seller RPC configuration, and #362 for new-provider trust/display UX context. This PR does not change reputation scoring.

## Release Notes

- Fresh CLI configs now include a default Base mainnet chain selection for payment readiness checks
- Seller setup now prompts for an optional custom Base network RPC URL
- Seller setup/start now replaces the generic default node name with a stable peer-derived display name

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes