### PR TITLE
Chat: switching model mid-conversation now actually changes the model for the next send

### DIFF
--- a/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
@@ -833,3 +833,123 @@ test('opening a conversation does not switch workspace if it matches the current
   await new Promise((resolve) => setTimeout(resolve, 100));
   assert.equal(workspaceCallLog.length, 0, 'should not call chatAiSetWorkspace when workspace already matches');
 });
+
+test('switching service mid-conversation routes the next send to the new model', async () => {
+  // Regression: handleServiceChange used to update only the dropdown value
+  // and the conversation's peerId, leaving conversation.service pointing at
+  // the original model. dispatchChatRequest() resolves via
+  // getConversationServiceSelection(), which prefers conversation.service
+  // over chatSelectedServiceValue (by design, to keep background catalog
+  // refreshes from silently rebinding an open thread). The combined effect
+  // was: user picks model B in the dropdown, but the next send still goes
+  // out as model A. This test pins the fix.
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  uiState.chatServiceOptions = [
+    {
+      id: 'model-a', label: 'Model A', provider: 'openai', protocol: 'openai-chat-completions', count: 1,
+      value: `openai${SEP}model-a${SEP}peer-a`, peerId: 'peer-a', peerDisplayName: 'Peer A', peerLabel: 'Peer A',
+      inputUsdPerMillion: null, outputUsdPerMillion: null, categories: [], description: '',
+    },
+    {
+      id: 'model-b', label: 'Model B', provider: 'openai', protocol: 'openai-chat-completions', count: 1,
+      value: `openai${SEP}model-b${SEP}peer-b`, peerId: 'peer-b', peerDisplayName: 'Peer B', peerLabel: 'Peer B',
+      inputUsdPerMillion: null, outputUsdPerMillion: null, categories: [], description: '',
+    },
+  ];
+
+  const conversations: Conversation[] = [
+    {
+      id: 'conv-a',
+      title: 'Conversation A',
+      service: 'model-a',
+      provider: 'openai',
+      peerId: 'peer-a',
+      messages: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+  ];
+
+  const sends: Array<{
+    conversationId: string;
+    message: string;
+    service?: string;
+    provider?: string;
+    peerId?: string;
+  }> = [];
+  const streamDoneHandlers: Array<(data: { conversationId: string }) => void> = [];
+
+  const bridge: DesktopBridge = {
+    chatAiListConversations: async () => ({ ok: true, data: [...conversations] }),
+    chatAiGetConversation: async (id) => {
+      const conversation = conversations.find((c) => c.id === id);
+      return conversation
+        ? { ok: true, data: { ...conversation, messages: [...conversation.messages] } }
+        : { ok: false, error: 'not found' };
+    },
+    chatPrepareAttachments: async () => ({ ok: true, data: [] }),
+    chatAiSendStream: async (conversationId, message, service, provider, _attachments, peerId) => {
+      sends.push({ conversationId, message, service, provider, peerId });
+      return { ok: true };
+    },
+    onChatAiStreamDone: (handler) => {
+      streamDoneHandlers.push(handler);
+      return () => undefined;
+    },
+    chatAiSelectPeer: async () => ({ ok: true }),
+  };
+
+  const api = initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+  await api.refreshChatConversations();
+  await api.openConversation('conv-a');
+
+  // First send: original model. Sanity check.
+  api.sendMessage('hello from model a');
+  await waitFor(() => sends.length === 1);
+  assert.deepEqual(sends[0], {
+    conversationId: 'conv-a',
+    message: 'hello from model a',
+    service: 'model-a',
+    provider: 'openai',
+    peerId: 'peer-a',
+  });
+
+  // Close out the first send so the conversation isn't marked as having a
+  // request in progress — otherwise the second sendMessage below would
+  // be rejected by isConversationSending(convId).
+  for (const handler of streamDoneHandlers) {
+    handler({ conversationId: 'conv-a' });
+  }
+  await waitFor(() => uiState.chatSendingConversationIds.length === 0);
+
+  // User switches to model B from the dropdown while conv-a is open.
+  api.handleServiceChange(`openai${SEP}model-b${SEP}peer-b`, 'peer-b');
+  assert.equal(uiState.chatSelectedServiceValue, `openai${SEP}model-b${SEP}peer-b`);
+  assert.equal(uiState.chatSelectedPeerId, 'peer-b');
+
+  // Second send on the SAME conversation: must go to model B + peer B.
+  api.sendMessage('hello from model b');
+  await waitFor(() => sends.length === 2);
+  assert.deepEqual(sends[1], {
+    conversationId: 'conv-a',
+    message: 'hello from model b',
+    service: 'model-b',
+    provider: 'openai',
+    peerId: 'peer-b',
+  });
+
+  // The sidebar summary should also reflect the new binding so the chat
+  // list row stops showing the stale model name.
+  const summary = (uiState.chatConversations as { id: string; service?: string; peerId?: string }[])
+    .find((c) => c.id === 'conv-a');
+  assert.equal(summary?.service, 'model-b');
+  assert.equal(summary?.peerId, 'peer-b');
+
+  for (const handler of streamDoneHandlers) {
+    handler({ conversationId: 'conv-a' });
+  }
+  await waitFor(() => uiState.chatSendingConversationIds.length === 0);
+});

--- a/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
@@ -835,14 +835,6 @@ test('opening a conversation does not switch workspace if it matches the current
 });
 
 test('switching service mid-conversation routes the next send to the new model', async () => {
-  // Regression: handleServiceChange used to update only the dropdown value
-  // and the conversation's peerId, leaving conversation.service pointing at
-  // the original model. dispatchChatRequest() resolves via
-  // getConversationServiceSelection(), which prefers conversation.service
-  // over chatSelectedServiceValue (by design, to keep background catalog
-  // refreshes from silently rebinding an open thread). The combined effect
-  // was: user picks model B in the dropdown, but the next send still goes
-  // out as model A. This test pins the fix.
   installDomTimers();
 
   const uiState = createInitialUiState();
@@ -906,7 +898,6 @@ test('switching service mid-conversation routes the next send to the new model',
   await api.refreshChatConversations();
   await api.openConversation('conv-a');
 
-  // First send: original model. Sanity check.
   api.sendMessage('hello from model a');
   await waitFor(() => sends.length === 1);
   assert.deepEqual(sends[0], {
@@ -917,20 +908,15 @@ test('switching service mid-conversation routes the next send to the new model',
     peerId: 'peer-a',
   });
 
-  // Close out the first send so the conversation isn't marked as having a
-  // request in progress — otherwise the second sendMessage below would
-  // be rejected by isConversationSending(convId).
   for (const handler of streamDoneHandlers) {
     handler({ conversationId: 'conv-a' });
   }
   await waitFor(() => uiState.chatSendingConversationIds.length === 0);
 
-  // User switches to model B from the dropdown while conv-a is open.
   api.handleServiceChange(`openai${SEP}model-b${SEP}peer-b`, 'peer-b');
   assert.equal(uiState.chatSelectedServiceValue, `openai${SEP}model-b${SEP}peer-b`);
   assert.equal(uiState.chatSelectedPeerId, 'peer-b');
 
-  // Second send on the SAME conversation: must go to model B + peer B.
   api.sendMessage('hello from model b');
   await waitFor(() => sends.length === 2);
   assert.deepEqual(sends[1], {
@@ -941,8 +927,6 @@ test('switching service mid-conversation routes the next send to the new model',
     peerId: 'peer-b',
   });
 
-  // The sidebar summary should also reflect the new binding so the chat
-  // list row stops showing the stale model name.
   const summary = (uiState.chatConversations as { id: string; service?: string; peerId?: string }[])
     .find((c) => c.id === 'conv-a');
   assert.equal(summary?.service, 'model-b');

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -2249,10 +2249,6 @@ export function initChatModule({
     }
     uiState.chatSelectedPeerId = peerId;
 
-    // Resolve the (service, provider) pair the user just picked. The option
-    // catalog is the source of truth when available; otherwise decode the
-    // encoded value directly. Decoding is what handles the Discover
-    // card-click case where the chosen entry may not be in the catalog yet.
     const decoded = decodeChatServiceSelection(value);
     const nextServiceId = normalizeChatServiceId(selectedOption?.id ?? decoded.id);
     const nextProvider = normalizeProviderId(selectedOption?.provider ?? decoded.provider);
@@ -2261,26 +2257,11 @@ export function initChatModule({
       activeConversation.peerId = peerId || undefined;
       activeConversation.peerLabel = selectedOption?.peerDisplayName || selectedOption?.peerLabel || undefined;
 
-      // CRITICAL: also persist the new (service, provider) onto the active
-      // conversation. dispatchChatRequest() resolves the model via
-      // getConversationServiceSelection(), which prefers conversation.service
-      // over chatSelectedServiceValue — by design, so background catalog
-      // refreshes can't silently rebind an open thread to a different
-      // model. The flip side is that explicit user switches MUST update the
-      // conversation fields, otherwise the dropdown shows the new model
-      // but the next send still goes to the old one.
-      //
-      // Guarded: only write when we actually decoded a non-empty service id
-      // (clearing peer with an empty value must not wipe the conversation's
-      // bound model).
       if (nextServiceId) {
         activeConversation.service = nextServiceId;
         activeConversation.provider = nextProvider ?? '';
       }
 
-      // Mirror onto the conversation summary the sidebar renders from, so
-      // the chat-list row reflects the new model immediately rather than
-      // waiting for the next chatAiListConversations() refresh.
       const convId = activeConversation.id;
       if (convId && Array.isArray(uiState.chatConversations)) {
         const list = uiState.chatConversations as ChatConversationSummary[];

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -2248,9 +2248,52 @@ export function initChatModule({
       peerId = selectedOption?.peerId || '';
     }
     uiState.chatSelectedPeerId = peerId;
+
+    // Resolve the (service, provider) pair the user just picked. The option
+    // catalog is the source of truth when available; otherwise decode the
+    // encoded value directly. Decoding is what handles the Discover
+    // card-click case where the chosen entry may not be in the catalog yet.
+    const decoded = decodeChatServiceSelection(value);
+    const nextServiceId = normalizeChatServiceId(selectedOption?.id ?? decoded.id);
+    const nextProvider = normalizeProviderId(selectedOption?.provider ?? decoded.provider);
+
     if (activeConversation) {
       activeConversation.peerId = peerId || undefined;
       activeConversation.peerLabel = selectedOption?.peerDisplayName || selectedOption?.peerLabel || undefined;
+
+      // CRITICAL: also persist the new (service, provider) onto the active
+      // conversation. dispatchChatRequest() resolves the model via
+      // getConversationServiceSelection(), which prefers conversation.service
+      // over chatSelectedServiceValue — by design, so background catalog
+      // refreshes can't silently rebind an open thread to a different
+      // model. The flip side is that explicit user switches MUST update the
+      // conversation fields, otherwise the dropdown shows the new model
+      // but the next send still goes to the old one.
+      //
+      // Guarded: only write when we actually decoded a non-empty service id
+      // (clearing peer with an empty value must not wipe the conversation's
+      // bound model).
+      if (nextServiceId) {
+        activeConversation.service = nextServiceId;
+        activeConversation.provider = nextProvider ?? '';
+      }
+
+      // Mirror onto the conversation summary the sidebar renders from, so
+      // the chat-list row reflects the new model immediately rather than
+      // waiting for the next chatAiListConversations() refresh.
+      const convId = activeConversation.id;
+      if (convId && Array.isArray(uiState.chatConversations)) {
+        const list = uiState.chatConversations as ChatConversationSummary[];
+        const summary = list.find((c) => c.id === convId);
+        if (summary) {
+          summary.peerId = peerId || '';
+          summary.peerLabel = activeConversation.peerLabel ?? '';
+          if (nextServiceId) {
+            summary.service = nextServiceId;
+            summary.provider = nextProvider ?? '';
+          }
+        }
+      }
     }
     if (bridge?.chatAiSelectPeer) {
       void bridge.chatAiSelectPeer({


### PR DESCRIPTION
## Symptom

Switching the model in the header dropdown mid-conversation was reflected in the UI, but the next send went to the previous model.

Repro:
1. Open an existing conversation that was started with model A on peer A.
2. Pick model B / peer B from the header service dropdown.
3. Send a message.
4. The outbound `chatAiSendStream` request carries `service: 'model-A'`, `peerId: 'peer-A'`. The conversation continues with the old model.

## Root cause

`dispatchChatRequest()` resolves the outbound `(service, provider, peer)` triple via `getConversationServiceSelection(convId)`, which **prefers `conversation.service` over `chatSelectedServiceValue`**.

That policy is deliberate. The chat-list catalog is refreshed in the background (Discover re-sorts, peers come and go, etc.), and the dropdown's selected value can shift underneath an open thread. Reading `chatSelectedServiceValue` at send-time would let that background reshuffle silently rebind the open thread to a different peer's service — exactly the bug class fixed earlier ("kimi-k2.6 chat became chaotic-pm chat"). The comment in `applyChatServiceOptions` even spells this out: *"Active conversations are immutable unless the user explicitly switches service/peer."*

The problem: the **explicit-switch** path (`handleServiceChange`) wasn't actually mutating those conversation fields. It updated:
- `uiState.chatSelectedServiceValue` ✓
- `uiState.chatSelectedPeerId` ✓
- `activeConversation.peerId` ✓
- `activeConversation.peerLabel` ✓
- `activeConversation.service` ✗
- `activeConversation.provider` ✗

So an explicit user switch was indistinguishable from a transient catalog reshuffle at send-time, and the immutability policy correctly held the line — against the user's actual intent.

## Fix

In `handleServiceChange`:

- Decode the chosen `(service, provider)` from the catalog option when available, falling back to decoding the encoded value directly (handles the Discover card-click case where the chosen entry may not be in the catalog yet).
- Write `service` and `provider` onto `activeConversation` whenever the decoded service id is non-empty. The non-empty guard is critical: clearing peer with an empty value (`clearPinnedPeer`-adjacent paths) must not wipe the conversation's bound model.
- Mirror the same fields plus the new `peerId`/`peerLabel` onto the matching `ChatConversationSummary` in `uiState.chatConversations`, so the sidebar chat-list row reflects the new model immediately without waiting for the next `chatAiListConversations()` refresh.

## Test

New case in `chat.peer-routing.test.ts`: **"switching service mid-conversation routes the next send to the new model"**.

1. Open `conv-a` (bound to `model-a` / `peer-a`).
2. Send once — assert outbound `service: 'model-a'`, `peerId: 'peer-a'`. (sanity)
3. Call `handleServiceChange('openai\x01model-b\x01peer-b', 'peer-b')`.
4. Send again on the same conversation.
5. Assert outbound `service: 'model-b'`, `peerId: 'peer-b'`.
6. Assert the `chatConversations` summary for `conv-a` now reads `service: 'model-b'`, `peerId: 'peer-b'`.

All 9 existing peer-routing tests still pass.

## Verification

- `npx tsc --noEmit -p tsconfig.renderer.json` — clean.
- `npx tsx --test src/renderer/modules/chat.peer-routing.test.ts` — 9/9 pass.
