### PR TITLE
fix(payments): Guard reserve headroom

### DIFF
--- a/packages/contracts/AntseedChannels.sol
+++ b/packages/contracts/AntseedChannels.sol
@@ -46,7 +46,7 @@ contract AntseedChannels is EIP712, Pausable, Ownable, ReentrancyGuard {
     uint256 public PLATFORM_FEE_BPS = 200;
     uint256 public MAX_PLATFORM_FEE_BPS = 1000;
     uint256 public TIMEOUT_GRACE_PERIOD = 15 minutes;
-    uint256 public TOP_UP_SETTLED_THRESHOLD_BPS = 8500;
+    uint256 public TOP_UP_SETTLED_THRESHOLD_BPS = 6500;
 
     // ─── Enums & Structs ────────────────────────────────────────────
     enum ChannelStatus { None, Active, Settled, TimedOut }
@@ -190,7 +190,7 @@ contract AntseedChannels is EIP712, Pausable, Ownable, ReentrancyGuard {
     /**
      * @notice Top up an active channel by increasing the reserve ceiling.
      *         Seller calls this when the buyer's cumulative spending approaches
-     *         the current deposit. Requires at least 85% of the current deposit
+     *         the current deposit. Requires at least 65% of the current deposit
      *         to be settled (proven via SpendingAuth) before allowing more funds.
      *         Accepts the latest SpendingAuth to settle before raising the ceiling.
      *
@@ -223,7 +223,7 @@ contract AntseedChannels is EIP712, Pausable, Ownable, ReentrancyGuard {
             _settleSpend(channelId, channel, cumulativeAmount, metadata, spendingSig);
         }
 
-        // Require at least 85% of current deposit to be settled before topping up
+        // Require enough current deposit to be settled before topping up
         uint256 threshold = (uint256(channel.deposit) * TOP_UP_SETTLED_THRESHOLD_BPS) / 10000;
         if (channel.settled < threshold) revert TopUpThresholdNotMet();
 

--- a/packages/contracts/test/AntseedChannels.t.sol
+++ b/packages/contracts/test/AntseedChannels.t.sol
@@ -728,6 +728,10 @@ contract AntseedChannelsTest is Test {
         assertEq(channels.PLATFORM_FEE_BPS(), 300);
     }
 
+    function test_defaultTopUpSettledThresholdBps() public view {
+        assertEq(channels.TOP_UP_SETTLED_THRESHOLD_BPS(), 6500);
+    }
+
     function test_setPlatformFeeBps_revert_aboveMax() public {
         vm.expectRevert(AntseedChannels.InvalidFee.selector);
         channels.setPlatformFeeBps(1001);
@@ -805,8 +809,8 @@ contract AntseedChannelsTest is Test {
         bytes32 salt = keccak256("session-topup");
         bytes32 channelId = doReserve(salt, USDC_100, USDC_150);
 
-        // Top up with inline settle of 85 USDC (85% threshold met)
-        uint128 settleAmount = 85_000_000;
+        // Top up with inline settle of 65 USDC (65% threshold met)
+        uint128 settleAmount = 65_000_000;
         bytes memory spendingSig = signSpendingAuth(BUYER_PK, channelId, settleAmount, 5000, 2000);
 
         uint128 newMax = USDC_150;
@@ -823,11 +827,11 @@ contract AntseedChannelsTest is Test {
         assertEq(sSettled, settleAmount);
         assertEq(sDeadline, newDeadline);
 
-        // reserved = 100 - 85 (settle freed) + 50 (topUp locked) = 65
+        // reserved = 100 - 65 (settle freed) + 50 (topUp locked) = 85
         (, uint256 reserved,) = deposits.getBuyerBalance(buyer);
-        assertEq(reserved, 65_000_000);
+        assertEq(reserved, 85_000_000);
 
-        // Seller received 85 USDC minus platform fee directly
+        // Seller received 65 USDC minus platform fee directly
         uint256 platformFee = (uint256(settleAmount) * 200) / 10000;
         assertEq(usdc.balanceOf(seller), settleAmount - platformFee);
     }
@@ -836,7 +840,7 @@ contract AntseedChannelsTest is Test {
         bytes32 salt = keccak256("session-topup-fail");
         bytes32 channelId = doReserve(salt, USDC_100, USDC_150);
 
-        // Only settle 50% (50 USDC out of 100) — below 85% threshold
+        // Only settle 50% (50 USDC out of 100) — below 65% threshold
         uint128 settleAmount = USDC_50;
         bytes memory spendingSig = signSpendingAuth(BUYER_PK, channelId, settleAmount, 3000, 1000);
 

--- a/packages/contracts/test/AntseedChannelsV2Emissions.t.sol
+++ b/packages/contracts/test/AntseedChannelsV2Emissions.t.sol
@@ -821,8 +821,8 @@ contract AntseedChannelsV2EmissionsTest is Test {
         bytes32 salt = keccak256("session-topup");
         bytes32 channelId = doReserve(salt, USDC_100, USDC_150);
 
-        // Top up with inline settle of 85 USDC (85% threshold met)
-        uint128 settleAmount = 85_000_000;
+        // Top up with inline settle of 65 USDC (65% threshold met)
+        uint128 settleAmount = 65_000_000;
         bytes memory spendingSig = signSpendingAuth(BUYER_PK, channelId, settleAmount, 5000, 2000);
 
         uint128 newMax = USDC_150;
@@ -839,11 +839,11 @@ contract AntseedChannelsV2EmissionsTest is Test {
         assertEq(sSettled, settleAmount);
         assertEq(sDeadline, newDeadline);
 
-        // reserved = 100 - 85 (settle freed) + 50 (topUp locked) = 65
+        // reserved = 100 - 65 (settle freed) + 50 (topUp locked) = 85
         (, uint256 reserved,) = deposits.getBuyerBalance(buyer);
-        assertEq(reserved, 65_000_000);
+        assertEq(reserved, 85_000_000);
 
-        // Seller received 85 USDC minus platform fee directly
+        // Seller received 65 USDC minus platform fee directly
         uint256 platformFee = (uint256(settleAmount) * 200) / 10000;
         assertEq(usdc.balanceOf(seller), settleAmount - platformFee);
     }
@@ -852,7 +852,7 @@ contract AntseedChannelsV2EmissionsTest is Test {
         bytes32 salt = keccak256("session-topup-fail");
         bytes32 channelId = doReserve(salt, USDC_100, USDC_150);
 
-        // Only settle 50% (50 USDC out of 100) — below 85% threshold
+        // Only settle 50% (50 USDC out of 100) — below 65% threshold
         uint128 settleAmount = USDC_50;
         bytes memory spendingSig = signSpendingAuth(BUYER_PK, channelId, settleAmount, 3000, 1000);
 

--- a/packages/node/src/p2p/payment-codec.ts
+++ b/packages/node/src/p2p/payment-codec.ts
@@ -1,5 +1,6 @@
 import {
   PAYMENT_CODE_CHANNEL_EXHAUSTED,
+  PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED,
   type SpendingAuthPayload,
   type AuthAckPayload,
   type PaymentRequiredPayload,
@@ -90,7 +91,7 @@ export function decodePaymentRequired(data: Uint8Array): PaymentRequiredPayload 
   if (typeof obj.currentAcceptedCumulative === 'string') result.currentAcceptedCumulative = obj.currentAcceptedCumulative;
   if (typeof obj.channelId === 'string') result.channelId = obj.channelId;
   if (typeof obj.reserveMaxAmount === 'string') result.reserveMaxAmount = obj.reserveMaxAmount;
-  if (obj.code === PAYMENT_CODE_CHANNEL_EXHAUSTED) result.code = obj.code;
+  if (obj.code === PAYMENT_CODE_CHANNEL_EXHAUSTED || obj.code === PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED) result.code = obj.code;
   return result;
 }
 

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -29,9 +29,8 @@ import { estimateCostFromBytes, computeCostUsdc, type ServicePricing } from './p
 /** Default tolerance: accept seller claims up to 1.4x buyer's estimate. */
 const DEFAULT_COST_TOLERANCE = 1.4;
 /** Fraction of reserve ceiling at which to signal a top-up is needed.
- *  Trigger well before the contract's TOP_UP_SETTLED_THRESHOLD_BPS (85%)
- *  so that by the time the seller calls topUp() on-chain, enough has been
- *  settled to pass the threshold check. */
+ *  Matches the contract's TOP_UP_SETTLED_THRESHOLD_BPS (65%) so the seller
+ *  can top up as soon as the buyer has signed enough settleable spend. */
 const DEFAULT_TOPUP_THRESHOLD = 0.65;
 
 export interface BuyerPaymentConfig {
@@ -907,7 +906,7 @@ export class BuyerPaymentManager {
 
     // When a topUp is needed, first sign at the current ceiling so the seller
     // has a high-enough settled amount to pass the on-chain TopUpThresholdNotMet
-    // check (contract requires 85% of deposit to be settleable before topUp).
+    // check (contract requires 65% of deposit to be settleable before topUp).
     // We cap at the old ceiling here; the topUp is sent AFTER so the seller
     // processes the SpendingAuth first, then the topUp with adequate settle amount.
     const effectiveAmount = needsTopUp
@@ -947,10 +946,9 @@ export class BuyerPaymentManager {
 
     // Send topUp AFTER the SpendingAuth so the seller processes the higher
     // cumulative first — this ensures the on-chain settle amount meets the
-    // contract's TopUpThresholdNotMet requirement (85% of deposit must be
+    // contract's TopUpThresholdNotMet requirement (65% of deposit must be
     // settleable before topUp is allowed). Also proactively send the top-up
-    // once the signed cumulative reaches the buyer's 65% threshold; the seller
-    // may defer the on-chain topUp until the contract's 85% gate is satisfied.
+    // once the signed cumulative reaches that threshold.
     if (needsTopUp || this._needsTopUp(sellerPeerId)) {
       await this._topUpAfterSpendAuthBestEffort(sellerPeerId, paymentMux, 'handleNeedAuth');
     }

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -3,7 +3,11 @@ import type { PeerConnection } from '../p2p/connection-manager.js';
 import { PaymentMux } from '../p2p/payment-mux.js';
 import type { PeerInfo, PeerId } from '../types/peer.js';
 import type { SerializedHttpRequest, SerializedHttpResponse } from '../types/http.js';
-import { PAYMENT_CODE_CHANNEL_EXHAUSTED, type PaymentRequiredPayload } from '../types/protocol.js';
+import {
+  PAYMENT_CODE_CHANNEL_EXHAUSTED,
+  PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED,
+  type PaymentRequiredPayload,
+} from '../types/protocol.js';
 import type { BuyerPaymentManager } from './buyer-payment-manager.js';
 import type { DepositsClient } from './evm/deposits-client.js';
 import type { ChannelsClient } from './evm/channels-client.js';
@@ -349,11 +353,47 @@ export class BuyerPaymentNegotiator {
       : responseAlreadyHasRequirements && directPaymentBody?.reserveMaxAmount != null
         ? safeBigInt(String(directPaymentBody.reserveMaxAmount))
         : null;
+    const reserveHeadroomRequired = buffered?.code === PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED
+      || (responseAlreadyHasRequirements && directPaymentBody?.code === PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED);
     const channelExhausted = buffered?.code === PAYMENT_CODE_CHANNEL_EXHAUSTED
       || (responseAlreadyHasRequirements && directPaymentBody?.code === PAYMENT_CODE_CHANNEL_EXHAUSTED)
-      || (requiredCumulativeTarget != null && sellerReserveMax != null && requiredCumulativeTarget > sellerReserveMax);
+      || (!reserveHeadroomRequired && requiredCumulativeTarget != null && sellerReserveMax != null && requiredCumulativeTarget > sellerReserveMax);
 
     const hasActiveSession = hadLockedSession || this._bpm.getActiveSession(peer.peerId) != null;
+
+    if (reserveHeadroomRequired && hasActiveSession) {
+      if (!this._depositsClient) {
+        return returnNegotiationFailure(
+          'deposits_not_configured',
+          'Buyer deposits are not configured, so automatic reserve top-up is unavailable.',
+          503,
+        );
+      }
+
+      try {
+        const balance = await this._depositsClient.getBuyerBalance(this._identity.wallet.address);
+        if (balance.available <= 0n) {
+          return returnPaymentRequired('insufficient_deposits', 'buyer deposits balance is zero before reserve top-up');
+        }
+      } catch (err) {
+        debugWarn(`[BuyerNegotiator] Failed to check buyer balance before reserve top-up: ${err instanceof Error ? err.message : err}`);
+      }
+
+      debugLog(
+        `[BuyerNegotiator] Reserve headroom required for ${peer.peerId.slice(0, 12)}... ` +
+        `(required=${requiredCumulativeTarget ?? 'n/a'} reserveMax=${sellerReserveMax ?? 'n/a'}) — topping up and retrying`,
+      );
+      const pmux = this.getOrCreatePaymentMux(peer.peerId, conn);
+      try {
+        await this._bpm.topUpReserve(peer.peerId, pmux);
+      } catch (err) {
+        if (err instanceof Error && err.message.startsWith('Insufficient buyer deposits')) {
+          return returnPaymentRequired('insufficient_deposits', err.message);
+        }
+        throw err;
+      }
+      return { action: 'retry' };
+    }
 
     if (channelExhausted && hasActiveSession) {
       debugLog(

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -562,7 +562,7 @@ export class SellerPaymentManager {
           if (failureKind === 'retryable-threshold') {
             // TopUpThresholdNotMet is a timing/settlement race: keep the
             // ReserveAuth pending and retry after a later SpendingAuth raises
-            // the settle amount enough to satisfy the contract's 85% gate.
+            // the settle amount enough to satisfy the contract's 65% gate.
             debugWarn(
               `[SellerPayment] Top-up threshold not met: channel=${channelId.slice(0, 18)}... ` +
               `error=${this._formatError(topUpErr)} — ` +

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -14,9 +14,13 @@ import type {
   SerializedHttpResponse,
 } from './types/http.js';
 import { parseResponseUsage } from './utils/response-usage.js';
-import { computeCostUsdc } from './payments/pricing.js';
+import { computeCostUsdc, estimateTokensFromBytes, type ServicePricing } from './payments/pricing.js';
 import { debugLog, debugWarn } from './utils/debug.js';
-import { PAYMENT_CODE_CHANNEL_EXHAUSTED } from './types/protocol.js';
+import {
+  PAYMENT_CODE_CHANNEL_EXHAUSTED,
+  PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED,
+  type PaymentRequiredPayload,
+} from './types/protocol.js';
 
 export interface SellerRequestHandlerDeps {
   providers: Provider[];
@@ -32,6 +36,8 @@ export interface SellerRequestHandlerDeps {
 const METADATA_REFRESH_DEBOUNCE_MS = 200;
 /** Time to wait for a catch-up SpendingAuth before returning 402. */
 const DEFAULT_CATCH_UP_WAIT_MS = 5_000;
+/** Mirrors AntseedChannels.TOP_UP_SETTLED_THRESHOLD_BPS. */
+const TOP_UP_SETTLED_THRESHOLD_BPS = 6_500n;
 /**
  * Handles all seller-side request processing: provider matching, execution,
  * cost tracking, payment auth checks, and load management.
@@ -235,26 +241,7 @@ export class SellerRequestHandler {
               const comparator = spent > accepted ? '>' : '==';
               debugLog(`[SellerHandler] Budget exhausted for ${buyerPeerId.slice(0, 12)}... (spent=${spent} ${comparator} accepted=${accepted}) — returning 402 with requiredCumulativeAmount=${target}, awaiting higher SpendingAuth`);
             }
-            mux.sendProxyResponse({
-              requestId: request.requestId,
-              statusCode: 402,
-              headers: { "content-type": "application/json" },
-              body: new TextEncoder().encode(JSON.stringify({
-                error: 'payment_required',
-                minBudgetPerRequest: requirements.minBudgetPerRequest,
-                suggestedAmount: requirements.suggestedAmount,
-                requiredCumulativeAmount: requirements.requiredCumulativeAmount,
-                currentSpent: requirements.currentSpent,
-                currentAcceptedCumulative: requirements.currentAcceptedCumulative,
-                channelId: requirements.channelId,
-                ...(requirements.reserveMaxAmount != null ? { reserveMaxAmount: requirements.reserveMaxAmount } : {}),
-                ...(requirements.code != null ? { code: requirements.code } : {}),
-                ...(requirements.inputUsdPerMillion != null ? { inputUsdPerMillion: requirements.inputUsdPerMillion } : {}),
-                ...(requirements.outputUsdPerMillion != null ? { outputUsdPerMillion: requirements.outputUsdPerMillion } : {}),
-                ...(requirements.cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion: requirements.cachedInputUsdPerMillion } : {}),
-              })),
-            });
-            paymentMux.sendPaymentRequired(requirements);
+            this._sendPaymentRequiredResponse(mux, paymentMux, request, requirements);
             // Auto-sign catch-up via NeedAuth so a transient underfund recovers
             // without the 402 round-tripping to the user.
             if (!isFullyExhausted) {
@@ -267,6 +254,56 @@ export class SellerRequestHandler {
               }, buyerPeerId, 'budget-catch-up');
             }
             return;
+          }
+
+          if (!isBlocked && reserveMax > 0n && spent <= accepted) {
+            const providerPricing = this.resolveProviderPricing(provider, request);
+            const baseRequirements = spm.getPaymentRequirements(
+              request.requestId, buyerPeerId, providerPricing,
+            );
+            const configuredMinimum = this._safeBigInt(baseRequirements.minBudgetPerRequest) ?? 0n;
+            const requestEstimate = this._estimateMaxRequestCostUsdc(request, providerPricing);
+            const estimatedHeadroom = requestEstimate?.cost ?? 0n;
+            const requiredHeadroom = estimatedHeadroom > configuredMinimum ? estimatedHeadroom : configuredMinimum;
+            const remainingHeadroom = reserveMax > spent ? reserveMax - spent : 0n;
+
+            if (requiredHeadroom > 0n && requiredHeadroom > remainingHeadroom) {
+              const canTopUpNow = this._canTopUpAtCurrentAccepted(accepted, reserveMax);
+              const requiredCumulative = canTopUpNow ? spent + requiredHeadroom : spent;
+              const code = canTopUpNow
+                ? PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED
+                : PAYMENT_CODE_CHANNEL_EXHAUSTED;
+              const requirements = {
+                ...baseRequirements,
+                requiredCumulativeAmount: requiredCumulative.toString(),
+                currentSpent: spent.toString(),
+                currentAcceptedCumulative: accepted.toString(),
+                channelId: session.sessionId,
+                reserveMaxAmount: reserveMax.toString(),
+                code,
+              };
+              const estimateText = requestEstimate
+                ? `estimate=${estimatedHeadroom} (inputTokens=${requestEstimate.inputTokens} maxOutputTokens=${requestEstimate.maxOutputTokens})`
+                : `minimum=${configuredMinimum}`;
+              if (canTopUpNow) {
+                debugLog(
+                  `[SellerHandler] Reserve headroom insufficient for ${buyerPeerId.slice(0, 12)}... ` +
+                  `(spent=${spent} accepted=${accepted} reserveMax=${reserveMax} remaining=${remainingHeadroom} ` +
+                  `requiredHeadroom=${requiredHeadroom} ${estimateText}) — requesting top-up before routing`,
+                );
+              } else {
+                debugLog(
+                  `[SellerHandler] Reserve headroom insufficient before top-up threshold for ${buyerPeerId.slice(0, 12)}... ` +
+                  `(spent=${spent} accepted=${accepted} reserveMax=${reserveMax} remaining=${remainingHeadroom} ` +
+                  `requiredHeadroom=${requiredHeadroom} ${estimateText}) — closing and requesting fresh reserve`,
+                );
+                void spm.settleSession(buyerPeerId).catch((err) => {
+                  debugWarn(`[SellerHandler] Failed to close low-headroom session: ${err instanceof Error ? err.message : err}`);
+                });
+              }
+              this._sendPaymentRequiredResponse(mux, paymentMux, request, requirements);
+              return;
+            }
           }
         }
       }
@@ -543,6 +580,95 @@ export class SellerRequestHandler {
       .filter((value) => value.length > 0);
 
     return providers[0] ?? null;
+  }
+
+  private _estimateMaxRequestCostUsdc(
+    request: SerializedHttpRequest,
+    pricing: ServicePricing,
+  ): { cost: bigint; inputTokens: number; maxOutputTokens: number } | null {
+    const contentType = request.headers["content-type"] ?? request.headers["Content-Type"] ?? "";
+    if (!contentType.toLowerCase().includes("application/json")) {
+      return null;
+    }
+
+    const parsed = this._parseJsonBody(request.body);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+
+    const body = parsed as Record<string, unknown>;
+    const maxOutputTokens = this._extractMaxOutputTokens(body);
+    const inputTokens = estimateTokensFromBytes(request.body);
+    const cost = computeCostUsdc(inputTokens, maxOutputTokens, pricing);
+    return { cost, inputTokens, maxOutputTokens };
+  }
+
+  private _canTopUpAtCurrentAccepted(accepted: bigint, reserveMax: bigint): boolean {
+    const threshold = (reserveMax * TOP_UP_SETTLED_THRESHOLD_BPS) / 10_000n;
+    return accepted >= threshold;
+  }
+
+  private _extractMaxOutputTokens(body: Record<string, unknown>): number {
+    const candidates = [
+      body["max_tokens"],
+      body["max_completion_tokens"],
+      body["max_output_tokens"],
+      body["maxTokens"],
+      body["maxCompletionTokens"],
+      body["maxOutputTokens"],
+    ];
+
+    for (const value of candidates) {
+      const parsed = this._parsePositiveInteger(value);
+      if (parsed !== null) return parsed;
+    }
+    return 0;
+  }
+
+  private _parsePositiveInteger(value: unknown): number | null {
+    const numeric = typeof value === 'number'
+      ? value
+      : typeof value === 'string'
+        ? Number(value)
+        : NaN;
+    if (!Number.isFinite(numeric) || numeric <= 0) return null;
+    return Math.floor(numeric);
+  }
+
+  private _safeBigInt(value: string): bigint | null {
+    try {
+      return BigInt(value);
+    } catch {
+      return null;
+    }
+  }
+
+  private _sendPaymentRequiredResponse(
+    mux: ProxyMux,
+    paymentMux: PaymentMux,
+    request: SerializedHttpRequest,
+    requirements: PaymentRequiredPayload,
+  ): void {
+    mux.sendProxyResponse({
+      requestId: request.requestId,
+      statusCode: 402,
+      headers: { "content-type": "application/json" },
+      body: new TextEncoder().encode(JSON.stringify({
+        error: 'payment_required',
+        minBudgetPerRequest: requirements.minBudgetPerRequest,
+        suggestedAmount: requirements.suggestedAmount,
+        ...(requirements.requiredCumulativeAmount != null ? { requiredCumulativeAmount: requirements.requiredCumulativeAmount } : {}),
+        ...(requirements.currentSpent != null ? { currentSpent: requirements.currentSpent } : {}),
+        ...(requirements.currentAcceptedCumulative != null ? { currentAcceptedCumulative: requirements.currentAcceptedCumulative } : {}),
+        ...(requirements.channelId != null ? { channelId: requirements.channelId } : {}),
+        ...(requirements.reserveMaxAmount != null ? { reserveMaxAmount: requirements.reserveMaxAmount } : {}),
+        ...(requirements.code != null ? { code: requirements.code } : {}),
+        ...(requirements.inputUsdPerMillion != null ? { inputUsdPerMillion: requirements.inputUsdPerMillion } : {}),
+        ...(requirements.outputUsdPerMillion != null ? { outputUsdPerMillion: requirements.outputUsdPerMillion } : {}),
+        ...(requirements.cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion: requirements.cachedInputUsdPerMillion } : {}),
+      })),
+    });
+    paymentMux.sendPaymentRequired(requirements);
   }
 
   private async _executeRequest(

--- a/packages/node/src/types/protocol.ts
+++ b/packages/node/src/types/protocol.ts
@@ -89,21 +89,26 @@ export interface PaymentRequiredPayload {
   /** Channel ID for the exhausted session (so buyer can match it locally). */
   channelId?: string;
   /**
-   * On-chain reserve ceiling for this channel. When present and the seller's
-   * `requiredCumulativeAmount` exceeds it, the channel is permanently
-   * exhausted and the buyer must retire it and open a new one — no amount
-   * of additional signing on the same channel will be accepted.
+   * On-chain reserve ceiling for this channel. With `channel_exhausted`, a
+   * `requiredCumulativeAmount` above this ceiling means the buyer must retire
+   * the channel and open a replacement. With `reserve_headroom_required`, the
+   * seller is asking the buyer to top up the existing channel before retrying
+   * the request; the target is a forward-looking headroom estimate, not a
+   * claimable SpendingAuth amount for delivered work.
    */
   reserveMaxAmount?: string;
   /**
    * Stable machine-readable code so callers can switch on it without coupling
-   * to internal phrasing. Only set on irrecoverable 402s today.
+   * to internal phrasing.
    */
   code?: PaymentRequiredCode;
 }
 
 export const PAYMENT_CODE_CHANNEL_EXHAUSTED = 'channel_exhausted' as const;
-export type PaymentRequiredCode = typeof PAYMENT_CODE_CHANNEL_EXHAUSTED;
+export const PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED = 'reserve_headroom_required' as const;
+export type PaymentRequiredCode =
+  | typeof PAYMENT_CODE_CHANNEL_EXHAUSTED
+  | typeof PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED;
 
 /**
  * Seller tells buyer that the current cumulative authorization is insufficient.

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -9,7 +9,7 @@ import type { ChannelStore } from '../src/payments/channel-store.js';
 import type { StoredChannel } from '../src/payments/channel-store.js';
 import type { Identity } from '../src/p2p/identity.js';
 import type { PeerConnection } from '../src/p2p/connection-manager.js';
-import type { PaymentRequiredPayload } from '../src/types/protocol.js';
+import { PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED, type PaymentRequiredPayload } from '../src/types/protocol.js';
 
 const enc = new TextEncoder();
 
@@ -273,6 +273,47 @@ describe('BuyerPaymentNegotiator', () => {
         85119n, // <— the catch-up target the seller asked for
       );
       expect(result.action).toBe('retry');
+    });
+
+    it('tops up the active reserve and retries when seller requires reserve headroom', async () => {
+      await simulateSuccessfulNegotiation(negotiator, bpm, peer, conn);
+      (bpm.authorizeSpending as ReturnType<typeof vi.fn>).mockClear();
+      (bpm.extendCurrentSpendingAuth as ReturnType<typeof vi.fn>).mockClear();
+      (bpm.topUpReserve as ReturnType<typeof vi.fn>).mockClear();
+
+      const activeSession = makeActiveSession(peer.peerId);
+      (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(activeSession);
+
+      const result = await negotiator.handle402(makeReserveHeadroomResponse(), peer, conn, makeRequest());
+
+      expect(bpm.topUpReserve).toHaveBeenCalledWith(peer.peerId, expect.anything());
+      expect(bpm.extendCurrentSpendingAuth).not.toHaveBeenCalled();
+      expect(bpm.retireSession).not.toHaveBeenCalled();
+      expect(bpm.authorizeSpending).not.toHaveBeenCalled();
+      expect(result.action).toBe('retry');
+    });
+
+    it('returns payment_required when reserve-headroom top-up deposits are insufficient', async () => {
+      await simulateSuccessfulNegotiation(negotiator, bpm, peer, conn);
+      (bpm.authorizeSpending as ReturnType<typeof vi.fn>).mockClear();
+      (bpm.extendCurrentSpendingAuth as ReturnType<typeof vi.fn>).mockClear();
+      (bpm.topUpReserve as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('Insufficient buyer deposits for reserve top-up: available=500000 required=1000000'),
+      );
+
+      const activeSession = makeActiveSession(peer.peerId);
+      (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(activeSession);
+
+      const result = await negotiator.handle402(makeReserveHeadroomResponse(), peer, conn, makeRequest());
+
+      expect(bpm.topUpReserve).toHaveBeenCalledWith(peer.peerId, expect.anything());
+      expect(bpm.extendCurrentSpendingAuth).not.toHaveBeenCalled();
+      expect(bpm.retireSession).not.toHaveBeenCalled();
+      expect(bpm.authorizeSpending).not.toHaveBeenCalled();
+      expect(result.action).toBe('return');
+      const res = (result as { action: 'return'; response: SerializedHttpResponse }).response;
+      const body = JSON.parse(new TextDecoder().decode(res.body)) as Record<string, unknown>;
+      expect(body.code).toBe('insufficient_deposits');
     });
 
     it('retires session as settled and renegotiates without retrying extend when seller flags channel_exhausted', async () => {
@@ -847,6 +888,20 @@ function make402Response(body: Record<string, unknown> = {}): SerializedHttpResp
     headers: { 'content-type': 'application/json' },
     body: enc.encode(JSON.stringify(body)),
   };
+}
+
+function makeReserveHeadroomResponse(): SerializedHttpResponse {
+  return make402Response({
+    error: 'payment_required',
+    code: PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED,
+    minBudgetPerRequest: '500000',
+    suggestedAmount: '1000000',
+    requiredCumulativeAmount: '1184445',
+    currentSpent: '684445',
+    currentAcceptedCumulative: '684445',
+    reserveMaxAmount: '1000000',
+    channelId: '0x' + 'cd'.repeat(32),
+  });
 }
 
 function makeRequest(): SerializedHttpRequest {

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -4,7 +4,7 @@ import type { SerializedHttpRequest } from '../src/types/http.js';
 import type { Provider } from '../src/interfaces/seller-provider.js';
 import { decodeHttpResponse, encodeHttpRequest } from '../src/proxy/request-codec.js';
 import { decodeFrame } from '../src/p2p/message-protocol.js';
-import { MessageType, PAYMENT_CODE_CHANNEL_EXHAUSTED } from '../src/types/protocol.js';
+import { MessageType, PAYMENT_CODE_CHANNEL_EXHAUSTED, PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED } from '../src/types/protocol.js';
 
 function makeProvider(inputUsdPerMillion: number, outputUsdPerMillion: number, opts: {
   name: string;
@@ -502,6 +502,125 @@ describe('SellerRequestHandler payment pricing selection', () => {
     expect(settleSession).toHaveBeenCalledOnce();
     const response = decodeHttpResponse(decodeFrame(sentFrames[0]!)!.message.payload);
     expect(response.statusCode).toBe(402);
+  });
+
+  it('requests a reserve top-up before routing when confirmed headroom is below the seller minimum', async () => {
+    const provider = makeProvider(1, 1, { name: 'paid-tier', services: ['local-test'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
+
+    const sendPaymentRequired = vi.fn();
+    const sendNeedAuth = vi.fn();
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: makeSpmMock({
+        getCumulativeSpend: () => 684_445n,
+        getAcceptedCumulative: () => 684_445n,
+        getReserveMax: () => 1_000_000n,
+        getEffectiveReserveMax: () => 1_000_000n,
+        getPaymentRequirements: () => ({ minBudgetPerRequest: '500000', suggestedAmount: '1000000' }),
+      }),
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-preflight-min', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test', messages: [{ role: 'user', content: 'hi' }] })) }) });
+
+    expect(provider.handleRequest).not.toHaveBeenCalled();
+    expect(sendNeedAuth).not.toHaveBeenCalled();
+    expect(sendPaymentRequired).toHaveBeenCalledWith(expect.objectContaining({
+      code: PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED,
+      requiredCumulativeAmount: '1184445',
+      currentSpent: '684445',
+      reserveMaxAmount: '1000000',
+    }));
+    const response = decodeHttpResponse(decodeFrame(sentFrames[0]!)!.message.payload);
+    expect(response.statusCode).toBe(402);
+    const body = JSON.parse(new TextDecoder().decode(response.body));
+    expect(body).toMatchObject({ code: PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED, requiredCumulativeAmount: '1184445', reserveMaxAmount: '1000000' });
+  });
+
+  it('closes for a fresh reserve when max-token estimate exceeds headroom before top-up threshold', async () => {
+    const provider = makeProvider(0, 100, { name: 'paid-tier', services: ['expensive-output'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
+
+    const sendPaymentRequired = vi.fn();
+    const settleSession = vi.fn(async () => {});
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: makeSpmMock({
+        getCumulativeSpend: () => 100_000n,
+        getAcceptedCumulative: () => 100_000n,
+        getReserveMax: () => 1_000_000n,
+        getEffectiveReserveMax: () => 1_000_000n,
+        getPaymentRequirements: () => ({ minBudgetPerRequest: '10000', suggestedAmount: '1000000' }),
+        settleSession,
+      }),
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired } as any;
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-preflight-max', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'expensive-output', messages: [{ role: 'user', content: 'hi' }], max_tokens: 10_000 })) }) });
+
+    expect(provider.handleRequest).not.toHaveBeenCalled();
+    expect(settleSession).toHaveBeenCalledOnce();
+    expect(sendPaymentRequired).toHaveBeenCalledWith(expect.objectContaining({
+      code: PAYMENT_CODE_CHANNEL_EXHAUSTED,
+      requiredCumulativeAmount: '100000',
+      reserveMaxAmount: '1000000',
+    }));
+    const response = decodeHttpResponse(decodeFrame(sentFrames[0]!)!.message.payload);
+    expect(response.statusCode).toBe(402);
+  });
+
+  it('routes when the preflight max-token estimate fits inside confirmed reserve headroom', async () => {
+    const provider = makeProvider(0, 100, { name: 'paid-tier', services: ['bounded-output'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ usage: { prompt_tokens: 0, completion_tokens: 1 } })) }));
+
+    const sendPaymentRequired = vi.fn();
+    const sendNeedAuth = vi.fn();
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: makeSpmMock({
+        getCumulativeSpend: () => 100_000n,
+        getAcceptedCumulative: () => 100_000n,
+        getReserveMax: () => 1_000_000n,
+        getEffectiveReserveMax: () => 1_000_000n,
+        getPaymentRequirements: () => ({ minBudgetPerRequest: '10000', suggestedAmount: '1000000' }),
+        awaitAcceptedAtLeast: async () => true,
+      }),
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-preflight-fits', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'bounded-output', messages: [{ role: 'user', content: 'hi' }], max_tokens: 100 })) }) });
+
+    expect(provider.handleRequest).toHaveBeenCalledOnce();
+    expect(sendPaymentRequired).not.toHaveBeenCalled();
+    expect(sendNeedAuth).toHaveBeenCalledOnce();
+    const responseFrames = sentFrames.map((f) => decodeFrame(f)).filter((d) => d?.message.type === MessageType.HttpResponse);
+    const response = decodeHttpResponse(responseFrames[0]!.message.payload);
+    expect(response.statusCode).toBe(200);
   });
 
   it('stops serving when spend reached the on-chain ceiling even if a higher topUp is pending', async () => {

--- a/packages/node/tests/payment-codec.test.ts
+++ b/packages/node/tests/payment-codec.test.ts
@@ -5,6 +5,7 @@ import {
   encodePaymentRequired, decodePaymentRequired,
   encodeNeedAuth, decodeNeedAuth,
 } from '../src/p2p/payment-codec.js';
+import { PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED } from '../src/types/protocol.js';
 
 describe('payment codec round-trips', () => {
   it('SpendingAuth', () => {
@@ -78,6 +79,23 @@ describe('payment codec round-trips', () => {
       channelId: '0x' + 'cd'.repeat(32),
       reserveMaxAmount: '11000000',
       code: 'channel_exhausted' as const,
+    };
+    const encoded = encodePaymentRequired(payload);
+    const decoded = decodePaymentRequired(encoded);
+    expect(decoded).toEqual(payload);
+  });
+
+  it('PaymentRequired with reserve_headroom_required code', () => {
+    const payload = {
+      minBudgetPerRequest: '500000',
+      suggestedAmount: '1000000',
+      requestId: 'req-headroom',
+      requiredCumulativeAmount: '1184445',
+      currentSpent: '684445',
+      currentAcceptedCumulative: '684445',
+      channelId: '0x' + 'ef'.repeat(32),
+      reserveMaxAmount: '1000000',
+      code: PAYMENT_CODE_RESERVE_HEADROOM_REQUIRED,
     };
     const encoded = encodePaymentRequired(payload);
     const decoded = decodePaymentRequired(encoded);


### PR DESCRIPTION
## Description

Adds a seller-side preflight reserve headroom guard before provider routing so requests are not served when their minimum/estimated max cost cannot fit inside the confirmed on-chain reserve. Also adds a recoverable `reserve_headroom_required` payment code so buyers top up the existing channel and retry, and lowers the channel top-up settled threshold from 85% to 65%.

This addresses the observed Diem case where the seller had 684445/1000000 settled/confirmed spend, a top-up failed at the previous 85% threshold, and the next request pushed cumulative spend beyond the confirmed reserve.

## Release Notes

- Sellers now request a reserve top-up before routing paid work when confirmed channel headroom is too low for the next request.
- Buyers automatically respond to recoverable reserve-headroom 402s by topping up the active channel and retrying.
- Channel top-ups are allowed once 65% of the current reserve is settled, reducing top-up failures near the reserve ceiling.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
