### PR TITLE
fix(desktop): handle Ctrl++ zoom-in on Windows keyboards

### DIFF
--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -96,6 +96,18 @@ export function createWindow(config: WindowConfig): void {
     if (devToolsShortcut && mainWindow) {
       mainWindow.webContents.openDevTools({ mode: 'detach' });
     }
+
+    // Windows: Ctrl++ sends Ctrl+Shift+= which does not match the viewMenu's
+    // CmdOrCtrl+= zoom-in accelerator. Handle it explicitly so zoom is symmetrical.
+    if (
+      input.type === 'keyDown' &&
+      input.control &&
+      !input.alt &&
+      input.key === '+' &&
+      mainWindow
+    ) {
+      mainWindow.webContents.setZoomLevel(mainWindow.webContents.getZoomLevel() + 0.5);
+    }
   });
 
   mainWindow.on('closed', () => {


### PR DESCRIPTION
Fixes #339.

## Problem

`Ctrl++` does not zoom in on AntStation Desktop for Windows users. `Ctrl+-` (zoom out)
and `Ctrl+0` (reset) work correctly.

Root cause: Electron's built-in `viewMenu` role registers `CmdOrCtrl+=` for Zoom In.
On a Windows US keyboard, pressing `Ctrl++` sends `Ctrl+Shift+=` (because `+` is the
shifted `=` key) — this does not match `CmdOrCtrl+=`, so the event is silently dropped.
`Ctrl+-` works because `-` requires no Shift.

The code path: `apps/desktop/src/main/window.ts:92` — the `before-input-event` handler.

## Fix

Add an explicit `input.key === '+'` guard inside the existing `before-input-event`
callback (`window.ts:92-99`). When `Ctrl` is held and the key is `+`, call
`setZoomLevel(current + 0.5)` directly — the same increment Electron's viewMenu uses
internally. macOS and Ctrl+scroll are unaffected.

The handler also gates on `input.type === 'keyDown'` so the zoom only fires once per
keystroke (the `before-input-event` fires for both keyDown and keyUp, and `setZoomLevel`
is not idempotent, so without the guard a single press would zoom by +1.0 instead of +0.5).

## Test plan

- [ ] Open AntStation on Windows
- [ ] Press `Ctrl++` → confirm view zooms in
- [ ] Press `Ctrl+-` → confirm view zooms out (unchanged)
- [ ] Press `Ctrl+0` → confirm view resets (unchanged)
- [ ] Repeat on macOS to confirm no regression (Cmd++ should still work via viewMenu)

## Disclosure

This PR was drafted with assistance from a Claude Code agent. The change has been
reviewed and is being submitted by me (@Augustas11).
