### PR TITLE
refactor(desktop): extract localhost references into shared constants

### DIFF
--- a/apps/desktop/src/main/chat-dev-tools.ts
+++ b/apps/desktop/src/main/chat-dev-tools.ts
@@ -2,6 +2,7 @@ import { type Static, Type } from '@sinclair/typebox';
 import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { createConnection } from 'node:net';
+import { LOCALHOST } from './constants.js';
 import type { ToolDefinition } from '@mariozechner/pi-coding-agent';
 
 type SendToRenderer = (channel: string, payload: unknown) => void;
@@ -109,7 +110,7 @@ function waitForPort(port: number, timeoutMs: number, signal?: AbortSignal): Pro
     const check = () => {
       if (signal?.aborted) { resolve(false); return; }
       if (Date.now() > deadline) { resolve(false); return; }
-      const sock = createConnection({ host: '127.0.0.1', port });
+      const sock = createConnection({ host: LOCALHOST, port });
       sock.on('connect', () => { sock.destroy(); resolve(true); });
       sock.on('error', () => { setTimeout(check, 500); });
     };

--- a/apps/desktop/src/main/constants.ts
+++ b/apps/desktop/src/main/constants.ts
@@ -4,3 +4,6 @@ import path from 'node:path';
 export const DEFAULT_CONFIG_PATH = path.join(homedir(), '.antseed', 'config.json');
 export const DEFAULT_BUYER_STATE_PATH = path.join(homedir(), '.antseed', 'buyer.state.json');
 export const DEFAULT_DASHBOARD_PORT = 3117;
+
+export const LOCALHOST = '127.0.0.1';
+export const LOCALHOST_URL = `http://${LOCALHOST}`;

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -117,7 +117,7 @@ const APP_ICON_PATH = resolveAppIconPath();
 // in some surfaces because the underlying bundle is Electron.app.
 app.setName(APP_NAME);
 
-import { DEFAULT_CONFIG_PATH } from './constants.js';
+import { DEFAULT_CONFIG_PATH, LOCALHOST, LOCALHOST_URL } from './constants.js';
 import { asRecord, asString } from './utils.js';
 
 function resolveActiveConfigPath(): string {
@@ -216,7 +216,7 @@ async function requestBuyerPeerRefresh(): Promise<void> {
   const timer = setTimeout(() => controller.abort(), 60_000);
 
   try {
-    const response = await fetch(`http://127.0.0.1:${port}/_antseed/peers/refresh`, {
+    const response = await fetch(`${LOCALHOST_URL}:${port}/_antseed/peers/refresh`, {
       method: 'POST',
       signal: controller.signal,
     });
@@ -308,8 +308,8 @@ async function startPaymentsPortal(): Promise<void> {
       port: PAYMENTS_PORT,
       identityHex,
     });
-    await paymentsServer.listen({ port: PAYMENTS_PORT, host: '127.0.0.1' });
-    console.log(`[desktop] Payments portal running at http://127.0.0.1:${PAYMENTS_PORT}`);
+    await paymentsServer.listen({ port: PAYMENTS_PORT, host: LOCALHOST });
+    console.log(`[desktop] Payments portal running at ${LOCALHOST_URL}:${PAYMENTS_PORT}`);
   } catch (err) {
     console.error('[desktop] Failed to start payments portal:', err instanceof Error ? err.message : String(err));
     paymentsServer = null;
@@ -342,7 +342,7 @@ ipcMain.handle('payments:open-portal', async (_event, tab?: string) => {
     // Set ANTSEED_PAYMENTS_DEV_URL to override (default: http://localhost:5175).
     // When dev mode is detected but the dev server is not reachable, we still fall back to the Fastify URL.
     const devUrl = isDev ? (process.env['ANTSEED_PAYMENTS_DEV_URL'] || 'http://localhost:5175') : null;
-    const base = devUrl ?? `http://127.0.0.1:${PAYMENTS_PORT}`;
+    const base = devUrl ?? `${LOCALHOST_URL}:${PAYMENTS_PORT}`;
     const url = qs ? `${base}?${qs}` : base;
     const { default: open } = await import('open');
     await open(url);

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -42,7 +42,7 @@ import {
   loadChatWorkspaceDir,
   persistChatWorkspaceDir,
 } from './chat-workspace.js';
-import { DEFAULT_BUYER_STATE_PATH } from './constants.js';
+import { DEFAULT_BUYER_STATE_PATH, LOCALHOST, LOCALHOST_URL } from './constants.js';
 import { PROXY_PROVIDER_ID, normalizeProviderId, sanitizeProviderHint } from './chat-provider-hint.js';
 import { asErrorMessage } from './utils.js';
 import {
@@ -1004,7 +1004,7 @@ function makeProxyService(
     id: serviceId,
     name: serviceId,
     provider: PROXY_PROVIDER_ID,
-    baseUrl: needsV1 ? `http://127.0.0.1:${port}/v1` : `http://127.0.0.1:${port}`,
+    baseUrl: needsV1 ? `${LOCALHOST_URL}:${port}/v1` : `${LOCALHOST_URL}:${port}`,
     reasoning: true,
     input: inputModalities,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -1099,7 +1099,7 @@ function mergeAssistantMessagesForUi(base: AiChatMessage | null, next: AiChatMes
 
 async function isPortReachable(port: number, timeoutMs = 700): Promise<boolean> {
   return await new Promise((resolve) => {
-    const socket = createConnection({ host: '127.0.0.1', port: Math.floor(port) });
+    const socket = createConnection({ host: LOCALHOST, port: Math.floor(port) });
 
     let settled = false;
     const finish = (ok: boolean): void => {
@@ -1607,7 +1607,7 @@ async function generateConversationTitleWithModel({
   };
   if (peerId) headers['x-antseed-pin-peer'] = peerId;
 
-  let url = `http://127.0.0.1:${proxyPort}/v1/messages`;
+  let url = `${LOCALHOST_URL}:${proxyPort}/v1/messages`;
   let body: Record<string, unknown> = {
     model: serviceId,
     max_tokens: 32,
@@ -1616,7 +1616,7 @@ async function generateConversationTitleWithModel({
   };
 
   if (protocol === 'openai-chat-completions') {
-    url = `http://127.0.0.1:${proxyPort}/v1/chat/completions`;
+    url = `${LOCALHOST_URL}:${proxyPort}/v1/chat/completions`;
     body = {
       model: serviceId,
       max_tokens: 32,
@@ -1626,7 +1626,7 @@ async function generateConversationTitleWithModel({
       ],
     };
   } else if (protocol === 'openai-responses') {
-    url = `http://127.0.0.1:${proxyPort}/v1/responses`;
+    url = `${LOCALHOST_URL}:${proxyPort}/v1/responses`;
     body = {
       model: serviceId,
       max_output_tokens: 32,
@@ -2432,7 +2432,7 @@ export function registerPiChatHandlers({
     params: { port: number; path: string; method: string; headers: Record<string, string>; body: string },
   ) => {
     try {
-      const url = `http://127.0.0.1:${params.port}${params.path}`;
+      const url = `${LOCALHOST_URL}:${params.port}${params.path}`;
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), 60_000);
       const res = await fetch(url, {
@@ -2473,7 +2473,7 @@ export function registerPiChatHandlers({
       await Promise.all(uniqueCatalogPeerIds.map(async (peerId) => {
         try {
           const resp = await fetch(
-            `http://127.0.0.1:${buyerPort}/_antseed/metering/${encodeURIComponent(peerId)}`,
+            `${LOCALHOST_URL}:${buyerPort}/_antseed/metering/${encodeURIComponent(peerId)}`,
           );
           if (!resp.ok) return;
           const body = await resp.json() as Record<string, unknown> | null;
@@ -2758,7 +2758,7 @@ export function registerPiChatHandlers({
     // Eager connection warmup via buyer proxy
     const proxyPort = await resolveProxyPort(configPath);
     try {
-      const response = await fetch(`http://127.0.0.1:${proxyPort}/_antseed/connect`, {
+      const response = await fetch(`${LOCALHOST_URL}:${proxyPort}/_antseed/connect`, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ peerId }),

--- a/apps/desktop/src/renderer/constants.ts
+++ b/apps/desktop/src/renderer/constants.ts
@@ -1,0 +1,2 @@
+export const LOCALHOST = '127.0.0.1';
+export const LOCALHOST_URL = `http://${LOCALHOST}`;

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1,4 +1,5 @@
 import type { DiscoverRow, RendererUiState } from '../core/state';
+import { LOCALHOST_URL } from '../constants';
 import type { BadgeTone } from '../core/state';
 import { notifyUiStateChanged, notifyUiStateChangedSync } from '../core/store';
 import { normalizeDiscoverRow, projectRowsToChatServiceOptions } from './discover-rows.js';
@@ -738,7 +739,7 @@ export function initChatModule({
         ltTokens: uiState.chatLifetimeTotalTokens,
         ltSessions: uiState.chatLifetimeSessions,
       };
-      const url = `http://127.0.0.1:${port}/_antseed/metering/${encodeURIComponent(sellerPeerId)}`;
+      const url = `${LOCALHOST_URL}:${port}/_antseed/metering/${encodeURIComponent(sellerPeerId)}`;
       const resp = await fetch(url);
       if (!resp.ok) return;
       const stats = (await resp.json()) as MeteringPeerStats;


### PR DESCRIPTION
## Summary

Replaces all hardcoded `'127.0.0.1'` and `'http://127.0.0.1'` references across the desktop app with shared constants.

### Constants added

**`apps/desktop/src/main/constants.ts`**
```ts
export const LOCALHOST = '127.0.0.1';
export const LOCALHOST_URL = `http://${LOCALHOST}`;
```

**`apps/desktop/src/renderer/constants.ts`** (new file)
```ts
export const LOCALHOST = '127.0.0.1';
export const LOCALHOST_URL = `http://${LOCALHOST}`;
```

### Files updated
- `main/constants.ts` — Added `LOCALHOST` and `LOCALHOST_URL`
- `main/main.ts` — 4 replacements (fetch URLs, server listen host, console log)
- `main/pi-chat-engine.ts` — 6 replacements (proxy URLs, socket connections)
- `main/chat-dev-tools.ts` — 1 replacement (socket connection)
- `renderer/constants.ts` — New file
- `renderer/modules/chat.ts` — 1 replacement (metering fetch URL)

### Not changed
- Test fixture data (`pi-chat-engine.discover-catalog.test.ts`) — those `host: '127.0.0.1'` values represent mock peer network addresses, not our localhost proxy
- Comment in `chat-provider-hint.ts` — documentation reference only