### PR TITLE
docs(cli): Clarify buyer data dirs

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -63,6 +63,30 @@ antseed seller start
 
 `config.json` is the durable source of truth. Env vars are for secrets and one-off overrides.
 
+### Buyer state isolation
+
+Buyer runtime state lives in the data directory, not just in the config file. By default that directory is `~/.antseed`, which contains `buyer.state.json`, SQLite databases, payment-channel state, and the fallback `identity.key`.
+
+Use a separate data directory for each independent buyer node, service integration, test run, or concurrent process:
+
+```bash
+export BUYDIR="$HOME/.antseed-buyer-myapp"
+mkdir -p "$BUYDIR"
+
+ANTSEED_DATA_DIR="$BUYDIR" \
+antseed --data-dir "$BUYDIR" buyer start \
+  --peer <peer-id> \
+  --port 8380
+```
+
+Notes:
+
+- `--data-dir <path>` is the most explicit option and is recommended in service managers such as systemd.
+- `ANTSEED_DATA_DIR=<path>` is the environment-variable equivalent for scripts and wrappers.
+- Do not reuse the same buyer data directory across concurrent buyer processes.
+- If behavior looks stale or unexpected, confirm which `buyer.state.json` and SQLite files the process logged at startup.
+- `ANTSEED_HOME` is not the buyer state-isolation knob for the CLI; use `--data-dir` or `ANTSEED_DATA_DIR`.
+
 ## Plugins
 
 Antseed uses an open plugin ecosystem. Provider and router plugins are installed into `~/.antseed/plugins/` via npm.

--- a/apps/website/docs/cli/flags.md
+++ b/apps/website/docs/cli/flags.md
@@ -10,11 +10,13 @@ hide_title: true
 
 ```bash title="flags"
 -c, --config <path>     Path to config file (default: ~/.antseed/config.json)
---data-dir <path>       Path to node identity/state directory (default: ~/.antseed)
+--data-dir <path>       Path to node identity/state directory (env: ANTSEED_DATA_DIR, default: ~/.antseed)
 -v, --verbose            Enable verbose logging
 --version                Show version
 --help                   Show help
 ```
+
+`--data-dir` controls buyer/seller identity and runtime state: `identity.key`, `buyer.state.json`, SQLite databases, and payment-channel files. Use a separate data directory for each independent buyer process. The environment-variable equivalent is `ANTSEED_DATA_DIR=<path>`; prefer the explicit flag in service manager commands.
 
 ## Seller Start Flags
 
@@ -46,6 +48,7 @@ See [Metrics](/docs/guides/metrics) for details.
 | Variable | Description |
 |---|---|
 | `ANTSEED_IDENTITY_HEX` | secp256k1 private key (64 hex chars). When set, used instead of `identity.key` file. Cleared from process environment after read. |
+| `ANTSEED_DATA_DIR` | Node identity/state directory when `--data-dir` is not supplied. Use separate values for independent buyer processes. |
 | `ANTSEED_DEBUG` | Enable verbose runtime logs (`0` or `1`) |
 | `ANTSEED_ENV_FILE` | Override env file path for runtime env loading |
 | ~~`ANTSEED_ALLOWED_SERVICES`~~ | Removed as a user-facing env var. The set of announced services is now derived from the keys under `seller.providers[name].services` in `config.json`. The CLI still injects the env var for plugins internally. |

--- a/apps/website/docs/getting-started/configuration.md
+++ b/apps/website/docs/getting-started/configuration.md
@@ -63,7 +63,7 @@ Use `config.json` for durable node behavior. Use env vars for secrets and tempor
 | Service list and categories | `ANTSEED_DEBUG=1` |
 | Pricing defaults and per-service pricing | One-off runtime overrides in deployment scripts |
 | `payments.crypto.rpcUrl` for durable RPC config | `ANTSEED_BASE_RPC_URL` for deployment-specific Base RPC endpoints |
-| Buyer proxy port | |
+| Buyer proxy port | `ANTSEED_DATA_DIR` for per-process buyer state isolation |
 | Bootstrap nodes | |
 
 For example, this is a normal production pattern:
@@ -114,6 +114,24 @@ antseed seller start --provider together --input-usd-per-million 0.7
 ```
 
 That changes only the current process. It does not rewrite `config.json`.
+
+## Data Directory vs Config File
+
+`config.json` controls durable settings, but buyer runtime state is isolated by the data directory. The default data directory is `~/.antseed`; it contains `buyer.state.json`, SQLite databases, payment-channel files, and the fallback `identity.key`.
+
+For each independent buyer node, service integration, isolated test, or concurrent process, use a separate data directory:
+
+```bash
+export BUYDIR="$HOME/.antseed-buyer-myapp"
+mkdir -p "$BUYDIR"
+
+ANTSEED_DATA_DIR="$BUYDIR" \
+antseed --data-dir "$BUYDIR" buyer start \
+  --peer <peer-id> \
+  --port 8380
+```
+
+Prefer `--data-dir` in service/systemd scripts. `ANTSEED_DATA_DIR` is equivalent when the flag is not supplied. If buyer behavior looks stale or files appear in an unexpected place, check the startup log for the resolved data directory and `buyer.state.json` path. Do not rely on `ANTSEED_HOME` for CLI buyer state isolation.
 
 ## Config Sections
 

--- a/apps/website/docs/guides/using-the-api.md
+++ b/apps/website/docs/guides/using-the-api.md
@@ -35,6 +35,26 @@ Until a peer is pinned, every request returns `no_peer_pinned` — there is no a
 
 `antseed buyer start` does not require a pre-existing `~/.antseed/config.json`. If the file is missing, the CLI starts with built-in defaults such as router `local` and proxy port `8377`.
 
+## Buyer state isolation
+
+Buyer runtime state is stored in the CLI data directory. By default this is `~/.antseed`, where the proxy writes `buyer.state.json`, SQLite databases, payment-channel files, and the fallback `identity.key`.
+
+For multiple buyer nodes, service integrations, isolated tests, or concurrent processes, give each buyer its own data directory:
+
+```bash
+export BUYDIR="$HOME/.antseed-buyer-myapp"
+mkdir -p "$BUYDIR"
+
+ANTSEED_DATA_DIR="$BUYDIR" \
+antseed --data-dir "$BUYDIR" buyer start \
+  --peer <peer-id> \
+  --port 8380
+```
+
+Use `--data-dir <path>` in service/systemd scripts because it is explicit. `ANTSEED_DATA_DIR=<path>` is useful for wrappers and local scripts. Do not reuse the same buyer data directory across concurrent processes.
+
+If the buyer proxy starts but appears to use stale pins, waits on broad discovery, times out before payment negotiation, or shows sessions/channels in an unexpected place, check the startup log for the resolved data directory and `buyer.state.json` path. `ANTSEED_HOME` is not the CLI state-isolation setting; use `--data-dir` or `ANTSEED_DATA_DIR`.
+
 Extra buyer config is optional. Add it only for advanced customization such as pricing caps, reputation thresholds, bootstrap nodes, or chain settings:
 
 ```json

--- a/skills/hermes-antseed/SKILL.md
+++ b/skills/hermes-antseed/SKILL.md
@@ -97,10 +97,18 @@ Foreground, for a laptop or a quick test:
 antseed buyer start
 ```
 
+For an isolated Hermes buyer, use a dedicated data directory. This is where AntSeed writes `buyer.state.json`, SQLite databases, payment-channel state, and the fallback `identity.key`:
+
+```bash
+export BUYDIR="$HOME/.antseed-buyer-hermes"
+mkdir -p "$BUYDIR"
+ANTSEED_DATA_DIR="$BUYDIR" antseed --data-dir "$BUYDIR" buyer start
+```
+
 Advanced: if Hermes must use a non-default proxy port:
 
 ```bash
-antseed buyer start --port 5005
+antseed --data-dir "$BUYDIR" buyer start --port 5005
 ```
 
 Persistent (Linux, systemd):
@@ -116,7 +124,8 @@ Wants=network-online.target
 Type=simple
 User=$USER
 Environment=ANTSEED_IDENTITY_HEX=<64-hex-no-0x>
-ExecStart=/usr/bin/env antseed buyer start
+Environment=ANTSEED_DATA_DIR=%h/.antseed-buyer-hermes
+ExecStart=/usr/bin/env antseed --data-dir %h/.antseed-buyer-hermes buyer start
 Restart=on-failure
 RestartSec=10
 

--- a/skills/openclaw-antseed/SKILL.md
+++ b/skills/openclaw-antseed/SKILL.md
@@ -66,10 +66,18 @@ Run in a terminal or set up as a persistent service:
 antseed buyer start
 ```
 
+For an isolated OpenClaw buyer, use a dedicated data directory. This is where AntSeed writes `buyer.state.json`, SQLite databases, payment-channel state, and the fallback `identity.key`:
+
+```bash
+export BUYDIR="$HOME/.antseed-buyer-openclaw"
+mkdir -p "$BUYDIR"
+ANTSEED_DATA_DIR="$BUYDIR" antseed --data-dir "$BUYDIR" buyer start
+```
+
 Advanced: if you intentionally want a non-default port:
 
 ```bash
-antseed buyer start --port 5005
+antseed --data-dir "$BUYDIR" buyer start --port 5005
 ```
 
 ### Persistent service (systemd)
@@ -84,13 +92,14 @@ Wants=network-online.target
 [Service]
 Type=simple
 User=$USER
-ExecStart=/usr/bin/env antseed buyer start
+Environment=ANTSEED_IDENTITY_HEX=<private-key-hex-no-0x>
+Environment=ANTSEED_DATA_DIR=%h/.antseed-buyer-openclaw
+ExecStart=/usr/bin/env antseed --data-dir %h/.antseed-buyer-openclaw buyer start
 Restart=on-failure
 RestartSec=10
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=antseed-buyer
-Environment=ANTSEED_IDENTITY_HEX=<private-key-hex-no-0x>
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description

Clarifies that buyer runtime state is isolated by `--data-dir` / `ANTSEED_DATA_DIR`, not `ANTSEED_HOME`. Adds guidance for separate buyer data directories in CLI, website, and integration docs.

Fixes #518.

## Release Notes

- Documented how to isolate buyer state with `--data-dir` and `ANTSEED_DATA_DIR`

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [ ] Lint and unit tests pass locally with my changes

## Verification

Not run; documentation-only change.