### PR TITLE
fix(node): Stop short deposit auth retries

### DIFF
--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -973,7 +973,25 @@ export class BuyerPaymentManager {
 
     const prevCeiling = this._getCeiling(sellerPeerId);
     const newCeiling = prevCeiling + this._config.maxReserveAmountUsdc;
+    const additionalReserve = newCeiling - prevCeiling;
     const deadline = Math.floor(Date.now() / 1000) + this._config.defaultAuthDurationSecs;
+
+    try {
+      const balance = await this.getBalance();
+      if (balance.available < additionalReserve) {
+        throw new Error(
+          `Insufficient buyer deposits for reserve top-up: available=${balance.available} required=${additionalReserve}`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith('Insufficient buyer deposits')) {
+        throw err;
+      }
+      debugWarn(
+        `[BuyerPayment] topUpReserve: unable to verify buyer deposits before signing top-up: ` +
+        `${err instanceof Error ? err.message : err}`,
+      );
+    }
 
     debugLog(`[BuyerPayment] topUpReserve: channel=${session.sessionId.slice(0, 18)}... ceiling ${prevCeiling} → ${newCeiling}`);
 

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -42,6 +42,16 @@ interface LastResponseCost {
   service?: string;
 }
 
+class InsufficientBuyerDepositsError extends Error {
+  constructor(
+    readonly available: bigint,
+    readonly required: bigint,
+  ) {
+    super(`Buyer deposits available=${available} are below required reserve=${required}`);
+    this.name = 'InsufficientBuyerDepositsError';
+  }
+}
+
 function parsePaymentRequiredBody(body: Uint8Array): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(new TextDecoder().decode(body)) as Record<string, unknown>;
@@ -245,6 +255,25 @@ export class BuyerPaymentNegotiator {
       : await this._awaitPaymentRequired(peer.peerId, conn, waitMs);
     if (buffered) this._bufferedPaymentRequired.delete(peer.peerId);
 
+    const bodyRequirements: PaymentRequiredPayload | null = responseAlreadyHasRequirements && directPaymentBody != null
+      ? {
+        minBudgetPerRequest: String(directPaymentBody.minBudgetPerRequest ?? '10000'),
+        suggestedAmount: String(directPaymentBody.suggestedAmount ?? '100000'),
+        requestId: req.requestId,
+        ...(directPaymentBody.inputUsdPerMillion != null ? { inputUsdPerMillion: Number(directPaymentBody.inputUsdPerMillion) } : {}),
+        ...(directPaymentBody.outputUsdPerMillion != null ? { outputUsdPerMillion: Number(directPaymentBody.outputUsdPerMillion) } : {}),
+        ...(directPaymentBody.cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion: Number(directPaymentBody.cachedInputUsdPerMillion) } : {}),
+      }
+      : null;
+    const paymentRequirements = buffered ?? bodyRequirements;
+
+    const requestedReserveAmount = (() => {
+      if (!paymentRequirements) return null;
+      const suggested = safeBigInt(paymentRequirements.suggestedAmount);
+      if (suggested == null || suggested <= 0n) return null;
+      return suggested > this._bpm.maxReserveAmountUsdc ? this._bpm.maxReserveAmountUsdc : suggested;
+    })();
+
     // Stable machine-readable codes for the 402 body. Kept deliberately small
     // so callers (desktop UI, other SDK consumers) can switch on them without
     // being coupled to internal debug strings.
@@ -385,12 +414,21 @@ export class BuyerPaymentNegotiator {
       );
     }
 
-    // Check on-chain balance
+    // Check on-chain balance before sending ReserveAuth. The seller locks the full
+    // reserve ceiling on-chain, so a positive-but-too-small available balance would
+    // otherwise make reserve()/topUp() revert with InsufficientBalance and trigger a
+    // noisy 402/auth-rejection retry loop.
     try {
       const buyerAddr = this._identity.wallet.address;
       const balance = await this._depositsClient.getBuyerBalance(buyerAddr);
       if (balance.available <= 0n) {
         return returnPaymentRequired('insufficient_deposits', 'buyer deposits balance is zero');
+      }
+      if (requestedReserveAmount != null && balance.available < requestedReserveAmount) {
+        return returnPaymentRequired(
+          'insufficient_deposits',
+          `buyer available deposits ${balance.available} are below requested reserve ${requestedReserveAmount}`,
+        );
       }
     } catch (err) {
       debugWarn(`[BuyerNegotiator] Failed to check buyer balance: ${err instanceof Error ? err.message : err}`);
@@ -399,15 +437,7 @@ export class BuyerPaymentNegotiator {
     // Re-buffer the PaymentRequired so _doNegotiatePayment can consume it
     if (buffered) {
       this._bufferedPaymentRequired.set(peer.peerId, buffered);
-    } else if (responseAlreadyHasRequirements && directPaymentBody) {
-      const bodyRequirements: PaymentRequiredPayload = {
-        minBudgetPerRequest: String(directPaymentBody.minBudgetPerRequest ?? '10000'),
-        suggestedAmount: String(directPaymentBody.suggestedAmount ?? '100000'),
-        requestId: req.requestId,
-        ...(directPaymentBody.inputUsdPerMillion != null ? { inputUsdPerMillion: Number(directPaymentBody.inputUsdPerMillion) } : {}),
-        ...(directPaymentBody.outputUsdPerMillion != null ? { outputUsdPerMillion: Number(directPaymentBody.outputUsdPerMillion) } : {}),
-        ...(directPaymentBody.cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion: Number(directPaymentBody.cachedInputUsdPerMillion) } : {}),
-      };
+    } else if (bodyRequirements) {
       this._bufferedPaymentRequired.set(peer.peerId, bodyRequirements);
     }
 
@@ -418,6 +448,12 @@ export class BuyerPaymentNegotiator {
       return { action: 'retry' };
     } catch (err) {
       this._lockedPeers.delete(peer.peerId);
+      if (err instanceof InsufficientBuyerDepositsError) {
+        return returnPaymentRequired(
+          'insufficient_deposits',
+          `buyer available deposits ${err.available} are below requested reserve ${err.required}`,
+        );
+      }
       throw err;
     }
   }
@@ -689,6 +725,18 @@ export class BuyerPaymentNegotiator {
     }
     if (amount <= 0n) {
       throw new Error(`Invalid reserve amount for payment to ${peer.peerId.slice(0, 12)}...`);
+    }
+
+    if (this._depositsClient) {
+      try {
+        const balance = await this._depositsClient.getBuyerBalance(this._identity.wallet.address);
+        if (balance.available < amount) {
+          throw new InsufficientBuyerDepositsError(balance.available, amount);
+        }
+      } catch (err) {
+        if (err instanceof InsufficientBuyerDepositsError) throw err;
+        debugWarn(`[BuyerNegotiator] Failed to re-check buyer balance before reserve: ${err instanceof Error ? err.message : err}`);
+      }
     }
 
     const sellerEvmAddr = await this._resolveSellerAddr(peer);

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -42,16 +42,6 @@ interface LastResponseCost {
   service?: string;
 }
 
-class InsufficientBuyerDepositsError extends Error {
-  constructor(
-    readonly available: bigint,
-    readonly required: bigint,
-  ) {
-    super(`Buyer deposits available=${available} are below required reserve=${required}`);
-    this.name = 'InsufficientBuyerDepositsError';
-  }
-}
-
 function parsePaymentRequiredBody(body: Uint8Array): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(new TextDecoder().decode(body)) as Record<string, unknown>;
@@ -448,12 +438,6 @@ export class BuyerPaymentNegotiator {
       return { action: 'retry' };
     } catch (err) {
       this._lockedPeers.delete(peer.peerId);
-      if (err instanceof InsufficientBuyerDepositsError) {
-        return returnPaymentRequired(
-          'insufficient_deposits',
-          `buyer available deposits ${err.available} are below requested reserve ${err.required}`,
-        );
-      }
       throw err;
     }
   }
@@ -725,18 +709,6 @@ export class BuyerPaymentNegotiator {
     }
     if (amount <= 0n) {
       throw new Error(`Invalid reserve amount for payment to ${peer.peerId.slice(0, 12)}...`);
-    }
-
-    if (this._depositsClient) {
-      try {
-        const balance = await this._depositsClient.getBuyerBalance(this._identity.wallet.address);
-        if (balance.available < amount) {
-          throw new InsufficientBuyerDepositsError(balance.available, amount);
-        }
-      } catch (err) {
-        if (err instanceof InsufficientBuyerDepositsError) throw err;
-        debugWarn(`[BuyerNegotiator] Failed to re-check buyer balance before reserve: ${err instanceof Error ? err.message : err}`);
-      }
     }
 
     const sellerEvmAddr = await this._resolveSellerAddr(peer);

--- a/packages/node/tests/payment-negotiation.test.ts
+++ b/packages/node/tests/payment-negotiation.test.ts
@@ -7,7 +7,10 @@ import { PaymentMux } from '../src/p2p/payment-mux.js';
 import { MessageType, type FramedMessage, type PaymentRequiredPayload } from '../src/types/protocol.js';
 import * as codec from '../src/p2p/payment-codec.js';
 import type { PeerConnection } from '../src/p2p/connection-manager.js';
+import type { SerializedHttpRequest, SerializedHttpResponse } from '../src/types/http.js';
 import { SellerPaymentManager, type SellerPaymentConfig } from '../src/payments/seller-payment-manager.js';
+import { BuyerPaymentManager } from '../src/payments/buyer-payment-manager.js';
+import { BuyerPaymentNegotiator } from '../src/payments/buyer-payment-negotiator.js';
 import { ChannelStore } from '../src/payments/channel-store.js';
 import type { Identity } from '../src/p2p/identity.js';
 import { bytesToHex } from '../src/utils/hex.js';
@@ -497,5 +500,123 @@ describe('PaymentRequired codec with pricing', () => {
     const decoded = codec.decodePaymentRequired(codec.encodePaymentRequired(SAMPLE_PAYMENT_REQUIRED));
     expect(decoded.inputUsdPerMillion).toBeUndefined();
     expect(decoded.outputUsdPerMillion).toBeUndefined();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Buyer: insufficient deposit handling
+// ═══════════════════════════════════════════════════════════════
+
+describe('Buyer insufficient deposit handling', () => {
+  let tempDir: string;
+  let store: ChannelStore;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'buyer-insufficient-deposits-'));
+    store = new ChannelStore(tempDir);
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function makeBuyerPaymentManager(): { buyer: BuyerPaymentManager; buyerIdentity: Identity } {
+    const buyerIdentity = createTestIdentity();
+    const buyer = new BuyerPaymentManager(buyerIdentity, {
+      rpcUrl: 'http://127.0.0.1:8545',
+      depositsContractAddress: '0x' + 'dd'.repeat(20),
+      channelsContractAddress: CONTRACT_ADDR,
+      usdcAddress: '0x' + 'ee'.repeat(20),
+      identityRegistryAddress: '0x' + 'ff'.repeat(20),
+      chainId: CHAIN_ID,
+      defaultAuthDurationSecs: 3600,
+      maxPerRequestUsdc: 500_000n,
+      maxReserveAmountUsdc: 1_000_000n,
+      dataDir: tempDir,
+    }, store);
+    return { buyer, buyerIdentity };
+  }
+
+  function makeMux(): import('../src/p2p/payment-mux.js').PaymentMux & { sentSpendingAuths: unknown[] } {
+    const mux = {
+      sentSpendingAuths: [] as unknown[],
+      sendSpendingAuth(payload: unknown) { mux.sentSpendingAuths.push(payload); },
+      sendAuthAck() {},
+      sendPaymentRequired() {},
+      sendNeedAuth() {},
+      onSpendingAuth() {},
+      onAuthAck() {},
+      onPaymentRequired() {},
+      onNeedAuth() {},
+      handleFrame: vi.fn(),
+    };
+    return mux as unknown as import('../src/p2p/payment-mux.js').PaymentMux & { sentSpendingAuths: unknown[] };
+  }
+
+  it('returns payment_required before reserve when available deposit is below reserve amount', async () => {
+    const { buyer, buyerIdentity } = makeBuyerPaymentManager();
+    const depositsClient = {
+      getBuyerBalance: vi.fn().mockResolvedValue({ available: 500_000n, reserved: 0n, lastActivityAt: 0n }),
+    };
+    const negotiator = new BuyerPaymentNegotiator(
+      buyerIdentity,
+      buyer,
+      depositsClient as never,
+      null,
+      store,
+      {},
+      { emit: vi.fn() },
+    );
+
+    const conn = mockConnection();
+    const peer = {
+      peerId: toPeerId('a'.repeat(40)),
+      lastSeen: Date.now(),
+      providers: ['openai'],
+    };
+    const req: SerializedHttpRequest = {
+      requestId: 'req-short-balance',
+      method: 'POST',
+      path: '/v1/chat/completions',
+      headers: {},
+      body: new Uint8Array(0),
+    };
+    const response: SerializedHttpResponse = {
+      requestId: req.requestId,
+      statusCode: 402,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({
+        error: 'payment_required',
+        minBudgetPerRequest: '10000',
+        suggestedAmount: '1000000',
+      })),
+    };
+
+    const result = await negotiator.handle402(response, peer, conn, req);
+
+    expect(result.action).toBe('return');
+    if (result.action === 'return') {
+      const body = JSON.parse(new TextDecoder().decode(result.response.body)) as Record<string, unknown>;
+      expect(body.code).toBe('insufficient_deposits');
+    }
+    expect(depositsClient.getBuyerBalance).toHaveBeenCalledOnce();
+    expect(conn.send).not.toHaveBeenCalled();
+  });
+
+  it('does not send a top-up ReserveAuth when available deposit cannot cover the added reserve', async () => {
+    const { buyer } = makeBuyerPaymentManager();
+    const mux = makeMux();
+    const sellerPeerId = fakePeerId('seller-top-up-short');
+
+    await buyer.authorizeSpending(sellerPeerId, mux, 10_000n, 1_000_000n);
+    vi.spyOn(buyer.depositsClient, 'getBuyerBalance').mockResolvedValue({
+      available: 500_000n,
+      reserved: 1_000_000n,
+      lastActivityAt: 0n,
+    });
+
+    await expect(buyer.topUpReserve(sellerPeerId, mux)).rejects.toThrow('Insufficient buyer deposits');
+    expect(mux.sentSpendingAuths).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Description

Prevents buyers from repeatedly signing payment authorizations when their available deposit is below the reserve amount the seller will lock on-chain. The buyer now returns a normalized `payment_required` response before reserve negotiation and skips reserve top-up signatures when the added reserve cannot be covered.

## Release Notes

- Fixed repeated payment authorization retries when buyer deposits are too low to open or top up a channel
- Buyers now receive a clear `insufficient_deposits` payment response instead of hammering sellers with failing reserve attempts

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
