### PR TITLE
Sidebar: scroll-driven nav collapse + chat header action chips

### DIFF
--- a/apps/desktop/src/renderer/ui/components/Sidebar.module.scss
+++ b/apps/desktop/src/renderer/ui/components/Sidebar.module.scss
@@ -5,10 +5,57 @@
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
-  padding: 8px 0;
+  /* Single scroll container for the whole sidebar. The top nav uses
+     position: sticky so Discover / API / Settings stay pinned while the
+     warning, dev section, and chat list scroll underneath as one
+     continuous column. */
+  padding: 0 0 8px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  /* CRITICAL: disable scroll anchoring. The nav strip's height is
+     interpolated inline by JS as the user scrolls, which shrinks the
+     scroll content. Without this rule, the browser would compensate
+     by adjusting scrollTop to keep visible content stable — fighting
+     the user's scroll input and creating a feedback loop where the
+     strip grows back as soon as it tries to shrink. The result is
+     scroll "pushing back up" until the user pushes hard enough to
+     overcome the anchoring. Disabling anchoring lets scrollTop track
+     the user's input directly, which is what our progress calculation
+     assumes. */
+  overflow-anchor: none;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+
+  /* Belt-and-braces: opt every descendant out of being an anchor
+     candidate too. Some engines still pick a child element as the
+     anchor even when the scroll container has overflow-anchor: none. */
+  * {
+    overflow-anchor: none;
+  }
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 3px;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--border-light, var(--border));
+  }
 }
 
 .sidebar-warning {
+  /* Same flex-shrink pinning as the nav strip — keeps the warning at
+     natural height inside the flex-column sidebar even when the chat
+     list below grows large. */
+  flex: 0 0 auto;
   margin: 8px;
   padding: 8px 10px;
   border-radius: var(--radius-sm);
@@ -19,12 +66,130 @@
   line-height: 1.4;
 }
 
+/* Fixed sticky-nav height in the fully collapsed state. Used as the
+   `top:` value for the sticky "Conversations" header below. The
+   matching pixel value is also captured at runtime by
+   measureLayout() so the JS interpolation lands exactly here. */
+$collapsed-nav-height: 45px;
+
 .sidebar-nav {
+  /* Plain vertical nav by default. No CSS interpolation magic — if JS
+     hasn't run yet (or fails to mount), the user still sees a normal
+     menu at full size. Scroll-driven motion is owned entirely by
+     Sidebar.tsx, which:
+       1. Measures the expanded and collapsed icon positions once
+          after mount (and on resize).
+       2. On every scroll frame, writes inline `transform` on each
+          icon wrapper, inline `opacity` on each label, and inline
+          `height` + `overflow:hidden` on this <ul>, interpolated by
+          progress = scrollTop / 56.
+       3. At progress >= 1, snaps to the canonical compact endpoint
+          by toggling .sidebar-nav-collapsed and clearing the inline
+          writes — below.
+     The inline writes always win over these rules, so no calc() /
+     custom-property fallbacks are needed.
+
+     `flex-shrink: 0` is critical — the parent .sidebar is a flex
+     column with overflow-y: auto, so without it the chat list (which
+     can grow to dozens of rows) would squeeze this strip down to
+     nothing and the user would see no menu at all. We want the strip
+     at natural size and the <aside> itself to scroll. */
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  flex: 0 0 auto;
   list-style: none;
-  padding: 4px 8px 8px;
+  margin: 0;
+  padding: 8px 8px;
   display: flex;
   flex-direction: column;
+  align-items: stretch;
   gap: 2px;
+  background: var(--bg-primary);
+  border-bottom: 1px solid transparent;
+  /* No `overflow: hidden` here at rest — it gets applied inline by JS
+     only while the height is being actively interpolated, so the
+     natural-size strip never clips its own icons. */
+
+  li {
+    width: 100%;
+    flex: 0 0 auto;
+  }
+}
+
+/* Wrapper around the icon glyph. JS writes inline `transform` on this
+   node each frame to slide it from its expanded position to its
+   compact-row position. Kept tightly sized so transform offsets match
+   the measured deltas precisely. */
+.sidebar-btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  will-change: transform;
+}
+
+.sidebar-btn-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Fully-collapsed endpoint. JS adds .sidebar-nav-collapsed only when
+   the scroll passes the full range; at that point we clear the inline
+   writes so the canonical compact geometry takes over. */
+.sidebar-nav-collapsed {
+  .sidebar-nav {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-around;
+    align-items: center;
+    gap: 4px;
+    padding: 6px 8px;
+    height: $collapsed-nav-height;
+    border-bottom-color: var(--border);
+
+    li {
+      width: 36px;
+    }
+  }
+
+  .sidebar-nav .sidebar-btn {
+    width: 36px;
+    height: 32px;
+    padding: 0;
+    gap: 0;
+    justify-content: center;
+  }
+
+  .sidebar-btn-icon {
+    /* Static endpoint owns the position now — transform must reset to
+       0 so the inline transform JS wrote during the slide doesn't
+       persist. JS also clears it explicitly when it adds this class. */
+    transform: none;
+  }
+
+  .sidebar-btn-label {
+    width: 0;
+    max-width: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  /* When the nav is fully collapsed, the conversations label pins
+     itself flush under the strip so the user always has the search
+     affordance + count visible while scrolling history. */
+  .recent-sessions-label {
+    position: sticky;
+    top: $collapsed-nav-height;
+    z-index: 2;
+    background: var(--bg-primary);
+    border-bottom: 1px solid var(--border);
+    padding-top: 8px;
+    padding-bottom: 8px;
+  }
 }
 
 .sidebar-btn {
@@ -41,7 +206,12 @@
   font-weight: 500;
   text-align: left;
   border-radius: var(--radius-sm);
-  transition: all 0.15s ease;
+  /* Only colors transition — sizing/layout swaps between expanded and
+     collapsed states are owned by the FLIP animation in Sidebar.tsx,
+     so we don't want CSS to interpolate width/padding underneath it. */
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
 
   &:hover {
     background: var(--bg-hover);
@@ -123,16 +293,30 @@
   }
 }
 
-/* Chat sidebar (conversation list) */
+/* Chat sidebar (conversation list)
+
+   The chat sidebar no longer owns its own scroll — the outer .sidebar
+   container scrolls the entire column as one, so this block just grows
+   with its content. */
 
 .chat-sidebar {
   display: flex;
   flex-direction: column;
-  flex: 2;
-  overflow-y: auto;
+  flex: 0 0 auto;
 }
 
-.chat-sidebar-label {
+.recent-sessions {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  padding-bottom: 6px;
+}
+
+.recent-sessions-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   padding: 12px 16px 6px;
   font-size: 11px;
   font-weight: 600;
@@ -140,140 +324,154 @@
   letter-spacing: 0.3px;
 }
 
-.chat-conversation-list {
-  flex: 1;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-/* ── Peer group ────────────────────────────────────────────────────── */
-
-.peer-group {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.peer-group-expanded {
-  .peer-group-header {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    background: var(--bg-primary);
-  }
-}
-
-.peer-group-header {
-  display: flex;
+/* "All Chats <count>" pairing. The count is a quiet badge so it reads as
+   metadata, not an action target — the search icon to its right carries
+   the affordance. */
+.recent-sessions-label-text {
+  display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 8px;
-  margin: 0 4px;
-  border: none;
-  background: none;
-  border-radius: var(--radius-sm);
+  min-width: 0;
+}
+
+.recent-sessions-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--bg-hover, rgba(255, 255, 255, 0.06));
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+/* Icon-only search trigger that replaces the bottom "Search all chats"
+   button. Sits at the right of the section label so the affordance is
+   discoverable without occupying a row of vertical space. */
+.recent-sessions-search-btn {
+  appearance: none;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-muted);
   cursor: pointer;
-  width: calc(100% - 8px);
-  text-align: left;
-  font-family: inherit;
-  transition: background 0.1s;
+  transition: background 0.12s ease, color 0.12s ease, box-shadow 0.12s ease;
 
   &:hover {
-    background: var(--bg-hover);
+    background: var(--bg-hover, rgba(255, 255, 255, 0.06));
+    color: var(--text-primary);
+  }
 
-    .peer-group-add {
-      opacity: 1;
-    }
+  &:focus-visible {
+    outline: none;
+    color: var(--text-primary);
+    box-shadow: 0 0 0 2px rgba(var(--accent-green-rgb, 74, 222, 128), 0.35);
   }
 }
 
-.peer-group-chevron {
-  flex-shrink: 0;
+/* Conversation list — grows with its content; the outer .sidebar owns
+   the scrollbar so the user sees one continuous scrolling column. */
+.recent-sessions-list {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 1px;
+  padding-bottom: 2px;
+}
+
+.recent-session-item {
+  margin-inline: 6px;
+  padding-block: 7px;
+}
+
+.recent-session-meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
   color: var(--text-muted);
-  transition: transform 0.15s ease;
-  transform: rotate(-90deg);
+  font-size: 11px;
+  line-height: 14px;
+  white-space: nowrap;
+  overflow: hidden;
 }
 
-.peer-group-chevron-open {
-  transform: rotate(0deg);
-}
-
-.peer-group-avatar {
-  width: 16px;
-  height: 16px;
+.recent-session-avatar {
+  width: 13px;
+  height: 13px;
   border-radius: 50%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  font-size: 10px;
-  font-weight: 700;
   color: #fff;
+  font-size: 8px;
+  font-weight: 700;
   line-height: 1;
 }
 
-.peer-group-name {
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text-primary);
-  flex: 1;
+.recent-session-peer {
+  flex: 1 1 auto;
   min-width: 0;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.peer-group-add {
-  flex-shrink: 0;
+.recent-session-detail {
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  padding: 0;
-  border: none;
-  background: none;
-  border-radius: 4px;
-  cursor: pointer;
+  gap: 5px;
+  min-width: 0;
   color: var(--text-muted);
-  opacity: 0;
-  transition: opacity 0.1s, color 0.1s;
-
-  &:hover {
-    color: var(--text-primary);
-  }
+  font-size: 11px;
+  line-height: 14px;
+  white-space: nowrap;
+  overflow: hidden;
+  padding-left: 1px;
 }
 
-.peer-group-convs {
-  display: none;
-  flex-direction: column;
-  gap: 1px;
-  padding-left: 4px;
+.recent-session-service {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.peer-group-convs-open {
-  display: flex;
+.recent-session-cost {
+  flex: 0 0 auto;
 }
 
-/* ── Conversation preview with cost ────────────────────────────────── */
-
-.chat-conv-preview-sep {
-  display: inline-block;
-  width: 12px;
-  text-align: center;
-
-  &::before {
-    content: '';
-    display: inline-block;
-    width: 2px;
-    height: 2px;
-    border-radius: 50%;
-    background: var(--text-muted);
-    vertical-align: middle;
-  }
+.recent-session-time {
+  flex: 0 0 auto;
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 11px;
+  white-space: nowrap;
 }
+
+.recent-session-dot {
+  width: 2px;
+  height: 2px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  background: var(--text-muted);
+  opacity: 0.8;
+}
+
+/* ── Conversation rows ─────────────────────────────────────────────── */
 
 .chat-conv-cost {
   color: var(--text-muted);
@@ -287,7 +485,7 @@
   gap: 2px;
   min-width: 0;
   border-radius: var(--radius-sm);
-  margin: 0 4px;
+  margin: 0 8px;
   position: relative;
 
   &:hover {
@@ -321,36 +519,6 @@
   animation: chat-conv-running-pulse 1.4s ease-in-out infinite;
 }
 
-/* Identification icon: this peer routes settlement through a recognised
-   on-chain pool (e.g. DIEM Staking Pool). Sits inline between the peer
-   name and any per-peer status indicators (running dot, add button). No
-   background / border — it's purely informational and shares the same
-   `--text-muted` color as other sidebar metadata. */
-.peer-group-proxy-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 14px;
-  height: 14px;
-  color: var(--text-muted);
-  cursor: help;
-}
-
-/* Active indicator on a collapsed peer when one of its chats is running.
-   Same visual language as .chat-conv-running-dot so the user reads it as
-   the same "working" signal at a different scope. (Issue #461.) */
-.peer-group-running-dot {
-  flex-shrink: 0;
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--accent-green, #4ade80);
-  box-shadow: 0 0 0 0 rgba(var(--accent-green-rgb, 74, 222, 128), 0.6);
-  animation: chat-conv-running-pulse 1.4s ease-in-out infinite;
-  margin-right: 2px;
-}
-
 @keyframes chat-conv-running-pulse {
   0%, 100% {
     opacity: 1;
@@ -379,22 +547,6 @@
   align-items: center;
   flex-shrink: 0;
   margin-left: auto;
-}
-
-.chat-conv-preview {
-  display: none;
-  font-size: 11px;
-  color: var(--text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 14px;
-}
-
-.chat-conv-time {
-  font-size: 10px;
-  color: var(--text-muted);
-  flex-shrink: 0;
 }
 
 .chat-conv-menu-btn {
@@ -470,31 +622,6 @@
   outline: none;
 }
 
-.chat-conv-meta {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 10px;
-  color: var(--text-muted);
-  opacity: 0.8;
-}
-
-.chat-conv-unread {
-  display: inline-block;
-  background: var(--accent);
-  color: white;
-  font-size: 10px;
-  font-weight: 700;
-  min-width: 16px;
-  height: 16px;
-  line-height: 16px;
-  text-align: center;
-  border-radius: 8px;
-  padding: 0 4px;
-  float: right;
-  margin-top: 2px;
-}
-
 .chat-conv-session {
   display: flex;
   align-items: center;
@@ -540,4 +667,192 @@
   font-size: 14px;
   text-align: center;
   padding: 40px 16px;
+}
+
+/* ── Chat search modal ─────────────────────────────────────────────── */
+
+.chat-search-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.42);
+  backdrop-filter: blur(6px);
+}
+
+.chat-search-modal {
+  width: min(720px, calc(100vw - 48px));
+  max-height: min(720px, calc(100vh - 48px));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--bg-card);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.32);
+}
+
+.chat-search-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 22px 14px;
+  border-bottom: 1px solid var(--border);
+
+  h2 {
+    margin: 0;
+    color: var(--text-primary);
+    font-size: 18px;
+    font-weight: 650;
+    line-height: 1.2;
+  }
+
+  p {
+    margin: 5px 0 0;
+    color: var(--text-muted);
+    font-size: 12px;
+    line-height: 1.4;
+  }
+}
+
+.chat-search-close {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--bg-hover);
+    color: var(--text-primary);
+    outline: none;
+  }
+}
+
+.chat-search-input {
+  margin: 16px 22px 8px;
+  padding: 11px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  outline: none;
+
+  &:focus {
+    border-color: rgba(var(--accent-green-rgb, 74, 222, 128), 0.55);
+    box-shadow: 0 0 0 3px rgba(var(--accent-green-rgb, 74, 222, 128), 0.12);
+  }
+
+  &::placeholder {
+    color: var(--text-muted);
+  }
+}
+
+.chat-search-summary {
+  padding: 0 22px 8px;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.chat-search-results {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+  padding: 0 14px 16px;
+}
+
+.chat-search-result {
+  display: grid;
+  gap: 5px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 12px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+
+  &:hover,
+  &:focus-visible {
+    background: var(--bg-hover);
+    border-color: var(--border);
+    outline: none;
+  }
+}
+
+.chat-search-result-active {
+  background: var(--bg-hover);
+  border-color: rgba(var(--accent-green-rgb, 74, 222, 128), 0.35);
+}
+
+.chat-search-result-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.chat-search-result-title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-search-result-meta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 11px;
+  line-height: 14px;
+  white-space: nowrap;
+
+  span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &:not(:last-child)::after {
+      content: '';
+      display: inline-block;
+      width: 2px;
+      height: 2px;
+      margin-left: 7px;
+      border-radius: 50%;
+      background: var(--text-muted);
+      vertical-align: middle;
+      opacity: 0.8;
+    }
+  }
+}
+
+.chat-search-empty {
+  padding: 44px 16px 52px;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
 }

--- a/apps/desktop/src/renderer/ui/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/ui/components/Sidebar.tsx
@@ -1,4 +1,13 @@
-import { memo, useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import {
+  memo,
+  useState,
+  useMemo,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  type RefObject,
+} from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { HierarchySquare03Icon } from '@hugeicons/core-free-icons';
 import { UserGroupIcon } from '@hugeicons/core-free-icons';
@@ -6,14 +15,10 @@ import { PeerToPeer02Icon } from '@hugeicons/core-free-icons';
 import { Settings02Icon } from '@hugeicons/core-free-icons';
 import { CommandLineIcon } from '@hugeicons/core-free-icons';
 import { MoreVerticalIcon } from '@hugeicons/core-free-icons';
-import { Add01Icon } from '@hugeicons/core-free-icons';
+import { Search01Icon } from '@hugeicons/core-free-icons';
 import { ComputerTerminal01Icon } from '@hugeicons/core-free-icons';
 import { DiscoverCircleIcon } from '@hugeicons/core-free-icons';
-import { ArrowDown01Icon } from '@hugeicons/core-free-icons';
-import { ContractsIcon } from '@hugeicons/core-free-icons';
 import { getPeerGradient, getPeerDisplayName, formatCompactTokens } from '../../core/peer-utils';
-import { getKnownProxy, type KnownProxy } from '../../core/known-proxies';
-import { InfoTooltip } from './InfoTooltip';
 import type { ViewName } from '../types';
 import { useUiSnapshot } from '../hooks/useUiSnapshot';
 import { useActions } from '../hooks/useActions';
@@ -32,6 +37,8 @@ type NavEntry = {
   icon: IconData;
 };
 
+type ConvRecord = Record<string, unknown>;
+
 const baseEntries: NavEntry[] = [
   { label: 'Discover', view: 'discover', icon: DiscoverCircleIcon },
   { label: 'API', view: 'external-clients', icon: ComputerTerminal01Icon },
@@ -47,6 +54,10 @@ const devEntries: NavEntry[] = [
   { label: 'Peers', view: 'peers', icon: UserGroupIcon },
   { label: 'Logs', view: 'desktop', icon: CommandLineIcon },
 ];
+
+const EMPTY_CONVERSATIONS: unknown[] = [];
+const RECENT_SESSION_WINDOW_MS = 24 * 60 * 60 * 1000;
+const RECENT_SESSION_CLOCK_MS = 60 * 1000;
 
 const SidebarWarning = memo(function SidebarWarning() {
   const { connectWarning } = useUiSnapshot();
@@ -71,6 +82,72 @@ function shortServiceName(service: unknown): string {
   return raw.replace(/^claude-/, '').replace(/-20\d{6,}/, '');
 }
 
+function formatUsdc(value: number): string {
+  return value < 0.01 && value > 0 ? '<0.01' : value.toFixed(2);
+}
+
+function getConversationId(conv: ConvRecord): string {
+  return String(conv.id ?? '');
+}
+
+function getConversationCreatedAt(conv: ConvRecord): number {
+  const createdAt = Number(conv.createdAt);
+  return Number.isFinite(createdAt) && createdAt > 0 ? createdAt : 0;
+}
+
+function getConversationUpdatedAt(conv: ConvRecord): number {
+  const updatedAt = Number(conv.updatedAt);
+  if (Number.isFinite(updatedAt) && updatedAt > 0) return updatedAt;
+  return getConversationCreatedAt(conv);
+}
+
+function compareConversationsByActivity(left: ConvRecord, right: ConvRecord): number {
+  const updatedDelta = getConversationUpdatedAt(right) - getConversationUpdatedAt(left);
+  if (updatedDelta !== 0) return updatedDelta;
+
+  const createdDelta = getConversationCreatedAt(right) - getConversationCreatedAt(left);
+  if (createdDelta !== 0) return createdDelta;
+
+  return getConversationId(left).localeCompare(getConversationId(right));
+}
+
+function isRecentConversation(conv: ConvRecord, now: number): boolean {
+  const updatedAt = getConversationUpdatedAt(conv);
+  return updatedAt > 0 && now - updatedAt <= RECENT_SESSION_WINDOW_MS;
+}
+
+function getConversationPeerName(
+  conv: ConvRecord,
+  peerDisplayNameById: ReadonlyMap<string, string>,
+): string {
+  const peerId = String(conv.peerId || '').trim();
+  if (!peerId) return 'Other';
+  return peerDisplayNameById.get(peerId)
+    || getPeerDisplayName(String(conv.peerLabel || ''))
+    || `${peerId.slice(0, 12)}...`;
+}
+
+function conversationMatchesSearch(
+  conv: ConvRecord,
+  peerName: string,
+  query: string,
+): boolean {
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) return true;
+
+  const haystack = [
+    conv.title,
+    conv.service,
+    conv.provider,
+    conv.peerLabel,
+    conv.peerId,
+    conv.workspacePath,
+    peerName,
+  ].map((value) => String(value || '').toLowerCase()).join(' ');
+
+  return terms.every((term) => haystack.includes(term));
+}
+
 function ConvContextMenu({
   convId,
   convTitle,
@@ -79,7 +156,7 @@ function ConvContextMenu({
 }: {
   convId: string;
   convTitle: string;
-  anchorRef: React.RefObject<HTMLButtonElement | null>;
+  anchorRef: RefObject<HTMLButtonElement | null>;
   onClose: () => void;
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
@@ -159,281 +236,315 @@ function ConvContextMenu({
   );
 }
 
-function formatUsdc(value: number): string {
-  return value < 0.01 && value > 0 ? '<0.01' : value.toFixed(2);
-}
-
-/* ── Peer group type ───────────────────────────────────────────────── */
-
-type ConvRecord = Record<string, unknown>;
-
-type PeerGroup = {
-  peerId: string;
-  peerLabel: string;
-  displayName: string;
-  gradient: string;
-  conversations: ConvRecord[];
-  /**
-   * Identification for a recognised on-chain seller-proxy contract (e.g.
-   * DIEM Staking Pool). Looked up from Discover rows by `peerId` so the
-   * chat sidebar surfaces the same contract icon shown in Discover.
-   */
-  knownProxy: KnownProxy | null;
-};
-
-function groupByPeer(
-  conversations: unknown[],
-  knownProxyByPeerId: ReadonlyMap<string, KnownProxy>,
-): PeerGroup[] {
-  const groups = new Map<string, PeerGroup>();
-  const ungrouped: ConvRecord[] = [];
-
-  for (const item of conversations) {
-    const conv = item as ConvRecord;
-    const peerId = String(conv.peerId || '').trim();
-    const peerLabel = String(conv.peerLabel || '').trim();
-
-    if (!peerId) {
-      ungrouped.push(conv);
-      continue;
-    }
-
-    let group = groups.get(peerId);
-    const displayName = getPeerDisplayName(peerLabel);
-    if (!group) {
-      group = {
-        peerId,
-        peerLabel,
-        displayName: displayName || peerId.slice(0, 12) + '...',
-        gradient: getPeerGradient(peerId),
-        conversations: [],
-        knownProxy: knownProxyByPeerId.get(peerId) ?? null,
-      };
-      groups.set(peerId, group);
-    } else if (displayName && group.displayName === peerId.slice(0, 12) + '...') {
-      group.peerLabel = peerLabel;
-      group.displayName = displayName;
-    }
-    group.conversations.push(conv);
-  }
-
-  const result = Array.from(groups.values());
-  if (ungrouped.length > 0) {
-    result.push({
-      peerId: '',
-      peerLabel: '',
-      displayName: 'Other',
-      gradient: 'linear-gradient(180deg, #9a9a96, #6b6b68)',
-      conversations: ungrouped,
-      knownProxy: null,
-    });
-  }
-  return result;
-}
-
-/* ── Peer group component ──────────────────────────────────────────── */
-
-function PeerGroupSection({
-  group,
-  expanded,
-  onToggle,
+function ConversationListRow({
+  conv,
   activeConvId,
   sendingConvIds,
   chatActiveChannels,
+  peerDisplayNameById,
   onSelectConv,
-  onNewChat,
   onCloseChannel,
   menuOpenId,
   setMenuOpenId,
   menuBtnRefs,
 }: {
-  group: PeerGroup;
-  expanded: boolean;
-  onToggle: () => void;
+  conv: ConvRecord;
   activeConvId: string | null;
-  sendingConvIds: Set<string>;
+  sendingConvIds: ReadonlySet<string>;
   chatActiveChannels: Map<string, { reservedUsdc: string; peerName: string }>;
+  peerDisplayNameById: ReadonlyMap<string, string>;
   onSelectConv: (id: string) => void;
-  onNewChat: (peerId: string) => void;
   onCloseChannel: () => void;
   menuOpenId: string | null;
   setMenuOpenId: (id: string | null) => void;
-  menuBtnRefs: React.RefObject<Map<string, HTMLButtonElement | null>>;
+  menuBtnRefs: RefObject<Map<string, HTMLButtonElement | null>>;
 }) {
-  const headerRef = useRef<HTMLDivElement>(null);
-  const convsRef = useRef<HTMLDivElement>(null);
-  const letter = (group.displayName || '?').charAt(0).toUpperCase();
-
-  // When the group is collapsed, surface a single running indicator on the
-  // peer header if any of its conversations is in flight — otherwise a user
-  // who collapses a peer can't tell that work is still happening underneath.
-  // When expanded, the existing per-chat dots are visible, so we don't
-  // duplicate the indicator at the peer level. (Issue #461.)
-  const hasRunningConv = !expanded && group.conversations.some(
-    (conv) => sendingConvIds.has(String(conv.id ?? '')),
-  );
-
-  // Scroll the header into view and animate convs open when expanded
-  useEffect(() => {
-    if (expanded && headerRef.current) {
-      headerRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    }
-  }, [expanded]);
+  const id = getConversationId(conv);
+  const title = String(conv.title || 'Untitled chat');
+  const isActive = id === activeConvId;
+  const isRunning = sendingConvIds.has(id);
+  const serviceLabel = shortServiceName(conv.service);
+  const totalCost = Number(conv.totalEstimatedCostUsd) || 0;
+  const totalTokens = Number(conv.totalTokens) || 0;
+  const costLabel = totalTokens > 0
+    ? `$${formatUsdc(totalCost)}/${formatCompactTokens(totalTokens)}`
+    : '';
+  const convPeerId = String(conv.peerId || '').trim();
+  const peerName = getConversationPeerName(conv, peerDisplayNameById);
+  const session = convPeerId ? chatActiveChannels.get(convPeerId) : undefined;
+  const usedUsdc = Number(conv.totalEstimatedCostUsd) || 0;
+  const timeLabel = formatChatTime(getConversationUpdatedAt(conv));
+  const avatarLetter = (peerName || '?').charAt(0).toUpperCase();
+  const avatarGradient = convPeerId
+    ? getPeerGradient(convPeerId)
+    : 'linear-gradient(180deg, #9a9a96, #6b6b68)';
 
   return (
-    <div className={`${styles.peerGroup}${expanded ? ` ${styles.peerGroupExpanded}` : ''}`}>
-      <div
-        ref={headerRef}
-        className={styles.peerGroupHeader}
-        role="button"
-        tabIndex={0}
-        onClick={onToggle}
-        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(); } }}
-      >
-        <HugeiconsIcon
-          icon={ArrowDown01Icon}
-          size={12}
-          strokeWidth={1.5}
-          className={`${styles.peerGroupChevron}${expanded ? ` ${styles.peerGroupChevronOpen}` : ''}`}
-        />
-        <span className={styles.peerGroupAvatar} style={{ background: group.gradient }}>
-          {letter}
-        </span>
-        <span className={styles.peerGroupName}>{group.displayName}</span>
-        {group.knownProxy && (
-          /* Mirror the Discover card / filter-list affordance: this peer
-             settles through a recognised on-chain pool. Uses the shared
-             `InfoTooltip` so all three call sites render the same panel. */
-          <InfoTooltip
-            align="left"
-            content={(
-              <>
-                <strong>{group.knownProxy.label}</strong>
-                <span>{group.knownProxy.description}</span>
-              </>
-            )}
-          >
-            <span
-              className={styles.peerGroupProxyIcon}
-              aria-label={`${group.knownProxy.label}: ${group.knownProxy.description}`}
-              /* The peer-group header is a clickable expand/collapse target,
-                 so stop click propagation from the icon. */
-              onClick={(e) => e.stopPropagation()}
-            >
-              <HugeiconsIcon icon={ContractsIcon} size={12} strokeWidth={1.8} />
-            </span>
-          </InfoTooltip>
-        )}
-        {hasRunningConv && (
+    <div
+      className={`${styles.chatConvItem} ${styles.recentSessionItem}${isActive ? ` ${styles.active}` : ''}`}
+      onClick={() => onSelectConv(id)}
+    >
+      <div className={styles.chatConvTop}>
+        <div className={styles.chatConvPeer}>{title}</div>
+        {isRunning && (
           <span
-            className={styles.peerGroupRunningDot}
+            className={styles.chatConvRunningDot}
             role="status"
-            aria-label={`A chat in ${group.displayName} is running`}
-            title="A chat in this peer is running"
+            aria-label="Request in progress"
+            title="Request in progress"
           />
         )}
-        {group.peerId && (
+        <div className={styles.chatConvRight}>
           <button
-            className={styles.peerGroupAdd}
+            className={styles.chatConvMenuBtn}
+            ref={(el) => { if (el) menuBtnRefs.current?.set(id, el); else menuBtnRefs.current?.delete(id); }}
             onClick={(e) => {
               e.stopPropagation();
-              onNewChat(group.peerId);
+              setMenuOpenId(menuOpenId === id ? null : id);
             }}
-            aria-label={`New chat with ${group.displayName}`}
           >
-            <HugeiconsIcon icon={Add01Icon} size={12} strokeWidth={1.5} />
+            <HugeiconsIcon icon={MoreVerticalIcon} size={14} strokeWidth={1.5} />
           </button>
-        )}
+        </div>
       </div>
-
-      <div
-        ref={convsRef}
-        className={`${styles.peerGroupConvs}${expanded ? ` ${styles.peerGroupConvsOpen}` : ''}`}
-      >
-        {group.conversations.map((conv) => {
-            const id = String(conv.id ?? '');
-            const isActive = id === activeConvId;
-            const isRunning = sendingConvIds.has(id);
-            const title = String(conv.title || '');
-            const serviceLabel = shortServiceName(conv.service);
-            const totalCost = Number(conv.totalEstimatedCostUsd) || 0;
-            const totalTokens = Number(conv.totalTokens) || 0;
-            const costLabel = totalTokens > 0
-              ? `$${formatUsdc(totalCost)}/${formatCompactTokens(totalTokens)}`
-              : '';
-            const convPeerId = String(conv.peerId || '').trim();
-            const session = convPeerId ? chatActiveChannels.get(convPeerId) : undefined;
-            const usedUsdc = Number(conv.totalEstimatedCostUsd) || 0;
-
-            return (
-              <div
-                key={id}
-                className={`${styles.chatConvItem}${isActive ? ` ${styles.active}` : ''}`}
-                onClick={() => onSelectConv(id)}
-              >
-                <div className={styles.chatConvTop}>
-                  <div className={styles.chatConvPeer}>{title}</div>
-                  {isRunning && (
-                    <span
-                      className={styles.chatConvRunningDot}
-                      role="status"
-                      aria-label="Request in progress"
-                      title="Request in progress"
-                    />
-                  )}
-                  <div className={styles.chatConvRight}>
-                    <button
-                      className={styles.chatConvMenuBtn}
-                      ref={(el) => { if (el) menuBtnRefs.current?.set(id, el); else menuBtnRefs.current?.delete(id); }}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setMenuOpenId(menuOpenId === id ? null : id);
-                      }}
-                    >
-                      <HugeiconsIcon icon={MoreVerticalIcon} size={14} strokeWidth={1.5} />
-                    </button>
-                  </div>
-                </div>
-                {(serviceLabel || costLabel) && (
-                  <div className={styles.chatConvPreview}>
-                    {serviceLabel}
-                    {serviceLabel && costLabel && <span className={styles.chatConvPreviewSep} />}
-                    {costLabel && <span className={styles.chatConvCost}>{costLabel}</span>}
-                  </div>
-                )}
-                {session && (
-                  <div className={styles.chatConvSession}>
-                    <span className={styles.chatConvSessionInfo}>
-                      Reserved ${formatUsdc(Number(session.reservedUsdc) || 0)} · Used ${formatUsdc(usedUsdc)}
-                    </span>
-                    <button
-                      className={styles.chatConvCloseBtn}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onCloseChannel();
-                      }}
-                    >
-                      Close
-                    </button>
-                  </div>
-                )}
-                {menuOpenId === id && (
-                  <ConvContextMenu
-                    convId={id}
-                    convTitle={title}
-                    anchorRef={{ current: menuBtnRefs.current?.get(id) ?? null }}
-                    onClose={() => setMenuOpenId(null)}
-                  />
-                )}
-              </div>
-            );
-          })}
+      <div className={styles.recentSessionMeta}>
+        <span className={styles.recentSessionAvatar} style={{ background: avatarGradient }}>
+          {avatarLetter}
+        </span>
+        <span className={styles.recentSessionPeer}>{peerName}</span>
+        {costLabel && <span className={`${styles.chatConvCost} ${styles.recentSessionCost}`}>{costLabel}</span>}
+        <span className={styles.recentSessionTime}>{timeLabel}</span>
       </div>
+      {session && (
+        <div className={styles.chatConvSession}>
+          <span className={styles.chatConvSessionInfo}>
+            Reserved ${formatUsdc(Number(session.reservedUsdc) || 0)} · Used ${formatUsdc(usedUsdc)}
+          </span>
+          <button
+            className={styles.chatConvCloseBtn}
+            onClick={(e) => {
+              e.stopPropagation();
+              onCloseChannel();
+            }}
+          >
+            Close
+          </button>
+        </div>
+      )}
+      {menuOpenId === id && (
+        <ConvContextMenu
+          convId={id}
+          convTitle={title}
+          anchorRef={{ current: menuBtnRefs.current?.get(id) ?? null }}
+          onClose={() => setMenuOpenId(null)}
+        />
+      )}
     </div>
   );
 }
 
-const EMPTY_CONVERSATIONS: unknown[] = [];
+function ChatListSection({
+  conversations,
+  totalConversationCount,
+  activeConvId,
+  sendingConvIds,
+  chatActiveChannels,
+  peerDisplayNameById,
+  onSelectConv,
+  onCloseChannel,
+  onOpenChatSearch,
+  menuOpenId,
+  setMenuOpenId,
+  menuBtnRefs,
+}: {
+  conversations: ConvRecord[];
+  totalConversationCount: number;
+  activeConvId: string | null;
+  sendingConvIds: ReadonlySet<string>;
+  chatActiveChannels: Map<string, { reservedUsdc: string; peerName: string }>;
+  peerDisplayNameById: ReadonlyMap<string, string>;
+  onSelectConv: (id: string) => void;
+  onCloseChannel: () => void;
+  onOpenChatSearch: () => void;
+  menuOpenId: string | null;
+  setMenuOpenId: (id: string | null) => void;
+  menuBtnRefs: RefObject<Map<string, HTMLButtonElement | null>>;
+}) {
+  return (
+    <section className={styles.recentSessions} aria-labelledby="chat-list-label">
+      <div className={styles.recentSessionsLabel} id="chat-list-label">
+        <span className={styles.recentSessionsLabelText}>
+          <span>Conversations</span>
+          {totalConversationCount > 0 && (
+            <span className={styles.recentSessionsCount} aria-label={`${totalConversationCount} total conversations`}>
+              {totalConversationCount}
+            </span>
+          )}
+        </span>
+        <button
+          type="button"
+          className={styles.recentSessionsSearchBtn}
+          onClick={onOpenChatSearch}
+          aria-label="Search conversations"
+          title="Search conversations"
+        >
+          <HugeiconsIcon icon={Search01Icon} size={13} strokeWidth={1.8} />
+        </button>
+      </div>
+      <div className={styles.recentSessionsList}>
+        {conversations.length === 0 ? (
+          <div className={styles.chatEmpty}>No conversations yet</div>
+        ) : (
+          conversations.map((conv) => (
+            <ConversationListRow
+              key={getConversationId(conv)}
+              conv={conv}
+              activeConvId={activeConvId}
+              sendingConvIds={sendingConvIds}
+              chatActiveChannels={chatActiveChannels}
+              peerDisplayNameById={peerDisplayNameById}
+              onSelectConv={onSelectConv}
+              onCloseChannel={onCloseChannel}
+              menuOpenId={menuOpenId}
+              setMenuOpenId={setMenuOpenId}
+              menuBtnRefs={menuBtnRefs}
+            />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ChatSearchModal({
+  conversations,
+  activeConvId,
+  sendingConvIds,
+  peerDisplayNameById,
+  onSelectConv,
+  onClose,
+}: {
+  conversations: ConvRecord[];
+  activeConvId: string | null;
+  sendingConvIds: ReadonlySet<string>;
+  peerDisplayNameById: ReadonlyMap<string, string>;
+  onSelectConv: (id: string) => void;
+  onClose: () => void;
+}) {
+  const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  const results = useMemo(() => {
+    return conversations
+      .filter((conv) => conversationMatchesSearch(
+        conv,
+        getConversationPeerName(conv, peerDisplayNameById),
+        query,
+      ))
+      .sort(compareConversationsByActivity);
+  }, [conversations, peerDisplayNameById, query]);
+
+  return (
+    <div
+      className={styles.chatSearchOverlay}
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <section
+        className={styles.chatSearchModal}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="chat-search-title"
+      >
+        <header className={styles.chatSearchHeader}>
+          <div>
+            <h2 id="chat-search-title">Conversations</h2>
+            <p>Search across every peer, session title, service, and workspace.</p>
+          </div>
+          <button className={styles.chatSearchClose} onClick={onClose} aria-label="Close chat search">
+            ×
+          </button>
+        </header>
+
+        <input
+          ref={inputRef}
+          className={styles.chatSearchInput}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search conversations, peers, services..."
+        />
+
+        <div className={styles.chatSearchSummary}>
+          {results.length} of {conversations.length} conversation{conversations.length === 1 ? '' : 's'}
+        </div>
+
+        <div className={styles.chatSearchResults}>
+          {results.length === 0 ? (
+            <div className={styles.chatSearchEmpty}>No chats match that search.</div>
+          ) : (
+            results.map((conv) => {
+              const id = getConversationId(conv);
+              const title = String(conv.title || 'Untitled chat');
+              const peerName = getConversationPeerName(conv, peerDisplayNameById);
+              const serviceLabel = shortServiceName(conv.service);
+              const totalCost = Number(conv.totalEstimatedCostUsd) || 0;
+              const totalTokens = Number(conv.totalTokens) || 0;
+              const costLabel = totalTokens > 0
+                ? `$${formatUsdc(totalCost)}/${formatCompactTokens(totalTokens)}`
+                : '';
+              const timeLabel = formatChatTime(getConversationUpdatedAt(conv));
+              const isActive = id === activeConvId;
+              const isRunning = sendingConvIds.has(id);
+
+              return (
+                <button
+                  key={id}
+                  className={`${styles.chatSearchResult}${isActive ? ` ${styles.chatSearchResultActive}` : ''}`}
+                  onClick={() => {
+                    onSelectConv(id);
+                    onClose();
+                  }}
+                >
+                  <span className={styles.chatSearchResultMain}>
+                    <span className={styles.chatSearchResultTitle}>{title}</span>
+                    {isRunning && (
+                      <span
+                        className={styles.chatConvRunningDot}
+                        role="status"
+                        aria-label="Request in progress"
+                        title="Request in progress"
+                      />
+                    )}
+                  </span>
+                  <span className={styles.chatSearchResultMeta}>
+                    <span>{peerName}</span>
+                    {serviceLabel && <span>{serviceLabel}</span>}
+                    {costLabel && <span>{costLabel}</span>}
+                    <span>{timeLabel}</span>
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
 
 function ChatSidebar({ onSelectView }: { onSelectView: (view: ViewName) => void }) {
   const {
@@ -441,102 +552,63 @@ function ChatSidebar({ onSelectView }: { onSelectView: (view: ViewName) => void 
     chatActiveConversation,
     chatSendingConversationIds,
     chatActiveChannels,
-    chatServiceOptions,
     discoverRows,
   } = useUiSnapshot();
   const actions = useActions();
   const conversations = Array.isArray(chatConversations) ? chatConversations : EMPTY_CONVERSATIONS;
+  const allConversations = conversations as ConvRecord[];
   const sendingConvIds = useMemo(
     () => new Set(Array.isArray(chatSendingConversationIds) ? chatSendingConversationIds : []),
     [chatSendingConversationIds],
   );
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
-  const [expandedPeerIds, setExpandedPeerIds] = useState<Set<string>>(() => new Set());
+  const [recentNow, setRecentNow] = useState(() => Date.now());
+  const [chatSearchOpen, setChatSearchOpen] = useState(false);
   const menuBtnRefs = useRef<Map<string, HTMLButtonElement | null>>(new Map());
 
-  /**
-   * peerId → known seller-proxy metadata. Built from the same `discoverRows`
-   * stream that powers Discover, so the chat sidebar stays consistent with
-   * the badge shown on the Discover card / peer-filter list. We dedupe by
-   * peerId because one peer can publish many service rows.
-   */
-  const knownProxyByPeerId = useMemo(() => {
-    const map = new Map<string, KnownProxy>();
-    const rows = Array.isArray(discoverRows) ? discoverRows : [];
-    for (const r of rows) {
-      if (!r.peerId || map.has(r.peerId)) continue;
-      const proxy = getKnownProxy(r.sellerContract);
-      if (proxy) map.set(r.peerId, proxy);
-    }
-    return map;
-  }, [discoverRows]);
-
-  const peerGroups = useMemo(
-    () => groupByPeer(conversations, knownProxyByPeerId),
-    [conversations, knownProxyByPeerId],
-  );
-
-  // Auto-expand the peer that owns the active conversation — only when the
-  // active conversation changes, not on every conversation list refresh.
-  const prevActiveConvRef = useRef<string | null>(null);
   useEffect(() => {
-    if (chatActiveConversation === prevActiveConvRef.current) return;
-    prevActiveConvRef.current = chatActiveConversation;
-    if (!chatActiveConversation) return;
-    const activeConv = conversations.find(
-      (c) => String((c as ConvRecord).id ?? '') === chatActiveConversation,
-    ) as ConvRecord | undefined;
-    const peerId = activeConv ? String(activeConv.peerId || '').trim() : '';
-    if (peerId) {
-      setExpandedPeerIds((prev) => {
-        if (prev.has(peerId)) return prev;
-        const next = new Set(prev);
-        next.add(peerId);
-        return next;
-      });
-    }
-  }, [chatActiveConversation, conversations]);
-
-  const handleTogglePeer = useCallback((peerId: string) => {
-    setExpandedPeerIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(peerId)) {
-        next.delete(peerId);
-      } else {
-        next.add(peerId);
-      }
-      return next;
-    });
+    const timer = window.setInterval(() => setRecentNow(Date.now()), RECENT_SESSION_CLOCK_MS);
+    return () => window.clearInterval(timer);
   }, []);
+
+  const peerDisplayNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    const rows = Array.isArray(discoverRows) ? discoverRows : [];
+
+    for (const row of rows) {
+      const peerId = String(row.peerId || '').trim();
+      if (!peerId || map.has(peerId)) continue;
+      const name = getPeerDisplayName(row.peerLabel) || String(row.peerDisplayName || '').trim();
+      if (name) map.set(peerId, name);
+    }
+
+    for (const conv of allConversations) {
+      const peerId = String(conv.peerId || '').trim();
+      if (!peerId || map.has(peerId)) continue;
+      const name = getPeerDisplayName(String(conv.peerLabel || ''));
+      if (name) map.set(peerId, name);
+    }
+
+    return map;
+  }, [allConversations, discoverRows]);
+
+  // Sort the full list — the row itself is scrollable, so we render every
+  // conversation rather than slicing. "Recent" (touched in the last 24 h)
+  // still floats to the top so the active workstream stays one glance away;
+  // older chats sort by activity beneath them.
+  const sidebarConversations = useMemo(() => {
+    return [...allConversations].sort((left, right) => {
+      const leftRecent = isRecentConversation(left, recentNow) ? 1 : 0;
+      const rightRecent = isRecentConversation(right, recentNow) ? 1 : 0;
+      if (leftRecent !== rightRecent) return rightRecent - leftRecent;
+      return compareConversationsByActivity(left, right);
+    });
+  }, [allConversations, recentNow]);
 
   const handleSelectConv = useCallback((id: string) => {
     void actions.openConversation(id);
     onSelectView('chat');
   }, [actions, onSelectView]);
-
-  const handleNewChat = useCallback((peerId: string) => {
-    actions.startNewChat();
-    if (peerId) {
-      // Pin the new chat to this peer and pre-select a service it offers.
-      // Prefer a service matching the most recent conversation with the peer
-      // (conv.service matches option.id), otherwise fall back to any option
-      // for that peer.
-      const group = peerGroups.find((g) => g.peerId === peerId);
-      const recentService = group && group.conversations.length > 0
-        ? String((group.conversations[0] as ConvRecord).service || '').trim()
-        : '';
-      const options = Array.isArray(chatServiceOptions) ? chatServiceOptions : [];
-      const match =
-        (recentService
-          ? options.find((o) => o.peerId === peerId && o.id === recentService)
-          : undefined) ||
-        options.find((o) => o.peerId === peerId);
-      if (match) {
-        actions.handleServiceChange(match.value, peerId);
-      }
-    }
-    onSelectView('chat');
-  }, [actions, onSelectView, peerGroups, chatServiceOptions]);
 
   const handleCloseChannel = useCallback(() => {
     actions.requestChannelClose();
@@ -544,46 +616,261 @@ function ChatSidebar({ onSelectView }: { onSelectView: (view: ViewName) => void 
 
   return (
     <aside className={styles.chatSidebar}>
-      <div className={styles.chatSidebarLabel}>Peers</div>
-      <div className={styles.chatConversationList}>
-        {conversations.length === 0 ? (
-          <div className={styles.chatEmpty}>No conversations yet</div>
-        ) : (
-          peerGroups.map((group) => {
-            const key = group.peerId || '__other';
-            return (
-              <PeerGroupSection
-                key={key}
-                group={group}
-                expanded={expandedPeerIds.has(key)}
-                onToggle={() => handleTogglePeer(key)}
-                activeConvId={chatActiveConversation}
-                sendingConvIds={sendingConvIds}
-                chatActiveChannels={chatActiveChannels}
-                onSelectConv={handleSelectConv}
-                onNewChat={handleNewChat}
-                onCloseChannel={handleCloseChannel}
-                menuOpenId={menuOpenId}
-                setMenuOpenId={setMenuOpenId}
-                menuBtnRefs={menuBtnRefs}
-              />
-            );
-          })
-        )}
-      </div>
+      <ChatListSection
+        conversations={sidebarConversations}
+        totalConversationCount={allConversations.length}
+        activeConvId={chatActiveConversation}
+        sendingConvIds={sendingConvIds}
+        chatActiveChannels={chatActiveChannels}
+        peerDisplayNameById={peerDisplayNameById}
+        onSelectConv={handleSelectConv}
+        onCloseChannel={handleCloseChannel}
+        onOpenChatSearch={() => setChatSearchOpen(true)}
+        menuOpenId={menuOpenId}
+        setMenuOpenId={setMenuOpenId}
+        menuBtnRefs={menuBtnRefs}
+      />
+      {chatSearchOpen && (
+        <ChatSearchModal
+          conversations={allConversations}
+          activeConvId={chatActiveConversation}
+          sendingConvIds={sendingConvIds}
+          peerDisplayNameById={peerDisplayNameById}
+          onSelectConv={handleSelectConv}
+          onClose={() => setChatSearchOpen(false)}
+        />
+      )}
     </aside>
   );
 }
 
+// Scroll distance (in px) over which the top nav interpolates from
+// fully expanded (vertical list with labels) to fully collapsed (3
+// icons in a row). Picked to feel responsive: ~one notch of a
+// trackpad / mousewheel completes the collapse.
+const NAV_COLLAPSE_SCROLL_RANGE_PX = 56;
+
+type NavLayoutCache = {
+  expandedHeight: number;
+  collapsedHeight: number;
+  iconDeltas: Map<string, { dx: number; dy: number }>;
+};
+
 export function Sidebar({ activeView, onSelectView }: SidebarProps) {
   const { devMode } = useUiSnapshot();
   const navEntries = [...baseEntries, ...configEntries];
+  const sidebarRef = useRef<HTMLElement | null>(null);
+  const navRef = useRef<HTMLUListElement | null>(null);
+
+  // Per-button refs. We hand both the icon-wrapper span and the label
+  // span their own refs so the scroll-driven interpolation can write
+  // individualized inline transforms and opacities each frame.
+  // Reusing the same nodes (rather than swapping markup) keeps focus
+  // and ARIA stable across the transition.
+  const navIconRefs = useRef(new Map<string, HTMLElement>());
+  const navLabelRefs = useRef(new Map<string, HTMLElement>());
+
+  // Measured layout endpoints. Captured by measureLayout() after
+  // mount and any resize — we briefly toggle the collapsed class
+  // (without painting) to read the compact-row positions for every
+  // icon, then return the DOM to its previous state. The deltas are
+  // what scroll progress interpolates across each frame.
+  const layoutCacheRef = useRef<NavLayoutCache | null>(null);
+
+  // Throttling + bail-out state.
+  const lastProgressRef = useRef<number>(-1);
+  const rafRef = useRef<number | null>(null);
+
+  /** Capture both layout endpoints without ever painting an intermediate state.
+   *  Bails (and leaves the cache untouched) if the icons haven't rendered
+   *  yet — e.g. HugeiconsIcon SVGs not committed on the first paint — since
+   *  measuring then would yield a zero-height strip that we'd pin via
+   *  inline styles. The ResizeObserver will trigger a fresh attempt once
+   *  the icons actually take up space. */
+  const measureLayout = useCallback(() => {
+    const sidebar = sidebarRef.current;
+    const nav = navRef.current;
+    if (!sidebar || !nav) return;
+
+    // Strip any inline interpolation we left from a previous frame so
+    // we read true layout positions, not transformed ones.
+    nav.style.height = '';
+    nav.style.overflow = '';
+    for (const node of navIconRefs.current.values()) {
+      node.style.transform = '';
+    }
+    for (const node of navLabelRefs.current.values()) {
+      node.style.opacity = '';
+      node.style.width = '';
+    }
+
+    // 1) Expanded layout endpoint (the default class state).
+    const expandedIconRects = new Map<string, DOMRect>();
+    for (const [id, node] of navIconRefs.current) {
+      expandedIconRects.set(id, node.getBoundingClientRect());
+    }
+    const expandedHeight = nav.getBoundingClientRect().height;
+
+    // 2) Collapsed layout endpoint. Toggling the class within the same
+    // synchronous block means the browser never paints the
+    // intermediate state to the screen.
+    sidebar.classList.add(styles.sidebarNavCollapsed);
+    const collapsedIconRects = new Map<string, DOMRect>();
+    for (const [id, node] of navIconRefs.current) {
+      collapsedIconRects.set(id, node.getBoundingClientRect());
+    }
+    const collapsedHeight = nav.getBoundingClientRect().height;
+    sidebar.classList.remove(styles.sidebarNavCollapsed);
+
+    // Sanity check: if the strip has no expanded height yet, or the
+    // expanded height isn't strictly greater than the collapsed one,
+    // measurement happened before layout settled (icons still 0×0).
+    // Leave the cache as-is and wait for the next ResizeObserver tick.
+    if (expandedHeight <= 0 || expandedHeight <= collapsedHeight) {
+      return;
+    }
+
+    const iconDeltas = new Map<string, { dx: number; dy: number }>();
+    for (const [id, expanded] of expandedIconRects) {
+      const collapsed = collapsedIconRects.get(id);
+      if (!collapsed) continue;
+      iconDeltas.set(id, {
+        dx: collapsed.left - expanded.left,
+        dy: collapsed.top - expanded.top,
+      });
+    }
+
+    layoutCacheRef.current = { expandedHeight, collapsedHeight, iconDeltas };
+    // Force the next applyProgress() to write again even if scrollTop
+    // hasn't moved — our deltas are different now.
+    lastProgressRef.current = -1;
+  }, []);
+
+  /** Drive the inline styles from the current scroll position. */
+  const applyProgress = useCallback(() => {
+    rafRef.current = null;
+    const sidebar = sidebarRef.current;
+    const nav = navRef.current;
+    if (!sidebar || !nav) return;
+
+    const progress = Math.max(0, Math.min(1, sidebar.scrollTop / NAV_COLLAPSE_SCROLL_RANGE_PX));
+    if (Math.abs(progress - lastProgressRef.current) < 0.002) return;
+    lastProgressRef.current = progress;
+
+    const fullyCollapsed = progress >= 0.999;
+    const fullyExpanded = progress <= 0.001;
+    const cache = layoutCacheRef.current;
+
+    if (fullyCollapsed) {
+      // Snap to the real compact endpoint so hit-testing, hover
+      // backgrounds, and the sticky "Conversations" header below line
+      // up to the actual rendered positions. Clear all inline writes
+      // — CSS owns the static endpoint state.
+      sidebar.classList.add(styles.sidebarNavCollapsed);
+      nav.style.height = '';
+      nav.style.overflow = '';
+      for (const node of navIconRefs.current.values()) node.style.transform = '';
+      for (const node of navLabelRefs.current.values()) {
+        node.style.opacity = '';
+        node.style.width = '';
+      }
+      return;
+    }
+
+    // The DOM stays in the expanded layout for any progress < 1, so
+    // the collapsed class must be off whenever we're not at the
+    // endpoint — otherwise the static compact rules would fight with
+    // the inline transforms.
+    sidebar.classList.remove(styles.sidebarNavCollapsed);
+
+    if (fullyExpanded || !cache) {
+      // At rest (or before the first valid measurement): let CSS own
+      // every layout property. Critically we DO NOT pin nav.style.height
+      // here — doing so on first paint, before icons have laid out,
+      // would lock the strip at a stale tiny height and clip its
+      // contents. Same reason we clear inline overflow.
+      nav.style.height = '';
+      nav.style.overflow = '';
+      for (const node of navIconRefs.current.values()) node.style.transform = '';
+      for (const node of navLabelRefs.current.values()) {
+        node.style.opacity = '';
+        node.style.width = '';
+      }
+      return;
+    }
+
+    // Mid-slide: interpolate strip height, icon positions, and label
+    // opacity inline. Apply overflow:hidden inline (only here) so the
+    // shrinking strip cleanly clips its descending icons during the
+    // slide — at rest the SCSS leaves overflow visible so the natural
+    // expanded layout is never at risk of self-clipping.
+    const height = cache.expandedHeight + (cache.collapsedHeight - cache.expandedHeight) * progress;
+    nav.style.height = `${height}px`;
+    nav.style.overflow = 'hidden';
+
+    for (const [id, node] of navIconRefs.current) {
+      const delta = cache.iconDeltas.get(id);
+      if (!delta) continue;
+      node.style.transform = `translate(${delta.dx * progress}px, ${delta.dy * progress}px)`;
+    }
+
+    // Labels fade out in the first ~60% of the scroll so the text is
+    // fully gone before the icons settle into the row.
+    const labelOpacity = Math.max(0, 1 - progress * 1.66);
+    for (const node of navLabelRefs.current.values()) {
+      node.style.opacity = String(labelOpacity);
+    }
+  }, []);
+
+  const scheduleApply = useCallback(() => {
+    if (rafRef.current != null) return;
+    rafRef.current = requestAnimationFrame(applyProgress);
+  }, [applyProgress]);
+
+  // Measure once after the initial layout, and re-measure when devMode
+  // toggles (it inserts/removes its own list which could shift sticky
+  // positions). useLayoutEffect so the first paint is already in sync
+  // with the current scrollTop.
+  useLayoutEffect(() => {
+    measureLayout();
+    applyProgress();
+  }, [measureLayout, applyProgress, devMode]);
+
+  useEffect(() => {
+    const sidebar = sidebarRef.current;
+    if (!sidebar) return undefined;
+    sidebar.addEventListener('scroll', scheduleApply, { passive: true });
+    let ro: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(() => {
+        measureLayout();
+        applyProgress();
+      });
+      ro.observe(sidebar);
+    }
+    return () => {
+      sidebar.removeEventListener('scroll', scheduleApply);
+      ro?.disconnect();
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [scheduleApply, measureLayout, applyProgress]);
 
   return (
-    <aside className={styles.sidebar}>
-      <SidebarWarning />
-
-      <ul className={styles.sidebarNav} role="tablist" aria-label="Dashboard Views">
+    <aside ref={sidebarRef} className={styles.sidebar}>
+      {/*
+        Top nav (Discover / API / Settings). The same buttons render in
+        both states — we never swap the markup. Crossing the scroll
+        threshold toggles `sidebar-nav-collapsed` on the scroll
+        container, which compacts the list via CSS; a FLIP pass
+        (capture-rects → commit → animate transform back to 0) makes
+        each icon visibly slide from its old position into the new one.
+        Keeping the nodes stable preserves focus, ARIA roles, and
+        keyboard navigation across the transition.
+      */}
+      <ul ref={navRef} className={styles.sidebarNav} role="tablist" aria-label="Dashboard Views">
         {navEntries.map(({ label, view, icon }) => {
           const isActive = activeView === view;
           return (
@@ -594,14 +881,33 @@ export function Sidebar({ activeView, onSelectView }: SidebarProps) {
                 role="tab"
                 aria-selected={isActive ? 'true' : 'false'}
                 onClick={() => onSelectView(view)}
+                title={label}
               >
-                <HugeiconsIcon icon={icon} size={18} strokeWidth={1.5} />
-                {label}
+                <span
+                  className={styles.sidebarBtnIcon}
+                  ref={(node) => {
+                    if (node) navIconRefs.current.set(view, node);
+                    else navIconRefs.current.delete(view);
+                  }}
+                >
+                  <HugeiconsIcon icon={icon} size={18} strokeWidth={1.5} />
+                </span>
+                <span
+                  className={styles.sidebarBtnLabel}
+                  ref={(node) => {
+                    if (node) navLabelRefs.current.set(view, node);
+                    else navLabelRefs.current.delete(view);
+                  }}
+                >
+                  {label}
+                </span>
               </button>
             </li>
           );
         })}
       </ul>
+
+      <SidebarWarning />
 
       {devMode && (
         <>

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
@@ -197,39 +197,76 @@
   color: var(--accent-green);
 }
 
-.header-copy-button {
+/* Small text + icon buttons that sit after the service switcher in the
+   chat header. Two flavours:
+   - default  → neutral utility action (e.g. "Copy IDs")
+   - accent   → create action tinted accent-green (e.g. "New chat")
+   Sized to align with the service dropdown's height so the whole header
+   row reads as a single control cluster. Spacing comes from the parent
+   service-switcher's flex gap. */
+.header-action-button {
   appearance: none;
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  padding: 0;
-  border: 0;
-  border-radius: 4px;
+  gap: 5px;
+  height: 24px;
+  padding: 0 9px;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
   background: transparent;
   color: var(--text-muted);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
   cursor: pointer;
-  opacity: 0.72;
-  transition: color 0.12s ease, background 0.12s ease, opacity 0.12s ease;
+  transition: background 0.12s ease, color 0.12s ease, border-color 0.12s ease,
+    box-shadow 0.12s ease;
 
-  &:hover,
-  &:focus-visible {
-    color: var(--accent);
+  svg {
+    flex-shrink: 0;
+  }
+
+  &:hover {
     background: var(--bg-hover, rgba(0, 0, 0, 0.04));
-    opacity: 1;
+    color: var(--text-primary);
+    border-color: var(--border);
   }
 
   &:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 1px;
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(var(--accent-green-rgb), 0.35);
   }
 }
 
-.header-copy-button-copied {
-  color: var(--accent-green, #10b981);
-  opacity: 1;
+/* Copied confirmation — lock to green while the toast is visible so the
+   user gets unambiguous feedback. */
+.header-action-button-copied {
+  color: var(--accent-green);
+  border-color: rgba(var(--accent-green-rgb), 0.4);
+  background: rgba(var(--accent-green-rgb), 0.08);
+
+  &:hover {
+    color: var(--accent-green);
+    border-color: rgba(var(--accent-green-rgb), 0.4);
+    background: rgba(var(--accent-green-rgb), 0.08);
+  }
+}
+
+/* Accent variant: tinted chip used for the "New chat" CTA so it reads
+   as a create action rather than another utility. */
+.header-action-button-accent {
+  color: var(--accent-green);
+  border-color: rgba(var(--accent-green-rgb), 0.32);
+  background: rgba(var(--accent-green-rgb), 0.08);
+
+  &:hover {
+    color: var(--accent-green);
+    border-color: rgba(var(--accent-green-rgb), 0.55);
+    background: rgba(var(--accent-green-rgb), 0.16);
+  }
 }
 
 .service-separator {

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -554,6 +554,20 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     [actions, snap.chatServiceOptions],
   );
 
+  // Start a fresh conversation with the peer currently shown in this view,
+  // pre-selecting the same service so the user can keep working with the
+  // same provider in a clean thread. Available whenever there is an active
+  // conversation with a known peer (issue: new-chat-with-peer affordance).
+  const handleNewChatWithCurrentPeer = useCallback(() => {
+    const peerId = currentPeerId;
+    const serviceValue = snap.chatSelectedServiceValue;
+    actions.startNewChat();
+    if (peerId && serviceValue) {
+      actions.handleServiceChange(serviceValue, peerId);
+    }
+    inputRef.current?.focus();
+  }, [actions, currentPeerId, snap.chatSelectedServiceValue]);
+
   const handleServiceSwitch = useCallback(
     (nextValue: string) => {
       if (!nextValue || nextValue === snap.chatSelectedServiceValue) return;
@@ -913,12 +927,25 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
               {headerCopyValue && (
                 <button
                   type="button"
-                  className={`${styles.headerCopyButton}${headerCopied ? ` ${styles.headerCopyButtonCopied}` : ''}`}
+                  className={`${styles.headerActionButton}${headerCopied ? ` ${styles.headerActionButtonCopied}` : ''}`}
                   onClick={copyHeaderIdentifiers}
                   aria-label={headerCopied ? `Copied ${headerCopyValue}` : `Copy peer ID and service key ${headerCopyValue}`}
                   title={headerCopied ? 'Copied peer ID and service key' : `Copy peer ID and service key: ${headerCopyValue}`}
                 >
-                  <HugeiconsIcon icon={headerCopied ? Tick02Icon : Copy01Icon} size={13} strokeWidth={1.7} />
+                  <HugeiconsIcon icon={headerCopied ? Tick02Icon : Copy01Icon} size={12} strokeWidth={1.8} />
+                  <span>{headerCopied ? 'Copied' : 'Copy IDs'}</span>
+                </button>
+              )}
+              {snap.chatActiveConversation && currentPeerId && (
+                <button
+                  type="button"
+                  className={`${styles.headerActionButton} ${styles.headerActionButtonAccent}`}
+                  onClick={handleNewChatWithCurrentPeer}
+                  title={`Start a new chat with ${peerDisplayName || 'this peer'}`}
+                  aria-label={`Start a new chat with ${peerDisplayName || 'this peer'}`}
+                >
+                  <HugeiconsIcon icon={Add01Icon} size={12} strokeWidth={2} />
+                  <span>New chat</span>
                 </button>
               )}
               {!tooltipDismissed && peerServiceOptions.length >= 2 && (
@@ -936,12 +963,25 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
               {headerCopyValue && (
                 <button
                   type="button"
-                  className={`${styles.headerCopyButton}${headerCopied ? ` ${styles.headerCopyButtonCopied}` : ''}`}
+                  className={`${styles.headerActionButton}${headerCopied ? ` ${styles.headerActionButtonCopied}` : ''}`}
                   onClick={copyHeaderIdentifiers}
                   aria-label={headerCopied ? `Copied ${headerCopyValue}` : `Copy peer ID and service key ${headerCopyValue}`}
                   title={headerCopied ? 'Copied peer ID and service key' : `Copy peer ID and service key: ${headerCopyValue}`}
                 >
-                  <HugeiconsIcon icon={headerCopied ? Tick02Icon : Copy01Icon} size={13} strokeWidth={1.7} />
+                  <HugeiconsIcon icon={headerCopied ? Tick02Icon : Copy01Icon} size={12} strokeWidth={1.8} />
+                  <span>{headerCopied ? 'Copied' : 'Copy IDs'}</span>
+                </button>
+              )}
+              {snap.chatActiveConversation && currentPeerId && (
+                <button
+                  type="button"
+                  className={`${styles.headerActionButton} ${styles.headerActionButtonAccent}`}
+                  onClick={handleNewChatWithCurrentPeer}
+                  title={`Start a new chat with ${peerDisplayName || 'this peer'}`}
+                  aria-label={`Start a new chat with ${peerDisplayName || 'this peer'}`}
+                >
+                  <HugeiconsIcon icon={Add01Icon} size={12} strokeWidth={2} />
+                  <span>New chat</span>
                 </button>
               )}
             </span>


### PR DESCRIPTION
## Summary

Two related UI passes on the desktop renderer:

1. **Chat header** gets a pair of text+icon action chips ("Copy IDs", "New chat") replacing the icon-only copy button. The "new chat with this peer" affordance moves here from the sidebar so it's contextual to the conversation the user is actually viewing.

2. **Sidebar** is restructured into a single scroll column and the top nav (Discover / API / Settings) animates from a labeled vertical menu into a compact horizontal icon row **in lockstep with the user's scroll** — not after a threshold, not as a hard snap.

## Commits

### `ChatView: add 'Copy IDs' and 'New chat' header actions`
- New `.header-action-button` class with `-copied` and `-accent` modifiers; the old `.header-copy-button` styles are gone.
- "Copy IDs" (neutral) — same copy behavior as before, now with a label. Locks green briefly while showing "Copied".
- "New chat" (accent-green tinted) — calls `actions.startNewChat()` then `actions.handleServiceChange(...)` to preselect the same service for the same peer, then focuses the input.

### `Sidebar: flatten chat list, scroll-driven nav collapse`

**Chat list:**
- Dropped the peer-group accordion. Conversations render as a single flat reverse-chronological list — grouping was hiding recent activity behind collapsed sections.
- Dropped the `MAX_VISIBLE_CHAT_ROWS` slice and the bottom "Search all chats · N more" button — with a single scrollable sidebar there's no reason to truncate.
- Renamed "All Chats" → "Conversations" everywhere (label, modal heading, placeholder, summary, aria-labels).
- Section header is now `Conversations <count-badge>` on the left + an icon-only search trigger on the right.
- Pulled `ConversationListRow` out as its own component so unrelated state changes don't re-render every row.

**Scroll-driven nav:**
- The `<aside>` is the single scroll container. Nav, warning, dev section, and chat list scroll underneath as one continuous column.
- The nav `<ul>` is `position: sticky` and interpolates from expanded (vertical, labeled) to collapsed (45px horizontal icon row) as `scrollTop` crosses 0 → 56px.
- Motion is owned entirely by JS — the same DOM nodes are reused (preserving focus / ARIA / keyboard nav):
  1. `measureLayout()` captures expanded vs. collapsed icon positions once after mount (and on `ResizeObserver` ticks) by briefly toggling the collapsed class within a single synchronous block — no paint of the intermediate state.
  2. `applyProgress()` runs rAF-throttled on every scroll event. While `0 < progress < 1` it writes inline `transform` per icon, `opacity` per label, and `height` + `overflow: hidden` on the strip.
  3. At `progress >= 1`, the canonical `.sidebar-nav-collapsed` class takes over so hit-testing and the sticky "Conversations" header dock to the real geometry.
- Sanity guard: `measureLayout()` bails if `expandedHeight <= 0 || expandedHeight <= collapsedHeight`. First paint (before HugeiconsIcon SVGs have laid out) doesn't pin a stale tiny height; the `ResizeObserver` retries on the next layout tick.

**Layout safety fixes uncovered along the way:**
- `.sidebar-nav` + `.sidebar-warning` get `flex: 0 0 auto`. Without this the flex-column `.sidebar` shrinks the nav strip to nothing once the chat list grows tall — that's what was causing the "empty rounded box where the menu should be" symptom.
- `.sidebar` (and every descendant) gets `overflow-anchor: none`. Otherwise scroll anchoring fights the JS-driven height change in a feedback loop: user scrolls, strip shrinks, browser anchors `scrollTop` back to 0, strip grows back, user has to scroll *hard* before anything happens.
- `.sidebar-nav` has no `overflow` at rest; JS applies `overflow: hidden` inline only while it's pinning a non-natural height, so the expanded strip never clips its own icons.

## Why JS-driven instead of CSS transitions / FLIP

- CSS transitions can't animate `flex-direction: column → row`.
- Width/padding transitions on their own produced jitter and didn't actually slide the icons along a diagonal path.
- A pure FLIP "capture rects → commit → animate transform" pass snapped on a scroll threshold, then played a fixed-duration animation that ignored what the user did next. The current approach makes the icons physically follow scroll input frame-by-frame; if you stop mid-slide, the strip stays at whatever partial state you stopped at.

## Verification
- `npx tsc --noEmit -p tsconfig.renderer.json` — clean.
- `npx sass --no-source-map src/renderer/ui/components/Sidebar.module.scss /tmp/_sidebar_check.css` — clean.

## Test
- Open the app with the sidebar visible.
- Confirm Discover / API / Settings render at natural size at rest.
- Scroll the sidebar slowly — icons should slide diagonally toward the compact row, labels should fade out around the midpoint, strip height should shrink to 45px.
- Scroll back to top — exact reverse path; menu returns to full size.
- Past the collapse, "Conversations · N · 🔍" should pin flush beneath the icon strip while history scrolls under it.
- In any active conversation, the header should show `Copy IDs` and `New chat` chips to the right of the service switcher; clicking `New chat` starts a fresh thread with the same peer + service preselected.
