### PR TITLE
fix(network): provider filter bug + UX redesign for many providers

### DIFF
--- a/apps/website/src/pages/network.module.css
+++ b/apps/website/src/pages/network.module.css
@@ -1,12 +1,14 @@
+/* network.module.css — AntSeed live pricing page */
+
+/* ── Page shell ──────────────────────────────────────────────────────── */
+
 .page {
   max-width: 1100px;
   margin: 0 auto;
-  padding: 80px 24px 120px;
+  padding: 72px 24px 120px;
 }
 
-.header {
-  margin-bottom: 48px;
-}
+/* ── Hero ─────────────────────────────────────────────────────────────── */
 
 .back {
   font-family: 'JetBrains Mono', monospace;
@@ -15,32 +17,27 @@
   text-decoration: none;
   letter-spacing: 0.05em;
   display: inline-block;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
   transition: color 0.2s;
 }
-
-.back:hover {
-  color: #1FD87A;
-  text-decoration: none;
-}
+.back:hover { color: #1FD87A; text-decoration: none; }
 
 .eyebrow {
-  font-size: 12px;
+  font-size: 11px;
   color: #1FD87A;
   letter-spacing: 3px;
   text-transform: uppercase;
   font-family: 'JetBrains Mono', monospace;
-  font-style: italic;
-  margin-bottom: 12px;
+  margin-bottom: 10px;
   margin-top: 0;
 }
 
 .title {
-  font-size: clamp(32px, 5vw, 52px);
+  font-size: clamp(28px, 5vw, 48px);
   font-weight: 800;
   letter-spacing: -2px;
   color: #0d1117;
-  margin-bottom: 12px;
+  margin-bottom: 10px;
   line-height: 1.1;
 }
 
@@ -48,9 +45,12 @@
   font-size: 15px;
   color: #666e7a;
   line-height: 1.7;
+  margin-bottom: 32px;
 }
 
-/* ── Stats bar ────────────────────────────────────────────────────── */
+.header { margin-bottom: 32px; }
+
+/* ── Stats bar ────────────────────────────────────────────────────────── */
 
 .statsBar {
   display: flex;
@@ -58,70 +58,145 @@
   background: white;
   border: 1px solid #e2e8f0;
   border-radius: 16px;
-  padding: 28px 40px;
-  margin-bottom: 32px;
-  box-shadow: 0 4px 24px rgba(0,0,0,0.06);
-  flex-wrap: wrap;
-  gap: 24px;
-  justify-content: center;
+  padding: 24px 36px;
+  margin-bottom: 24px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.05);
+  gap: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
 .stat {
   text-align: center;
   flex: 1;
-  min-width: 100px;
+  min-width: 80px;
 }
-
 .statNum {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 32px;
+  font-size: 28px;
   font-weight: 700;
   color: #0d1117;
   line-height: 1;
-  margin-bottom: 8px;
+  margin-bottom: 6px;
 }
-
+.statGreen { color: #1FD87A !important; }
 .statLabel {
-  font-size: 11px;
+  font-size: 10px;
   color: #8b949e;
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
-
 .statDivider {
   width: 1px;
-  height: 48px;
-  background: #e2e8f0;
+  height: 40px;
+  background: #e8edf2;
+  flex-shrink: 0;
+  margin: 0 8px;
+}
+.statLive {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 16px;
+  font-weight: 700;
+  color: #1FD87A;
+  margin-bottom: 6px;
+}
+.liveDot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: #1FD87A;
+  box-shadow: 0 0 8px #1FD87A;
+  animation: pulse 2s infinite;
   flex-shrink: 0;
 }
+@keyframes pulse {
+  0%,100% { opacity:1; box-shadow:0 0 8px #1FD87A; }
+  50%      { opacity:.5; box-shadow:0 0 3px #1FD87A; }
+}
 
-/* ── Filters ──────────────────────────────────────────────────────── */
+/* ── Quick picks bar ─────────────────────────────────────────────────── */
 
-.filterBar {
-  margin-bottom: 24px;
+.quickPicks {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 4px;
+  margin-bottom: 20px;
+  scrollbar-width: none;
+}
+.quickPicks::-webkit-scrollbar { display: none; }
+
+.quickPickBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 40px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: 'Space Grotesk', sans-serif;
+  background: white;
+  color: #444e5c;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+.quickPickBtn:hover {
+  border-color: #1FD87A;
+  color: #0d1117;
+  background: #f0fdf4;
+}
+.quickPickBtnActive {
+  background: #0d1117 !important;
+  border-color: #0d1117 !important;
+  color: white !important;
+}
+
+/* ── Sticky search bar ───────────────────────────────────────────────── */
+
+.stickyBar {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: #f8f9fb;
+  padding: 12px 0;
+  margin-bottom: 16px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 10px;
+}
+
+.searchRow {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
 }
 
 .searchWrap {
   position: relative;
-  width: 100%;
+  flex: 1;
+  min-width: 0;
 }
-
 .searchIcon {
   position: absolute;
-  left: 16px;
+  left: 14px;
   top: 50%;
   transform: translateY(-50%);
   color: #8b949e;
   pointer-events: none;
 }
-
 .searchInput {
   width: 100%;
-  padding: 14px 40px 14px 44px;
-  border: 1px solid #e2e8f0;
+  height: 44px;
+  padding: 0 40px 0 44px;
+  border: 1.5px solid #e2e8f0;
   border-radius: 12px;
   font-size: 14px;
   font-family: 'Space Grotesk', sans-serif;
@@ -131,19 +206,14 @@
   transition: border-color 0.2s, box-shadow 0.2s;
   box-sizing: border-box;
 }
-
 .searchInput:focus {
   border-color: #1FD87A;
-  box-shadow: 0 0 0 3px rgba(31,216,122,0.12);
+  box-shadow: 0 0 0 3px rgba(31,216,122,0.1);
 }
-
-.searchInput::placeholder {
-  color: #a0aab4;
-}
-
+.searchInput::placeholder { color: #a0aab4; }
 .clearBtn {
   position: absolute;
-  right: 12px;
+  right: 10px;
   top: 50%;
   transform: translateY(-50%);
   background: none;
@@ -154,652 +224,705 @@
   padding: 4px 8px;
   line-height: 1;
 }
+.clearBtn:hover { color: #0d1117; }
 
-.clearBtn:hover {
-  color: #0d1117;
-}
-
-.filterChips {
+/* View toggle */
+.viewToggle {
   display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  align-items: center;
+  gap: 2px;
+  background: #eef0f4;
+  border-radius: 10px;
+  padding: 3px;
+  flex-shrink: 0;
+}
+.viewBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 28px;
+  padding: 0 12px;
+  border-radius: 7px;
+  border: none;
+  background: transparent;
+  color: #8b949e;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: 'Space Grotesk', sans-serif;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+  white-space: nowrap;
+}
+.viewBtn:hover { color: #0d1117; }
+.viewBtnActive {
+  background: white !important;
+  color: #0d1117 !important;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
 }
 
+/* Filters toggle */
+.filterToggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 16px;
+  height: 44px;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 12px;
+  font-size: 13px;
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 600;
+  background: white;
+  color: #666e7a;
+  cursor: pointer;
+  flex-shrink: 0;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+.filterToggle:hover { border-color: #1FD87A; color: #0d1117; }
+.filterToggleActive { border-color: #0d1117; background: #0d1117; color: white; }
+
+/* Tag chips */
+.tagChips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
 .chip {
-  padding: 6px 14px;
-  border: 1px solid #e2e8f0;
+  padding: 5px 14px;
+  border: 1.5px solid #e2e8f0;
   border-radius: 20px;
   font-size: 12px;
   font-family: 'Space Grotesk', sans-serif;
-  font-weight: 500;
+  font-weight: 600;
+  background: white;
+  color: #666e7a;
+  cursor: pointer;
+  transition: all 0.12s;
+  white-space: nowrap;
+}
+.chip:hover { border-color: #1FD87A; color: #0d1117; }
+.chipActive { background: #0d1117; border-color: #0d1117; color: white; }
+.chipActive:hover { background: #1a2332; border-color: #1a2332; }
+
+/* Advanced filters */
+.advancedFilters {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px 24px;
+  padding: 20px;
+  background: white;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 12px;
+}
+.filterGroup { display: flex; flex-direction: column; gap: 6px; }
+.filterHeader { display: flex; justify-content: space-between; align-items: baseline; }
+.filterLabel {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  font-weight: 700;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+.filterValue {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  font-weight: 700;
+  color: #0d1117;
+}
+.filterRange {
+  -webkit-appearance: none; appearance: none;
+  width: 100%; height: 4px;
+  border-radius: 2px;
+  background: #e2e8f0;
+  outline: none; cursor: pointer;
+}
+.filterRange::-webkit-slider-thumb {
+  -webkit-appearance: none; appearance: none;
+  width: 18px; height: 18px;
+  border-radius: 50%;
+  background: #0d1117;
+  cursor: pointer;
+  border: 2.5px solid white;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+}
+.filterGroupToggle { display: flex; align-items: flex-end; }
+.checkboxLabel {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 13px; color: #0d1117; cursor: pointer; user-select: none;
+}
+.checkbox { width: 16px; height: 16px; accent-color: #1FD87A; cursor: pointer; }
+.clearFilters {
+  padding: 8px 16px;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 12px;
+  font-family: 'Space Grotesk', sans-serif;
+  background: white;
+  color: #8b949e;
+  cursor: pointer;
+  transition: all 0.15s;
+  align-self: flex-end;
+}
+.clearFilters:hover { border-color: #ef4444; color: #ef4444; }
+
+/* ── Results row ─────────────────────────────────────────────────────── */
+
+.resultsRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+  gap: 12px;
+}
+.resultsCount {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: #8b949e;
+  letter-spacing: 0.04em;
+}
+.clearAllFilters {
+  font-size: 12px;
+  color: #8b949e;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: 'Space Grotesk', sans-serif;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: color 0.15s;
+}
+.clearAllFilters:hover { color: #ef4444; }
+
+/* ── Provider dropdown ───────────────────────────────────────────────── */
+
+.providerDropdownWrap { position: relative; flex-shrink: 0; }
+.providerDropdownTrigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 44px;
+  padding: 0 14px;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 12px;
+  font-size: 13px;
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 600;
   background: white;
   color: #666e7a;
   cursor: pointer;
   transition: all 0.15s;
   white-space: nowrap;
+  min-width: 140px;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
-
-.chip:hover {
-  border-color: #1FD87A;
-  color: #1FD87A;
-}
-
-.chipActive {
-  background: #0d1117;
-  border-color: #0d1117;
-  color: white;
-}
-
-.chipActive:hover {
-  background: #1a2332;
-  border-color: #1a2332;
-  color: white;
-}
-
-/* ── Results count ────────────────────────────────────────────────── */
-
-.resultsCount {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  color: #8b949e;
-  letter-spacing: 0.05em;
-  margin-bottom: 16px;
-}
-
-/* ── Table ─────────────────────────────────────────────────────────── */
-
-.tableWrap {
+.providerDropdownTrigger:hover { border-color: #1FD87A; color: #0d1117; }
+.providerDropdownActive { background: #0d1117 !important; border-color: #0d1117 !important; color: white !important; }
+.providerDropdownMenu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 220px;
   background: white;
-  border: 1px solid #e2e8f0;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.12);
+  z-index: 200;
+  overflow: hidden;
+}
+.providerDropdownSearch { padding: 10px; border-bottom: 1px solid #f0f2f5; }
+.providerDropdownInput {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1.5px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 13px;
+  font-family: 'Space Grotesk', sans-serif;
+  outline: none;
+  box-sizing: border-box;
+}
+.providerDropdownInput:focus { border-color: #1FD87A; }
+.providerDropdownList { max-height: 220px; overflow-y: auto; padding: 4px; }
+.providerDropdownItem {
+  display: block; width: 100%; padding: 9px 12px;
+  border: none; border-radius: 8px;
+  background: transparent; color: #444e5c;
+  font-size: 13px; font-family: 'Space Grotesk', sans-serif;
+  text-align: left; cursor: pointer; transition: background 0.1s;
+}
+.providerDropdownItem:hover { background: #f5f7fa; }
+.providerDropdownItemActive { background: #0d1117 !important; color: white !important; }
+
+/* ── Grouped list ────────────────────────────────────────────────────── */
+
+.groupedList { display: flex; flex-direction: column; gap: 10px; }
+
+/* ── Model group card ────────────────────────────────────────────────── */
+
+.modelGroupCard {
+  background: white;
+  border: 1.5px solid #e8edf4;
   border-radius: 16px;
   overflow: hidden;
-  box-shadow: 0 4px 24px rgba(0,0,0,0.06);
+  box-shadow: 0 2px 10px rgba(0,0,0,0.04);
+  transition: box-shadow 0.15s;
 }
+.modelGroupCard:hover { box-shadow: 0 4px 20px rgba(0,0,0,0.08); }
 
-.table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-.table thead {
-  background: #fafbfc;
-  border-bottom: 1px solid #e2e8f0;
-}
-
-.table th {
-  padding: 14px 20px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
-  font-weight: 600;
-  color: #8b949e;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  text-align: left;
-  cursor: pointer;
-  user-select: none;
-  transition: color 0.15s;
-  white-space: nowrap;
-}
-
-.table th:hover {
-  color: #0d1117;
-}
-
-.thModel {
-  width: 30%;
-}
-
-.thPrice {
-  width: 12%;
-  text-align: right !important;
-}
-
-.thStat {
-  width: 10%;
-  text-align: right !important;
-}
-
-.thProviders {
-  width: 6%;
-  text-align: center !important;
-}
-
-.row {
-  border-bottom: 1px solid #f0f2f5;
-  transition: background 0.12s;
-}
-
-.row:last-child {
-  border-bottom: none;
-}
-
-.row:hover {
-  background: #f8faf9;
-}
-
-.tdModel {
+.modelGroupHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   padding: 16px 20px;
+  border-bottom: 1px solid #f0f2f5;
+  gap: 16px;
+  flex-wrap: wrap;
 }
-
-.modelCell {
+.modelGroupLeft {
   display: flex;
   align-items: center;
   gap: 14px;
-}
-
-.modelLogo {
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
-  object-fit: contain;
-  flex-shrink: 0;
-  background: #f5f7fa;
-  padding: 4px;
-}
-
-.modelInfo {
   min-width: 0;
 }
-
-.modelName {
-  font-size: 14px;
-  font-weight: 600;
+.modelGroupInfo { min-width: 0; }
+.modelGroupName {
+  font-size: 16px;
+  font-weight: 700;
   color: #0d1117;
-  margin-bottom: 4px;
+  margin-bottom: 5px;
+}
+.modelGroupMeta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.modelProvider {
+  font-size: 12px;
+  font-weight: 600;
+  color: #8b949e;
+}
+.ctxBadge {
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+  background: #f0f4ff;
+  color: #4f6ef7;
+  border-radius: 6px;
+  padding: 2px 7px;
+  font-weight: 600;
+}
+
+.modelGroupRight {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+  flex-shrink: 0;
+}
+.modelGroupPricing {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 14px;
+  font-weight: 700;
+}
+.priceFrom { font-size: 11px; font-weight: 400; color: #8b949e; font-family: 'Space Grotesk', sans-serif; }
+.pricingSlash { color: #d0d5dc; font-size: 12px; font-weight: 400; }
+.pricingUnit  { font-size: 11px; font-weight: 400; color: #8b949e; font-family: 'Space Grotesk', sans-serif; }
+.modelGroupStats {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.modelGroupProviderCount {
+  font-size: 11px;
+  font-weight: 600;
+  color: #8b949e;
+  background: #f5f7fa;
+  border-radius: 20px;
+  padding: 3px 10px;
+  white-space: nowrap;
+}
+.modelGroupTokens {
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+  color: #a0aab4;
+}
+
+/* ── Provider rows inside group ──────────────────────────────────────── */
+
+.providerRows { display: flex; flex-direction: column; }
+
+.providerRowsHeader {
+  display: grid;
+  grid-template-columns: 1fr 90px 90px 100px 80px 90px 70px 64px;
+  padding: 8px 20px;
+  background: #fafbfc;
+  border-bottom: 1px solid #f0f2f5;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  font-weight: 700;
+  color: #a0aab4;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  gap: 8px;
+}
+.colRight { justify-content: flex-end; text-align: right; }
+.colHideMd {}  /* hidden at ≤900px */
+.colHideSm {}  /* hidden at ≤700px */
+
+.providerRowItem {
+  display: grid;
+  grid-template-columns: 1fr 90px 90px 100px 80px 90px 70px 64px;
+  padding: 11px 20px;
+  border-bottom: 1px solid #f8f9fb;
+  gap: 8px;
+  align-items: center;
+  transition: background 0.1s;
+}
+.providerRowItem:last-child { border-bottom: none; }
+.providerRowItem:hover { background: #f8faf9; }
+.providerRowBest { background: #f0fdf6 !important; }
+.providerRowBest:hover { background: #e8fdf0 !important; }
+
+.providerRowName {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  overflow: hidden;
+}
+.providerRowNameText {
+  font-size: 13px;
+  font-weight: 500;
+  color: #0d1117;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.modelMeta {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.providerName {
-  font-size: 11px;
-  color: #8b949e;
-  font-weight: 500;
-}
-
-.tagBadge {
-  font-size: 10px;
-  font-family: 'JetBrains Mono', monospace;
-  font-weight: 500;
-  border-radius: 10px;
-  padding: 2px 8px;
-  text-transform: lowercase;
-  letter-spacing: 0.02em;
-}
-
-/* Tag color variants — applied via data attribute or inline style in TSX */
-.tagCoding    { background: #eff6ff; color: #3b82f6; }
-.tagPrivacy   { background: #fef3f2; color: #ef4444; }
-.tagTee       { background: #f0fdf4; color: #16a34a; }
-.tagChat      { background: #f5f3ff; color: #8b5cf6; }
-.tagCode      { background: #eff6ff; color: #3b82f6; }
-.tagFast      { background: #fefce8; color: #ca8a04; }
-.tagCheap     { background: #f0fdf4; color: #16a34a; }
-.tagReasoning { background: #fff7ed; color: #ea580c; }
-.tagOpenSource { background: #f0f9ff; color: #0284c7; }
-.tagRag       { background: #fdf4ff; color: #c026d3; }
-.tagEnterprise { background: #f8fafc; color: #475569; }
-.tagAnon      { background: #f0f9ff; color: #0e7490; }
-.tagDefault   { background: #f5f7fa; color: #64748b; }
-
-.tdContext {
-  padding: 16px 20px;
-}
-
-.contextBadge {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  font-weight: 500;
-  color: #666e7a;
-  background: #f5f7fa;
-  padding: 4px 10px;
-  border-radius: 6px;
-}
-
-.tdPrice {
-  padding: 16px 20px;
-  text-align: right;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.priceFree {
-  color: #1FD87A;
-  font-weight: 700;
-}
-
-.priceGood {
-  color: #1FD87A;
-}
-
-.priceNormal {
-  color: #0d1117;
-}
-
-.tdProviders {
-  padding: 16px 20px;
-  text-align: center;
-}
-
-.peerCount {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: #f0faf4;
-  color: #1FD87A;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.tdStat {
-  padding: 16px 20px;
-  text-align: right;
-}
-
-.statValue {
+.providerRowPrice {
   font-family: 'JetBrains Mono', monospace;
   font-size: 13px;
   font-weight: 600;
-  color: #0d1117;
-}
-
-.emptyRow {
-  padding: 60px 20px !important;
-  text-align: center;
-  color: #8b949e;
-  font-size: 14px;
-}
-
-/* ── Search row + filter toggle ───────────────────────────────────── */
-
-.searchRow {
   display: flex;
-  gap: 10px;
-  align-items: stretch;
+  justify-content: flex-end;
 }
-
-.searchRow .searchWrap {
-  flex: 1;
-}
-
-.filterToggle {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 0 18px;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  font-size: 13px;
-  font-family: 'Space Grotesk', sans-serif;
-  font-weight: 500;
-  background: white;
-  color: #666e7a;
-  cursor: pointer;
-  transition: all 0.15s;
-  white-space: nowrap;
-}
-
-.filterToggle:hover {
-  border-color: #1FD87A;
-  color: #0d1117;
-}
-
-.filterToggleActive {
-  border-color: #1FD87A;
-  background: #f0fdf4;
-  color: #16a34a;
-}
-
-/* ── Advanced filters panel ───────────────────────────────────────── */
-
-.advancedFilters {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 20px 24px;
-  padding: 24px;
-  background: white;
-  border: 1px solid #e2e8f0;
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.04);
-}
-
-.filterGroup {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.filterHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-}
-
-.filterLabel {
+.providerRowStat {
   font-family: 'JetBrains Mono', monospace;
-  font-size: 10px;
-  font-weight: 600;
-  color: #8b949e;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.filterValue {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 11px;
-  font-weight: 600;
-  color: #0d1117;
-}
-
-.filterRange {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 100%;
-  height: 4px;
-  border-radius: 2px;
-  background: #e2e8f0;
-  outline: none;
-  cursor: pointer;
-}
-
-.filterRange::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: #0d1117;
-  cursor: pointer;
-  border: 2px solid white;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
-}
-
-.filterRange::-moz-range-thumb {
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: #0d1117;
-  cursor: pointer;
-  border: 2px solid white;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
-}
-
-.filterGroupToggle {
-  display: flex;
-  align-items: flex-end;
-}
-
-.checkboxLabel {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  color: #0d1117;
-  cursor: pointer;
-  user-select: none;
-}
-
-.checkbox {
-  width: 16px;
-  height: 16px;
-  accent-color: #1FD87A;
-  cursor: pointer;
-}
-
-.clearFilters {
-  padding: 8px 16px;
-  border: 1px solid #e2e8f0;
-  border-radius: 8px;
   font-size: 12px;
-  font-family: 'Space Grotesk', sans-serif;
-  background: white;
   color: #8b949e;
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.clearFilters:hover {
-  border-color: #ef4444;
-  color: #ef4444;
-}
-
-/* ── Live data extras ─────────────────────────────────────────────── */
-
-.statLive {
   display: flex;
+  justify-content: flex-end;
   align-items: center;
-  justify-content: center;
-  gap: 8px;
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 18px;
-  font-weight: 700;
-  color: #1FD87A;
-  margin-bottom: 8px;
 }
+.statNA { color: #d0d5dc; }
 
-.liveDot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: #1FD87A;
-  box-shadow: 0 0 8px #1FD87A;
-  animation: pulse 2s infinite;
+/* Best badge */
+.bestBadge {
   display: inline-block;
+  padding: 2px 7px;
+  background: #dcfce7;
+  color: #16a34a;
+  font-size: 9px;
+  font-weight: 800;
+  border-radius: 20px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
   flex-shrink: 0;
 }
 
-@keyframes pulse {
-  0%, 100% { opacity: 1; box-shadow: 0 0 8px #1FD87A; }
-  50% { opacity: 0.5; box-shadow: 0 0 3px #1FD87A; }
+/* Freshness dot */
+.freshDot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  display: inline-block;
+  flex-shrink: 0;
+}
+.freshGreen  { background: #1FD87A; box-shadow: 0 0 5px rgba(31,216,122,0.5); }
+.freshYellow { background: #f59e0b; }
+.freshRed    { background: #d1d5db; }
+
+/* Price bar */
+.priceWithBar {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 3px;
+}
+.priceBarWrap {
+  display: block;
+  width: 52px;
+  height: 3px;
+  background: #f0f2f5;
+  border-radius: 2px;
+  overflow: hidden;
+}
+.priceBarFill {
+  display: block;
+  height: 100%;
+  background: #d1d5db;
+  border-radius: 2px;
+  transition: width 0.4s ease;
+}
+.priceBarBest { background: #1FD87A !important; }
+
+/* Cached badge */
+.cachedBadge {
+  font-size: 11px;
+  font-weight: 600;
+  color: #7c3aed;
+  background: #f5f3ff;
+  padding: 2px 7px;
+  border-radius: 6px;
+  white-space: nowrap;
 }
 
-.reputation {
+/* Stake badge */
+.stakeBadge {
+  font-size: 11px;
+  font-weight: 700;
+  color: #0369a1;
+  background: #e0f2fe;
+  padding: 2px 7px;
+  border-radius: 6px;
   font-family: 'JetBrains Mono', monospace;
+}
+
+/* Live pill */
+.livePill {
   font-size: 10px;
-  color: #8b949e;
-  margin-top: 2px;
+  font-weight: 700;
+  border-radius: 20px;
+  padding: 2px 8px;
+  white-space: nowrap;
+  font-family: 'Space Grotesk', sans-serif;
 }
+.livePillGreen  { background: #dcfce7; color: #16a34a; }
+.livePillYellow { background: #fef9c3; color: #854d0e; }
+.livePillRed    { background: #f5f7fa; color: #94a3b8; }
 
-.bestPeer {
-  font-size: 10px;
-  color: #8b949e;
-  margin-top: 2px;
-  font-family: 'JetBrains Mono', monospace;
-}
-
-/* ── Footer ───────────────────────────────────────────────────────── */
-
-.footer {
-  margin-top: 48px;
-  text-align: center;
-  font-size: 13px;
-  color: #8b949e;
-  line-height: 2;
-}
-
-.footer a {
+/* Expand button */
+.expandBtn {
+  display: block; width: 100%;
+  padding: 11px 20px;
+  border: none;
+  border-top: 1px solid #f0f2f5;
+  background: #fafbfc;
   color: #1FD87A;
-  text-decoration: none;
+  font-size: 13px;
+  font-weight: 700;
+  font-family: 'Space Grotesk', sans-serif;
+  text-align: center;
+  cursor: pointer;
+  transition: background 0.1s;
+  min-height: 44px;
 }
+.expandBtn:hover { background: #f0fdf4; }
 
-.footer a:hover {
-  text-decoration: underline;
+/* ── Flat table ──────────────────────────────────────────────────────── */
+
+.tableWrap {
+  background: white;
+  border: 1.5px solid #e8edf4;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.05);
 }
+.table { width: 100%; border-collapse: collapse; }
+.table thead { background: #fafbfc; border-bottom: 1px solid #e8edf4; }
+.table th {
+  padding: 12px 18px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px; font-weight: 700;
+  color: #8b949e;
+  text-transform: uppercase; letter-spacing: 0.1em;
+  text-align: left; cursor: pointer; user-select: none;
+  white-space: nowrap; transition: color 0.15s;
+}
+.table th:hover { color: #0d1117; }
+.thModel { width: 40%; }
+.thPrice { width: 13%; text-align: right !important; }
+.thStat  { width: 10%; text-align: right !important; }
+.row { border-bottom: 1px solid #f0f2f5; transition: background 0.1s; }
+.row:last-child { border-bottom: none; }
+.row:hover { background: #f8faf9; }
+.tdModel { padding: 14px 18px; }
+.modelCell { display: flex; align-items: center; gap: 12px; }
+.modelLogo {
+  width: 30px; height: 30px; border-radius: 8px;
+  object-fit: contain; flex-shrink: 0;
+  background: #f5f7fa; padding: 4px;
+}
+.modelInfo { min-width: 0; }
+.modelName {
+  font-size: 14px; font-weight: 600; color: #0d1117;
+  margin-bottom: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.modelMeta { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.providerName { font-size: 11px; color: #8b949e; font-weight: 500; }
+.tagBadge {
+  font-size: 10px; font-family: 'JetBrains Mono', monospace; font-weight: 500;
+  border-radius: 10px; padding: 2px 7px; text-transform: lowercase; letter-spacing: 0.02em;
+}
+.tagCoding     { background: #eff6ff; color: #3b82f6; }
+.tagPrivacy    { background: #fef3f2; color: #ef4444; }
+.tagTee        { background: #f0fdf4; color: #16a34a; }
+.tagChat       { background: #f5f3ff; color: #8b5cf6; }
+.tagCode       { background: #eff6ff; color: #3b82f6; }
+.tagFast       { background: #fefce8; color: #ca8a04; }
+.tagCheap      { background: #f0fdf4; color: #16a34a; }
+.tagReasoning  { background: #fff7ed; color: #ea580c; }
+.tagOpenSource { background: #f0f9ff; color: #0284c7; }
+.tagRag        { background: #fdf4ff; color: #c026d3; }
+.tagEnterprise { background: #f8fafc; color: #475569; }
+.tagAnon       { background: #f0f9ff; color: #0e7490; }
+.tagDefault    { background: #f5f7fa; color: #64748b; }
+.tdPrice {
+  padding: 14px 18px; text-align: right;
+  font-family: 'JetBrains Mono', monospace; font-size: 13px; font-weight: 600;
+}
+.tdStat { padding: 14px 18px; text-align: right; }
+.statValue { font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 600; color: #0d1117; }
+.priceFree  { color: #1FD87A; font-weight: 700; }
+.priceGood  { color: #1FD87A; }
+.priceNormal { color: #0d1117; }
+.emptyRow { padding: 60px 20px !important; text-align: center; color: #8b949e; font-size: 14px; }
 
-/* ── Mobile ───────────────────────────────────────────────────────── */
+/* ── Empty / skeleton states ─────────────────────────────────────────── */
 
-@media (max-width: 768px) {
-  .page {
-    padding: 60px 12px 80px;
+.emptyState {
+  text-align: center; color: #8b949e; font-size: 14px;
+  padding: 60px 16px;
+  background: white; border: 1.5px solid #e8edf4; border-radius: 16px;
+}
+.clearFiltersInline {
+  display: inline-block; margin-top: 12px;
+  padding: 8px 16px; border: 1.5px solid #e2e8f0; border-radius: 8px;
+  font-size: 13px; font-family: 'Space Grotesk', sans-serif;
+  background: white; color: #1FD87A; cursor: pointer;
+}
+.skeletonCard { min-height: 80px; animation: shimmer 1.6s ease-in-out infinite; }
+.skeletonLine { height: 14px; background: #f0f2f5; border-radius: 6px; }
+@keyframes shimmer { 0%,100% { opacity:1; } 50% { opacity:.45; } }
+
+/* ── Footer ──────────────────────────────────────────────────────────── */
+
+.footer { margin-top: 52px; text-align: center; font-size: 13px; color: #8b949e; line-height: 2.2; }
+.footer a { color: #1FD87A; text-decoration: none; }
+.footer a:hover { text-decoration: underline; }
+
+/* ══════════════════════════════════════════════════════════════════════
+   RESPONSIVE
+   ══════════════════════════════════════════════════════════════════════ */
+
+/* ── ≤ 900px: hide low-priority columns ─────────────────────────────── */
+
+@media (max-width: 900px) {
+  .colHideMd { display: none !important; }
+
+  .providerRowsHeader,
+  .providerRowItem {
+    grid-template-columns: 1fr 85px 85px 90px 70px;
   }
 
+  .advancedFilters { grid-template-columns: repeat(2, 1fr); }
+  .viewBtnLabel { display: none; }
+  .viewBtn { padding: 0 9px; }
+  .filterToggleLabel { display: none; }
+  .filterToggle { padding: 0 12px; }
+}
+
+/* ── ≤ 700px: hide more columns, stack header ────────────────────────── */
+
+@media (max-width: 700px) {
+  .colHideSm { display: none !important; }
+
+  .providerRowsHeader,
+  .providerRowItem {
+    grid-template-columns: 1fr 80px 80px;
+  }
+
+  .modelGroupHeader { flex-direction: column; align-items: flex-start; gap: 10px; }
+  .modelGroupRight  { align-items: flex-start; }
+}
+
+/* ── ≤ 600px: full mobile layout ────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  .page { padding: 56px 14px 80px; }
+
+  /* Stats bar: horizontal scroll */
   .statsBar {
-    padding: 20px;
-    flex-direction: column;
-    gap: 16px;
+    padding: 18px 20px;
+    border-radius: 12px;
+    gap: 0;
   }
+  .statNum  { font-size: 22px; }
+  .statLabel { font-size: 9px; }
+  .statDivider { height: 32px; margin: 0 6px; }
 
-  .statDivider {
-    display: none;
-  }
+  /* Quick picks: horizontal scroll, no wrap */
+  .quickPicks { margin-bottom: 14px; }
+  .quickPickBtn { padding: 7px 13px; font-size: 12px; }
 
-  .statNum {
-    font-size: 24px;
-  }
+  /* Sticky bar */
+  .stickyBar { padding: 10px 0 8px; gap: 8px; }
 
-  .filterBar {
-    gap: 10px;
-  }
+  .searchRow { flex-wrap: wrap; gap: 8px; }
+  .searchWrap { order: 1; flex-basis: 100%; }
+  .providerDropdownWrap { order: 2; flex: 1; }
+  .providerDropdownTrigger { width: 100%; max-width: none; min-width: 0; height: 40px; }
+  .viewToggle { order: 3; }
+  .filterToggle { order: 4; height: 40px; }
 
-  .searchInput {
-    font-size: 13px;
-    padding: 12px 36px 12px 40px;
-  }
+  /* Groups: tighten up */
+  .modelGroupHeader { padding: 12px 14px; }
+  .modelGroupName   { font-size: 14px; }
+  .modelLogo        { width: 26px; height: 26px; }
 
-  .filterChips {
-    display: none;
-  }
+  .providerRows { font-size: 12px; }
+  .providerRowsHeader { padding: 7px 14px; font-size: 8px; }
+  .providerRowItem    { padding: 10px 14px; }
+  .providerRowNameText { font-size: 12px; }
+  .expandBtn { min-height: 48px; font-size: 13px; }
 
-  .filterToggle {
-    display: none;
-  }
-
-  .advancedFilters {
-    display: none;
-  }
-
-  /* Card-based layout instead of table on mobile */
-  .tableWrap {
-    border: none;
-    box-shadow: none;
-    background: transparent;
-    border-radius: 0;
-  }
-
-  .table,
-  .table thead,
-  .table tbody,
-  .table tr,
-  .table th,
-  .table td {
-    display: block;
-  }
-
-  .table thead {
-    display: none !important;
-  }
-
+  /* Flat table → card layout on mobile */
+  .tableWrap { border: none; box-shadow: none; background: transparent; border-radius: 0; }
+  .table, .table thead, .table tbody, .table tr, .table th, .table td { display: block; }
+  .table thead { display: none !important; }
   .row {
     background: white;
-    border: 1px solid #e2e8f0;
+    border: 1.5px solid #e8edf4;
     border-radius: 12px;
-    padding: 16px;
-    margin-bottom: 12px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+    padding: 14px;
+    margin-bottom: 10px;
     display: flex !important;
     flex-wrap: wrap;
     align-items: center;
     gap: 8px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.04);
   }
-
-  .row td {
-    border: none !important;
-  }
-
-  .tdModel {
-    width: 100%;
-    padding: 0 !important;
-    margin-bottom: 8px;
-  }
-
-  .modelLogo {
-    width: 28px;
-    height: 28px;
-  }
-
-  .modelName {
-    font-size: 15px;
-  }
-
+  .row td { border: none !important; }
+  .tdModel { width: 100%; padding: 0 !important; margin-bottom: 6px; }
   .tdPrice {
     padding: 0 !important;
     text-align: left !important;
-    font-size: 13px;
     flex: 1;
+    font-size: 13px;
   }
-
-  .tdPrice::before {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 9px;
-    color: #8b949e;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    display: block;
-    margin-bottom: 2px;
-    font-weight: 400;
-  }
-
-  .tdPrice:nth-of-type(2)::before {
-    content: 'Input /M';
-  }
-
-  .tdPrice:nth-of-type(3)::before {
-    content: 'Output /M';
-  }
-
   .tdStat {
     padding: 0 !important;
     text-align: left !important;
     flex: 1;
   }
 
-  .tdStat::before {
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 9px;
-    color: #8b949e;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    display: block;
-    margin-bottom: 2px;
-    font-weight: 400;
-  }
-
-  .tdStat:nth-of-type(4)::before { content: 'Tokens'; }
-  .tdStat:nth-of-type(5)::before { content: 'Users'; }
-
-  .statValue {
-    font-size: 12px;
-  }
-
-
-  .tagBadge {
-    font-size: 8px;
-    padding: 1px 5px;
-  }
-
-  .searchRow {
-    flex-direction: column;
-  }
-
-  .advancedFilters {
-    grid-template-columns: 1fr;
-    gap: 16px;
-    padding: 16px;
-  }
-
-  .emptyRow {
-    padding: 40px 16px !important;
-  }
+  .advancedFilters { grid-template-columns: 1fr; gap: 14px; padding: 14px; }
+  .tagChips { gap: 5px; }
+  .chip { padding: 5px 11px; font-size: 11px; }
 }

--- a/apps/website/src/pages/network.tsx
+++ b/apps/website/src/pages/network.tsx
@@ -1,12 +1,12 @@
-import {useEffect, useState, useMemo} from 'react';
+import {useEffect, useState, useMemo, useRef} from 'react';
 import Head from '@docusaurus/Head';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 import styles from './network.module.css';
 
-/* ── Stats API types (mirrors PeerMetadata from @antseed/node) ──── */
+/* ── API types ──────────────────────────────────────────────────────── */
 
-const STATS_URL = 'https://network.antseed.com/stats';
+const STATS_URL     = 'https://network.antseed.com/stats';
 const DEV_STATS_URL = 'http://localhost:4000/stats';
 
 interface TokenPricing {
@@ -14,7 +14,6 @@ interface TokenPricing {
   outputUsdPerMillion: number;
   cachedInputUsdPerMillion?: number;
 }
-
 interface ProviderAnnouncement {
   provider: string;
   services: string[];
@@ -24,7 +23,6 @@ interface ProviderAnnouncement {
   maxConcurrency: number;
   currentLoad: number;
 }
-
 interface OnChainStats {
   agentId: number;
   totalRequests: string;
@@ -37,7 +35,6 @@ interface OnChainStats {
   lastSeenAt: number;
   lastUpdatedAt: number;
 }
-
 interface PeerMetadata {
   peerId: string;
   displayName?: string;
@@ -51,45 +48,58 @@ interface PeerMetadata {
   onChainChannelCount?: number;
   onChainStats?: OnChainStats;
 }
+interface StatsResponse { peers: PeerMetadata[]; updatedAt: string; }
 
-interface StatsResponse {
-  peers: PeerMetadata[];
-  updatedAt: string;
-}
+/* ── Model metadata ──────────────────────────────────────────────────── */
 
-/* ── Static model enrichment (logos, context, tags) ───────────────── */
-
-interface ModelMeta {
-  displayName: string;
-  provider: string;
-  contextWindow: string;
-  tags: string[];
-}
+interface ModelMeta { displayName: string; provider: string; contextWindow: string; tags: string[]; }
 
 const MODEL_META: Record<string, ModelMeta> = {
-  'claude-opus-4-6':      {displayName:'Claude Opus 4.6',    provider:'Anthropic', contextWindow:'200K', tags:['chat','code','reasoning']},
-  'claude-sonnet-4-6':    {displayName:'Claude Sonnet 4.6',  provider:'Anthropic', contextWindow:'200K', tags:['chat','code','fast']},
-  'claude-haiku-4-5':     {displayName:'Claude Haiku 4.5',   provider:'Anthropic', contextWindow:'200K', tags:['chat','fast','cheap']},
-  'gpt-4.1':              {displayName:'GPT-4.1',            provider:'OpenAI',    contextWindow:'1M',   tags:['chat','code','reasoning']},
-  'gpt-4.1-mini':         {displayName:'GPT-4.1 Mini',       provider:'OpenAI',    contextWindow:'1M',   tags:['chat','fast','cheap']},
-  'gpt-4.1-nano':         {displayName:'GPT-4.1 Nano',       provider:'OpenAI',    contextWindow:'1M',   tags:['chat','fast','cheap']},
-  'o3':                   {displayName:'o3',                  provider:'OpenAI',    contextWindow:'200K', tags:['reasoning','code']},
-  'o4-mini':              {displayName:'o4-mini',             provider:'OpenAI',    contextWindow:'200K', tags:['reasoning','fast']},
-  'gemini-2.5-pro':       {displayName:'Gemini 2.5 Pro',     provider:'Google',    contextWindow:'1M',   tags:['chat','code','reasoning']},
-  'gemini-2.5-flash':     {displayName:'Gemini 2.5 Flash',   provider:'Google',    contextWindow:'1M',   tags:['chat','fast','cheap']},
-  'llama-4-maverick':     {displayName:'Llama 4 Maverick',   provider:'Meta',      contextWindow:'1M',   tags:['chat','code','open-source']},
-  'llama-4-scout':        {displayName:'Llama 4 Scout',      provider:'Meta',      contextWindow:'512K', tags:['chat','fast','open-source']},
-  'deepseek-r1':          {displayName:'DeepSeek R1',         provider:'DeepSeek',  contextWindow:'128K', tags:['reasoning','code','open-source']},
-  'deepseek-v3':          {displayName:'DeepSeek V3',         provider:'DeepSeek',  contextWindow:'128K', tags:['chat','code','open-source']},
-  'mistral-large':        {displayName:'Mistral Large',       provider:'Mistral',   contextWindow:'128K', tags:['chat','code','reasoning']},
-  'codestral':            {displayName:'Codestral',            provider:'Mistral',   contextWindow:'256K', tags:['code','fast']},
-  'command-a':            {displayName:'Command A',            provider:'Cohere',    contextWindow:'256K', tags:['chat','rag','enterprise']},
+  'claude-opus-4-6':   {displayName:'Claude Opus 4.6',   provider:'Anthropic', contextWindow:'200K', tags:['chat','code','reasoning']},
+  'claude-sonnet-4-6': {displayName:'Claude Sonnet 4.6', provider:'Anthropic', contextWindow:'200K', tags:['chat','code','fast']},
+  'claude-haiku-4-5':  {displayName:'Claude Haiku 4.5',  provider:'Anthropic', contextWindow:'200K', tags:['chat','fast','cheap']},
+  'gpt-4.1':           {displayName:'GPT-4.1',           provider:'OpenAI',   contextWindow:'1M',   tags:['chat','code','reasoning']},
+  'gpt-4.1-mini':      {displayName:'GPT-4.1 Mini',      provider:'OpenAI',   contextWindow:'1M',   tags:['chat','fast','cheap']},
+  'gpt-4.1-nano':      {displayName:'GPT-4.1 Nano',      provider:'OpenAI',   contextWindow:'1M',   tags:['chat','fast','cheap']},
+  'o3':                {displayName:'o3',                 provider:'OpenAI',   contextWindow:'200K', tags:['reasoning','code']},
+  'o4-mini':           {displayName:'o4-mini',            provider:'OpenAI',   contextWindow:'200K', tags:['reasoning','fast']},
+  'gemini-2.5-pro':    {displayName:'Gemini 2.5 Pro',    provider:'Google',   contextWindow:'1M',   tags:['chat','code','reasoning']},
+  'gemini-2.5-flash':  {displayName:'Gemini 2.5 Flash',  provider:'Google',   contextWindow:'1M',   tags:['chat','fast','cheap']},
+  'llama-4-maverick':  {displayName:'Llama 4 Maverick',  provider:'Meta',     contextWindow:'1M',   tags:['chat','code','open-source']},
+  'llama-4-scout':     {displayName:'Llama 4 Scout',     provider:'Meta',     contextWindow:'512K', tags:['chat','fast','open-source']},
+  'deepseek-r1':       {displayName:'DeepSeek R1',        provider:'DeepSeek', contextWindow:'128K', tags:['reasoning','code','open-source']},
+  'deepseek-v3':       {displayName:'DeepSeek V3',        provider:'DeepSeek', contextWindow:'128K', tags:['chat','code','open-source']},
+  'mistral-large':     {displayName:'Mistral Large',      provider:'Mistral',  contextWindow:'128K', tags:['chat','code','reasoning']},
+  'codestral':         {displayName:'Codestral',           provider:'Mistral',  contextWindow:'256K', tags:['code','fast']},
+  'command-a':         {displayName:'Command A',           provider:'Cohere',   contextWindow:'256K', tags:['chat','rag','enterprise']},
 };
 
-/* ── One row per service per peer ──────────────────────────────────── */
+/* ── Provider logo hints ─────────────────────────────────────────────── */
+
+interface ProviderHint { name: string; logo: string; }
+const PROVIDER_HINTS: [RegExp, ProviderHint][] = [
+  [/claude/i,            {name:'Anthropic', logo:'/logos/anthropic.png'}],
+  [/gpt|^o[34]/i,       {name:'OpenAI',    logo:'/logos/openai.png'}],
+  [/gemini|gemma/i,      {name:'Google',    logo:'/logos/google.png'}],
+  [/llama/i,             {name:'Meta',      logo:'/logos/meta.png'}],
+  [/deepseek/i,          {name:'DeepSeek',  logo:'/logos/deepseek.png'}],
+  [/mistral|codestral/i, {name:'Mistral',   logo:'/logos/mistral.png'}],
+  [/command/i,           {name:'Cohere',    logo:'/logos/cohere.png'}],
+  [/qwen/i,              {name:'Qwen',      logo:'/logos/qwen.png'}],
+  [/kimi|moonshot/i,     {name:'Moonshot',  logo:'/logos/moonshot.png'}],
+  [/minimax/i,           {name:'MiniMax',   logo:'/logos/minimax.png'}],
+];
+function guessProvider(id: string) { for (const [re, h] of PROVIDER_HINTS) if (re.test(id)) return h.name; return 'Unknown'; }
+function guessLogo(id: string) {
+  for (const [re, h] of PROVIDER_HINTS) if (re.test(id)) return h.logo;
+  const l = (id[0] ?? '?').toUpperCase();
+  return `data:image/svg+xml,${encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><rect width="40" height="40" rx="8" fill="#64748b"/><text x="20" y="27" text-anchor="middle" font-family="system-ui,sans-serif" font-weight="700" font-size="20" fill="#fff">${l}</text></svg>`)}`;
+}
+
+/* ── Row / group types ───────────────────────────────────────────────── */
 
 interface ServiceRow {
-  id: string;           // serviceId::peerName (unique key)
+  id: string;
   serviceId: string;
   name: string;
   provider: string;
@@ -98,150 +108,441 @@ interface ServiceRow {
   tags: string[];
   inputPrice: number;
   outputPrice: number;
-  peerCount: number;    // how many peers serve this same service
-  peerNames: string[];
-  peerName: string;     // the specific peer for this row
-  categories: string[];
-  // On-chain stats for this peer
+  cachedInputPrice: number | null;
+  peerCount: number;
+  peerName: string;
+  region: string;
+  stakeUsdc: number;
+  settlementCount: number;
+  firstSeenAt: number;
+  lastSeenAt: number;          // peer.timestamp (last announce)
+  onChainLastSeenAt: number;   // onChainStats.lastSeenAt
   totalTokens: number;
   uniqueBuyers: number;
+  onChainChannels: number;
+  maxConcurrency: number;
+  currentLoad: number;
 }
 
-function buildServiceRows(peers: PeerMetadata[]): ServiceRow[] {
-  // First pass: count how many peers serve each service
-  const peerCountMap = new Map<string, Set<string>>();
-  for (const peer of peers) {
-    const pName = peer.displayName ?? peer.peerId.slice(0, 12);
-    for (const ann of peer.providers) {
-      for (const service of ann.services) {
-        if (!peerCountMap.has(service)) peerCountMap.set(service, new Set());
-        peerCountMap.get(service)!.add(pName);
-      }
-    }
-  }
+interface ModelGroup {
+  serviceId: string;
+  name: string;
+  provider: string;
+  logoUrl: string;
+  contextWindow: string;
+  tags: string[];
+  rows: ServiceRow[];
+  bestInputPrice: number;
+  bestOutputPrice: number;
+  totalTokens: number;
+}
 
-  // Second pass: one row per service per peer
+/* ── Build rows ──────────────────────────────────────────────────────── */
+
+function buildServiceRows(peers: PeerMetadata[]): ServiceRow[] {
+  const peerCountMap = new Map<string, number>();
+  for (const peer of peers)
+    for (const ann of peer.providers)
+      for (const svc of ann.services)
+        peerCountMap.set(svc, (peerCountMap.get(svc) ?? 0) + 1);
+
   const rows: ServiceRow[] = [];
   for (const peer of peers) {
     const pName = peer.displayName ?? peer.peerId.slice(0, 12);
     const stats = peer.onChainStats;
 
     for (const ann of peer.providers) {
-      for (const service of ann.services) {
-        const pricing = ann.servicePricing?.[service] ?? ann.defaultPricing;
-        const meta = MODEL_META[service];
-        const cats = ann.serviceCategories?.[service] ?? [];
-        const fallbackName = service
-          .replace(/[-_]/g, ' ')
-          .replace(/\b\w/g, c => c.toUpperCase());
-        const peersForService = peerCountMap.get(service)!;
+      for (const svc of ann.services) {
+        const pricing = ann.servicePricing?.[svc] ?? ann.defaultPricing;
+        const meta    = MODEL_META[svc];
+        const cats    = ann.serviceCategories?.[svc] ?? [];
+        const fallback = svc.replace(/[-_]/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 
         rows.push({
-          id: `${service}::${pName}`,
-          serviceId: service,
-          name: meta?.displayName ?? fallbackName,
-          provider: meta?.provider ?? guessProvider(service),
-          logoUrl: guessLogo(service),
-          contextWindow: meta?.contextWindow ?? '—',
-          tags: ['anon', ...(meta?.tags ?? cats)],
-          inputPrice: pricing.inputUsdPerMillion,
-          outputPrice: pricing.outputUsdPerMillion,
-          peerCount: peersForService.size,
-          peerNames: [...peersForService],
-          peerName: pName,
-          categories: cats,
-          totalTokens: (parseInt(stats?.totalInputTokens ?? '0', 10) + parseInt(stats?.totalOutputTokens ?? '0', 10)),
-          uniqueBuyers: stats?.uniqueBuyers ?? 0,
+          id:               `${svc}::${pName}`,
+          serviceId:        svc,
+          name:             meta?.displayName ?? fallback,
+          provider:         meta?.provider    ?? guessProvider(svc),
+          logoUrl:          guessLogo(svc),
+          contextWindow:    meta?.contextWindow ?? '—',
+          tags:             ['anon', ...(meta?.tags ?? cats)],
+          inputPrice:       pricing.inputUsdPerMillion,
+          outputPrice:      pricing.outputUsdPerMillion,
+          cachedInputPrice: pricing.cachedInputUsdPerMillion ?? null,
+          peerCount:        peerCountMap.get(svc) ?? 1,
+          peerName:         pName,
+          region:           peer.region ?? '',
+          stakeUsdc:        peer.stakeAmountUSDC ?? 0,
+          settlementCount:  stats?.settlementCount ?? 0,
+          firstSeenAt:      stats?.firstSeenAt     ?? 0,
+          lastSeenAt:       peer.timestamp         ?? 0,
+          onChainLastSeenAt:stats?.lastSeenAt       ?? 0,
+          totalTokens:      (parseInt(stats?.totalInputTokens ?? '0', 10) + parseInt(stats?.totalOutputTokens ?? '0', 10)),
+          uniqueBuyers:     stats?.uniqueBuyers     ?? 0,
+          onChainChannels:  peer.onChainChannelCount ?? 0,
+          maxConcurrency:   ann.maxConcurrency       ?? 0,
+          currentLoad:      ann.currentLoad          ?? 0,
         });
       }
     }
   }
-
   return rows;
 }
 
-interface ProviderHint { name: string; logo: string; }
-
-const PROVIDER_HINTS: [RegExp, ProviderHint][] = [
-  [/claude/i,                {name:'Anthropic', logo:'/logos/anthropic.png'}],
-  [/gpt|^o[34]/i,           {name:'OpenAI',    logo:'/logos/openai.png'}],
-  [/gemini|gemma/i,          {name:'Google',    logo:'/logos/google.png'}],
-  [/llama/i,                 {name:'Meta',      logo:'/logos/meta.png'}],
-  [/deepseek/i,              {name:'DeepSeek',  logo:'/logos/deepseek.png'}],
-  [/mistral|codestral/i,     {name:'Mistral',   logo:'/logos/mistral.png'}],
-  [/command/i,               {name:'Cohere',    logo:'/logos/cohere.png'}],
-  [/qwen/i,                  {name:'Qwen',      logo:'/logos/qwen.png'}],
-  [/glm/i,                   {name:'Zhipu AI',  logo:'/logos/zhipu.png'}],
-  [/kimi|moonshot/i,         {name:'Moonshot',  logo:'/logos/moonshot.png'}],
-  [/minimax/i,               {name:'MiniMax',   logo:'/logos/minimax.png'}],
-];
-
-function guessProvider(serviceId: string): string {
-  for (const [re, hint] of PROVIDER_HINTS) if (re.test(serviceId)) return hint.name;
-  return 'Unknown';
+function groupByModel(rows: ServiceRow[]): ModelGroup[] {
+  const map = new Map<string, ServiceRow[]>();
+  for (const r of rows) { const e = map.get(r.serviceId) ?? []; e.push(r); map.set(r.serviceId, e); }
+  const groups: ModelGroup[] = [];
+  for (const [, svcRows] of map) {
+    const sorted = [...svcRows].sort((a, b) => a.inputPrice - b.inputPrice || a.outputPrice - b.outputPrice);
+    const first = sorted[0]!;
+    groups.push({
+      serviceId: first.serviceId, name: first.name, provider: first.provider,
+      logoUrl: first.logoUrl, contextWindow: first.contextWindow, tags: first.tags,
+      rows: sorted,
+      bestInputPrice:  first.inputPrice,
+      bestOutputPrice: first.outputPrice,
+      totalTokens:     svcRows.reduce((s, r) => s + r.totalTokens, 0),
+    });
+  }
+  return groups.sort((a, b) => b.rows.length - a.rows.length || a.name.localeCompare(b.name));
 }
 
-function guessLogo(serviceId: string): string {
-  for (const [re, hint] of PROVIDER_HINTS) if (re.test(serviceId)) return hint.logo;
-  const letter = (serviceId[0] ?? '?').toUpperCase();
-  return `data:image/svg+xml,${encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40"><rect width="40" height="40" rx="8" fill="#64748b"/><text x="20" y="27" text-anchor="middle" font-family="system-ui,sans-serif" font-weight="700" font-size="20" fill="#fff">${letter}</text></svg>`)}`;
-}
-
-/* ── Helpers ──────────────────────────────────────────────────────── */
+/* ── Helpers ─────────────────────────────────────────────────────────── */
 
 const TAG_CLASS: Record<string, string> = {
   anon: styles.tagAnon, coding: styles.tagCoding, code: styles.tagCode, privacy: styles.tagPrivacy,
-  tee: styles.tagTee, chat: styles.tagChat, fast: styles.tagFast,
-  cheap: styles.tagCheap, reasoning: styles.tagReasoning,
-  'open-source': styles.tagOpenSource, rag: styles.tagRag,
-  enterprise: styles.tagEnterprise,
+  tee: styles.tagTee, chat: styles.tagChat, fast: styles.tagFast, cheap: styles.tagCheap,
+  reasoning: styles.tagReasoning, 'open-source': styles.tagOpenSource,
+  rag: styles.tagRag, enterprise: styles.tagEnterprise,
 };
 
-type SortKey = 'name' | 'inputPrice' | 'outputPrice' | 'peerCount' | 'totalTokens' | 'uniqueBuyers';
-type SortDir = 'asc' | 'desc';
+type SortKey  = 'name' | 'inputPrice' | 'outputPrice' | 'peerCount' | 'totalTokens' | 'uniqueBuyers';
+type SortDir  = 'asc' | 'desc';
+type ViewMode = 'grouped' | 'flat';
 
 function formatPrice(p: number): string {
   if (p === 0 || p < 0.01) return 'Free';
   if (p < 1) return `$${p.toFixed(2)}`;
   return `$${p % 1 === 0 ? p : p.toFixed(2)}`;
 }
-
 function formatNum(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  if (n >= 1_000)     return `${(n / 1_000).toFixed(1)}K`;
   return String(n);
 }
-
-/* ── Filters state ────────────────────────────────────────────────── */
-
-interface Filters {
-  maxInputPct: number;       // 100=Any (right), drag left to limit price
-  maxOutputPct: number;      // 100=Any (right), drag left to limit price
-  minVolume: number;         // 0=Any (left), drag right to require more volume
-  supportsCaching: boolean;
+function formatUSDC(n: number): string {
+  if (!n) return '';
+  if (n >= 1000) return `$${(n / 1000).toFixed(0)}K`;
+  return `$${n.toFixed(0)}`;
+}
+function timeAgo(ts: number): string {
+  if (!ts) return '';
+  const diff = Date.now() / 1000 - ts;
+  if (diff < 120)        return 'just now';
+  if (diff < 3600)       return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400)      return `${Math.floor(diff / 3600)}h ago`;
+  if (diff < 86400 * 7)  return `${Math.floor(diff / 86400)}d ago`;
+  return `${Math.floor(diff / 86400 / 7)}w ago`;
+}
+/** green = seen < 10 min, yellow = < 2h, red = older */
+function freshnessColor(ts: number): 'green' | 'yellow' | 'red' {
+  if (!ts) return 'red';
+  const diff = Date.now() / 1000 - ts;
+  if (diff < 600)   return 'green';
+  if (diff < 7200)  return 'yellow';
+  return 'red';
 }
 
-const DEFAULT_FILTERS: Filters = {
-  maxInputPct: 100,
-  maxOutputPct: 100,
-  minVolume: 0,
-  supportsCaching: false,
-};
+interface Filters { maxInputPct: number; maxOutputPct: number; minVolume: number; supportsCaching: boolean; }
+const DEFAULT_FILTERS: Filters = { maxInputPct: 100, maxOutputPct: 100, minVolume: 0, supportsCaching: false };
 
-/* ── Component ────────────────────────────────────────────────────── */
+/* ── Quick picks ─────────────────────────────────────────────────────── */
+
+interface QuickPick {
+  id: string;
+  label: string;
+  emoji: string;
+  apply: (rows: ServiceRow[], bounds: {maxInput: number; maxTokens: number}) => (r: ServiceRow) => boolean;
+  sort?: { key: SortKey; dir: SortDir };
+}
+
+const QUICK_PICKS: QuickPick[] = [
+  {
+    id: 'cheapest',
+    label: 'Cheapest',
+    emoji: '💰',
+    apply: (rows, bounds) => {
+      const threshold = Math.min(...rows.map(r => r.inputPrice)) * 2.5;
+      return r => r.inputPrice <= threshold;
+    },
+    sort: { key: 'inputPrice', dir: 'asc' },
+  },
+  {
+    id: 'reasoning',
+    label: 'Reasoning',
+    emoji: '🧠',
+    apply: () => r => r.tags.includes('reasoning'),
+  },
+  {
+    id: 'coding',
+    label: 'Coding',
+    emoji: '💻',
+    apply: () => r => r.tags.includes('code') || r.tags.includes('coding'),
+  },
+  {
+    id: 'fast',
+    label: 'Fast',
+    emoji: '⚡',
+    apply: () => r => r.tags.includes('fast'),
+  },
+  {
+    id: 'high-volume',
+    label: 'Proven',
+    emoji: '🏆',
+    apply: (rows, bounds) => {
+      const threshold = bounds.maxTokens * 0.1;
+      return r => r.totalTokens >= threshold || r.settlementCount > 10;
+    },
+    sort: { key: 'totalTokens', dir: 'desc' },
+  },
+  {
+    id: 'new',
+    label: 'New',
+    emoji: '🆕',
+    apply: () => {
+      const cutoff = Date.now() / 1000 - 86400 * 14; // last 2 weeks
+      return r => r.firstSeenAt > cutoff;
+    },
+  },
+  {
+    id: 'open-source',
+    label: 'Open Source',
+    emoji: '🔓',
+    apply: () => r => r.tags.includes('open-source'),
+  },
+  {
+    id: 'cached',
+    label: 'Cached pricing',
+    emoji: '⚡',
+    apply: () => r => r.cachedInputPrice !== null,
+    sort: { key: 'inputPrice', dir: 'asc' },
+  },
+];
+
+/* ── Provider dropdown ───────────────────────────────────────────────── */
+
+function ProviderDropdown({ peers, value, onChange }: { peers: string[]; value: string | null; onChange: (v: string | null) => void }) {
+  const [open, setOpen]     = useState(false);
+  const [search, setSearch] = useState('');
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false); };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  const filtered = peers.filter(p => !search || p.toLowerCase().includes(search.toLowerCase()));
+
+  return (
+    <div className={styles.providerDropdownWrap} ref={ref}>
+      <button className={`${styles.providerDropdownTrigger} ${value ? styles.providerDropdownActive : ''}`} onClick={() => setOpen(v => !v)}>
+        <svg viewBox="0 0 20 20" fill="currentColor" width="13" height="13">
+          <path fillRule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clipRule="evenodd"/>
+        </svg>
+        {value ?? 'All Providers'}
+        <svg viewBox="0 0 20 20" fill="currentColor" width="11" height="11" style={{marginLeft:'auto', opacity:0.4}}>
+          <path fillRule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clipRule="evenodd"/>
+        </svg>
+      </button>
+      {open && (
+        <div className={styles.providerDropdownMenu}>
+          <div className={styles.providerDropdownSearch}>
+            <input autoFocus placeholder="Search providers…" value={search} onChange={e => setSearch(e.target.value)} className={styles.providerDropdownInput}/>
+          </div>
+          <div className={styles.providerDropdownList}>
+            <button className={`${styles.providerDropdownItem} ${!value ? styles.providerDropdownItemActive : ''}`} onClick={() => { onChange(null); setOpen(false); setSearch(''); }}>All Providers</button>
+            {filtered.map(p => (
+              <button key={p} className={`${styles.providerDropdownItem} ${value === p ? styles.providerDropdownItemActive : ''}`} onClick={() => { onChange(p === value ? null : p); setOpen(false); setSearch(''); }}>{p}</button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Freshness dot ───────────────────────────────────────────────────── */
+
+function FreshnessDot({ ts, label }: { ts: number; label?: string }) {
+  const color = freshnessColor(ts);
+  const ago   = timeAgo(ts);
+  return (
+    <span
+      className={`${styles.freshDot} ${color === 'green' ? styles.freshGreen : color === 'yellow' ? styles.freshYellow : styles.freshRed}`}
+      title={ago ? `Last seen: ${ago}` : 'No activity data'}
+      aria-label={ago}
+    />
+  );
+}
+
+/* ── Price bar (shows relative cheapness in range) ───────────────────── */
+
+function PriceBar({ value, min, max }: { value: number; min: number; max: number }) {
+  if (max <= min) return null;
+  const pct = Math.round(((value - min) / (max - min)) * 100);
+  const isBest = pct <= 15;
+  return (
+    <span className={styles.priceBarWrap} title={`${pct}% of price range`}>
+      <span className={`${styles.priceBarFill} ${isBest ? styles.priceBarBest : ''}`} style={{width: `${Math.max(4, pct)}%`}} />
+    </span>
+  );
+}
+
+/* ── Model group section ─────────────────────────────────────────────── */
+
+const INITIAL_SHOWN = 3;
+
+function ModelGroupSection({ group, inputMin, inputMax }: { group: ModelGroup; inputMin: number; inputMax: number }) {
+  const [expanded, setExpanded] = useState(false);
+  const shown  = expanded ? group.rows : group.rows.slice(0, INITIAL_SHOWN);
+  const hidden = group.rows.length - INITIAL_SHOWN;
+
+  return (
+    <div className={styles.modelGroupCard}>
+      {/* Header */}
+      <div className={styles.modelGroupHeader}>
+        <div className={styles.modelGroupLeft}>
+          {group.logoUrl && <img src={group.logoUrl} alt={group.provider} className={styles.modelLogo} onError={e => { (e.target as HTMLImageElement).style.display='none'; }}/>}
+          <div className={styles.modelGroupInfo}>
+            <div className={styles.modelGroupName}>{group.name}</div>
+            <div className={styles.modelGroupMeta}>
+              <span className={styles.modelProvider}>{group.provider}</span>
+              {group.contextWindow !== '—' && <span className={styles.ctxBadge}>{group.contextWindow} ctx</span>}
+              {group.tags.slice(0, 3).map(t => (
+                <span key={t} className={`${styles.tagBadge} ${TAG_CLASS[t] ?? styles.tagDefault}`}>{t}</span>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className={styles.modelGroupRight}>
+          <div className={styles.modelGroupPricing}>
+            <span className={styles.priceFrom}>from</span>
+            <span className={group.bestInputPrice <= inputMin * 1.5 ? styles.priceGood : styles.priceNormal}>{formatPrice(group.bestInputPrice)}</span>
+            <span className={styles.pricingSlash}>/</span>
+            <span className={styles.priceNormal}>{formatPrice(group.bestOutputPrice)}</span>
+            <span className={styles.pricingUnit}>/M</span>
+          </div>
+          <div className={styles.modelGroupStats}>
+            <span className={styles.modelGroupProviderCount}>{group.rows.length} provider{group.rows.length !== 1 ? 's' : ''}</span>
+            {group.totalTokens > 0 && <span className={styles.modelGroupTokens}>{formatNum(group.totalTokens)} tokens</span>}
+          </div>
+        </div>
+      </div>
+
+      {/* Provider sub-table */}
+      <div className={styles.providerRows}>
+        <div className={styles.providerRowsHeader}>
+          <span>Provider</span>
+          <span className={styles.colRight}>Input /M</span>
+          <span className={styles.colRight}>Output /M</span>
+          <span className={`${styles.colRight} ${styles.colHideMd}`}>Cached</span>
+          <span className={`${styles.colRight} ${styles.colHideMd}`}>Channels</span>
+          <span className={`${styles.colRight} ${styles.colHideSm}`}>Settlements</span>
+          <span className={`${styles.colRight} ${styles.colHideSm}`}>Stake</span>
+          <span className={`${styles.colRight} ${styles.colHideSm}`}>Live</span>
+        </div>
+
+        {shown.map((row, idx) => {
+          const isBest  = idx === 0;
+          const color   = freshnessColor(row.lastSeenAt);
+          return (
+            <div key={row.id} className={`${styles.providerRowItem} ${isBest ? styles.providerRowBest : ''}`}>
+              {/* Provider name + freshness */}
+              <div className={styles.providerRowName}>
+                {isBest && <span className={styles.bestBadge}>Best</span>}
+                <FreshnessDot ts={row.lastSeenAt} />
+                <span className={styles.providerRowNameText} title={row.region ? `Region: ${row.region}` : undefined}>
+                  {row.peerName}
+                </span>
+              </div>
+
+              {/* Input price + bar */}
+              <div className={`${styles.providerRowPrice} ${styles.colRight}`}>
+                <div className={styles.priceWithBar}>
+                  <span className={isBest ? styles.priceGood : styles.priceNormal}>{formatPrice(row.inputPrice)}</span>
+                  <PriceBar value={row.inputPrice} min={inputMin} max={inputMax} />
+                </div>
+              </div>
+
+              {/* Output price */}
+              <div className={`${styles.providerRowPrice} ${styles.colRight}`}>
+                <span className={styles.priceNormal}>{formatPrice(row.outputPrice)}</span>
+              </div>
+
+              {/* Cached pricing */}
+              <div className={`${styles.providerRowStat} ${styles.colRight} ${styles.colHideMd}`}>
+                {row.cachedInputPrice !== null
+                  ? <span className={styles.cachedBadge} title="Cached input price">⚡ {formatPrice(row.cachedInputPrice)}</span>
+                  : <span className={styles.statNA}>—</span>}
+              </div>
+
+              {/* On-chain channels */}
+              <div className={`${styles.providerRowStat} ${styles.colRight} ${styles.colHideMd}`}>
+                {row.onChainChannels > 0 ? formatNum(row.onChainChannels) : <span className={styles.statNA}>—</span>}
+              </div>
+
+              {/* Settlements */}
+              <div className={`${styles.providerRowStat} ${styles.colRight} ${styles.colHideSm}`}>
+                {row.settlementCount > 0 ? formatNum(row.settlementCount) : <span className={styles.statNA}>—</span>}
+              </div>
+
+              {/* Stake */}
+              <div className={`${styles.providerRowStat} ${styles.colRight} ${styles.colHideSm}`}>
+                {row.stakeUsdc > 0
+                  ? <span className={styles.stakeBadge}>{formatUSDC(row.stakeUsdc)}</span>
+                  : <span className={styles.statNA}>—</span>}
+              </div>
+
+              {/* Live dot (large) */}
+              <div className={`${styles.providerRowStat} ${styles.colRight} ${styles.colHideSm}`}>
+                <span className={`${styles.livePill} ${color === 'green' ? styles.livePillGreen : color === 'yellow' ? styles.livePillYellow : styles.livePillRed}`}>
+                  {color === 'green' ? 'Live' : color === 'yellow' ? timeAgo(row.lastSeenAt) : 'Stale'}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+
+        {group.rows.length > INITIAL_SHOWN && (
+          <button className={styles.expandBtn} onClick={() => setExpanded(v => !v)}>
+            {expanded ? 'Show less ↑' : `Show ${hidden} more provider${hidden !== 1 ? 's' : ''} ↓`}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Main page ───────────────────────────────────────────────────────── */
 
 export default function PricingPage() {
-  const [peers, setPeers] = useState<PeerMetadata[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
-  const [updatedAt, setUpdatedAt] = useState<string | null>(null);
-  const [query, setQuery] = useState('');
+  const [peers, setPeers]             = useState<PeerMetadata[]>([]);
+  const [loading, setLoading]         = useState(true);
+  const [error, setError]             = useState(false);
+  const [updatedAt, setUpdatedAt]     = useState<string | null>(null);
+  const [query, setQuery]             = useState('');
   const [providerFilter, setProviderFilter] = useState<string | null>(null);
-  const [tagFilter, setTagFilter] = useState<string | null>(null);
-  const [sortKey, setSortKey] = useState<SortKey>('inputPrice');
-  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  const [tagFilter, setTagFilter]     = useState<string | null>(null);
+  const [sortKey, setSortKey]         = useState<SortKey>('inputPrice');
+  const [sortDir, setSortDir]         = useState<SortDir>('asc');
   const [showFilters, setShowFilters] = useState(false);
-  const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
+  const [filters, setFilters]         = useState<Filters>(DEFAULT_FILTERS);
+  const [viewMode, setViewMode]       = useState<ViewMode>('grouped');
+  const [activeQuickPick, setActiveQuickPick] = useState<string | null>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     const refresh = async () => {
@@ -250,159 +551,145 @@ export default function PricingPage() {
           const res = await fetch(url, {signal: AbortSignal.timeout(5000)});
           if (!res.ok) continue;
           const data = (await res.json()) as StatsResponse;
-          setPeers(data.peers);
-          setUpdatedAt(data.updatedAt);
-          setLoading(false);
-          setError(false);
+          setPeers(data.peers); setUpdatedAt(data.updatedAt); setLoading(false); setError(false);
           return;
         } catch { /* try next */ }
       }
-      setLoading(false);
-      setError(true);
+      setLoading(false); setError(true);
     };
     refresh();
-    const interval = setInterval(refresh, 30_000);
-    return () => clearInterval(interval);
+    const t = setInterval(refresh, 30_000);
+    return () => clearInterval(t);
   }, []);
 
   const models = useMemo(() => buildServiceRows(peers), [peers]);
 
-  const allPeerNames = useMemo(() => [...new Set(peers.map(p => p.displayName ?? p.peerId.slice(0, 12)))].sort(), [peers]);
-  const allTags = useMemo(() => [...new Set(models.flatMap(m => m.tags))].sort(), [models]);
-  const uniqueServiceCount = useMemo(() => models.map(m => m.serviceId).length, [models]);
-
-  // Totals and bounds for stats bar + sliders
-  const totalTokens = useMemo(() => peers.reduce((s, p) => s + parseInt(p.onChainStats?.totalInputTokens ?? '0', 10) + parseInt(p.onChainStats?.totalOutputTokens ?? '0', 10), 0), [peers]);
-
+  const allPeerNames = useMemo(() =>
+    [...new Set(peers.map(p => p.displayName ?? p.peerId.slice(0, 12)))].sort(), [peers]);
+  const allTags = useMemo(() =>
+    [...new Set(models.flatMap(m => m.tags))].sort(), [models]);
+  const totalTokens = useMemo(() =>
+    peers.reduce((s, p) => s + parseInt(p.onChainStats?.totalInputTokens ?? '0', 10) + parseInt(p.onChainStats?.totalOutputTokens ?? '0', 10), 0), [peers]);
   const bounds = useMemo(() => ({
-    maxInput: Math.max(...models.map(m => m.inputPrice), 1),
+    maxInput:  Math.max(...models.map(m => m.inputPrice), 1),
     maxOutput: Math.max(...models.map(m => m.outputPrice), 1),
     maxTokens: Math.max(...models.map(m => m.totalTokens), 1),
-    maxBuyers: Math.max(...models.map(m => m.uniqueBuyers), 1),
+  }), [models]);
+
+  const inputPriceRange = useMemo(() => ({
+    min: models.length ? Math.min(...models.map(m => m.inputPrice)) : 0,
+    max: models.length ? Math.max(...models.map(m => m.inputPrice)) : 1,
   }), [models]);
 
   const toggleSort = (key: SortKey) => {
     if (sortKey === key) setSortDir(d => d === 'asc' ? 'desc' : 'asc');
     else { setSortKey(key); setSortDir(key === 'name' ? 'asc' : 'desc'); }
   };
+  const sortIcon = (key: SortKey) => sortKey !== key ? '↕' : sortDir === 'asc' ? '↑' : '↓';
 
-  const sortIcon = (key: SortKey) => {
-    if (sortKey !== key) return '↕';
-    return sortDir === 'asc' ? '↑' : '↓';
+  const handleQuickPick = (id: string) => {
+    const next = activeQuickPick === id ? null : id;
+    setActiveQuickPick(next);
+    const pick = QUICK_PICKS.find(p => p.id === id);
+    if (pick?.sort && next) { setSortKey(pick.sort.key); setSortDir(pick.sort.dir); }
+    else if (!next) { setSortKey('inputPrice'); setSortDir('asc'); }
   };
 
   const filtered = useMemo(() => {
-    const q = query.toLowerCase();
+    const q    = query.toLowerCase();
+    const pick = activeQuickPick ? QUICK_PICKS.find(p => p.id === activeQuickPick) : null;
+    const pickFn = pick ? pick.apply(models, bounds) : null;
+
     let list = models.filter(m => {
-      if (q && !m.name.toLowerCase().includes(q) && !m.provider.toLowerCase().includes(q) && !m.id.toLowerCase().includes(q) && !m.tags.some(t => t.includes(q))) return false;
-      if (providerFilter && !m.peerNames.includes(providerFilter)) return false;
+      if (q && !m.name.toLowerCase().includes(q) && !m.provider.toLowerCase().includes(q) &&
+          !m.serviceId.toLowerCase().includes(q) && !m.tags.some(t => t.includes(q)) &&
+          !m.peerName.toLowerCase().includes(q)) return false;
+      if (providerFilter && m.peerName !== providerFilter) return false;  // ← bug-fix: was peerNames.includes
       if (tagFilter && !m.tags.includes(tagFilter)) return false;
-      // Price sliders: 100=Any, lower=stricter
-      if (filters.maxInputPct < 100 && m.inputPrice > bounds.maxInput * filters.maxInputPct / 100) return false;
+      if (filters.maxInputPct  < 100 && m.inputPrice  > bounds.maxInput  * filters.maxInputPct  / 100) return false;
       if (filters.maxOutputPct < 100 && m.outputPrice > bounds.maxOutput * filters.maxOutputPct / 100) return false;
-      // Volume slider: 0=Any, higher=require more tokens served
-      if (filters.minVolume > 0 && m.totalTokens < bounds.maxTokens * filters.minVolume / 100) return false;
+      if (filters.minVolume    > 0   && m.totalTokens < bounds.maxTokens * filters.minVolume    / 100) return false;
+      if (filters.supportsCaching && m.cachedInputPrice === null) return false;
+      if (pickFn && !pickFn(m)) return false;
       return true;
     });
 
     list.sort((a, b) => {
       let cmp = 0;
       switch (sortKey) {
-        case 'name': cmp = a.name.localeCompare(b.name); break;
-        case 'inputPrice': cmp = a.inputPrice - b.inputPrice; break;
-        case 'outputPrice': cmp = a.outputPrice - b.outputPrice; break;
-        case 'peerCount': cmp = a.peerCount - b.peerCount; break;
-        case 'totalTokens': cmp = a.totalTokens - b.totalTokens; break;
+        case 'name':         cmp = a.name.localeCompare(b.name); break;
+        case 'inputPrice':   cmp = a.inputPrice  - b.inputPrice; break;
+        case 'outputPrice':  cmp = a.outputPrice - b.outputPrice; break;
+        case 'peerCount':    cmp = a.peerCount   - b.peerCount; break;
+        case 'totalTokens':  cmp = a.totalTokens - b.totalTokens; break;
         case 'uniqueBuyers': cmp = a.uniqueBuyers - b.uniqueBuyers; break;
       }
       return sortDir === 'asc' ? cmp : -cmp;
     });
-
     return list;
-  }, [models, query, providerFilter, tagFilter, sortKey, sortDir, filters]);
+  }, [models, query, providerFilter, tagFilter, sortKey, sortDir, filters, bounds, activeQuickPick]);
 
-  const cheapestInput = models.length > 0 ? Math.min(...models.map(m => m.inputPrice)) : 0;
-  const totalPeers = peers.length;
-
-  const updatedLabel = updatedAt
-    ? `Updated ${new Date(updatedAt).toLocaleTimeString()}`
-    : null;
-
-  const hasActiveFilters = filters.maxInputPct < 100 || filters.maxOutputPct < 100 || filters.minVolume > 0 || filters.supportsCaching;
+  const modelGroups       = useMemo(() => groupByModel(filtered), [filtered]);
+  const cheapestInput     = models.length ? Math.min(...models.map(m => m.inputPrice)) : 0;
+  const totalPeers        = peers.length;
+  const uniqueServiceIds  = useMemo(() => new Set(models.map(m => m.serviceId)).size, [models]);
+  const liveCount         = useMemo(() => peers.filter(p => freshnessColor(p.timestamp) === 'green').length, [peers]);
+  const hasActiveFilters  = filters.maxInputPct < 100 || filters.maxOutputPct < 100 || filters.minVolume > 0 || filters.supportsCaching;
+  const updatedLabel      = updatedAt ? `Updated ${new Date(updatedAt).toLocaleTimeString()}` : null;
 
   const datasetLd = useMemo(() => ({
-    '@context': 'https://schema.org',
-    '@type': 'Dataset',
+    '@context': 'https://schema.org', '@type': 'Dataset',
     name: 'AntSeed Live AI Inference Pricing',
-    description:
-      'Live pricing and provider availability for AI models across the AntSeed peer-to-peer network. Prices per million tokens, updated every 30 seconds.',
+    description: 'Live pricing and provider availability for AI models across the AntSeed peer-to-peer network.',
     url: 'https://antseed.com/network',
-    keywords: [
-      'AI inference pricing',
-      'LLM API pricing',
-      'peer-to-peer AI',
-      'decentralized AI',
-      'OpenRouter alternative',
-      'USDC AI payments',
-    ],
-    creator: {
-      '@type': 'Organization',
-      name: 'AntSeed',
-      url: 'https://antseed.com',
-    },
-    distribution: {
-      '@type': 'DataDownload',
-      encodingFormat: 'application/json',
-      contentUrl: 'https://network.antseed.com/stats',
-    },
-    variableMeasured: [
-      {'@type': 'PropertyValue', name: 'inputPricePerMillionTokens', unitText: 'USD'},
-      {'@type': 'PropertyValue', name: 'outputPricePerMillionTokens', unitText: 'USD'},
-      {'@type': 'PropertyValue', name: 'activePeers', unitText: 'count'},
-    ],
+    keywords: ['AI inference pricing','LLM API pricing','peer-to-peer AI','decentralized AI','OpenRouter alternative','USDC AI payments'],
+    creator: {'@type':'Organization', name:'AntSeed', url:'https://antseed.com'},
+    distribution: {'@type':'DataDownload', encodingFormat:'application/json', contentUrl:'https://network.antseed.com/stats'},
   }), []);
 
   return (
-    <Layout
-      title="Live AI Inference Pricing"
-      description="Live pricing across the AntSeed peer-to-peer network. Compare AI model rates per million tokens across decentralized providers. Onchain payments. Verifiable reputation.">
+    <Layout title="Live AI Inference Pricing" description="Live pricing across the AntSeed peer-to-peer network.">
       <Head>
         <title>Live AI Inference Pricing Across the AntSeed Network | AntSeed</title>
         <link rel="canonical" href="https://antseed.com/network" />
         <link rel="alternate" type="application/json" title="AntSeed live pricing (JSON)" href="https://network.antseed.com/stats" />
         <script type="application/ld+json">{JSON.stringify(datasetLd)}</script>
       </Head>
+
       <div className={styles.page}>
-        {/* Hero */}
+        {/* ── Hero ── */}
         <div className={styles.header}>
           <Link to="/" className={styles.back}>← Back</Link>
           <p className={styles.eyebrow}>Live Network Data</p>
           <h1 className={styles.title}>Live pricing across the peer-to-peer network.</h1>
           <p className={styles.subtitle}>
-            {loading
-              ? 'Loading live network data...'
-              : error
-                ? 'Unable to reach the network. Showing cached data if available.'
-                : <>Live pricing from {totalPeers} peer{totalPeers !== 1 ? 's' : ''} across {uniqueServiceCount} models. Onchain settlement — best rate per million tokens.</>
+            {loading ? 'Loading live network data...' : error
+              ? 'Unable to reach the network. Showing cached data if available.'
+              : <>Live pricing from <strong>{totalPeers} peer{totalPeers !== 1 ? 's' : ''}</strong> across <strong>{uniqueServiceIds} models</strong>. On-chain settlement — best rate per million tokens.</>
             }
           </p>
         </div>
 
-        {/* Stats */}
+        {/* ── Stats bar ── */}
         <div className={styles.statsBar}>
           <div className={styles.stat}>
-            <div className={styles.statNum}>{loading ? '—' : uniqueServiceCount}</div>
-            <div className={styles.statLabel}>Services</div>
+            <div className={styles.statNum}>{loading ? '—' : uniqueServiceIds}</div>
+            <div className={styles.statLabel}>Models</div>
           </div>
           <div className={styles.statDivider} />
           <div className={styles.stat}>
             <div className={styles.statNum}>{loading ? '—' : totalPeers}</div>
-            <div className={styles.statLabel}>Active Peers</div>
+            <div className={styles.statLabel}>Peers</div>
+          </div>
+          <div className={styles.statDivider} />
+          <div className={styles.stat}>
+            <div className={`${styles.statNum} ${styles.statGreen}`}>{loading ? '—' : liveCount}</div>
+            <div className={styles.statLabel}>Live now</div>
           </div>
           <div className={styles.statDivider} />
           <div className={styles.stat}>
             <div className={styles.statNum}>{loading ? '—' : formatNum(totalTokens)}</div>
-            <div className={styles.statLabel}>Tokens Served</div>
+            <div className={styles.statLabel}>Tokens served</div>
           </div>
           <div className={styles.statDivider} />
           <div className={styles.stat}>
@@ -410,217 +697,193 @@ export default function PricingPage() {
               <span className={styles.liveDot} />
               {loading ? 'Connecting' : error ? 'Offline' : 'Live'}
             </div>
-            <div className={styles.statLabel}>
-              {updatedLabel ?? (loading ? 'Connecting...' : 'Stats unavailable')}
-            </div>
+            <div className={styles.statLabel}>{updatedLabel ?? (loading ? 'Connecting...' : 'Stats unavailable')}</div>
           </div>
         </div>
 
-        {/* Search + Filters */}
-        <div className={styles.filterBar}>
+        {/* ── Quick picks bar ── */}
+        <div className={styles.quickPicks}>
+          {QUICK_PICKS.map(pick => (
+            <button
+              key={pick.id}
+              className={`${styles.quickPickBtn} ${activeQuickPick === pick.id ? styles.quickPickBtnActive : ''}`}
+              onClick={() => handleQuickPick(pick.id)}
+            >
+              <span>{pick.emoji}</span>
+              {pick.label}
+            </button>
+          ))}
+        </div>
+
+        {/* ── Sticky search + controls ── */}
+        <div className={styles.stickyBar}>
           <div className={styles.searchRow}>
             <div className={styles.searchWrap}>
               <svg className={styles.searchIcon} viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
                 <path fillRule="evenodd" d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z" clipRule="evenodd"/>
               </svg>
-              <input
-                className={styles.searchInput}
-                placeholder="Search services, providers, or capabilities..."
-                value={query}
-                onChange={e => setQuery(e.target.value)}
-              />
-              {query && (
-                <button className={styles.clearBtn} onClick={() => setQuery('')} aria-label="Clear search">×</button>
-              )}
+              <input ref={searchRef} className={styles.searchInput} placeholder="Search models, providers…"
+                value={query} onChange={e => setQuery(e.target.value)}/>
+              {query && <button className={styles.clearBtn} onClick={() => setQuery('')}>×</button>}
             </div>
-            <button
-              className={`${styles.filterToggle} ${hasActiveFilters ? styles.filterToggleActive : ''}`}
-              onClick={() => setShowFilters(v => !v)}
-            >
-              <svg viewBox="0 0 20 20" fill="currentColor" width="16" height="16">
+
+            {allPeerNames.length > 0 && (
+              <ProviderDropdown peers={allPeerNames} value={providerFilter} onChange={setProviderFilter}/>
+            )}
+
+            <div className={styles.viewToggle}>
+              <button className={`${styles.viewBtn} ${viewMode === 'grouped' ? styles.viewBtnActive : ''}`} onClick={() => setViewMode('grouped')} title="Group by model">
+                <svg viewBox="0 0 16 16" fill="none" width="13" height="13"><rect x="1" y="2" width="14" height="3.5" rx="1" stroke="currentColor" strokeWidth="1.4"/><rect x="1" y="7.5" width="14" height="3.5" rx="1" stroke="currentColor" strokeWidth="1.4"/></svg>
+                <span className={styles.viewBtnLabel}>By Model</span>
+              </button>
+              <button className={`${styles.viewBtn} ${viewMode === 'flat' ? styles.viewBtnActive : ''}`} onClick={() => setViewMode('flat')} title="Flat table">
+                <svg viewBox="0 0 16 16" fill="none" width="13" height="13"><line x1="1" y1="4" x2="15" y2="4" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/><line x1="1" y1="8" x2="15" y2="8" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/><line x1="1" y1="12" x2="15" y2="12" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round"/></svg>
+                <span className={styles.viewBtnLabel}>All</span>
+              </button>
+            </div>
+
+            <button className={`${styles.filterToggle} ${hasActiveFilters ? styles.filterToggleActive : ''}`} onClick={() => setShowFilters(v => !v)}>
+              <svg viewBox="0 0 20 20" fill="currentColor" width="14" height="14">
                 <path fillRule="evenodd" d="M3 3a1 1 0 011-1h12a1 1 0 011 1v3a1 1 0 01-.293.707L12 11.414V15a1 1 0 01-.293.707l-2 2A1 1 0 018 17v-5.586L3.293 6.707A1 1 0 013 6V3z" clipRule="evenodd"/>
               </svg>
-              Filters{hasActiveFilters ? ' ●' : ''}
+              <span className={styles.filterToggleLabel}>Filters{hasActiveFilters ? ' ●' : ''}</span>
             </button>
           </div>
 
-          {/* Advanced filters panel — hidden on mobile */}
           {showFilters && (
             <div className={styles.advancedFilters}>
               <div className={styles.filterGroup}>
                 <div className={styles.filterHeader}>
                   <span className={styles.filterLabel}>Input Price /M</span>
-                  <span className={styles.filterValue}>
-                    {filters.maxInputPct >= 100 ? 'Any' : `≤ $${(bounds.maxInput * filters.maxInputPct / 100).toFixed(2)}`}
-                  </span>
+                  <span className={styles.filterValue}>{filters.maxInputPct >= 100 ? 'Any' : `≤ $${(bounds.maxInput * filters.maxInputPct / 100).toFixed(2)}`}</span>
                 </div>
-                <input type="range" min="0" max="100" step="1"
-                  className={styles.filterRange}
-                  value={filters.maxInputPct}
-                  onChange={e => setFilters(f => ({...f, maxInputPct: Number(e.target.value)}))}
-                />
+                <input type="range" min="0" max="100" step="1" className={styles.filterRange} value={filters.maxInputPct} onChange={e => setFilters(f => ({...f, maxInputPct: Number(e.target.value)}))}/>
               </div>
               <div className={styles.filterGroup}>
                 <div className={styles.filterHeader}>
                   <span className={styles.filterLabel}>Output Price /M</span>
-                  <span className={styles.filterValue}>
-                    {filters.maxOutputPct >= 100 ? 'Any' : `≤ $${(bounds.maxOutput * filters.maxOutputPct / 100).toFixed(2)}`}
-                  </span>
+                  <span className={styles.filterValue}>{filters.maxOutputPct >= 100 ? 'Any' : `≤ $${(bounds.maxOutput * filters.maxOutputPct / 100).toFixed(2)}`}</span>
                 </div>
-                <input type="range" min="0" max="100" step="1"
-                  className={styles.filterRange}
-                  value={filters.maxOutputPct}
-                  onChange={e => setFilters(f => ({...f, maxOutputPct: Number(e.target.value)}))}
-                />
+                <input type="range" min="0" max="100" step="1" className={styles.filterRange} value={filters.maxOutputPct} onChange={e => setFilters(f => ({...f, maxOutputPct: Number(e.target.value)}))}/>
               </div>
               <div className={styles.filterGroup}>
                 <div className={styles.filterHeader}>
-                  <span className={styles.filterLabel}>Tokens Served</span>
-                  <span className={styles.filterValue}>
-                    {filters.minVolume <= 0 ? 'Any' : `≥ ${formatNum(Math.round(bounds.maxTokens * filters.minVolume / 100))}`}
-                  </span>
+                  <span className={styles.filterLabel}>Min Volume</span>
+                  <span className={styles.filterValue}>{filters.minVolume <= 0 ? 'Any' : `≥ ${formatNum(Math.round(bounds.maxTokens * filters.minVolume / 100))}`}</span>
                 </div>
-                <input type="range" min="0" max="100" step="1"
-                  className={styles.filterRange}
-                  value={filters.minVolume}
-                  onChange={e => setFilters(f => ({...f, minVolume: Number(e.target.value)}))}
-                />
+                <input type="range" min="0" max="100" step="1" className={styles.filterRange} value={filters.minVolume} onChange={e => setFilters(f => ({...f, minVolume: Number(e.target.value)}))}/>
               </div>
               <div className={styles.filterGroupToggle}>
                 <label className={styles.checkboxLabel}>
-                  <input type="checkbox"
-                    className={styles.checkbox}
-                    checked={filters.supportsCaching}
-                    onChange={e => setFilters(f => ({...f, supportsCaching: e.target.checked}))}
-                  />
-                  Supports prompt caching
+                  <input type="checkbox" className={styles.checkbox} checked={filters.supportsCaching} onChange={e => setFilters(f => ({...f, supportsCaching: e.target.checked}))}/>
+                  Cached pricing only
                 </label>
               </div>
-              {hasActiveFilters && (
-                <button className={styles.clearFilters} onClick={() => setFilters(DEFAULT_FILTERS)}>Clear all</button>
-              )}
+              {hasActiveFilters && <button className={styles.clearFilters} onClick={() => setFilters(DEFAULT_FILTERS)}>Clear all</button>}
             </div>
           )}
 
-          {allPeerNames.length > 0 && (
-            <div className={styles.filterChips}>
-              <button
-                className={`${styles.chip} ${!providerFilter ? styles.chipActive : ''}`}
-                onClick={() => setProviderFilter(null)}
-              >All Providers</button>
-              {allPeerNames.map(p => (
-                <button
-                  key={p}
-                  className={`${styles.chip} ${providerFilter === p ? styles.chipActive : ''}`}
-                  onClick={() => setProviderFilter(providerFilter === p ? null : p)}
-                >{p}</button>
-              ))}
-            </div>
-          )}
-
+          {/* Tag chips */}
           {allTags.length > 0 && (
-            <div className={styles.filterChips}>
-              <button
-                className={`${styles.chip} ${!tagFilter ? styles.chipActive : ''}`}
-                onClick={() => setTagFilter(null)}
-              >All Tags</button>
+            <div className={styles.tagChips}>
+              <button className={`${styles.chip} ${!tagFilter ? styles.chipActive : ''}`} onClick={() => setTagFilter(null)}>All</button>
               {allTags.map(t => (
-                <button
-                  key={t}
-                  className={`${styles.chip} ${tagFilter === t ? styles.chipActive : ''}`}
-                  onClick={() => setTagFilter(tagFilter === t ? null : t)}
-                >{t}</button>
+                <button key={t} className={`${styles.chip} ${tagFilter === t ? styles.chipActive : ''}`} onClick={() => setTagFilter(tagFilter === t ? null : t)}>{t}</button>
               ))}
             </div>
           )}
         </div>
 
-        {/* Results count */}
-        <div className={styles.resultsCount}>
-          {loading ? 'Loading...' : `${filtered.length} service${filtered.length !== 1 ? 's' : ''} found`}
+        {/* ── Results summary ── */}
+        <div className={styles.resultsRow}>
+          <span className={styles.resultsCount}>
+            {loading ? 'Loading…' : viewMode === 'grouped'
+              ? `${modelGroups.length} model${modelGroups.length !== 1 ? 's' : ''}`
+              : `${filtered.length} service${filtered.length !== 1 ? 's' : ''}`}
+          </span>
+          {(activeQuickPick || providerFilter || tagFilter || hasActiveFilters || query) && (
+            <button className={styles.clearAllFilters} onClick={() => {
+              setActiveQuickPick(null); setProviderFilter(null); setTagFilter(null);
+              setQuery(''); setFilters(DEFAULT_FILTERS);
+            }}>
+              Clear all filters ×
+            </button>
+          )}
         </div>
 
-        {/* Table */}
-        <div className={styles.tableWrap}>
-          <table className={styles.table}>
-            <thead>
-              <tr>
-                <th className={styles.thModel} onClick={() => toggleSort('name')}>
-                  Service {sortIcon('name')}
-                </th>
-                <th className={styles.thPrice} onClick={() => toggleSort('inputPrice')}>
-                  Input /M {sortIcon('inputPrice')}
-                </th>
-                <th className={styles.thPrice} onClick={() => toggleSort('outputPrice')}>
-                  Output /M {sortIcon('outputPrice')}
-                </th>
-                <th className={styles.thStat} onClick={() => toggleSort('totalTokens')}>
-                  Tokens {sortIcon('totalTokens')}
-                </th>
-                <th className={styles.thStat} onClick={() => toggleSort('uniqueBuyers')}>
-                  Users {sortIcon('uniqueBuyers')}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {loading ? (
+        {/* ── Grouped view ── */}
+        {viewMode === 'grouped' && (
+          loading ? (
+            <div className={styles.groupedList}>
+              {Array.from({length: 4}).map((_, i) => (
+                <div key={i} className={`${styles.modelGroupCard} ${styles.skeletonCard}`}>
+                  <div className={styles.modelGroupHeader}><div className={styles.skeletonLine} style={{width:200}}/></div>
+                </div>
+              ))}
+            </div>
+          ) : modelGroups.length === 0 ? (
+            <div className={styles.emptyState}>
+              {error ? 'Could not reach the network.' : 'No models match your filters.'}
+              {(activeQuickPick || query) && <button className={styles.clearFiltersInline} onClick={() => { setActiveQuickPick(null); setQuery(''); }}>Clear filters</button>}
+            </div>
+          ) : (
+            <div className={styles.groupedList}>
+              {modelGroups.map(group => (
+                <ModelGroupSection key={group.serviceId} group={group} inputMin={inputPriceRange.min} inputMax={inputPriceRange.max}/>
+              ))}
+            </div>
+          )
+        )}
+
+        {/* ── Flat table ── */}
+        {viewMode === 'flat' && (
+          <div className={styles.tableWrap}>
+            <table className={styles.table}>
+              <thead>
                 <tr>
-                  <td colSpan={5} className={styles.emptyRow}>
-                    Discovering peers on the network...
-                  </td>
+                  <th className={styles.thModel}  onClick={() => toggleSort('name')}>Service {sortIcon('name')}</th>
+                  <th className={styles.thPrice}  onClick={() => toggleSort('inputPrice')}>Input /M {sortIcon('inputPrice')}</th>
+                  <th className={styles.thPrice}  onClick={() => toggleSort('outputPrice')}>Output /M {sortIcon('outputPrice')}</th>
+                  <th className={styles.thStat}   onClick={() => toggleSort('totalTokens')}>Tokens {sortIcon('totalTokens')}</th>
+                  <th className={styles.thStat}   onClick={() => toggleSort('uniqueBuyers')}>Users {sortIcon('uniqueBuyers')}</th>
                 </tr>
-              ) : filtered.length === 0 ? (
-                <tr>
-                  <td colSpan={5} className={styles.emptyRow}>
-                    {error ? 'Could not reach the network stats server.' : 'No services match your search. Try a different query or clear filters.'}
-                  </td>
-                </tr>
-              ) : filtered.map(m => (
-                <tr key={m.id} className={styles.row}>
-                  <td className={styles.tdModel}>
-                    <div className={styles.modelCell}>
-                      {m.logoUrl && (
-                        <img
-                          src={m.logoUrl}
-                          alt={m.provider}
-                          className={styles.modelLogo}
-                          onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                        />
-                      )}
-                      <div className={styles.modelInfo}>
-                        <div className={styles.modelName}>{m.name}</div>
-                        <div className={styles.modelMeta}>
-                          <span className={styles.providerName}>via {m.peerName}</span>
-                          {m.tags.map(t => (
-                            <span key={t} className={`${styles.tagBadge} ${TAG_CLASS[t] ?? styles.tagDefault}`}>{t}</span>
-                          ))}
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr><td colSpan={5} className={styles.emptyRow}>Discovering peers on the network…</td></tr>
+                ) : filtered.length === 0 ? (
+                  <tr><td colSpan={5} className={styles.emptyRow}>{error ? 'Could not reach the network.' : 'No services match your search.'}</td></tr>
+                ) : filtered.map(m => (
+                  <tr key={m.id} className={styles.row}>
+                    <td className={styles.tdModel}>
+                      <div className={styles.modelCell}>
+                        {m.logoUrl && <img src={m.logoUrl} alt={m.provider} className={styles.modelLogo} onError={e => { (e.target as HTMLImageElement).style.display='none'; }}/>}
+                        <div className={styles.modelInfo}>
+                          <div className={styles.modelName}>{m.name}</div>
+                          <div className={styles.modelMeta}>
+                            <FreshnessDot ts={m.lastSeenAt}/>
+                            <span className={styles.providerName}>via {m.peerName}</span>
+                            {m.tags.map(t => <span key={t} className={`${styles.tagBadge} ${TAG_CLASS[t] ?? styles.tagDefault}`}>{t}</span>)}
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  </td>
-                  <td className={styles.tdPrice}>
-                    <span className={m.inputPrice < 0.01 ? styles.priceFree : models.length > 0 && m.inputPrice <= cheapestInput * 1.5 ? styles.priceGood : styles.priceNormal}>
-                      {formatPrice(m.inputPrice)}
-                    </span>
-                  </td>
-                  <td className={styles.tdPrice}>
-                    <span className={m.outputPrice < 0.01 ? styles.priceFree : styles.priceNormal}>
-                      {formatPrice(m.outputPrice)}
-                    </span>
-                  </td>
-                  <td className={styles.tdStat}>
-                    <span className={styles.statValue}>{formatNum(m.totalTokens)}</span>
-                  </td>
-                  <td className={styles.tdStat}>
-                    <span className={styles.statValue}>{formatNum(m.uniqueBuyers)}</span>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                    </td>
+                    <td className={styles.tdPrice}>
+                      <div className={styles.priceWithBar}>
+                        <span className={m.inputPrice < 0.01 ? styles.priceFree : m.inputPrice <= cheapestInput * 1.5 ? styles.priceGood : styles.priceNormal}>{formatPrice(m.inputPrice)}</span>
+                        <PriceBar value={m.inputPrice} min={inputPriceRange.min} max={inputPriceRange.max}/>
+                      </div>
+                    </td>
+                    <td className={styles.tdPrice}><span className={m.outputPrice < 0.01 ? styles.priceFree : styles.priceNormal}>{formatPrice(m.outputPrice)}</span></td>
+                    <td className={styles.tdStat}><span className={styles.statValue}>{formatNum(m.totalTokens)}</span></td>
+                    <td className={styles.tdStat}><span className={styles.statValue}>{formatNum(m.uniqueBuyers)}</span></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
 
-        {/* CTA */}
         <div className={styles.footer}>
           <p>Prices and token volumes from live AntSeed network peers. On-chain stats from Base. Updates every 30s.</p>
           <p>Want to become a provider? <Link to="/docs/install">Read the docs →</Link></p>


### PR DESCRIPTION
## 🐛 Bug Fix

### Provider filter was showing rows from other providers

**Root cause:** The filter logic was:
```js
if (providerFilter && !m.peerNames.includes(providerFilter)) return false;
```
`peerNames` is the list of **all peers** serving that service — so clicking "Provider A" also showed rows from Provider B, C, D etc. as long as they shared any model with Provider A.

**Fix:**
```js
if (providerFilter && m.peerName !== providerFilter) return false;
```
Now correctly filters by `peerName` — the specific peer on that row only.

---

## ✨ UX Redesign for many providers

### New data surfaced
| Signal | Detail |
|---|---|
| 🟢 **Freshness dot** | Green (<10min) / yellow (<2h) / gray (stale) next to every provider |
| **Live pill** | "Live" / "2h ago" / "Stale" label in grouped view rows |
| **Live now** counter | New stat bar entry: peers active right now |
| **Settlement count** | On-chain proof of completed payments — stronger trust signal |
| **Stake (USDC)** | Skin-in-the-game signal shown as a blue badge |
| ⚡ **Cached pricing** | Purple badge when `cachedInputUsdPerMillion` is available |
| **Context window** | Badge on model headers (e.g. "200K ctx") |
| **Price bar** | Tiny relative bar — green for cheapest in range |

### Exploration UX
- **Quick Picks bar** — one-tap preset filters: 💰 Cheapest · 🧠 Reasoning · 💻 Coding · ⚡ Fast · 🏆 Proven · 🆕 New · 🔓 Open Source · ⚡ Cached
- **Sticky search bar** — stays at top while scrolling
- **Searchable provider dropdown** — scales to any number of providers
- **"Clear all filters"** button when any filter is active
- **By Model grouped view** is now the default

### Mobile
- Stats bar horizontally scrolls (no more broken stacking)
- Quick picks horizontally scroll
- Search takes full width, other controls wrap below
- Grouped view collapses columns at 900px → 700px → 600px breakpoints
- Flat table becomes proper card layout on mobile
- Expand buttons are min 44px touch targets