### PR TITLE
fix(payments): Reject insufficient topups

### DIFF
--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -123,6 +123,9 @@ export class SellerPaymentManager {
    *  subsumes the older request. */
   private readonly _pendingTopUp = new Map<string, { newMaxAmount: bigint; deadline: number; reserveAuthSig: string }>();
 
+  /** Channels that must not serve more paid work until closed/renegotiated. */
+  private readonly _blockedChannels = new Set<string>();
+
   /** channelIds with an in-flight close() tx/estimate. Prevents duplicate close submissions. */
   private readonly _closingChannels = new Set<string>();
 
@@ -254,6 +257,7 @@ export class SellerPaymentManager {
     this._hydratedChannelIds.delete(channelId);
     this._reserveMax.delete(channelId);
     this._pendingTopUp.delete(channelId);
+    this._blockedChannels.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
     this._releaseAcceptedWaiters(channelId);
     this._activeBuyers.delete(peerId);
@@ -574,10 +578,11 @@ export class SellerPaymentManager {
 
           debugWarn(
             `[SellerPayment] Top-up on-chain failed permanently: channel=${channelId.slice(0, 18)}... ` +
-            `kind=${failureKind} error=${this._formatError(topUpErr)} — settling latest auth and rejecting topUp`,
+            `kind=${failureKind} error=${this._formatError(topUpErr)} — closing latest auth and rejecting topUp`,
           );
           this._pendingTopUp.delete(channelId);
-          await this._settleLatestAuth(channelId, 'permanent topUp failure', { respectMinSettleDelta: false });
+          this._blockedChannels.add(channelId);
+          await this.settleSession(buyerPeerId);
           return 'rejected';
         }
         return 'accepted';
@@ -617,43 +622,19 @@ export class SellerPaymentManager {
           return 'rejected';
         }
 
-        // Reject if cumulative exceeds on-chain deposit — the contract would revert
-        // and we'd lose the last valid auth signature that close() could use.
-        // Exception: a retryable pending topUp may temporarily raise the
-        // effective ceiling. Non-retryable failures (notably InsufficientBalance)
-        // must not be treated as headroom or the seller keeps serving unpaid work.
+        // Reject if cumulative exceeds the on-chain deposit. Pending topUps do
+        // not count here: until topUp() succeeds, the extra funds are not
+        // locked, and accepting an over-reserve SpendingAuth would leave the
+        // seller with an auth the contract cannot settle.
         const currentReserveMax = this._reserveMax.get(channelId) ?? 0n;
         const pendingTopUpForCheck = this._pendingTopUp.get(channelId);
-        const effectiveMax = pendingTopUpForCheck
-          ? (pendingTopUpForCheck.newMaxAmount > currentReserveMax ? pendingTopUpForCheck.newMaxAmount : currentReserveMax)
-          : currentReserveMax;
-        if (effectiveMax > 0n && cumulativeAmount > effectiveMax) {
+        if (currentReserveMax > 0n && cumulativeAmount > currentReserveMax) {
           debugWarn(
             `[SellerPayment] Rejecting SpendingAuth exceeding deposit ceiling: ` +
             `cumulative=${cumulativeAmount} > reserveMax=${currentReserveMax}` +
             `${pendingTopUpForCheck ? ` (pending topUp to ${pendingTopUpForCheck.newMaxAmount})` : ''} channel=${channelId.slice(0, 18)}...`,
           );
           return 'rejected';
-        }
-
-        const requiresPendingTopUp = Boolean(
-          pendingTopUpForCheck && currentReserveMax > 0n && cumulativeAmount > currentReserveMax,
-        );
-        if (pendingTopUpForCheck && requiresPendingTopUp) {
-          const retryResult = await this._retryPendingTopUp(
-            channelId,
-            pendingTopUpForCheck,
-            cumulativeAmount,
-            payload.metadata || encodeMetadata(ZERO_METADATA),
-            payload.spendingAuthSig,
-          );
-          if (retryResult === 'permanent-failure') {
-            // The only thing making this auth valid was the pending topUp.
-            // Since that topUp is now known to be impossible, reject before
-            // mutating acceptedCumulative/latestAuth so close() never uses an
-            // over-ceiling SpendingAuth.
-            return 'rejected';
-          }
         }
 
         // Update tracking
@@ -681,13 +662,10 @@ export class SellerPaymentManager {
         debugLog(`[SellerPayment] Budget updated: channel=${channelId.slice(0, 18)}... cumulative=${cumulativeAmount}`);
 
         // Retry any deferred topUp now that we have a higher settle amount.
-        // If the SpendingAuth did not require the pending ceiling to be
-        // accepted, a permanent retry failure is safe to drop after committing
-        // this auth because the auth is still within the current on-chain max.
         const pendingTopUp = this._pendingTopUp.get(channelId);
-        if (pendingTopUp && !requiresPendingTopUp) {
+        if (pendingTopUp) {
           const { amount: retrySettleAmount, metadata: retryMetadata, sig: retrySig } = this._getSettleParams(channelId);
-          await this._retryPendingTopUp(channelId, pendingTopUp, retrySettleAmount, retryMetadata, retrySig);
+          await this._retryPendingTopUp(buyerPeerId, channelId, pendingTopUp, retrySettleAmount, retryMetadata, retrySig);
         }
 
         return 'accepted';
@@ -809,6 +787,7 @@ export class SellerPaymentManager {
   }
 
   private async _retryPendingTopUp(
+    buyerPeerId: string,
     channelId: string,
     pendingTopUp: { newMaxAmount: bigint; deadline: number; reserveAuthSig: string },
     settleAmount: bigint,
@@ -851,9 +830,10 @@ export class SellerPaymentManager {
 
       debugWarn(
         `[SellerPayment] Deferred topUp failed permanently: channel=${channelId.slice(0, 18)}... ` +
-        `kind=${failureKind} error=${this._formatError(retryErr)} — settling latest auth and dropping pending topUp`,
+        `kind=${failureKind} error=${this._formatError(retryErr)} — closing latest auth and dropping pending topUp`,
       );
-      await this._settleLatestAuth(channelId, 'permanent deferred topUp failure', { respectMinSettleDelta: false });
+      this._blockedChannels.add(channelId);
+      await this.settleSession(buyerPeerId);
       return 'permanent-failure';
     }
   }
@@ -1005,6 +985,15 @@ export class SellerPaymentManager {
       return false;
     }
 
+    const reserveMax = this._reserveMax.get(channelId) ?? 0n;
+    if (reserveMax > 0n && newCumulative > reserveMax) {
+      debugWarn(
+        `[SellerPayment] validateAndAcceptAuth: cumulative exceeds reserve ceiling ` +
+        `(${newCumulative} > ${reserveMax}) channel=${channelId.slice(0, 18)}...`,
+      );
+      return false;
+    }
+
     this._hydratedChannelIds.delete(channelId);
 
     // Update if strictly greater
@@ -1130,6 +1119,9 @@ export class SellerPaymentManager {
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
     this._closingChannels.delete(channelId);
+    this._reserveMax.delete(channelId);
+    this._pendingTopUp.delete(channelId);
+    this._blockedChannels.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
     this._hydratedChannelIds.delete(channelId);
     this._releaseAcceptedWaiters(channelId);
@@ -1282,11 +1274,14 @@ export class SellerPaymentManager {
     return this._reserveMax.get(sessionId) ?? 0n;
   }
 
-  /** Get the effective reserve max, considering pending (not-yet-on-chain) topUps. */
+  /** Get the effective reserve max for serving decisions. Pending topUps do not count until confirmed on-chain. */
   getEffectiveReserveMax(sessionId: string): bigint {
-    const onChain = this._reserveMax.get(sessionId) ?? 0n;
-    const pending = this._pendingTopUp.get(sessionId);
-    return pending && pending.newMaxAmount > onChain ? pending.newMaxAmount : onChain;
+    return this.getReserveMax(sessionId);
+  }
+
+  /** Whether this channel is blocked from serving more paid work. */
+  isChannelBlocked(sessionId: string): boolean {
+    return this._blockedChannels.has(sessionId);
   }
 
   /** Whether a topUp is pending (on-chain call deferred). */
@@ -1362,6 +1357,7 @@ export class SellerPaymentManager {
     this._closingChannels.delete(channelId);
     this._reserveMax.delete(channelId);
     this._pendingTopUp.delete(channelId);
+    this._blockedChannels.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
     this._hydratedChannelIds.delete(channelId);
     this._releaseAcceptedWaiters(channelId);

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -574,9 +574,10 @@ export class SellerPaymentManager {
 
           debugWarn(
             `[SellerPayment] Top-up on-chain failed permanently: channel=${channelId.slice(0, 18)}... ` +
-            `kind=${failureKind} error=${this._formatError(topUpErr)} — rejecting topUp`,
+            `kind=${failureKind} error=${this._formatError(topUpErr)} — settling latest auth and rejecting topUp`,
           );
           this._pendingTopUp.delete(channelId);
+          await this._settleLatestAuth(channelId, 'permanent topUp failure', { respectMinSettleDelta: false });
           return 'rejected';
         }
         return 'accepted';
@@ -748,6 +749,65 @@ export class SellerPaymentManager {
     return parts.filter(Boolean).join(' ');
   }
 
+  private async _settleLatestAuth(
+    channelId: string,
+    reason: string,
+    { respectMinSettleDelta = true }: { respectMinSettleDelta?: boolean } = {},
+  ): Promise<void> {
+    const { amount, metadata, sig } = this._getSettleParams(channelId);
+    if (amount <= 0n || sig === '0x') {
+      debugLog(`[SellerPayment] Skipping settle after ${reason}: channel=${channelId.slice(0, 18)}... no signed spend`);
+      return;
+    }
+
+    let delta: bigint | null = null;
+    if (respectMinSettleDelta) {
+      // Skip the getSession RPC entirely when our local cumulative hasn't
+      // moved since we last settled this channel — the contract would revert
+      // with InvalidAmount (strict `>` check) and we'd waste an RPC round-trip.
+      const lastSettled = this._lastSettledCumulative.get(channelId);
+      if (lastSettled !== undefined && amount <= lastSettled) {
+        debugLog(`[SellerPayment] Skip settle ${channelId.slice(0, 18)}... — cumulative unchanged since last settle (${amount})`);
+        return;
+      }
+
+      // Cache miss (e.g. after restart) or local cumulative has advanced —
+      // confirm against on-chain state in case another process settled.
+      let onChainSettled: bigint;
+      try {
+        const onChain = await this._channelsClient.getSession(channelId);
+        onChainSettled = onChain.settled;
+      } catch (err) {
+        debugWarn(`[SellerPayment] getSession failed for ${channelId.slice(0, 18)}...: ${err instanceof Error ? err.message : err} — attempting settle anyway`);
+        onChainSettled = 0n;
+      }
+      delta = amount - onChainSettled;
+      if (delta <= 0n) {
+        // Resync the cache so we stop hitting the RPC on every idle tick.
+        this._lastSettledCumulative.set(channelId, onChainSettled);
+        debugLog(`[SellerPayment] Skip settle ${channelId.slice(0, 18)}... — already settled on-chain (local=${amount}, onChain=${onChainSettled})`);
+        return;
+      }
+      if (delta < this._minSettleDelta) {
+        // Mark this cumulative as a no-op so the next tick short-circuits
+        // without re-querying getSession until amount actually advances.
+        this._lastSettledCumulative.set(channelId, amount);
+        debugLog(`[SellerPayment] Skip settle ${channelId.slice(0, 18)}... — delta=${delta} below minSettleDelta=${this._minSettleDelta}`);
+        return;
+      }
+    }
+
+    const deltaText = delta === null ? '' : ` delta=${delta}`;
+    debugLog(`[SellerPayment] Settling channel ${channelId.slice(0, 18)}... cumulative=${amount}${deltaText} (${reason})`);
+    try {
+      await this._channelsClient.settle(this._signer, channelId, amount, metadata, sig);
+      this._lastSettledCumulative.set(channelId, amount);
+      debugLog(`[SellerPayment] Settled channel ${channelId.slice(0, 18)}... — channel remains open`);
+    } catch (err) {
+      debugWarn(`[SellerPayment] Failed to settle channel after ${reason}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
   private async _retryPendingTopUp(
     channelId: string,
     pendingTopUp: { newMaxAmount: bigint; deadline: number; reserveAuthSig: string },
@@ -791,8 +851,9 @@ export class SellerPaymentManager {
 
       debugWarn(
         `[SellerPayment] Deferred topUp failed permanently: channel=${channelId.slice(0, 18)}... ` +
-        `kind=${failureKind} error=${this._formatError(retryErr)} — dropping pending topUp`,
+        `kind=${failureKind} error=${this._formatError(retryErr)} — settling latest auth and dropping pending topUp`,
       );
+      await this._settleLatestAuth(channelId, 'permanent deferred topUp failure', { respectMinSettleDelta: false });
       return 'permanent-failure';
     }
   }
@@ -1035,50 +1096,7 @@ export class SellerPaymentManager {
       if (settleOnly) return;
       debugLog(`[SellerPayment] Zero-cumulative channel ${channelId.slice(0, 18)}... — deferring to timeout checker`);
     } else if (settleOnly) {
-      if (amount === 0n) return;
-
-      // Skip the getSession RPC entirely when our local cumulative hasn't
-      // moved since we last settled this channel — the contract would revert
-      // with InvalidAmount (strict `>` check) and we'd waste an RPC round-trip.
-      const lastSettled = this._lastSettledCumulative.get(channelId);
-      if (lastSettled !== undefined && amount <= lastSettled) {
-        debugLog(`[SellerPayment] Skip settle ${channelId.slice(0, 18)}... — cumulative unchanged since last settle (${amount})`);
-        return;
-      }
-
-      // Cache miss (e.g. after restart) or local cumulative has advanced —
-      // confirm against on-chain state in case another process settled.
-      let onChainSettled: bigint;
-      try {
-        const onChain = await this._channelsClient.getSession(channelId);
-        onChainSettled = onChain.settled;
-      } catch (err) {
-        debugWarn(`[SellerPayment] getSession failed for ${channelId.slice(0, 18)}...: ${err instanceof Error ? err.message : err} — attempting settle anyway`);
-        onChainSettled = 0n;
-      }
-      const delta = amount - onChainSettled;
-      if (delta <= 0n) {
-        // Resync the cache so we stop hitting the RPC on every idle tick.
-        this._lastSettledCumulative.set(channelId, onChainSettled);
-        debugLog(`[SellerPayment] Skip settle ${channelId.slice(0, 18)}... — already settled on-chain (local=${amount}, onChain=${onChainSettled})`);
-        return;
-      }
-      if (delta < this._minSettleDelta) {
-        // Mark this cumulative as a no-op so the next tick short-circuits
-        // without re-querying getSession until amount actually advances.
-        this._lastSettledCumulative.set(channelId, amount);
-        debugLog(`[SellerPayment] Skip settle ${channelId.slice(0, 18)}... — delta=${delta} below minSettleDelta=${this._minSettleDelta}`);
-        return;
-      }
-
-      debugLog(`[SellerPayment] Settling channel ${channelId.slice(0, 18)}... cumulative=${amount} delta=${delta} (keeping open)`);
-      try {
-        await this._channelsClient.settle(this._signer, channelId, amount, metadata, sig);
-        this._lastSettledCumulative.set(channelId, amount);
-        debugLog(`[SellerPayment] Settled channel ${channelId.slice(0, 18)}... — channel remains open`);
-      } catch (err) {
-        debugWarn(`[SellerPayment] Failed to settle channel: ${err instanceof Error ? err.message : err}`);
-      }
+      await this._settleLatestAuth(channelId, 'idle settle', { respectMinSettleDelta: true });
       return;
     } else {
       if (this._closingChannels.has(channelId)) {

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -44,6 +44,11 @@ const DEFAULT_MIN_BUDGET_PER_REQUEST = '500000';
 export const DEFAULT_MIN_SETTLE_DELTA_STR = '2000';
 const DEFAULT_MIN_SETTLE_DELTA = BigInt(DEFAULT_MIN_SETTLE_DELTA_STR);
 
+const TOP_UP_THRESHOLD_NOT_MET_SELECTOR = '0x1ea4506b';
+const INSUFFICIENT_BALANCE_SELECTOR = '0xf4d678b8';
+
+type TopUpFailureKind = 'retryable-threshold' | 'insufficient-balance' | 'non-retryable';
+
 /** Stored auth entry for buyer's SpendingAuth signature. */
 interface LatestAuth {
   spendingAuthSig: string;
@@ -549,19 +554,30 @@ export class SellerPaymentManager {
 
           debugLog(`[SellerPayment] Top-up completed: channel=${channelId.slice(0, 18)}... new ceiling=${newMaxAmount}`);
         } catch (topUpErr) {
-          // On-chain topUp can fail (e.g. TopUpThresholdNotMet if not enough
-          // has been settled yet). Store the pending top-up so it can be
-          // retried after a subsequent SpendingAuth raises the settle amount.
+          const failureKind = this._classifyTopUpFailure(topUpErr);
+          if (failureKind === 'retryable-threshold') {
+            // TopUpThresholdNotMet is a timing/settlement race: keep the
+            // ReserveAuth pending and retry after a later SpendingAuth raises
+            // the settle amount enough to satisfy the contract's 85% gate.
+            debugWarn(
+              `[SellerPayment] Top-up threshold not met: channel=${channelId.slice(0, 18)}... ` +
+              `error=${this._formatError(topUpErr)} — ` +
+              `deferring topUp (will retry after next SpendingAuth)`,
+            );
+            this._storePendingTopUp(channelId, {
+              newMaxAmount,
+              deadline: topUpDeadline,
+              reserveAuthSig: payload.spendingAuthSig,
+            });
+            return 'accepted';
+          }
+
           debugWarn(
-            `[SellerPayment] Top-up on-chain failed: channel=${channelId.slice(0, 18)}... ` +
-            `error=${topUpErr instanceof Error ? topUpErr.message : topUpErr} — ` +
-            `deferring topUp (will retry after next SpendingAuth)`,
+            `[SellerPayment] Top-up on-chain failed permanently: channel=${channelId.slice(0, 18)}... ` +
+            `kind=${failureKind} error=${this._formatError(topUpErr)} — rejecting topUp`,
           );
-          this._pendingTopUp.set(channelId, {
-            newMaxAmount,
-            deadline: topUpDeadline,
-            reserveAuthSig: payload.spendingAuthSig,
-          });
+          this._pendingTopUp.delete(channelId);
+          return 'rejected';
         }
         return 'accepted';
       } else {
@@ -602,8 +618,9 @@ export class SellerPaymentManager {
 
         // Reject if cumulative exceeds on-chain deposit — the contract would revert
         // and we'd lose the last valid auth signature that close() could use.
-        // Exception: if there's a pending topUp that would raise the ceiling high
-        // enough, accept the SpendingAuth (the topUp will be retried after).
+        // Exception: a retryable pending topUp may temporarily raise the
+        // effective ceiling. Non-retryable failures (notably InsufficientBalance)
+        // must not be treated as headroom or the seller keeps serving unpaid work.
         const currentReserveMax = this._reserveMax.get(channelId) ?? 0n;
         const pendingTopUpForCheck = this._pendingTopUp.get(channelId);
         const effectiveMax = pendingTopUpForCheck
@@ -616,6 +633,26 @@ export class SellerPaymentManager {
             `${pendingTopUpForCheck ? ` (pending topUp to ${pendingTopUpForCheck.newMaxAmount})` : ''} channel=${channelId.slice(0, 18)}...`,
           );
           return 'rejected';
+        }
+
+        const requiresPendingTopUp = Boolean(
+          pendingTopUpForCheck && currentReserveMax > 0n && cumulativeAmount > currentReserveMax,
+        );
+        if (pendingTopUpForCheck && requiresPendingTopUp) {
+          const retryResult = await this._retryPendingTopUp(
+            channelId,
+            pendingTopUpForCheck,
+            cumulativeAmount,
+            payload.metadata || encodeMetadata(ZERO_METADATA),
+            payload.spendingAuthSig,
+          );
+          if (retryResult === 'permanent-failure') {
+            // The only thing making this auth valid was the pending topUp.
+            // Since that topUp is now known to be impossible, reject before
+            // mutating acceptedCumulative/latestAuth so close() never uses an
+            // over-ceiling SpendingAuth.
+            return 'rejected';
+          }
         }
 
         // Update tracking
@@ -642,40 +679,14 @@ export class SellerPaymentManager {
 
         debugLog(`[SellerPayment] Budget updated: channel=${channelId.slice(0, 18)}... cumulative=${cumulativeAmount}`);
 
-        // Retry any deferred topUp now that we have a higher settle amount
+        // Retry any deferred topUp now that we have a higher settle amount.
+        // If the SpendingAuth did not require the pending ceiling to be
+        // accepted, a permanent retry failure is safe to drop after committing
+        // this auth because the auth is still within the current on-chain max.
         const pendingTopUp = this._pendingTopUp.get(channelId);
-        if (pendingTopUp) {
-          this._pendingTopUp.delete(channelId);
+        if (pendingTopUp && !requiresPendingTopUp) {
           const { amount: retrySettleAmount, metadata: retryMetadata, sig: retrySig } = this._getSettleParams(channelId);
-          debugLog(`[SellerPayment] Retrying deferred topUp: channel=${channelId.slice(0, 18)}... settling=${retrySettleAmount} newMax=${pendingTopUp.newMaxAmount}`);
-          try {
-            await this._channelsClient.topUp(
-              this._signer,
-              channelId,
-              retrySettleAmount,
-              retryMetadata,
-              retrySig,
-              pendingTopUp.newMaxAmount,
-              BigInt(pendingTopUp.deadline),
-              pendingTopUp.reserveAuthSig,
-            );
-            this._reserveMax.set(channelId, pendingTopUp.newMaxAmount);
-            const topUpSession = this._channelStore.getChannel(channelId);
-            if (topUpSession) {
-              topUpSession.previousConsumption = pendingTopUp.newMaxAmount.toString();
-              topUpSession.deadline = pendingTopUp.deadline;
-              topUpSession.updatedAt = Date.now();
-              this._channelStore.upsertChannel(topUpSession);
-            }
-            debugLog(`[SellerPayment] Deferred topUp succeeded: channel=${channelId.slice(0, 18)}... new ceiling=${pendingTopUp.newMaxAmount}`);
-          } catch (retryErr) {
-            debugWarn(
-              `[SellerPayment] Deferred topUp retry failed: channel=${channelId.slice(0, 18)}... ` +
-              `error=${retryErr instanceof Error ? retryErr.message : retryErr}`,
-            );
-            // Re-queue for next attempt
-            this._pendingTopUp.set(channelId, pendingTopUp);
-          }
+          await this._retryPendingTopUp(channelId, pendingTopUp, retrySettleAmount, retryMetadata, retrySig);
         }
 
         return 'accepted';
@@ -683,6 +694,106 @@ export class SellerPaymentManager {
     } catch (err) {
       debugWarn(`[SellerPayment] Failed to process SpendingAuth: ${err instanceof Error ? err.message : err}`);
       return 'rejected';
+    }
+  }
+
+  private _storePendingTopUp(
+    channelId: string,
+    pending: { newMaxAmount: bigint; deadline: number; reserveAuthSig: string },
+  ): void {
+    const existing = this._pendingTopUp.get(channelId);
+    if (!existing || pending.newMaxAmount >= existing.newMaxAmount) {
+      this._pendingTopUp.set(channelId, pending);
+    }
+  }
+
+  private _formatError(err: unknown): string {
+    const text = this._flattenErrorText(err);
+    const formatted = text.length > 0 ? text : String(err);
+    return formatted.length > 500 ? `${formatted.slice(0, 500)}…` : formatted;
+  }
+
+  private _classifyTopUpFailure(err: unknown): TopUpFailureKind {
+    const text = this._flattenErrorText(err).toLowerCase();
+    if (text.includes('topupthresholdnotmet') || text.includes(TOP_UP_THRESHOLD_NOT_MET_SELECTOR)) {
+      return 'retryable-threshold';
+    }
+    if (text.includes('insufficientbalance') || text.includes(INSUFFICIENT_BALANCE_SELECTOR)) {
+      return 'insufficient-balance';
+    }
+    return 'non-retryable';
+  }
+
+  private _flattenErrorText(value: unknown, seen = new Set<object>(), depth = 0): string {
+    if (value == null || depth > 5) return '';
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return String(value);
+    if (typeof value !== 'object') return '';
+    if (seen.has(value)) return '';
+    seen.add(value);
+
+    const parts: string[] = [];
+    if (value instanceof Error) {
+      parts.push(value.name, value.message);
+      if ('cause' in value) {
+        parts.push(this._flattenErrorText((value as { cause?: unknown }).cause, seen, depth + 1));
+      }
+    }
+    for (const key of Object.getOwnPropertyNames(value)) {
+      if (key === 'stack') continue;
+      const nested = (value as Record<string, unknown>)[key];
+      parts.push(key);
+      parts.push(this._flattenErrorText(nested, seen, depth + 1));
+    }
+    return parts.filter(Boolean).join(' ');
+  }
+
+  private async _retryPendingTopUp(
+    channelId: string,
+    pendingTopUp: { newMaxAmount: bigint; deadline: number; reserveAuthSig: string },
+    settleAmount: bigint,
+    settleMetadata: string,
+    settleSig: string,
+  ): Promise<'succeeded' | 'retryable-failure' | 'permanent-failure'> {
+    this._pendingTopUp.delete(channelId);
+    debugLog(`[SellerPayment] Retrying deferred topUp: channel=${channelId.slice(0, 18)}... settling=${settleAmount} newMax=${pendingTopUp.newMaxAmount}`);
+    try {
+      await this._channelsClient.topUp(
+        this._signer,
+        channelId,
+        settleAmount,
+        settleMetadata,
+        settleSig,
+        pendingTopUp.newMaxAmount,
+        BigInt(pendingTopUp.deadline),
+        pendingTopUp.reserveAuthSig,
+      );
+      this._reserveMax.set(channelId, pendingTopUp.newMaxAmount);
+      const topUpSession = this._channelStore.getChannel(channelId);
+      if (topUpSession) {
+        topUpSession.previousConsumption = pendingTopUp.newMaxAmount.toString();
+        topUpSession.deadline = pendingTopUp.deadline;
+        topUpSession.updatedAt = Date.now();
+        this._channelStore.upsertChannel(topUpSession);
+      }
+      debugLog(`[SellerPayment] Deferred topUp succeeded: channel=${channelId.slice(0, 18)}... new ceiling=${pendingTopUp.newMaxAmount}`);
+      return 'succeeded';
+    } catch (retryErr) {
+      const failureKind = this._classifyTopUpFailure(retryErr);
+      if (failureKind === 'retryable-threshold') {
+        debugWarn(
+          `[SellerPayment] Deferred topUp threshold not met: channel=${channelId.slice(0, 18)}... ` +
+          `error=${this._formatError(retryErr)} — keeping pending`,
+        );
+        this._storePendingTopUp(channelId, pendingTopUp);
+        return 'retryable-failure';
+      }
+
+      debugWarn(
+        `[SellerPayment] Deferred topUp failed permanently: channel=${channelId.slice(0, 18)}... ` +
+        `kind=${failureKind} error=${this._formatError(retryErr)} — dropping pending topUp`,
+      );
+      return 'permanent-failure';
     }
   }
 

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -176,10 +176,12 @@ export class SellerRequestHandler {
           }
           let accepted = spm.getAcceptedCumulative(session.sessionId);
           const spent = spm.getCumulativeSpend(session.sessionId);
-          // Use the effective ceiling (includes pending topUp that hasn't
-          // confirmed on-chain yet) so we don't prematurely declare the
-          // channel exhausted while a topUp is in progress.
+          // Serving headroom only includes funds locked on-chain. Pending
+          // top-ups are not counted until topUp() succeeds, otherwise a large
+          // request could push spend above the current reserve before the extra
+          // funds are actually locked.
           const reserveMax = spm.getEffectiveReserveMax(session.sessionId);
+          const isBlocked = spm.isChannelBlocked(session.sessionId);
           // If spend has caught up and there is no headroom left in the reserve,
           // stop serving before accepting any additional request cost.
           const isAtExactSpendLimit = spent > 0n && spent === accepted && reserveMax > 0n && accepted >= reserveMax;
@@ -200,7 +202,7 @@ export class SellerRequestHandler {
               debugLog(`[SellerHandler] Caught up before 402 for ${buyerPeerId.slice(0, 12)}... (spent=${spent} accepted=${accepted})`);
             }
           }
-          if (spent > 0n && (spent > accepted || isAtExactSpendLimit)) {
+          if (isBlocked || (spent > 0n && (spent > accepted || isAtExactSpendLimit))) {
             const providerPricing = this.resolveProviderPricing(provider, request);
             const baseRequirements = spm.getPaymentRequirements(
               request.requestId, buyerPeerId, providerPricing,
@@ -210,7 +212,7 @@ export class SellerRequestHandler {
             // on-chain, so requiring more than `spent` would authorize payment
             // for work the seller has not delivered.
             const target = spent;
-            const isFullyExhausted = reserveMax > 0n && (accepted >= reserveMax || target > reserveMax);
+            const isFullyExhausted = isBlocked || (reserveMax > 0n && (accepted >= reserveMax || target > reserveMax));
             const requirements = {
               ...baseRequirements,
               requiredCumulativeAmount: target.toString(),
@@ -221,7 +223,8 @@ export class SellerRequestHandler {
               ...(isFullyExhausted ? { code: PAYMENT_CODE_CHANNEL_EXHAUSTED } : {}),
             };
             if (isFullyExhausted) {
-              debugLog(`[SellerHandler] Session fully exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} accepted=${accepted} target=${target} reserveMax=${reserveMax}) — closing and returning 402`);
+              const reason = isBlocked ? 'blocked' : 'fully exhausted';
+              debugLog(`[SellerHandler] Session ${reason} for ${buyerPeerId.slice(0, 12)}... (spent=${spent} accepted=${accepted} target=${target} reserveMax=${reserveMax}) — closing and returning 402`);
               // Default settleSession() performs final close(); do not use
               // settleOnly here because exhausted channels must release the
               // buyer's unused reserve before the buyer opens a replacement.

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -44,6 +44,7 @@ function makeSpmMock(overrides: Record<string, unknown> = {}): any {
     getEffectiveReserveMax() {
       return this.getReserveMax();
     },
+    isChannelBlocked: () => false,
     getPaymentRequirements: () => ({ minBudgetPerRequest: '10000', suggestedAmount: '1000000' }),
     waitForPendingAuths: async () => {},
     awaitAcceptedAtLeast: async () => false,
@@ -467,7 +468,43 @@ describe('SellerRequestHandler payment pricing selection', () => {
     expect(body).toMatchObject({ code: PAYMENT_CODE_CHANNEL_EXHAUSTED, requiredCumulativeAmount: '1000001', reserveMaxAmount: '1000000' });
   });
 
-  it('continues serving when spend reached the on-chain ceiling but a higher topUp is pending', async () => {
+  it('does not route a blocked channel after permanent top-up failure', async () => {
+    const provider = makeProvider(1, 1, { name: 'paid-tier', services: ['local-test'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
+
+    const sendPaymentRequired = vi.fn();
+    const settleSession = vi.fn(async () => {});
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: makeSpmMock({
+        getCumulativeSpend: () => 900_000n,
+        getAcceptedCumulative: () => 900_000n,
+        getReserveMax: () => 1_000_000n,
+        getEffectiveReserveMax: () => 1_000_000n,
+        isChannelBlocked: () => true,
+        settleSession,
+      }),
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired } as any;
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-blocked-topup', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })) }) });
+
+    expect(provider.handleRequest).not.toHaveBeenCalled();
+    expect(sendPaymentRequired).toHaveBeenCalledWith(expect.objectContaining({ code: PAYMENT_CODE_CHANNEL_EXHAUSTED, requiredCumulativeAmount: '900000', reserveMaxAmount: '1000000' }));
+    expect(settleSession).toHaveBeenCalledOnce();
+    const response = decodeHttpResponse(decodeFrame(sentFrames[0]!)!.message.payload);
+    expect(response.statusCode).toBe(402);
+  });
+
+  it('stops serving when spend reached the on-chain ceiling even if a higher topUp is pending', async () => {
     const provider = makeProvider(1, 1, { name: 'paid-tier', services: ['local-test'] });
     provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
 
@@ -479,7 +516,6 @@ describe('SellerRequestHandler payment pricing selection', () => {
         getCumulativeSpend: () => 1_000_000n,
         getAcceptedCumulative: () => 1_000_000n,
         getReserveMax: () => 1_000_000n,
-        getEffectiveReserveMax: () => 2_000_000n,
       }),
       sessionTracker: null,
       channelsClient: {} as any,
@@ -494,10 +530,10 @@ describe('SellerRequestHandler payment pricing selection', () => {
 
     await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-pending-topup', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })) }) });
 
-    expect(provider.handleRequest).toHaveBeenCalledOnce();
-    expect(sendPaymentRequired).not.toHaveBeenCalled();
-    expect(sendNeedAuth).toHaveBeenCalledOnce();
+    expect(provider.handleRequest).not.toHaveBeenCalled();
+    expect(sendPaymentRequired).toHaveBeenCalledWith(expect.objectContaining({ code: PAYMENT_CODE_CHANNEL_EXHAUSTED, reserveMaxAmount: '1000000' }));
+    expect(sendNeedAuth).not.toHaveBeenCalled();
     const response = decodeHttpResponse(decodeFrame(sentFrames[0]!)!.message.payload);
-    expect(response.statusCode).toBe(200);
+    expect(response.statusCode).toBe(402);
   });
 });

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -145,6 +145,7 @@ describe('SellerPaymentManager', () => {
     manager = new SellerPaymentManager(sellerIdentity, config, store);
 
     vi.spyOn(manager.channelsClient, 'reserve').mockResolvedValue('0xreserve-hash');
+    vi.spyOn(manager.channelsClient, 'settle').mockResolvedValue('0xsettle-hash');
     vi.spyOn(manager.channelsClient, 'close').mockResolvedValue('0xclose-hash');
     vi.spyOn(manager.channelsClient, 'requestClose').mockResolvedValue('0xrequesttimeout-hash');
     vi.spyOn(manager.channelsClient, 'withdraw').mockResolvedValue('0xwithdraw-hash');
@@ -317,6 +318,11 @@ describe('SellerPaymentManager', () => {
     });
 
     expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp2m, mux)).toBe('rejected');
+    expect(manager.channelsClient.settle).toHaveBeenCalledOnce();
+    const settleArgs = (manager.channelsClient.settle as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(settleArgs[1]).toBe(channelId);
+    expect(settleArgs[2]).toBe(900_000n);
+    expect(settleArgs[4]).toBe(auth900k.spendingAuthSig);
     expect(manager.hasPendingTopUp(channelId)).toBe(false);
     expect(manager.getEffectiveReserveMax(channelId)).toBe(1_000_000n);
     expect(manager.getReserveMax(channelId)).toBe(1_000_000n);
@@ -360,6 +366,11 @@ describe('SellerPaymentManager', () => {
     expect(await manager.handleSpendingAuth(buyerIdentity.peerId, overCeiling, mux)).toBe('rejected');
 
     expect(topUpSpy).toHaveBeenCalledTimes(2);
+    expect(manager.channelsClient.settle).toHaveBeenCalledOnce();
+    const settleArgs = (manager.channelsClient.settle as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(settleArgs[1]).toBe(channelId);
+    expect(settleArgs[2]).toBe(900_000n);
+    expect(settleArgs[4]).toBe(auth900k.spendingAuthSig);
     expect(manager.hasPendingTopUp(channelId)).toBe(false);
     expect(manager.getReserveMax(channelId)).toBe(1_000_000n);
     expect(manager.getEffectiveReserveMax(channelId)).toBe(1_000_000n);

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -283,11 +283,11 @@ describe('SellerPaymentManager', () => {
 
     expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp2m, mux)).toBe('accepted');
     expect(manager.hasPendingTopUp(channelId)).toBe(true);
-    expect(manager.getEffectiveReserveMax(channelId)).toBe(2_000_000n);
+    expect(manager.getEffectiveReserveMax(channelId)).toBe(1_000_000n);
 
     expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp3m, mux)).toBe('accepted');
     expect(manager.hasPendingTopUp(channelId)).toBe(true);
-    expect(manager.getEffectiveReserveMax(channelId)).toBe(3_000_000n);
+    expect(manager.getEffectiveReserveMax(channelId)).toBe(1_000_000n);
     expect(manager.getReserveMax(channelId)).toBe(1_000_000n);
     expect(topUpSpy).toHaveBeenCalledTimes(2);
     expect(topUpSpy.mock.calls[1]?.[5]).toBe(3_000_000n);
@@ -318,17 +318,52 @@ describe('SellerPaymentManager', () => {
     });
 
     expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp2m, mux)).toBe('rejected');
-    expect(manager.channelsClient.settle).toHaveBeenCalledOnce();
-    const settleArgs = (manager.channelsClient.settle as ReturnType<typeof vi.fn>).mock.calls[0]!;
-    expect(settleArgs[1]).toBe(channelId);
-    expect(settleArgs[2]).toBe(900_000n);
-    expect(settleArgs[4]).toBe(auth900k.spendingAuthSig);
+    expect(manager.channelsClient.settle).not.toHaveBeenCalled();
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    const closeArgs = (manager.channelsClient.close as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(closeArgs[1]).toBe(channelId);
+    expect(closeArgs[2]).toBe(900_000n);
+    expect(closeArgs[4]).toBe(auth900k.spendingAuthSig);
     expect(manager.hasPendingTopUp(channelId)).toBe(false);
-    expect(manager.getEffectiveReserveMax(channelId)).toBe(1_000_000n);
-    expect(manager.getReserveMax(channelId)).toBe(1_000_000n);
+    expect(manager.isChannelBlocked(channelId)).toBe(false);
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
+    expect(store.getChannel(channelId)!.status).toBe('settled');
   });
 
-  it('rejects an over-ceiling SpendingAuth if the deferred top-up retry fails permanently', async () => {
+  it('blocks the channel if permanent top-up failure cannot close immediately', async () => {
+    const channelId = makeChannelId(105);
+
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    const auth900k = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 900_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, auth900k, mux);
+    manager.recordSpend(channelId, 900_000n);
+
+    vi.spyOn(manager.channelsClient, 'topUp').mockRejectedValue(new Error('execution reverted: InsufficientBalance'));
+    vi.spyOn(manager.channelsClient, 'close').mockRejectedValue(new Error('close estimate failed'));
+
+    const topUp2m = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '2000000',
+      salt: '0x' + '07'.repeat(32),
+    });
+
+    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp2m, mux)).toBe('rejected');
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    expect(manager.hasPendingTopUp(channelId)).toBe(false);
+    expect(manager.isChannelBlocked(channelId)).toBe(true);
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
+    expect(store.getChannel(channelId)!.status).toBe('active');
+  });
+
+  it('closes the channel if a deferred top-up retry fails permanently', async () => {
     const channelId = makeChannelId(104);
 
     const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
@@ -356,25 +391,26 @@ describe('SellerPaymentManager', () => {
     expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp2m, mux)).toBe('accepted');
     expect(manager.hasPendingTopUp(channelId)).toBe(true);
 
-    const overCeiling = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
-      cumulativeAmount: 1_500_000n,
-      reserveMaxAmount: '2000000',
+    const withinReserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 950_000n,
+      reserveMaxAmount: '1000000',
     });
-    delete overCeiling.reserveSalt;
-    delete overCeiling.reserveMaxAmount;
-    delete overCeiling.reserveDeadline;
-    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, overCeiling, mux)).toBe('rejected');
+    delete withinReserve.reserveSalt;
+    delete withinReserve.reserveMaxAmount;
+    delete withinReserve.reserveDeadline;
+    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, withinReserve, mux)).toBe('accepted');
 
     expect(topUpSpy).toHaveBeenCalledTimes(2);
-    expect(manager.channelsClient.settle).toHaveBeenCalledOnce();
-    const settleArgs = (manager.channelsClient.settle as ReturnType<typeof vi.fn>).mock.calls[0]!;
-    expect(settleArgs[1]).toBe(channelId);
-    expect(settleArgs[2]).toBe(900_000n);
-    expect(settleArgs[4]).toBe(auth900k.spendingAuthSig);
+    expect(manager.channelsClient.settle).not.toHaveBeenCalled();
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    const closeArgs = (manager.channelsClient.close as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(closeArgs[1]).toBe(channelId);
+    expect(closeArgs[2]).toBe(950_000n);
+    expect(closeArgs[4]).toBe(withinReserve.spendingAuthSig);
     expect(manager.hasPendingTopUp(channelId)).toBe(false);
-    expect(manager.getReserveMax(channelId)).toBe(1_000_000n);
-    expect(manager.getEffectiveReserveMax(channelId)).toBe(1_000_000n);
-    expect(manager.getAcceptedCumulative(channelId)).toBe(900_000n);
+    expect(manager.isChannelBlocked(channelId)).toBe(false);
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
+    expect(store.getChannel(channelId)!.status).toBe('settled');
   });
 
   it('serializes a burst of concurrent SpendingAuth updates and ends at the latest cumulative amount', async () => {
@@ -414,7 +450,7 @@ describe('SellerPaymentManager', () => {
     expect(manager.getAcceptedCumulative(channelId)).toBe(2_000_000n);
   });
 
-  it('validateAndAcceptAuth respects a pending top-up ceiling before the on-chain reserve max is updated', async () => {
+  it('validateAndAcceptAuth ignores pending top-up headroom until on-chain reserve max is updated', async () => {
     const channelId = makeChannelId(102);
 
     const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
@@ -440,15 +476,15 @@ describe('SellerPaymentManager', () => {
     expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp2m, mux)).toBe('accepted');
     expect(manager.hasPendingTopUp(channelId)).toBe(true);
     expect(manager.getReserveMax(channelId)).toBe(1_000_000n);
-    expect(manager.getEffectiveReserveMax(channelId)).toBe(2_000_000n);
+    expect(manager.getEffectiveReserveMax(channelId)).toBe(1_000_000n);
 
     const followUp = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
       cumulativeAmount: 1_500_000n,
       reserveMaxAmount: '2000000',
     });
 
-    expect(await manager.validateAndAcceptAuth(buyerIdentity.peerId, followUp)).toBe(true);
-    expect(manager.getAcceptedCumulative(channelId)).toBe(1_500_000n);
+    expect(await manager.validateAndAcceptAuth(buyerIdentity.peerId, followUp)).toBe(false);
+    expect(manager.getAcceptedCumulative(channelId)).toBe(900_000n);
   });
 
   it('recovers an active on-chain channel when local seller session is missing', async () => {

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -292,6 +292,80 @@ describe('SellerPaymentManager', () => {
     expect(topUpSpy.mock.calls[1]?.[5]).toBe(3_000_000n);
   });
 
+  it('rejects a top-up that fails because buyer deposits are insufficient', async () => {
+    const channelId = makeChannelId(103);
+
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    const auth900k = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 900_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, auth900k, mux);
+    manager.recordSpend(channelId, 900_000n);
+
+    vi.spyOn(manager.channelsClient, 'topUp').mockRejectedValue(new Error('execution reverted: InsufficientBalance'));
+
+    const topUp2m = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '2000000',
+      salt: '0x' + '05'.repeat(32),
+    });
+
+    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp2m, mux)).toBe('rejected');
+    expect(manager.hasPendingTopUp(channelId)).toBe(false);
+    expect(manager.getEffectiveReserveMax(channelId)).toBe(1_000_000n);
+    expect(manager.getReserveMax(channelId)).toBe(1_000_000n);
+  });
+
+  it('rejects an over-ceiling SpendingAuth if the deferred top-up retry fails permanently', async () => {
+    const channelId = makeChannelId(104);
+
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    const auth900k = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 900_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, auth900k, mux);
+    manager.recordSpend(channelId, 900_000n);
+
+    const topUpSpy = vi.spyOn(manager.channelsClient, 'topUp')
+      .mockRejectedValueOnce(new Error('TopUpThresholdNotMet'))
+      .mockRejectedValueOnce(new Error('execution reverted: InsufficientBalance'));
+
+    const topUp2m = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '2000000',
+      salt: '0x' + '06'.repeat(32),
+    });
+    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp2m, mux)).toBe('accepted');
+    expect(manager.hasPendingTopUp(channelId)).toBe(true);
+
+    const overCeiling = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 1_500_000n,
+      reserveMaxAmount: '2000000',
+    });
+    delete overCeiling.reserveSalt;
+    delete overCeiling.reserveMaxAmount;
+    delete overCeiling.reserveDeadline;
+    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, overCeiling, mux)).toBe('rejected');
+
+    expect(topUpSpy).toHaveBeenCalledTimes(2);
+    expect(manager.hasPendingTopUp(channelId)).toBe(false);
+    expect(manager.getReserveMax(channelId)).toBe(1_000_000n);
+    expect(manager.getEffectiveReserveMax(channelId)).toBe(1_000_000n);
+    expect(manager.getAcceptedCumulative(channelId)).toBe(900_000n);
+  });
+
   it('serializes a burst of concurrent SpendingAuth updates and ends at the latest cumulative amount', async () => {
     const channelId = makeChannelId(101);
 


### PR DESCRIPTION
## Description

Prevents seller-side payment top-ups from being treated as pending headroom when the on-chain failure is permanent. Only `TopUpThresholdNotMet` is deferred for retry; `InsufficientBalance` and unknown top-up failures now reject the top-up, drop pending top-up state, and settle the latest valid SpendingAuth so the seller still claims delivered work.

## Release Notes

- Fixed a payment issue where sellers could continue serving requests after buyer top-ups failed due to insufficient deposits.
- Sellers now settle the latest valid authorization when a top-up fails permanently.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes