### PR TITLE
fix: stabilize pagination width across page navigation

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
@@ -245,7 +245,11 @@
 }
 
 .page-ellipsis {
-  min-width: 20px;
+  width: 32px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   color: var(--text-muted);
   font-size: 12px;
@@ -253,9 +257,9 @@
 }
 
 .page-btn {
-  min-width: 28px;
+  width: 32px;
   height: 28px;
-  padding: 0 10px;
+  padding: 0;
   border-radius: 6px;
   border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
   background: var(--bg-card);

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -343,16 +343,18 @@ function estimatePageSize(): number {
 }
 
 function buildPaginationTokens(page: number, totalPages: number): PaginationToken[] {
-  if (totalPages <= 5) {
+  if (totalPages <= 7) {
     return Array.from({ length: totalPages }, (_, index) => index + 1);
   }
 
+  // All branches below produce exactly 7 tokens so the pagination
+  // container keeps a stable width when navigating between pages.
   if (page <= 3) {
-    return [1, 2, 3, 'ellipsis', totalPages - 1, totalPages];
+    return [1, 2, 3, 4, 'ellipsis', totalPages - 1, totalPages];
   }
 
   if (page >= totalPages - 2) {
-    return [1, 2, 'ellipsis', totalPages - 2, totalPages - 1, totalPages];
+    return [1, 2, 'ellipsis', totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
   }
 
   return [1, 'ellipsis', page - 1, page, page + 1, 'ellipsis', totalPages];


### PR DESCRIPTION
## Problem
The pagination bar shifts/jumps horizontally when navigating between pages because:
1. Ellipsis slots were narrower than page buttons
2. Two-digit page numbers (e.g. `68`, `69`) made buttons wider than single-digit ones
3. The number of tokens changed between 6 and 7 depending on the current page

## Fix
- **Fixed-width slots**: Both `.page-btn` and `.page-ellipsis` now use a fixed `width: 32px` instead of `min-width`, so every slot takes the same space regardless of content
- **Consistent token count**: `buildPaginationTokens` now always returns exactly 7 tokens when `totalPages > 7`, and shows all pages when `totalPages <= 7`

Fixes #498