### PR TITLE
fix(discover): replace native title tooltip on +N pill with styled in-app tooltip

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
@@ -722,6 +722,33 @@
   padding: 12px 4px 16px;
 }
 
+.tagMore {
+  position: relative;
+  cursor: default;
+}
+
+.tagMoreTooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  opacity: 0;
+  pointer-events: none;
+  white-space: normal;
+  max-width: 220px;
+  transition: opacity 0.15s;
+  z-index: 10;
+}
+
+.tagMore:hover .tagMoreTooltip,
+.tagMore:focus-within .tagMoreTooltip {
+  opacity: 1;
+}
+
 @keyframes discover-drawer-in {
   from { transform: translateX(-100%); }
   to   { transform: translateX(0); }

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -684,12 +684,17 @@ function Card({
           ))}
           {item.tags.length > MAX_VISIBLE_CARD_TAGS && (
             <span
-              className={styles.tag}
-              title={item.tags.slice(MAX_VISIBLE_CARD_TAGS).map(formatCategoryLabel).join(', ')}
+              className={`${styles.tag} ${styles.tagMore}`}
+              tabIndex={0}
               aria-label={`${item.tags.length - MAX_VISIBLE_CARD_TAGS} more categories: `
                 + item.tags.slice(MAX_VISIBLE_CARD_TAGS).map(formatCategoryLabel).join(', ')}
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
             >
               +{item.tags.length - MAX_VISIBLE_CARD_TAGS}
+              <span role="tooltip" className={styles.tagMoreTooltip}>
+                {item.tags.slice(MAX_VISIBLE_CARD_TAGS).map(formatCategoryLabel).join(', ')}
+              </span>
             </span>
           )}
         </div>


### PR DESCRIPTION
Fixes #346.

## Problem
The `+N` overflow pill on Discover cards uses a native OS `title` attribute (`DiscoverWelcome.tsx:685-693`) to show the hidden category labels on hover. This produces the browser/OS grey tooltip — delayed, off-brand, and inaccessible to keyboard users.

## Fix
- Removed `title` prop from the pill `<span>`
- Added `tabIndex={0}` and `className={styles.tagMore}` for keyboard reach and CSS anchor
- Nested `<span role="tooltip" className={styles.tagMoreTooltip}>` inside with the same comma-joined labels
- Added `onClick`/`onKeyDown` stop-propagation so focusing the pill doesn't open a chat session
- Added `.tagMore` + `.tagMoreTooltip` in `DiscoverWelcome.module.scss` using existing design tokens (`--bg-card`, `--border-subtle`, `--radius-sm`); tooltip fades in via `opacity` transition on `:hover` and `:focus-within`

## Test plan
- [ ] Hover `+N` pill on a Discover card with 5+ categories — styled tooltip appears, no native browser tooltip
- [ ] Tab to the pill — tooltip appears via `:focus-within`; pressing Enter/Space does not start a chat
- [ ] Verify in both light and dark themes (CSS variables resolve correctly in both)

## Disclosure
This PR was drafted with assistance from a Claude Code agent. The change has been reviewed and is being submitted by me (@Augustas11).
