### PR TITLE
feat(desktop): add browser preview toggle to chat header

### DIFF
--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -1007,6 +1007,17 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                 <HugeiconsIcon icon={Search01Icon} size={15} strokeWidth={1.8} />
               </button>
             )}
+            {previewTargetUrl && (
+              <button
+                type="button"
+                className={`${styles.previewToggle}${previewOpen ? ` ${styles.previewToggleActive}` : ''}`}
+                onClick={() => setPreviewOpen((open) => !open)}
+                aria-label={previewOpen ? 'Close browser preview' : 'Open browser preview'}
+                title={previewOpen ? 'Close preview' : 'Open preview'}
+              >
+                <HugeiconsIcon icon={BrowserIcon} size={15} strokeWidth={1.8} />
+              </button>
+            )}
             <ChatSessionStats
               sessionCost={snap.chatSessionAccumulatedCostUsd}
               sessionTokens={snap.chatSessionTotalTokens}


### PR DESCRIPTION
Fixes #547.

## Problem

The browser preview pane can be closed but there is no UI control to reopen it. After
closing, users must trigger another preview-generating action to see the pane again.

## Fix

Add a preview toggle button to the chat header's right-side toolbar
(`ChatView.tsx`, in `.pageHeaderRight`). The button is rendered only when
`previewTargetUrl` is non-null — i.e. a preview URL has been seen in the current
session. Clicking it toggles `previewOpen` via the existing `setPreviewOpen` setter:
closes the pane if open, reopens it with the preserved `previewTargetUrl` if closed.

Reused existing SCSS classes `.previewToggle` and `.previewToggleActive` (already
defined in `ChatView.module.scss:31-57`) and the already-imported `BrowserIcon`. No
state restructuring, no IPC changes, no main-process changes.

The current `handleClosePreview` already preserves `previewTargetUrl` on close (only
sets `previewOpen=false`), so the URL survives without modification — the new button
just flips visibility.

Files changed: `apps/desktop/src/renderer/ui/components/views/ChatView.tsx`

## Test plan

- [ ] Open a chat, trigger a URL preview → pane opens
- [ ] Close the pane using the existing close button
- [ ] Confirm the toggle button (browser icon) appears in the chat header toolbar
- [ ] Click toggle → pane reopens with the same URL
- [ ] Click toggle again → pane closes
- [ ] Reload the app → confirm toggle button is not shown (no URL in session yet)
- [ ] Verify the button does not appear before any preview has been opened

## Disclosure

This PR was drafted with assistance from a Claude Code agent. The change has been
reviewed and is being submitted by me (@Augustas11).
