### PR TITLE
feat(desktop): move version to bottom bar, center update indicator in title bar

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -477,6 +477,7 @@ ipcMain.handle('app:get-setup-status', () => ({
 // language list, not the OS UI language, and can disagree on multilingual
 // systems.
 ipcMain.handle('app:get-system-locale', () => app.getLocale());
+ipcMain.handle('app:get-version', () => app.getVersion());
 
 ipcMain.handle('identity:get', async () => {
   try {

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -137,6 +137,9 @@ const api = {
   getSystemLocale(): Promise<string> {
     return ipcRenderer.invoke('app:get-system-locale') as Promise<string>;
   },
+  getAppVersion(): Promise<string> {
+    return ipcRenderer.invoke('app:get-version') as Promise<string>;
+  },
   getState(): Promise<RuntimeSnapshot> {
     return ipcRenderer.invoke('runtime:get-state') as Promise<RuntimeSnapshot>;
   },
@@ -292,6 +295,11 @@ const api = {
     const listener = (_: unknown, data: { conversationId: string; message: { role: string; content: unknown; createdAt?: number } }) => handler(data);
     ipcRenderer.on('chat:ai-user-persisted', listener);
     return () => ipcRenderer.off('chat:ai-user-persisted', listener);
+  },
+  onChatConversationTitleUpdated(handler: (data: { conversationId: string; title: string }) => void): () => void {
+    const listener = (_: unknown, data: { conversationId: string; title: string }) => handler(data);
+    ipcRenderer.on('chat:conversation-title-updated', listener);
+    return () => ipcRenderer.off('chat:conversation-title-updated', listener);
   },
   // Streaming events
   onChatAiStreamStart(handler: (data: { conversationId: string; turn: number }) => void): () => void {

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -137,6 +137,8 @@ export type DesktopBridge = {
     | 'openbsd' | 'sunos' | 'win32' | 'cygwin' | 'netbsd';
   /** Authoritative macOS UI locale (Electron `app.getLocale()`). */
   getSystemLocale?: () => Promise<string>;
+  /** Current app version from Electron `app.getVersion()`. */
+  getAppVersion?: () => Promise<string>;
   getState?: () => Promise<RuntimeSnapshot>;
   start?: (options: StartOptions) => Promise<unknown>;
   stop?: (mode: RuntimeMode) => Promise<unknown>;
@@ -188,6 +190,7 @@ export type DesktopBridge = {
   onChatAiDone?: (handler: (data: { conversationId: string; message: { role: string; content: unknown; createdAt?: number; meta?: Record<string, unknown> } }) => void) => () => void;
   onChatAiError?: (handler: (data: { conversationId: string; error: string }) => void) => () => void;
   onChatAiUserPersisted?: (handler: (data: { conversationId: string; message: { role: string; content: unknown; createdAt?: number } }) => void) => () => void;
+  onChatConversationTitleUpdated?: (handler: (data: { conversationId: string; title: string }) => void) => () => void;
   onChatAiStreamStart?: (handler: (data: { conversationId: string; turn: number }) => void) => () => void;
   onChatAiStreamDelta?: (handler: (data: { conversationId: string; index: number; blockType: string; text: string }) => void) => () => void;
   onChatAiStreamBlockStart?: (handler: (data: { conversationId: string; index: number; blockType: string; toolId?: string; toolName?: string }) => void) => () => void;

--- a/apps/desktop/src/renderer/ui/components/StreamingIndicator.module.scss
+++ b/apps/desktop/src/renderer/ui/components/StreamingIndicator.module.scss
@@ -5,9 +5,26 @@
   color: var(--text-muted);
   display: flex;
   align-items: center;
-  gap: 6px;
+  justify-content: space-between;
   transition: color 150ms ease, background-color 150ms ease;
   border-top: 1px solid var(--border-light);
+}
+
+.status-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.version-label {
+  font-size: 10px;
+  color: var(--text-muted);
+  opacity: 0.6;
+  white-space: nowrap;
+  user-select: none;
+  flex-shrink: 0;
+  margin-left: 12px;
 }
 
 .is-thinking {

--- a/apps/desktop/src/renderer/ui/components/StreamingIndicator.tsx
+++ b/apps/desktop/src/renderer/ui/components/StreamingIndicator.tsx
@@ -1,18 +1,32 @@
+import { useState, useEffect } from 'react';
 import { useUiSnapshot } from '../hooks/useUiSnapshot';
 import styles from './StreamingIndicator.module.scss';
 
+declare const __APP_VERSION__: string;
+
 export function StreamingIndicator() {
   const { chatStreamingIndicatorText, chatStreamingActive, runtimeActivity } = useUiSnapshot();
+  const [appVersion, setAppVersion] = useState<string>(typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '');
+
+  useEffect(() => {
+    const bridge = (window as unknown as { antseedDesktop?: { getAppVersion?: () => Promise<string> } }).antseedDesktop;
+    bridge?.getAppVersion?.().then((v) => setAppVersion(v)).catch(() => {});
+  }, []);
 
   return (
     <div className={`${styles.chatStreamingIndicator}${chatStreamingActive ? ` ${styles.isThinking}` : ''}`}>
-      <div>
-        {chatStreamingIndicatorText || 'Idle'}
+      <div className={styles.statusLeft}>
+        <div>
+          {chatStreamingIndicatorText || 'Idle'}
+        </div>
+        <span>·</span>
+        <div className={`runtime-activity-${runtimeActivity.tone}`} aria-live="polite">
+          {runtimeActivity.message || 'Idle'}
+        </div>
       </div>
-      <span>·</span>
-      <div className={`runtime-activity-${runtimeActivity.tone}`} aria-live="polite">
-        {runtimeActivity.message || 'Idle'}
-      </div>
+      {appVersion && (
+        <div className={styles.versionLabel}>v{appVersion}</div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/ui/components/TitleBar.module.scss
+++ b/apps/desktop/src/renderer/ui/components/TitleBar.module.scss
@@ -49,33 +49,66 @@
   -webkit-app-region: no-drag;
 }
 
-.title-bar-update-btn {
-  padding: 4px 10px;
+.title-bar-center {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1;
+  -webkit-app-region: no-drag;
+}
+
+.title-bar-update-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
   border-radius: 6px;
   border: none;
   font-size: 11px;
   font-weight: 600;
+  white-space: nowrap;
+  cursor: default;
+  user-select: none;
+  transition: all 0.15s ease;
+}
+
+.title-bar-update-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.title-bar-update-badge-ready {
   background: var(--accent-green);
   color: #ffffff;
   cursor: pointer;
-  white-space: nowrap;
-  transition: opacity 0.15s;
+
+  .title-bar-update-dot {
+    background: #ffffff;
+    animation: update-dot-pulse 1.5s ease-in-out infinite;
+  }
 
   &:hover {
-    background: var(--accent-green);
     opacity: 0.85;
   }
 }
 
-.title-bar-update-btn-downloading {
+.title-bar-update-badge-downloading {
   position: relative;
   overflow: hidden;
   background: var(--bg-hover);
+  border: 1px solid var(--accent-green);
   color: var(--text-secondary);
   cursor: default;
 
+  .title-bar-update-dot {
+    background: var(--accent-green);
+    animation: update-dot-pulse 1s ease-in-out infinite;
+  }
+
   &:hover {
-    background: var(--bg-hover);
     opacity: 1;
   }
 }
@@ -86,14 +119,22 @@
   bottom: 0;
   left: 0;
   background: var(--accent-green);
-  opacity: 0.35;
-  transition: width 0.2s ease;
+  opacity: 0.2;
+  transition: width 0.3s ease;
   pointer-events: none;
 }
 
 .title-bar-update-label {
   position: relative;
   z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+@keyframes update-dot-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
 }
 
 .title-bar-theme-toggle {
@@ -271,13 +312,3 @@
   }
 }
 
-.alpha-hint {
-  opacity: 0.6;
-  white-space: nowrap;
-  background: var(--danger);
-  color: #fff;
-  padding: 4px 8px;
-  border: 1px solid var(--border);
-  text-align: center;
-  border-radius: 8px;
-}

--- a/apps/desktop/src/renderer/ui/components/TitleBar.tsx
+++ b/apps/desktop/src/renderer/ui/components/TitleBar.tsx
@@ -103,30 +103,33 @@ export function TitleBar() {
       </div>
       <div className={styles.titleBarRight}>
         {updateState && (
-          updateState.status === 'ready' ? (
-            <button
-              className={styles.titleBarUpdateBtn}
-              onClick={handleUpdate}
-              aria-label={`Install v${updateState.version} and restart`}
-              title={`Install v${updateState.version} and restart`}
-            >
-              Update to v{updateState.version}
-            </button>
-          ) : (
-            <button
-              className={`${styles.titleBarUpdateBtn} ${styles.titleBarUpdateBtnDownloading}`}
-              disabled
-              aria-label={`Downloading v${updateState.version} ${updateState.percent}%`}
-              title={`Downloading v${updateState.version} — ${updateState.percent}%`}
-            >
-              <span className={styles.titleBarUpdateFill} style={{ width: `${updateState.percent}%` }} aria-hidden="true" />
-              <span className={styles.titleBarUpdateLabel}>Downloading v{updateState.version} · {updateState.percent}%</span>
-            </button>
-          )
+          <div className={styles.titleBarCenter}>
+            {updateState.status === 'ready' ? (
+              <button
+                className={`${styles.titleBarUpdateBadge} ${styles.titleBarUpdateBadgeReady}`}
+                onClick={handleUpdate}
+                aria-label={`Install v${updateState.version} and restart`}
+                title={`Click to install v${updateState.version} and restart`}
+              >
+                <span className={styles.titleBarUpdateDot} />
+                Update to v{updateState.version}
+              </button>
+            ) : (
+              <button
+                className={`${styles.titleBarUpdateBadge} ${styles.titleBarUpdateBadgeDownloading}`}
+                disabled
+                aria-label={`Downloading v${updateState.version} ${updateState.percent}%`}
+                title={`Downloading v${updateState.version} — ${updateState.percent}%`}
+              >
+                <span className={styles.titleBarUpdateFill} style={{ width: `${updateState.percent}%` }} aria-hidden="true" />
+                <span className={styles.titleBarUpdateLabel}>
+                  <span className={styles.titleBarUpdateDot} />
+                  Downloading v{updateState.version} · {updateState.percent}%
+                </span>
+              </button>
+            )}
+          </div>
         )}
-        <div className={styles.alphaHint}>
-          Alpha Version
-        </div>
         <div className={styles.titleBarCreditsWrapper}>
           <button
             className={styles.titleBarCreditsBtn}

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,8 +1,10 @@
 import path from 'node:path';
+import { readFileSync } from 'node:fs';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 const rendererRoot = path.resolve(__dirname, 'src/renderer');
+const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'));
 
 export default defineConfig({
   plugins: [react()],
@@ -16,6 +18,9 @@ export default defineConfig({
     modules: {
       localsConvention: 'camelCaseOnly'
     }
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
   },
   server: {
     host: '127.0.0.1',


### PR DESCRIPTION
## Summary

Replaces the static **Alpha Version** red badge in the title bar with two separate, cleaner UI elements:

### Version number → bottom status bar (right side)
- The current app version (e.g. `v0.1.89`) now shows in the existing bottom status bar, right-aligned
- Subtle and muted so it doesn't distract from the streaming/activity indicators on the left
- Uses build-time injection via Vite `define` (`__APP_VERSION__`) with runtime override from the Electron bridge

### Update indicator → title bar (centered)
- Only appears when there's an active update (downloading or ready to install)
- **Downloading**: Shows centered in the title bar with a green-bordered badge, animated progress fill, pulsing green dot, and percentage text (e.g. `Downloading v1.3.0 · 42%`)
- **Ready to install**: Green button with pulsing white dot — click to install and restart
- Hidden entirely when no update is available (clean title bar)

### Changes
- `main.ts` — Added `app:get-version` IPC handler
- `preload.cts` — Added `getAppVersion()` bridge method
- `bridge.ts` — Added type for `getAppVersion`
- `vite.config.ts` — Inject `__APP_VERSION__` at build time from package.json
- `TitleBar.tsx/scss` — Removed alpha badge + old update button; added centered update-only indicator
- `StreamingIndicator.tsx/scss` — Added version label on the right side of the bottom bar