### PR TITLE
feat(desktop): Add Whisper voice input

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,7 @@
     "build": "npm run build:main && npm run build:renderer",
     "build:main": "tsc -p tsconfig.main.json",
     "build:renderer": "vite build",
-    "test": "npm run build:main && node --test dist/main",
+    "test": "npm run build:main && node --test \"dist/main/*.test.js\"",
     "typecheck:renderer": "tsc -p tsconfig.renderer.json --noEmit",
     "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:main\" \"npm:dev:electron\"",
     "dev:debug": "concurrently -k \"npm:dev:renderer\" \"npm:dev:main\" \"npm:dev:electron:debug\"",

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -56,6 +56,7 @@ import { ensureConfig, readConfig, mergeConfig, readNodeStatus } from './config-
 import { registerAttachmentScheme, installAttachmentProtocol } from './attachment-protocol.js';
 import { resolveAttachmentPath } from './attachment-store.js';
 import { getWorkspacePickerDefaultDir } from './chat-workspace.js';
+import { transcribeWithWhisper, type SpeechTranscribePayload, type SpeechTranscribeResult } from './speech-to-text.js';
 
 // Re-export types that may be used by other main-process modules
 export type { LogEvent, RuntimeActivityEvent } from './log-parser.js';
@@ -477,6 +478,50 @@ ipcMain.handle('app:get-setup-status', () => ({
 // language list, not the OS UI language, and can disagree on multilingual
 // systems.
 ipcMain.handle('app:get-system-locale', () => app.getLocale());
+
+async function resolveSpeechTranscriptionOptions(): Promise<{
+  apiKey?: string;
+  apiKeyEnvName: string;
+  baseUrl?: string;
+  model?: string;
+}> {
+  let speechConfig: Record<string, unknown> = {};
+  try {
+    const config = await readConfig(ACTIVE_CONFIG_PATH);
+    speechConfig = asRecord(asRecord(config['buyer'])['speechToText']);
+  } catch {
+    // Config is optional for transcription; environment variables are enough.
+  }
+
+  const apiKeyEnvName = asString(speechConfig['apiKeyEnv'], 'OPENAI_API_KEY').trim() || 'OPENAI_API_KEY';
+  const configuredApiKey = process.env[apiKeyEnvName]?.trim();
+  const fallbackApiKey = apiKeyEnvName === 'OPENAI_API_KEY'
+    ? undefined
+    : process.env['OPENAI_API_KEY']?.trim();
+  const baseUrl = asString(
+    speechConfig['baseUrl'],
+    process.env['OPENAI_TRANSCRIPTION_BASE_URL'] || '',
+  ).trim();
+  const model = asString(
+    speechConfig['model'],
+    process.env['OPENAI_TRANSCRIPTION_MODEL'] || 'whisper-1',
+  ).trim();
+
+  return {
+    apiKey: configuredApiKey || fallbackApiKey,
+    apiKeyEnvName,
+    ...(baseUrl ? { baseUrl } : {}),
+    ...(model ? { model } : {}),
+  };
+}
+
+ipcMain.handle(
+  'speech:transcribe-whisper',
+  async (_event, payload: SpeechTranscribePayload): Promise<SpeechTranscribeResult> => {
+    const options = await resolveSpeechTranscriptionOptions();
+    return transcribeWithWhisper(payload, options);
+  },
+);
 
 ipcMain.handle('identity:get', async () => {
   try {

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -87,6 +87,10 @@ type RawChatAttachment = {
   base64: string;
 };
 
+type SpeechTranscribeResult =
+  | { ok: true; text: string }
+  | { ok: false; error: string };
+
 type PreparedChatAttachment = {
   id: string;
   /** Stable server-generated ID for the on-disk copy; used by the
@@ -223,6 +227,9 @@ const api = {
   },
   chatPrepareAttachments(conversationId: string, attachments: RawChatAttachment[]): Promise<{ ok: boolean; data?: PreparedChatAttachment[]; error?: string }> {
     return ipcRenderer.invoke('chat:prepare-attachments', conversationId, attachments);
+  },
+  speechTranscribeWhisper(payload: { dataUrl: string; mimeType?: string; language?: string }): Promise<SpeechTranscribeResult> {
+    return ipcRenderer.invoke('speech:transcribe-whisper', payload) as Promise<SpeechTranscribeResult>;
   },
   attachmentDownload(conversationId: string, attachmentId: string, suggestedName: string): Promise<{ ok: boolean; path?: string; error?: string }> {
     return ipcRenderer.invoke('attachment:download', conversationId, attachmentId, suggestedName);

--- a/apps/desktop/src/main/speech-to-text.test.ts
+++ b/apps/desktop/src/main/speech-to-text.test.ts
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { transcribeWithWhisper } from './speech-to-text.js';
+
+function audioDataUrl(mimeType = 'audio/webm', content = 'hello audio'): string {
+  return `data:${mimeType};base64,${Buffer.from(content).toString('base64')}`;
+}
+
+test('transcribeWithWhisper requires an API key', async () => {
+  const result = await transcribeWithWhisper(
+    { dataUrl: audioDataUrl() },
+    { apiKeyEnvName: 'OPENAI_API_KEY' },
+  );
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /OPENAI_API_KEY/);
+});
+
+test('transcribeWithWhisper posts audio to Whisper and returns transcript', async () => {
+  let observedUrl = '';
+  let observedAuthorization = '';
+  let observedModel: unknown = null;
+  let observedFile: unknown = null;
+
+  const result = await transcribeWithWhisper(
+    { dataUrl: audioDataUrl('audio/webm;codecs=opus') },
+    {
+      apiKey: 'sk-test',
+      baseUrl: 'https://api.openai.example/v1/',
+      fetchImpl: async (url, init) => {
+        observedUrl = url;
+        observedAuthorization = init.headers['Authorization'] ?? '';
+        observedModel = init.body.get('model');
+        observedFile = init.body.get('file');
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({ text: '  ship it professionally  ' }),
+        };
+      },
+    },
+  );
+
+  assert.deepEqual(result, { ok: true, text: 'ship it professionally' });
+  assert.equal(observedUrl, 'https://api.openai.example/v1/audio/transcriptions');
+  assert.equal(observedAuthorization, 'Bearer sk-test');
+  assert.equal(observedModel, 'whisper-1');
+  assert.ok(observedFile instanceof Blob);
+});
+
+test('transcribeWithWhisper rejects unsupported audio formats', async () => {
+  const result = await transcribeWithWhisper(
+    { dataUrl: audioDataUrl('text/plain') },
+    { apiKey: 'sk-test' },
+  );
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /Unsupported audio format/);
+});
+
+test('transcribeWithWhisper surfaces Whisper API errors', async () => {
+  const result = await transcribeWithWhisper(
+    { dataUrl: audioDataUrl() },
+    {
+      apiKey: 'sk-test',
+      fetchImpl: async () => ({
+        ok: false,
+        status: 401,
+        text: async () => JSON.stringify({ error: { message: 'bad key' } }),
+      }),
+    },
+  );
+
+  assert.equal(result.ok, false);
+  assert.match(result.error, /401/);
+  assert.match(result.error, /bad key/);
+});

--- a/apps/desktop/src/main/speech-to-text.ts
+++ b/apps/desktop/src/main/speech-to-text.ts
@@ -1,0 +1,215 @@
+export type SpeechTranscribePayload = {
+  dataUrl: string;
+  mimeType?: string;
+  language?: string;
+};
+
+export type SpeechTranscribeSuccess = {
+  ok: true;
+  text: string;
+};
+
+export type SpeechTranscribeFailure = {
+  ok: false;
+  error: string;
+};
+
+export type SpeechTranscribeResult = SpeechTranscribeSuccess | SpeechTranscribeFailure;
+
+type WhisperFetchResponse = {
+  ok: boolean;
+  status: number;
+  text: () => Promise<string>;
+};
+
+type WhisperFetch = (
+  url: string,
+  init: {
+    method: 'POST';
+    headers: Record<string, string>;
+    body: FormData;
+  },
+) => Promise<WhisperFetchResponse>;
+
+export type WhisperTranscriptionOptions = {
+  apiKey?: string;
+  apiKeyEnvName?: string;
+  baseUrl?: string;
+  model?: string;
+  fetchImpl?: WhisperFetch;
+};
+
+const MAX_WHISPER_AUDIO_BYTES = 25 * 1024 * 1024;
+const DEFAULT_WHISPER_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_WHISPER_MODEL = 'whisper-1';
+
+const ALLOWED_AUDIO_MIME_TYPES = new Set([
+  'audio/aac',
+  'audio/flac',
+  'audio/m4a',
+  'audio/mp3',
+  'audio/mp4',
+  'audio/mpeg',
+  'audio/mpga',
+  'audio/ogg',
+  'audio/wav',
+  'audio/webm',
+  'video/mp4',
+  'video/webm',
+]);
+
+function cleanBaseUrl(value: string | undefined): string {
+  const trimmed = value?.trim() || DEFAULT_WHISPER_BASE_URL;
+  return trimmed.replace(/\/+$/, '');
+}
+
+function normalizeMimeType(value: string | undefined): string {
+  const base = String(value || '').split(';')[0] ?? '';
+  return base.trim().toLowerCase();
+}
+
+function extensionForMimeType(mimeType: string): string {
+  switch (mimeType) {
+    case 'audio/aac':
+      return 'aac';
+    case 'audio/flac':
+      return 'flac';
+    case 'audio/m4a':
+      return 'm4a';
+    case 'audio/mp3':
+      return 'mp3';
+    case 'audio/mp4':
+    case 'video/mp4':
+      return 'mp4';
+    case 'audio/mpeg':
+    case 'audio/mpga':
+      return 'mpga';
+    case 'audio/ogg':
+      return 'ogg';
+    case 'audio/wav':
+      return 'wav';
+    case 'audio/webm':
+    case 'video/webm':
+      return 'webm';
+    default:
+      return 'webm';
+  }
+}
+
+function extractAudio(payload: SpeechTranscribePayload): { data: Buffer; mimeType: string } {
+  if (!payload || typeof payload.dataUrl !== 'string') {
+    throw new Error('Missing audio payload');
+  }
+
+  const match = /^data:([^;,]+)(?:;[^,]*)?;base64,(.+)$/s.exec(payload.dataUrl.trim());
+  if (!match) {
+    throw new Error('Audio payload must be a base64 data URL');
+  }
+
+  const mimeType = normalizeMimeType(payload.mimeType) || normalizeMimeType(match[1]);
+  if (!ALLOWED_AUDIO_MIME_TYPES.has(mimeType)) {
+    throw new Error(`Unsupported audio format: ${mimeType || 'unknown'}`);
+  }
+
+  const base64 = match[2]?.replace(/\s/g, '') || '';
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(base64)) {
+    throw new Error('Audio payload is not valid base64');
+  }
+
+  const data = Buffer.from(base64, 'base64');
+  if (data.length === 0) {
+    throw new Error('Recorded audio was empty');
+  }
+  if (data.length > MAX_WHISPER_AUDIO_BYTES) {
+    throw new Error('Recording is too large. Please keep voice notes under 25 MiB.');
+  }
+
+  return { data, mimeType };
+}
+
+function parseWhisperText(raw: string): string {
+  try {
+    const parsed = JSON.parse(raw) as { text?: unknown };
+    return typeof parsed.text === 'string' ? parsed.text.trim() : '';
+  } catch {
+    return '';
+  }
+}
+
+function cleanErrorBody(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  try {
+    const parsed = JSON.parse(trimmed) as { error?: { message?: unknown } | string };
+    if (typeof parsed.error === 'string') return parsed.error;
+    if (parsed.error && typeof parsed.error.message === 'string') return parsed.error.message;
+  } catch {
+    // Fall through to the raw body.
+  }
+  return trimmed.slice(0, 300);
+}
+
+export async function transcribeWithWhisper(
+  payload: SpeechTranscribePayload,
+  options: WhisperTranscriptionOptions = {},
+): Promise<SpeechTranscribeResult> {
+  const apiKey = options.apiKey?.trim();
+  const apiKeyEnvName = options.apiKeyEnvName?.trim() || 'OPENAI_API_KEY';
+  if (!apiKey) {
+    return {
+      ok: false,
+      error: `Whisper transcription needs an OpenAI API key. Set ${apiKeyEnvName} and try again.`,
+    };
+  }
+
+  let audio: { data: Buffer; mimeType: string };
+  try {
+    audio = extractAudio(payload);
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+
+  const model = options.model?.trim() || DEFAULT_WHISPER_MODEL;
+  const form = new FormData();
+  const file = new Blob([audio.data], { type: audio.mimeType });
+  form.append('file', file, `antstation-recording.${extensionForMimeType(audio.mimeType)}`);
+  form.append('model', model);
+  form.append('response_format', 'json');
+  const language = payload.language?.trim();
+  if (language) {
+    form.append('language', language);
+  }
+
+  try {
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const response = await fetchImpl(`${cleanBaseUrl(options.baseUrl)}/audio/transcriptions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: form,
+    });
+    const responseBody = await response.text();
+    if (!response.ok) {
+      const detail = cleanErrorBody(responseBody);
+      return {
+        ok: false,
+        error: detail
+          ? `Whisper transcription failed (${response.status}): ${detail}`
+          : `Whisper transcription failed with HTTP ${response.status}`,
+      };
+    }
+
+    const text = parseWhisperText(responseBody);
+    if (!text) {
+      return { ok: false, error: 'Whisper returned an empty transcript.' };
+    }
+
+    return { ok: true, text };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -107,6 +107,10 @@ export type RawChatAttachment = {
   base64: string;
 };
 
+export type SpeechTranscribeResult =
+  | { ok: true; text: string }
+  | { ok: false; error: string };
+
 export type PreparedChatAttachment = {
   id: string;
   /** Stable server-generated ID for the on-disk copy; used by the
@@ -168,6 +172,7 @@ export type DesktopBridge = {
   chatAiDeleteConversation?: (id: string) => Promise<{ ok: boolean }>;
   chatAiRenameConversation?: (id: string, title: string) => Promise<{ ok: boolean; error?: string }>;
   chatPrepareAttachments?: (conversationId: string, attachments: RawChatAttachment[]) => Promise<{ ok: boolean; data?: PreparedChatAttachment[]; error?: string }>;
+  speechTranscribeWhisper?: (payload: { dataUrl: string; mimeType?: string; language?: string }) => Promise<SpeechTranscribeResult>;
   attachmentDownload?: (conversationId: string, attachmentId: string, suggestedName: string) => Promise<{ ok: boolean; path?: string; error?: string }>;
   chatAiSend?: (conversationId: string, message: string, service?: string, provider?: string, attachments?: PreparedChatAttachment[], peerId?: string) => Promise<{ ok: boolean; error?: string }>;
   chatAiSendStream?: (conversationId: string, message: string, service?: string, provider?: string, attachments?: PreparedChatAttachment[], peerId?: string) => Promise<{ ok: boolean; error?: string; stopReason?: ChatAiStreamStopReason }>;

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
@@ -711,6 +711,12 @@
   justify-content: space-between;
 }
 
+.chat-input-actions-left {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 .chat-attach-btn {
   background: transparent;
   border: none;
@@ -736,6 +742,70 @@
 
 .chat-attach-btn-limited {
   opacity: 0.75;
+}
+
+.chat-voice-btn {
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  padding: 4px;
+  cursor: pointer;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s, background 0.15s, transform 0.15s;
+
+  &:hover:not(:disabled) {
+    color: var(--accent-green);
+    background: rgba(31, 216, 122, 0.08);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent-green);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    opacity: 0.45;
+    cursor: wait;
+  }
+}
+
+.chat-voice-btn-recording {
+  color: var(--danger);
+  background: rgba(var(--danger-rgb), 0.1);
+  animation: recording-pulse 1.2s ease-in-out infinite;
+
+  &:hover:not(:disabled) {
+    color: var(--danger);
+    background: rgba(var(--danger-rgb), 0.16);
+  }
+}
+
+.chat-voice-status {
+  margin: 8px 16px;
+  padding: 7px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(31, 216, 122, 0.24);
+  background: rgba(31, 216, 122, 0.08);
+  color: var(--accent-green);
+  font-size: 12px;
+  line-height: 1.4;
+  max-width: fit-content;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@keyframes recording-pulse {
+  0%, 100% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(1.08);
+  }
 }
 
 .chat-text-input {

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -3,6 +3,7 @@ import type { KeyboardEvent, MouseEvent } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
   Add01Icon,
+  AiMicIcon,
   ArrowUp02Icon,
   ArrowRight01Icon,
   ArrowDown02Icon,
@@ -12,6 +13,7 @@ import {
   Folder01Icon,
   GitBranchIcon,
   Search01Icon,
+  StopCircleIcon,
   Tick02Icon
 } from '@hugeicons/core-free-icons';
 import { useUiSnapshot } from '../../hooks/useUiSnapshot';
@@ -29,7 +31,7 @@ import { AttachmentViewer, type ViewerAttachment } from '../chat/AttachmentViewe
 import { BrowserPreview } from '../BrowserPreview';
 import type { ChatMessage } from '../chat/chat-shared';
 import { buildDisplayMessages } from '../chat/chat-shared';
-import type { ChatWorkspaceGitStatus, RawChatAttachment } from '../../../types/bridge';
+import type { ChatWorkspaceGitStatus, DesktopBridge, RawChatAttachment } from '../../../types/bridge';
 import { AntStationStackedLogo } from '../AntStationLogo';
 
 const SWITCH_DIALOG_DISMISSED_KEY = 'antseed:switchServiceConfirmDismissed';
@@ -47,6 +49,15 @@ const MAX_ATTACHMENTS = 5;
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 const MAX_TOTAL_ATTACHMENT_BYTES = 50 * 1024 * 1024;
 const NEAR_BOTTOM_PX = 40;
+const RECORDING_MIME_TYPE_CANDIDATES = [
+  'audio/webm;codecs=opus',
+  'audio/webm',
+  'audio/mp4',
+  'audio/ogg;codecs=opus',
+  'audio/wav',
+];
+
+type VoiceRecordStatus = 'idle' | 'requesting' | 'recording' | 'transcribing';
 
 function isNearScrollBottom(el: HTMLElement): boolean {
   return el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_PX;
@@ -167,6 +178,33 @@ function getGitStatusTitle(status: ChatWorkspaceGitStatus): string {
   return details.join('\n');
 }
 
+function getPreferredRecordingMimeType(): string {
+  if (typeof MediaRecorder === 'undefined' || typeof MediaRecorder.isTypeSupported !== 'function') {
+    return '';
+  }
+  return RECORDING_MIME_TYPE_CANDIDATES.find((type) => MediaRecorder.isTypeSupported(type)) || '';
+}
+
+function readBlobAsDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('Could not read recorded audio.'));
+    reader.onload = () => resolve(String(reader.result || ''));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function stopMediaStream(stream: MediaStream | null): void {
+  stream?.getTracks().forEach((track) => track.stop());
+}
+
+function formatRecordingDuration(seconds: number): string {
+  const safeSeconds = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(safeSeconds / 60);
+  const remainingSeconds = safeSeconds % 60;
+  return `${minutes}:${String(remainingSeconds).padStart(2, '0')}`;
+}
+
 
 type ChatViewProps = {
   active: boolean;
@@ -194,6 +232,9 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     text: string;
     attachments: RawChatAttachment[];
   } | null>(null);
+  const [voiceRecordStatus, setVoiceRecordStatus] = useState<VoiceRecordStatus>('idle');
+  const [voiceRecordError, setVoiceRecordError] = useState<string | null>(null);
+  const [recordingElapsedSeconds, setRecordingElapsedSeconds] = useState(0);
   // While the LLM is streaming we still let the user type/paste.
   // Drafts the user confirms (Enter / Send) are parked in this queue as
   // cards above the composer and ship one-per-turn as soon as the current
@@ -223,6 +264,10 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   const messageSearchInputRef = useRef<HTMLInputElement>(null);
   const messageRefs = useRef(new Map<string, HTMLDivElement>());
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const mediaStreamRef = useRef<MediaStream | null>(null);
+  const recordedAudioChunksRef = useRef<Blob[]>([]);
+  const recordingStartedAtRef = useRef<number>(0);
   const approvedLowReputationPeersRef = useRef<Set<string>>(new Set());
   const scrollRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -231,6 +276,26 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   const wasActiveRef = useRef<boolean>(active);
   const isUserScrolledUp = useRef(false);
   const isDragging = useRef(false);
+
+  useEffect(() => {
+    if (voiceRecordStatus !== 'recording') return undefined;
+    const timer = window.setInterval(() => {
+      const startedAt = recordingStartedAtRef.current;
+      setRecordingElapsedSeconds(startedAt > 0 ? Math.floor((Date.now() - startedAt) / 1000) : 0);
+    }, 500);
+    return () => window.clearInterval(timer);
+  }, [voiceRecordStatus]);
+
+  useEffect(() => () => {
+    const recorder = mediaRecorderRef.current;
+    if (recorder && recorder.state !== 'inactive') {
+      recorder.ondataavailable = null;
+      recorder.onstop = null;
+      recorder.stop();
+    }
+    stopMediaStream(mediaStreamRef.current);
+  }, []);
+
   const visibleMessages = useMemo(() => {
     const msgs = Array.isArray(snap.chatMessages) ? (snap.chatMessages as ChatMessage[]) : [];
     return buildDisplayMessages(msgs).filter((msg) => !isToolResultOnlyMessage(msg));
@@ -831,6 +896,131 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     }
   }, []);
 
+  const appendVoiceTranscript = useCallback((transcript: string) => {
+    const cleaned = transcript.trim();
+    if (!cleaned) return;
+    setInputValue((prev) => {
+      const trimmedPrev = prev.trimEnd();
+      return trimmedPrev ? `${trimmedPrev}\n${cleaned}` : cleaned;
+    });
+    requestAnimationFrame(() => {
+      handleInput();
+      inputRef.current?.focus();
+    });
+  }, [handleInput]);
+
+  const handleStopVoiceRecording = useCallback(() => {
+    const recorder = mediaRecorderRef.current;
+    if (recorder && recorder.state !== 'inactive') {
+      recorder.stop();
+    }
+  }, []);
+
+  const transcribeRecordedAudio = useCallback(async (blob: Blob) => {
+    const bridge = (window as unknown as { antseedDesktop?: DesktopBridge }).antseedDesktop;
+    if (!bridge?.speechTranscribeWhisper) {
+      setVoiceRecordError('Speech transcription is unavailable in this desktop build.');
+      setVoiceRecordStatus('idle');
+      return;
+    }
+
+    if (blob.size === 0) {
+      setVoiceRecordError('No audio was captured. Please try recording again.');
+      setVoiceRecordStatus('idle');
+      return;
+    }
+
+    setVoiceRecordStatus('transcribing');
+    setVoiceRecordError(null);
+    try {
+      const dataUrl = await readBlobAsDataUrl(blob);
+      const result = await bridge.speechTranscribeWhisper({
+        dataUrl,
+        mimeType: blob.type || undefined,
+      });
+      if (!result.ok) {
+        setVoiceRecordError(result.error || 'Whisper transcription failed.');
+        return;
+      }
+      appendVoiceTranscript(result.text);
+    } catch (error) {
+      setVoiceRecordError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setVoiceRecordStatus('idle');
+      setRecordingElapsedSeconds(0);
+    }
+  }, [appendVoiceTranscript]);
+
+  const handleStartVoiceRecording = useCallback(async () => {
+    setVoiceRecordError(null);
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setVoiceRecordError('Microphone recording is not supported on this system.');
+      return;
+    }
+    if (typeof MediaRecorder === 'undefined') {
+      setVoiceRecordError('Audio recording is not supported in this desktop runtime.');
+      return;
+    }
+
+    setVoiceRecordStatus('requesting');
+
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const preferredMimeType = getPreferredRecordingMimeType();
+      const recorder = preferredMimeType
+        ? new MediaRecorder(stream, { mimeType: preferredMimeType })
+        : new MediaRecorder(stream);
+      recordedAudioChunksRef.current = [];
+      mediaStreamRef.current = stream;
+      mediaRecorderRef.current = recorder;
+      recordingStartedAtRef.current = Date.now();
+      setRecordingElapsedSeconds(0);
+
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          recordedAudioChunksRef.current.push(event.data);
+        }
+      };
+      recorder.onerror = () => {
+        setVoiceRecordError('Microphone recording failed. Please try again.');
+        setVoiceRecordStatus('idle');
+        stopMediaStream(stream);
+      };
+      recorder.onstop = () => {
+        const mimeType = recorder.mimeType || preferredMimeType || 'audio/webm';
+        const blob = new Blob(recordedAudioChunksRef.current, { type: mimeType });
+        recordedAudioChunksRef.current = [];
+        mediaRecorderRef.current = null;
+        mediaStreamRef.current = null;
+        stopMediaStream(stream);
+        void transcribeRecordedAudio(blob);
+      };
+
+      recorder.start();
+      setVoiceRecordStatus('recording');
+      inputRef.current?.focus();
+    } catch (error) {
+      stopMediaStream(mediaStreamRef.current);
+      mediaStreamRef.current = null;
+      const message = error instanceof DOMException && error.name === 'NotAllowedError'
+        ? 'Microphone permission was denied. Enable microphone access and try again.'
+        : error instanceof Error
+          ? error.message
+          : String(error);
+      setVoiceRecordError(message);
+      setVoiceRecordStatus('idle');
+    }
+  }, [transcribeRecordedAudio]);
+
+  const handleToggleVoiceRecording = useCallback(() => {
+    if (voiceRecordStatus === 'recording') {
+      handleStopVoiceRecording();
+      return;
+    }
+    if (voiceRecordStatus === 'requesting' || voiceRecordStatus === 'transcribing') return;
+    void handleStartVoiceRecording();
+  }, [handleStartVoiceRecording, handleStopVoiceRecording, voiceRecordStatus]);
+
   const handleClosePreview = useCallback(() => {
     setPreviewOpen(false);
   }, []);
@@ -864,6 +1054,21 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     snap.chatSendingConversationId === snap.chatActiveConversation ||
     activeConversationIsSending
   );
+  const voiceButtonActive = voiceRecordStatus === 'recording';
+  const voiceButtonTitle = voiceRecordStatus === 'recording'
+    ? 'Stop recording and transcribe with Whisper'
+    : voiceRecordStatus === 'requesting'
+      ? 'Requesting microphone permission...'
+      : voiceRecordStatus === 'transcribing'
+        ? 'Transcribing with Whisper...'
+        : 'Record voice input with Whisper';
+  const voiceStatusLabel = voiceRecordStatus === 'recording'
+    ? `Recording ${formatRecordingDuration(recordingElapsedSeconds)} — click the mic to transcribe`
+    : voiceRecordStatus === 'requesting'
+      ? 'Waiting for microphone permission...'
+      : voiceRecordStatus === 'transcribing'
+        ? 'Transcribing with Whisper...'
+        : null;
 
   const workspacePath = snap.chatWorkspacePath || snap.chatWorkspaceDefaultPath;
   const workspaceLabel = getPathEnding(workspacePath);
@@ -1161,6 +1366,12 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
             {snap.chatError && <div className={styles.chatError}>{snap.chatError}</div>}
             {attachmentError && <div className={styles.chatError}>{attachmentError}</div>}
             {attachmentWarning && <div className={styles.chatWarning}>{attachmentWarning}</div>}
+            {voiceRecordError && <div className={styles.chatWarning}>{voiceRecordError}</div>}
+            {voiceStatusLabel && (
+              <div className={styles.chatVoiceStatus} aria-live="polite">
+                {voiceStatusLabel}
+              </div>
+            )}
             <LowBalanceWarning
               visible={snap.chatLowBalanceWarning}
               availableUsdc={snap.creditsAvailableUsdc}
@@ -1242,19 +1453,33 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                 onPaste={handlePaste}
               />
               <div className={styles.chatInputBottom}>
-                <button
-                  className={`${styles.chatAttachBtn} ${supportsMultimodal ? '' : styles.chatAttachBtnLimited}`}
-                  title={supportsMultimodal ? 'Attach files' : "Attach files (images unavailable for selected model)"}
-                  onClick={() => fileInputRef.current?.click()}
-                >
-                  <HugeiconsIcon icon={Add01Icon} size={18} strokeWidth={2} />
-                </button>
+                <div className={styles.chatInputActionsLeft}>
+                  <button
+                    type="button"
+                    className={`${styles.chatAttachBtn} ${supportsMultimodal ? '' : styles.chatAttachBtnLimited}`}
+                    title={supportsMultimodal ? 'Attach files' : "Attach files (images unavailable for selected model)"}
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <HugeiconsIcon icon={Add01Icon} size={18} strokeWidth={2} />
+                  </button>
+                  <button
+                    type="button"
+                    className={`${styles.chatVoiceBtn}${voiceButtonActive ? ` ${styles.chatVoiceBtnRecording}` : ''}`}
+                    title={voiceButtonTitle}
+                    aria-label={voiceButtonTitle}
+                    aria-pressed={voiceButtonActive}
+                    disabled={voiceRecordStatus === 'requesting' || voiceRecordStatus === 'transcribing'}
+                    onClick={handleToggleVoiceRecording}
+                  >
+                    <HugeiconsIcon icon={voiceButtonActive ? StopCircleIcon : AiMicIcon} size={18} strokeWidth={2} />
+                  </button>
+                </div>
                 {snap.chatAbortVisible ? (
-                  <button className={styles.chatAbortBtn} onClick={handleStop}>
+                  <button type="button" className={styles.chatAbortBtn} onClick={handleStop}>
                     Stop
                   </button>
                 ) : (
-                  <button className={styles.chatSendBtn} disabled={snap.chatSendDisabled && attachedFiles.length === 0} onClick={handleSend}>
+                  <button type="button" className={styles.chatSendBtn} disabled={snap.chatSendDisabled && attachedFiles.length === 0} onClick={handleSend}>
                     <HugeiconsIcon icon={ArrowUp02Icon} size={18} strokeWidth={2.5} />
                   </button>
                 )}


### PR DESCRIPTION
## Description

Adds a microphone recording option to the AntStation chat composer and transcribes recordings with Whisper before inserting the transcript into the editable prompt input. The desktop main process owns the Whisper API call behind a typed IPC bridge, validates supported audio formats and size limits, and surfaces microphone/API errors cleanly in the composer.

Closes #147
Refs #435

## Release Notes

- Added a record button in AntStation chat that captures microphone audio and inserts a Whisper transcript into the prompt composer.
- Added clear recording, transcription, permission-denied, and API-key error states for voice input.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Verification

- `pnpm --filter @antseed/api-adapter build`
- `pnpm --filter @antseed/node build`
- `pnpm --filter @antseed/payments build:server`
- `pnpm -C apps/desktop run typecheck:renderer`
- `pnpm -C apps/desktop run test`
- `pnpm -C apps/desktop run build:renderer`

## Configuration

Whisper transcription uses `OPENAI_API_KEY` by default. Advanced users can override `buyer.speechToText.apiKeyEnv`, `buyer.speechToText.baseUrl`, or `buyer.speechToText.model`; `OPENAI_TRANSCRIPTION_BASE_URL` and `OPENAI_TRANSCRIPTION_MODEL` are also supported.