### PR TITLE
fix(payments): Top up NeedAuth sessions

### DIFF
--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -948,8 +948,10 @@ export class BuyerPaymentManager {
     // Send topUp AFTER the SpendingAuth so the seller processes the higher
     // cumulative first — this ensures the on-chain settle amount meets the
     // contract's TopUpThresholdNotMet requirement (85% of deposit must be
-    // settleable before topUp is allowed).
-    if (needsTopUp) {
+    // settleable before topUp is allowed). Also proactively send the top-up
+    // once the signed cumulative reaches the buyer's 65% threshold; the seller
+    // may defer the on-chain topUp until the contract's 85% gate is satisfied.
+    if (needsTopUp || this._needsTopUp(sellerPeerId)) {
       await this._topUpAfterSpendAuthBestEffort(sellerPeerId, paymentMux, 'handleNeedAuth');
     }
   }

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -512,6 +512,41 @@ describe('BuyerPaymentManager', () => {
     expect(mux.sentSpendingAuths.length).toBeGreaterThanOrEqual(1);
   });
 
+  it('handleNeedAuth proactively top-ups after crossing the 65% reserve threshold', async () => {
+    store.close();
+    store = new ChannelStore(tempDir);
+    manager = new BuyerPaymentManager(
+      identity,
+      makeConfig(tempDir, { maxReserveAmountUsdc: 100_000n, maxPerRequestUsdc: 100_000n }),
+      store,
+    );
+    manager.setSigner(Wallet.createRandom());
+
+    const sellerPeerId = fakePeerId('seller-needauth-threshold-topup');
+    const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n);
+    mux.sentSpendingAuths.length = 0;
+
+    await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requiredCumulativeAmount: '65000',
+      currentAcceptedCumulative: '0',
+      deposit: '100000',
+      lastRequestCost: '65000',
+      inputTokens: '1000',
+      freshInputTokens: '1000',
+      outputTokens: '100',
+      cachedInputTokens: '0',
+    }, mux);
+
+    expect(mux.sentSpendingAuths).toHaveLength(2);
+    const spendingFirst = mux.sentSpendingAuths[0] as Record<string, unknown>;
+    const reserveSecond = mux.sentSpendingAuths[1] as Record<string, unknown>;
+    expect(spendingFirst.cumulativeAmount).toBe('65000');
+    expect(spendingFirst.reserveMaxAmount).toBeUndefined();
+    expect(reserveSecond.cumulativeAmount).toBe('65000');
+    expect(reserveSecond.reserveMaxAmount).toBe('200000');
+  });
+
   it('handleNeedAuth sends spending auth before reserve top-up when the ceiling blocks the required amount', async () => {
     store.close();
     store = new ChannelStore(tempDir);
@@ -780,16 +815,7 @@ describe('BuyerPaymentManager', () => {
     const channelId = await manager.authorizeSpending(sellerPeerId, mux, 100_000n, TEST_PRICING);
     manager.handleAuthAck(sellerPeerId, { channelId });
 
-    const reserveOnlyCost = 100_000n - SAMPLE_ESTIMATE.cost;
-    await manager.handleNeedAuth(sellerPeerId, {
-      channelId,
-      requiredCumulativeAmount: reserveOnlyCost.toString(),
-      currentAcceptedCumulative: '0',
-      deposit: '1000000',
-      lastRequestCost: reserveOnlyCost.toString(),
-    }, mux);
-
-    manager.recordResponseBytes(sellerPeerId, SAMPLE_INPUT, SAMPLE_OUTPUT);
+    (manager as unknown as { _verifiedCost: Map<string, bigint> })._verifiedCost.set(sellerPeerId, 100_000n);
     mux.sentSpendingAuths.length = 0;
     await manager.extendCurrentSpendingAuth(sellerPeerId, 1n, mux, 100_001n);
 


### PR DESCRIPTION
## Description

Fixes buyer-side NeedAuth handling so reserve top-ups are sent as soon as the signed cumulative spend reaches the buyer's 65% reserve threshold. This keeps active sessions funded proactively instead of waiting until the current reserve ceiling is exhausted.

## Release Notes

- Fixed active payment sessions to request reserve top-ups around the 65% threshold, reducing underfunded retries near the reserve ceiling.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
