### PR TITLE
feat(config): Add buyer peer refresh setting

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -171,7 +171,9 @@ Pricing is configured in USD per 1M tokens with role-specific defaults and optio
         "cachedInputUsdPerMillion": 50,
         "outputUsdPerMillion": 100
       }
-    }
+    },
+    "proxyPort": 8377,
+    "peerRefreshIntervalMs": 300000
   }
 }
 ```
@@ -224,10 +226,11 @@ antseed config seller set publicAddress "peer.example.com:6882"
 # Raise the seller per-request upload cap (bytes) for large Codex-style payloads
 antseed config seller set maxUploadBodyBytes 134217728
 
-# Buyer max pricing
+# Buyer max pricing and DHT peer refresh cadence
 antseed config buyer set maxPricing.defaults.inputUsdPerMillion 25
 antseed config buyer set maxPricing.defaults.cachedInputUsdPerMillion 12
 antseed config buyer set maxPricing.defaults.outputUsdPerMillion 75
+antseed config buyer set peerRefreshIntervalMs 300000
 ```
 
 Runtime-only overrides (do not write your config file):

--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -332,6 +332,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
       console.log(chalk.dim(`  max per-request USDC: ${(Number(maxPerRequestUsdc) / 1_000_000).toFixed(6)}`))
       console.log(chalk.dim(`  max reserve USDC: ${(Number(maxReserveAmountUsdc) / 1_000_000).toFixed(6)}`))
       console.log(chalk.dim(`  min peer reputation: ${effectiveBuyerConfig.minPeerReputation}`))
+      console.log(chalk.dim(`  peer refresh interval: ${effectiveBuyerConfig.peerRefreshIntervalMs}ms`))
       console.log(chalk.dim(`  proxy port: ${effectiveBuyerConfig.proxyPort}`))
       if (pinnedPeerId) {
         console.log(chalk.yellow(`  pinned peer: ${pinnedPeerId} (router bypassed)`))
@@ -383,7 +384,13 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
 
       const proxyPort = effectiveBuyerConfig.proxyPort
       const proxySpinner = ora(`Starting local proxy on port ${proxyPort}...`).start()
-      const proxy = new BuyerProxy({ port: proxyPort, node, pinnedPeerId, dataDir: globalOpts.dataDir })
+      const proxy = new BuyerProxy({
+        port: proxyPort,
+        node,
+        pinnedPeerId,
+        dataDir: globalOpts.dataDir,
+        backgroundRefreshIntervalMs: effectiveBuyerConfig.peerRefreshIntervalMs,
+      })
       let ownsProxyListener = false
 
       try {

--- a/apps/cli/src/config/defaults.ts
+++ b/apps/cli/src/config/defaults.ts
@@ -1,5 +1,7 @@
 import type { AntseedConfig } from './types.js';
 
+export const DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS = 5 * 60_000;
+
 /**
  * Create a default Antseed configuration with sensible defaults.
  */
@@ -25,6 +27,7 @@ export function createDefaultConfig(): AntseedConfig {
       },
       minPeerReputation: 0,
       proxyPort: 8377,
+      peerRefreshIntervalMs: DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS,
     },
     payments: {
       preferredMethod: 'crypto',

--- a/apps/cli/src/config/effective.test.ts
+++ b/apps/cli/src/config/effective.test.ts
@@ -44,6 +44,7 @@ test('effective seller config precedence is flags > env > config > defaults', ()
 test('effective buyer config precedence is flags > env > config > defaults', () => {
   const config = createDefaultConfig();
   config.buyer.minPeerReputation = 25;
+  config.buyer.peerRefreshIntervalMs = 120_000;
   config.buyer.maxPricing.defaults.inputUsdPerMillion = 70;
   config.buyer.maxPricing.defaults.outputUsdPerMillion = 80;
 
@@ -63,6 +64,7 @@ test('effective buyer config precedence is flags > env > config > defaults', () 
   });
 
   assert.equal(effective.minPeerReputation, 55);
+  assert.equal(effective.peerRefreshIntervalMs, 120_000);
   assert.equal(effective.maxPricing.defaults.inputUsdPerMillion, 90);
   assert.equal(effective.maxPricing.defaults.outputUsdPerMillion, 99);
 });

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS } from './defaults.js';
 import { loadConfig } from './loader.js';
 import { createDefaultConfig } from './defaults.js';
 import { deriveDisplayNameFromPeerId, shouldDeriveDisplayName } from './identity-display-name.js';
@@ -84,6 +85,50 @@ test('loadConfig treats legacy buyer minPeerReputation 50 as the new default', a
     async (configPath) => {
       const config = await loadConfig(configPath);
       assert.equal(config.buyer.minPeerReputation, 0);
+    }
+  );
+});
+
+test('loadConfig applies the default buyer peer refresh interval when missing', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      buyer: {
+        proxyPort: 9123,
+      },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.equal(config.buyer.peerRefreshIntervalMs, DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS);
+    }
+  );
+});
+
+test('loadConfig preserves explicit buyer peerRefreshIntervalMs', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      buyer: {
+        peerRefreshIntervalMs: 15_000,
+      },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.equal(config.buyer.peerRefreshIntervalMs, 15_000);
+    }
+  );
+});
+
+test('loadConfig rejects invalid buyer peerRefreshIntervalMs', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      buyer: {
+        peerRefreshIntervalMs: 999,
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        async () => loadConfig(configPath),
+        /buyer\.peerRefreshIntervalMs/
+      );
     }
   );
 });

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -229,6 +229,7 @@ function mergeBuyerConfig(
       maxPricing: mergeHierarchicalPricing(defaults.maxPricing, undefined),
       minPeerReputation: defaults.minPeerReputation,
       proxyPort: defaults.proxyPort,
+      peerRefreshIntervalMs: defaults.peerRefreshIntervalMs,
     };
   }
   return {
@@ -237,6 +238,9 @@ function mergeBuyerConfig(
     proxyPort: typeof value['proxyPort'] === 'number'
       ? value['proxyPort']
       : defaults.proxyPort,
+    peerRefreshIntervalMs: typeof value['peerRefreshIntervalMs'] === 'number'
+      ? value['peerRefreshIntervalMs']
+      : defaults.peerRefreshIntervalMs,
   };
 }
 

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -102,6 +102,8 @@ export interface BuyerCLIConfig {
   minPeerReputation: number;
   /** Local proxy listen port */
   proxyPort: number;
+  /** How often the buyer refreshes its peer list from the DHT in the background (ms) */
+  peerRefreshIntervalMs: number;
 }
 
 /**

--- a/apps/cli/src/config/validation.ts
+++ b/apps/cli/src/config/validation.ts
@@ -8,6 +8,7 @@ import type {
 const SERVICE_CATEGORY_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const MAX_PUBLIC_ADDRESS_LENGTH = 255;
 const MIN_SELLER_UPLOAD_BODY_BYTES = 1024 * 1024;
+const MIN_BUYER_PEER_REFRESH_INTERVAL_MS = 1_000;
 
 function validatePricingLeaf(
   path: string,
@@ -139,6 +140,10 @@ export function validateConfig(config: AntseedConfig): string[] {
 
   if (!Number.isInteger(config.buyer.proxyPort) || config.buyer.proxyPort < 1 || config.buyer.proxyPort > 65535) {
     errors.push('buyer.proxyPort must be an integer in range 1-65535');
+  }
+
+  if (!Number.isInteger(config.buyer.peerRefreshIntervalMs) || config.buyer.peerRefreshIntervalMs < MIN_BUYER_PEER_REFRESH_INTERVAL_MS) {
+    errors.push('buyer.peerRefreshIntervalMs must be an integer >= 1000');
   }
 
   if (!Number.isInteger(config.seller.maxConcurrentBuyers) || config.seller.maxConcurrentBuyers < 1) {

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { Readable } from 'node:stream'
 import test from 'node:test'
 import type { PeerInfo } from '@antseed/node'
+import { DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS } from '../config/defaults.js'
 import { BuyerProxy, parsePersistedPeers, selectCandidatePeersForRouting, rewriteServiceInBody } from './buyer-proxy.js'
 
 function makePeer(seed: string, providers: string[]): PeerInfo {
@@ -89,6 +90,27 @@ async function invokeProxy(proxy: BuyerProxy, req: Readable): Promise<ReturnType
   await (proxy as any)._handleRequest(req, res)
   return res
 }
+
+test('BuyerProxy defaults to the configured 5 min background refresh interval', () => {
+  const proxy = new BuyerProxy({
+    port: 0,
+    dataDir: '/tmp/antseed-test',
+    node: { router: null } as any,
+  })
+
+  assert.equal((proxy as any)._bgRefreshIntervalMs, DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS)
+})
+
+test('BuyerProxy accepts a custom background refresh interval', () => {
+  const proxy = new BuyerProxy({
+    port: 0,
+    dataDir: '/tmp/antseed-test',
+    node: { router: null } as any,
+    backgroundRefreshIntervalMs: 15_000,
+  })
+
+  assert.equal((proxy as any)._bgRefreshIntervalMs, 15_000)
+})
 
 test('selectCandidatePeersForRouting enforces explicit provider overrides even without request protocol', () => {
   const peers = [

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -52,6 +52,7 @@ import {
   attachAntseedTelemetryHeaders,
   attachStreamingAntseedHeaders,
 } from './telemetry.js'
+import { DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS } from '../config/defaults.js'
 
 // Re-export for backward compatibility (used by tests and other consumers)
 export { selectCandidatePeersForRouting, type CandidatePeerRouteSelection } from './routing.js'
@@ -67,8 +68,8 @@ export interface BuyerProxyConfig {
   /**
    * Max age for the in-memory peer cache before it is treated as stale (ms).
    * Stale caches can still be used for routing while background refresh repopulates.
-   * Default: 360000 (6 min) — chosen to exceed `backgroundRefreshIntervalMs`
-   * (5 min) so a healthy proxy never naturally reaches the "stale" threshold.
+   * Default: at least 360000 (6 min), and always above `backgroundRefreshIntervalMs`,
+   * so a healthy proxy never naturally reaches the "stale" threshold.
    */
   peerCacheTtlMs?: number
   /**
@@ -370,8 +371,8 @@ export class BuyerProxy {
   constructor(config: BuyerProxyConfig) {
     this._node = config.node
     this._port = config.port
-    this._bgRefreshIntervalMs = config.backgroundRefreshIntervalMs ?? 5 * 60_000
-    this._peerCacheTtlMs = Math.max(0, config.peerCacheTtlMs ?? 6 * 60_000)
+    this._bgRefreshIntervalMs = Math.max(1, config.backgroundRefreshIntervalMs ?? DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS)
+    this._peerCacheTtlMs = Math.max(0, config.peerCacheTtlMs ?? Math.max(6 * 60_000, this._bgRefreshIntervalMs + 60_000))
     this._stateDir = config.dataDir
     this._stateFile = join(config.dataDir, 'buyer.state.json')
     this._pinnedPeer = config.pinnedPeerId?.toLowerCase() ?? null

--- a/apps/desktop/src/main/config-io.test.ts
+++ b/apps/desktop/src/main/config-io.test.ts
@@ -8,6 +8,7 @@ import {
   DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION,
   DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION,
   DESKTOP_DEFAULT_MIN_PEER_REPUTATION,
+  DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS,
   ensureConfig,
   readConfig,
 } from './config-io.js';
@@ -37,6 +38,7 @@ test('ensureConfig creates config with desktop buyer max pricing defaults', asyn
   assert.equal(pricing.input, DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION);
   assert.equal(pricing.output, DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION);
   assert.equal((config.buyer as { minPeerReputation?: number }).minPeerReputation, DESKTOP_DEFAULT_MIN_PEER_REPUTATION);
+  assert.equal((config.buyer as { peerRefreshIntervalMs?: number }).peerRefreshIntervalMs, DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS);
 });
 
 test('ensureConfig clamps buyer max pricing above desktop defaults', async (t) => {
@@ -64,6 +66,7 @@ test('ensureConfig clamps buyer max pricing above desktop defaults', async (t) =
   assert.equal(pricing.input, DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION);
   assert.equal(pricing.output, DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION);
   assert.equal((config.buyer as { minPeerReputation?: number }).minPeerReputation, DESKTOP_DEFAULT_MIN_PEER_REPUTATION);
+  assert.equal((config.buyer as { peerRefreshIntervalMs?: number }).peerRefreshIntervalMs, DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS);
   assert.equal((config.identity as { displayName?: string }).displayName, 'Existing User');
 });
 
@@ -110,6 +113,29 @@ test('ensureConfig fills missing buyer max pricing defaults for existing configs
   assert.equal(pricing.output, DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION);
   assert.equal((config.buyer as { proxyPort?: number }).proxyPort, 9123);
   assert.equal((config.buyer as { minPeerReputation?: number }).minPeerReputation, 42);
+  assert.equal((config.buyer as { peerRefreshIntervalMs?: number }).peerRefreshIntervalMs, DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS);
+});
+
+test('ensureConfig preserves valid buyer peer refresh interval', async (t) => {
+  const { dir, configPath } = await makeTempConfigPath();
+  t.after(() => rm(dir, { recursive: true, force: true }));
+
+  await writeFile(configPath, JSON.stringify({
+    buyer: {
+      peerRefreshIntervalMs: 30_000,
+      maxPricing: {
+        defaults: {
+          inputUsdPerMillion: 4,
+          outputUsdPerMillion: 20,
+        },
+      },
+    },
+  }, null, 2));
+
+  await ensureConfig(configPath);
+
+  const config = await readConfig(configPath);
+  assert.equal((config.buyer as { peerRefreshIntervalMs?: number }).peerRefreshIntervalMs, 30_000);
 });
 
 test('ensureConfig preserves buyer max pricing at or below desktop defaults', async (t) => {

--- a/apps/desktop/src/main/config-io.ts
+++ b/apps/desktop/src/main/config-io.ts
@@ -8,6 +8,7 @@ import { asString, asNumber } from './utils.js';
 export const DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION = 5;
 export const DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION = 30;
 export const DESKTOP_DEFAULT_MIN_PEER_REPUTATION = 0;
+export const DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS = 5 * 60_000;
 
 const DEFAULT_CONFIG: Record<string, unknown> = {
   identity: { displayName: 'AntSeed Node' },
@@ -26,6 +27,7 @@ const DEFAULT_CONFIG: Record<string, unknown> = {
     },
     minPeerReputation: DESKTOP_DEFAULT_MIN_PEER_REPUTATION,
     proxyPort: 8377,
+    peerRefreshIntervalMs: DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS,
   },
   network: { bootstrapNodes: [] },
   payments: { preferredMethod: 'crypto', platformFeeRate: 0.05 },
@@ -47,7 +49,7 @@ async function writeConfigAtomic(config: Record<string, unknown>, configPath: st
   await rename(tmp, configPath);
 }
 
-function migrateDesktopBuyerMaxPricing(config: Record<string, unknown>): {
+function migrateDesktopBuyerDefaults(config: Record<string, unknown>): {
   config: Record<string, unknown>;
   migrated: boolean;
 } {
@@ -59,6 +61,7 @@ function migrateDesktopBuyerMaxPricing(config: Record<string, unknown>): {
   const output = defaults.outputUsdPerMillion;
 
   const minPeerReputation = buyer.minPeerReputation;
+  const peerRefreshIntervalMs = buyer.peerRefreshIntervalMs;
   const nextDefaults = { ...defaults };
   let migrated = false;
   let nextBuyer = buyer;
@@ -89,6 +92,18 @@ function migrateDesktopBuyerMaxPricing(config: Record<string, unknown>): {
     nextBuyer = {
       ...nextBuyer,
       minPeerReputation: DESKTOP_DEFAULT_MIN_PEER_REPUTATION,
+    };
+    migrated = true;
+  }
+
+  if (
+    typeof peerRefreshIntervalMs !== 'number' ||
+    !Number.isInteger(peerRefreshIntervalMs) ||
+    peerRefreshIntervalMs < 1000
+  ) {
+    nextBuyer = {
+      ...nextBuyer,
+      peerRefreshIntervalMs: DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS,
     };
     migrated = true;
   }
@@ -125,7 +140,7 @@ export async function ensureConfig(configPath = DEFAULT_CONFIG_PATH): Promise<vo
     return;
   }
 
-  const migration = migrateDesktopBuyerMaxPricing(existing);
+  const migration = migrateDesktopBuyerDefaults(existing);
   if (migration.migrated) {
     await writeConfigAtomic(migration.config, configPath);
   }

--- a/apps/desktop/src/renderer/core/state.ts
+++ b/apps/desktop/src/renderer/core/state.ts
@@ -43,6 +43,7 @@ export type PeerEntry = {
 
 export type ConfigFormData = {
   proxyPort: number;
+  peerRefreshIntervalMs: number;
   maxInputUsdPerMillion: number;
   maxOutputUsdPerMillion: number;
   minRep: number;

--- a/apps/desktop/src/renderer/modules/settings.ts
+++ b/apps/desktop/src/renderer/modules/settings.ts
@@ -21,6 +21,7 @@ function asRecord(value: unknown): Record<string, unknown> {
 const DESKTOP_DEV_MODE_KEY = 'antseed.desktop.devMode';
 const DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION = 5;
 const DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION = 30;
+const DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS = 5 * 60_000;
 
 function loadDesktopDevMode(): boolean {
   try {
@@ -67,6 +68,7 @@ export function initSettingsModule({
 
     applyConfigFormData({
       proxyPort: safeNumber(buyer.proxyPort, 8377),
+      peerRefreshIntervalMs: safeNumber(buyer.peerRefreshIntervalMs, DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS),
       maxInputUsdPerMillion: safeNumber(
         buyerMaxPricingDefaults.inputUsdPerMillion,
         DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION,
@@ -105,6 +107,7 @@ export function initSettingsModule({
         buyer: {
           ...asRecord(currentConfig.buyer),
           proxyPort: formData.proxyPort,
+          peerRefreshIntervalMs: formData.peerRefreshIntervalMs,
           maxPricing: {
             defaults: {
               inputUsdPerMillion: formData.maxInputUsdPerMillion,

--- a/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
@@ -12,6 +12,7 @@ export function ConfigView({ active }: ConfigViewProps) {
 
   // Local form state — initialized from config, edited locally, saved on button click
   const [proxyPort, setProxyPort] = useState('8377');
+  const [peerRefreshIntervalMs, setPeerRefreshIntervalMs] = useState('300000');
   const [minRep, setMinRep] = useState('0');
   const [chainId, setChainId] = useState('base-mainnet');
   const [dirty, setDirty] = useState(false);
@@ -21,6 +22,7 @@ export function ConfigView({ active }: ConfigViewProps) {
   useEffect(() => {
     if (configFormData && !initialized) {
       setProxyPort(String(configFormData.proxyPort));
+      setPeerRefreshIntervalMs(String(configFormData.peerRefreshIntervalMs));
       setMinRep(String(configFormData.minRep));
       setChainId(configFormData.cryptoChainId || 'base-mainnet');
       setInitialized(true);
@@ -41,6 +43,7 @@ export function ConfigView({ active }: ConfigViewProps) {
     await actions.saveConfig({
       ...configFormData,
       proxyPort: parseInt(proxyPort, 10) || 8377,
+      peerRefreshIntervalMs: Math.max(1000, parseInt(peerRefreshIntervalMs, 10) || 300000),
       minRep: parseInt(minRep, 10) || 0,
       cryptoChainId: chainId,
     });
@@ -76,6 +79,20 @@ export function ConfigView({ active }: ConfigViewProps) {
                 className="form-input settings-control"
                 value={proxyPort}
                 onChange={(e) => { setProxyPort(e.target.value); markDirty(); }}
+              />
+            </label>
+            <label className="settings-item">
+              <div className="settings-copy">
+                <h4>Peer Refresh Interval (ms)</h4>
+                <p>How often the buyer refreshes discovered peers from the DHT. Default: 300000.</p>
+              </div>
+              <input
+                type="number"
+                className="form-input settings-control"
+                min="1000"
+                step="1000"
+                value={peerRefreshIntervalMs}
+                onChange={(e) => { setPeerRefreshIntervalMs(e.target.value); markDirty(); }}
               />
             </label>
             <label className="settings-item">

--- a/apps/website/docs/getting-started/configuration.md
+++ b/apps/website/docs/getting-started/configuration.md
@@ -63,7 +63,7 @@ Use `config.json` for durable node behavior. Use env vars for secrets and tempor
 | Service list and categories | `ANTSEED_DEBUG=1` |
 | Pricing defaults and per-service pricing | One-off runtime overrides in deployment scripts |
 | `payments.crypto.rpcUrl` for durable RPC config | `ANTSEED_BASE_RPC_URL` for deployment-specific Base RPC endpoints |
-| Buyer proxy port | `ANTSEED_DATA_DIR` for per-process buyer state isolation |
+| Buyer proxy port and peer refresh interval | `ANTSEED_DATA_DIR` for per-process buyer state isolation |
 | Bootstrap nodes | |
 
 For example, this is a normal production pattern:
@@ -139,7 +139,7 @@ Prefer `--data-dir` in service/systemd scripts. `ANTSEED_DATA_DIR` is equivalent
 |---|---|
 | `identity` | Display name |
 | `seller` | Per-provider service offerings (plugin, pricing, categories, upstream model mapping), reserve floor, max concurrent buyers, agent directory |
-| `buyer` | Max pricing thresholds, proxy port |
+| `buyer` | Max pricing thresholds, proxy port, DHT peer refresh interval |
 | `payments` | Chain ID (`base-mainnet` by default) |
 | `network` | Bootstrap nodes |
 
@@ -250,13 +250,19 @@ antseed config seller set providers.together.services.deepseek-v3.1.pricing.inpu
 antseed config seller set providers.together.services.deepseek-v3.1.categories '["chat","math","coding","fast"]'
 ```
 
-## Buyer Pricing
+## Buyer Settings
 
 Buyers can cap what they're willing to pay to avoid expensive providers:
 
 ```bash
 antseed config buyer set maxPricing.defaults.inputUsdPerMillion 25
 antseed config buyer set maxPricing.defaults.outputUsdPerMillion 75
+```
+
+The buyer proxy refreshes its discovered peer cache from the DHT in the background. The default is 5 minutes, and you can tune it in milliseconds:
+
+```bash
+antseed config buyer set peerRefreshIntervalMs 300000
 ```
 
 ## Identity and Metadata


### PR DESCRIPTION
## Description

Adds a configurable `buyer.peerRefreshIntervalMs` setting while preserving the existing 5-minute default buyer DHT peer refresh cadence. The setting is wired into `antseed buyer start`, exposed in Desktop Settings, and documented for CLI and website users.

Closes #157

## Release Notes

- Added `buyer.peerRefreshIntervalMs` to tune buyer DHT peer refreshes from config
- Added Desktop Settings support for editing the peer refresh interval
- Preserved the existing 5-minute default refresh interval

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
