### PR TITLE
fix(desktop): add left accent border to assistant chat bubbles

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -273,10 +273,10 @@
     align-self: stretch;
     background: transparent;
     color: var(--text-primary);
-    border-left: 0;
+    border-left: 3px solid var(--accent, #1fd87a);
     border-radius: 0;
     width: 100%;
-    padding: 0 16px;
+    padding: 0 16px 0 13px;
 
   :global {
     /* Tool group — flat layout in both open and closed states */


### PR DESCRIPTION
Fixes #424.

## Problem

Assistant responses in AntStation chat have a transparent, borderless, full-width layout
(`.other` in `ChatBubble.module.scss:272`). When a long response streams in and the view
auto-scrolls to the latest token, the user has no visual anchor for "where the reply
started." They must scroll up to find their own prompt as a reference point.

## Fix

Add a 3px left accent border to the `.other` bubble style, using the existing brand
`--accent` CSS variable (which resolves to the same `#1fd87a` in both light and dark
themes — see `global.scss:18,62`). The horizontal padding is shifted from `0 16px` to
`0 16px 0 13px` so the content text alignment is unchanged.

This is the minimal Option #1 from the issue. Avatars, role headers, turn separators,
and auto-scroll changes are out of scope (each requires separate design or behavior work).

File changed: `apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss`

## Test plan

- [ ] Open AntStation and send a chat message
- [ ] Confirm assistant response has a green left accent border visible
- [ ] Confirm user message bubbles are unchanged
- [ ] Check in both light and dark themes that the border is visible (`--accent` is the
      same green in both, so contrast should be consistent)
- [ ] Confirm no horizontal layout shift (the `padding-left: 13px` compensates for the
      3px border width)

## Disclosure

This PR was drafted with assistance from a Claude Code agent. The change has been
reviewed and is being submitted by me (@Augustas11).
