### PR TITLE
feat(desktop): collapse per-peer chat sessions to 3 by default

### DIFF
--- a/apps/desktop/src/renderer/ui/components/Sidebar.module.scss
+++ b/apps/desktop/src/renderer/ui/components/Sidebar.module.scss
@@ -303,6 +303,23 @@
   }
 }
 
+.chat-conv-show-more {
+  margin: 2px 4px 4px 28px;
+  padding: 4px 8px;
+  background: none;
+  border: 0;
+  text-align: left;
+  font-size: 11px;
+  color: var(--text-muted);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+
+  &:hover {
+    color: var(--text-primary);
+    background: var(--bg-hover);
+  }
+}
+
 .chat-conv-top {
   display: flex;
   align-items: center;

--- a/apps/desktop/src/renderer/ui/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/ui/components/Sidebar.tsx
@@ -264,6 +264,28 @@ function PeerGroupSection({
   const convsRef = useRef<HTMLDivElement>(null);
   const letter = (group.displayName || '?').charAt(0).toUpperCase();
 
+  // Per-peer auto-collapse: show the 3 most-recent sessions by default. The
+  // active session is always kept visible — if it sits past the limit we swap
+  // it into the last slot so the user never loses sight of the chat they're
+  // currently in.
+  const MAX_VISIBLE_CONVS = 3;
+  const [showAllConvs, setShowAllConvs] = useState(false);
+  const visibleConvs = useMemo(() => {
+    if (showAllConvs || group.conversations.length <= MAX_VISIBLE_CONVS) {
+      return group.conversations;
+    }
+    const head = group.conversations.slice(0, MAX_VISIBLE_CONVS);
+    if (!activeConvId) return head;
+    const tail = group.conversations.slice(MAX_VISIBLE_CONVS);
+    const activeIdxInTail = tail.findIndex((c) => String(c.id ?? '') === activeConvId);
+    if (activeIdxInTail < 0) return head;
+    return [
+      ...head.slice(0, MAX_VISIBLE_CONVS - 1),
+      tail[activeIdxInTail],
+    ];
+  }, [group.conversations, showAllConvs, activeConvId]);
+  const hiddenCount = group.conversations.length - visibleConvs.length;
+
   // When the group is collapsed, surface a single running indicator on the
   // peer header if any of its conversations is in flight — otherwise a user
   // who collapses a peer can't tell that work is still happening underneath.
@@ -350,7 +372,7 @@ function PeerGroupSection({
         ref={convsRef}
         className={`${styles.peerGroupConvs}${expanded ? ` ${styles.peerGroupConvsOpen}` : ''}`}
       >
-        {group.conversations.map((conv) => {
+        {visibleConvs.map((conv) => {
             const id = String(conv.id ?? '');
             const isActive = id === activeConvId;
             const isRunning = sendingConvIds.has(id);
@@ -428,6 +450,15 @@ function PeerGroupSection({
               </div>
             );
           })}
+        {hiddenCount > 0 && (
+          <button
+            type="button"
+            className={styles.chatConvShowMore}
+            onClick={() => setShowAllConvs(true)}
+          >
+            Show {hiddenCount} more
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes #552.

## Problem

As users accumulate conversations across many peers, the AntStation sidebar becomes
very long. Older sessions take equal visual space alongside active ones, and there is
no grouping or folding inside each peer's session list.

## Fix

Per-peer session auto-collapse in `PeerGroupSection` (`Sidebar.tsx:236-434`): each
peer shows only its 3 most recent sessions by default, with a "Show N more" button
below the visible sessions to expand. Peers with 3 or fewer sessions render unchanged.

The data layer already returns sessions sorted newest-first (`pi-chat-engine.ts:1353`
sorts by `updatedAt` descending, and `groupByPeer` preserves array order), so no sort
change is needed.

### Active session guard

The currently-active conversation (the one the user has open) is never hidden by the
collapse. If it would otherwise sit beyond position 3, it is swapped into the last
visible slot — the user always sees the chat they're currently in, regardless of how
old it is relative to the peer's other sessions.

### State

`showAllConvs` is a local `useState` in `PeerGroupSection`. No persistence across app
restarts (matches the brief's v1 scope). No new bridge methods, no Zustand additions.

Files changed:
- `apps/desktop/src/renderer/ui/components/Sidebar.tsx` (+24 LoC: useMemo for
  visibleConvs with active-session preservation; "Show N more" button after the map)
- `apps/desktop/src/renderer/ui/components/Sidebar.module.scss` (+17 LoC: `.chatConvShowMore` class)

## Test plan

- [ ] With a peer that has > 3 sessions: confirm only 3 are shown and "Show N more"
      appears below them
- [ ] Click "Show N more" → all sessions appear
- [ ] With a peer that has ≤ 3 sessions: confirm all shown, no button
- [ ] With > 3 sessions, open a session at position 5 (4th-oldest): confirm it
      remains visible (swapped into last slot); "Show N more" still appears
- [ ] Confirm currently-streaming sessions are not hidden
- [ ] Collapse and re-expand a peer group: visible count resets to 3 (intentional —
      state is local per group section instance)

## Disclosure

This PR was drafted with assistance from a Claude Code agent. The change has been
reviewed and is being submitted by me (@Augustas11).
