### PR TITLE
feat(app): Show edit diff summary

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -318,6 +318,13 @@
       flex-direction: column;
     }
 
+    .tool-group-summary-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+    }
+
     .tool-group-summary-btn {
       appearance: none;
       border: 0;
@@ -325,6 +332,8 @@
       display: flex;
       align-items: center;
       gap: 8px;
+      flex: 1;
+      min-width: 0;
       width: 100%;
       padding: 4px 0;
       font-size: 12px;
@@ -380,15 +389,15 @@
       cursor: default;
     }
 
-    .tool-inline-row.has-inline-diff {
-      cursor: default;
-    }
-
+    .tool-inline-row.has-diff,
     .tool-inline-row.expandable {
       cursor: pointer;
     }
 
-
+    .tool-inline-row.has-diff:hover .tool-inline-label,
+    .tool-inline-row.expandable:hover .tool-inline-label {
+      color: var(--accent);
+    }
 
     .tool-inline-open {
       flex-shrink: 0;
@@ -491,6 +500,69 @@
 
     .diff-removals {
       color: var(--danger);
+    }
+
+    .tool-diff-summary {
+      appearance: none;
+      border: 0;
+      background: transparent;
+      padding: 0;
+      margin: 0;
+      flex-shrink: 0;
+      font: inherit;
+      cursor: pointer;
+    }
+
+    .tool-diff-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      flex-shrink: 0;
+      font-size: 12px;
+      font-weight: 700;
+      line-height: 1.2;
+    }
+
+    .tool-diff-pill.compact {
+      font-size: 11.5px;
+    }
+
+    .tool-diff-summary:focus-visible {
+      outline: 1px solid color-mix(in srgb, var(--accent-green) 42%, transparent);
+      outline-offset: 2px;
+      border-radius: 3px;
+    }
+
+    .tool-diff-separator {
+      color: var(--text-faint);
+      font-weight: 500;
+    }
+
+    .tool-change-summary-row {
+      appearance: none;
+      width: 100%;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: color-mix(in srgb, var(--bg-card-alt) 78%, transparent);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      margin: 6px 0 8px;
+      padding: 7px 9px;
+      color: var(--text-secondary);
+      font-family: var(--font-sans);
+      font-size: 12px;
+      font-weight: 600;
+      text-align: left;
+      cursor: pointer;
+      transition: background 0.12s ease, border-color 0.12s ease;
+    }
+
+    .tool-change-summary-row:hover {
+      background: color-mix(in srgb, var(--accent-green) 7%, var(--bg-card-alt));
+      border-color: color-mix(in srgb, var(--accent-green) 28%, var(--border));
+      color: var(--text-primary);
     }
 
     .tool-spinner {

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -32,6 +32,34 @@ function getToolKind(name: unknown): string {
   return String(name || '').trim().toLowerCase();
 }
 
+function getToolInputString(input: unknown, keys: string[]): string {
+  if (!input || typeof input !== 'object') return '';
+  const payload = input as Record<string, unknown>;
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value === 'string') return value;
+  }
+  return '';
+}
+
+function splitContentLinesForDiff(content: string): string[] {
+  if (content.length === 0) return [];
+  const withoutFinalNewline = content.endsWith('\n') ? content.slice(0, -1) : content;
+  return withoutFinalNewline.split('\n');
+}
+
+function buildNewFileDiff(block: ContentBlock): string {
+  const kind = getToolKind(block.name);
+  if (kind !== 'write' && kind !== 'write_file') return '';
+
+  const content = getToolInputString(block.input, ['content', 'text', 'data']);
+  if (content.length === 0) return '';
+
+  const path = getToolInputString(block.input, ['path', 'filePath', 'file', 'target']) || 'new file';
+  const addedLines = splitContentLinesForDiff(content).map((line) => `+${line}`);
+  return [`--- /dev/null`, `+++ ${path}`, '@@', ...addedLines].join('\n');
+}
+
 function extractToolDiff(block: ContentBlock): string {
   const detailsDiff = block.details?.diff;
   if (typeof detailsDiff === 'string' && detailsDiff.trim().length > 0) {
@@ -41,7 +69,7 @@ function extractToolDiff(block: ContentBlock): string {
   if (/^--- .*?\n\+\+\+ .*?\n@@/m.test(output)) {
     return output;
   }
-  return '';
+  return buildNewFileDiff(block);
 }
 
 function countDiffStats(diff: string): { additions: number; removals: number } {
@@ -258,22 +286,59 @@ function ThinkingBlockView({ block, highlightQuery, activeHighlight }: { block: 
   );
 }
 
-function ToolDiffInline({ diff }: { diff: string }) {
+function createCombinedDiffItem(items: ToolRenderItem[]): ToolRenderItem | null {
+  const changedItems = items.filter((item) => item.diff.trim().length > 0);
+  if (changedItems.length === 0) return null;
+
+  const additions = changedItems.reduce((sum, item) => sum + item.additions, 0);
+  const removals = changedItems.reduce((sum, item) => sum + item.removals, 0);
+  const diff = changedItems
+    .map((item) => item.diff.trimEnd())
+    .filter(Boolean)
+    .join('\n\n');
+
+  return {
+    id: 'combined-diff',
+    label: `${changedItems.length} ${changedItems.length === 1 ? 'file' : 'files'} changed this round`,
+    kind: 'edit',
+    status: changedItems.some((item) => item.status === 'error') ? 'error' : 'success',
+    output: '',
+    outputLineCount: 0,
+    diff,
+    additions,
+    removals,
+  };
+}
+
+function DiffStatsText({ additions, removals }: { additions: number; removals: number }) {
   return (
-    <div className={styles.toolInlineDiff}>
-      {diff.split('\n').map((line, index) => {
-        let cls = styles.diffContext;
-        if (line.startsWith('+') && !line.startsWith('+++')) cls = styles.diffAdded;
-        else if (line.startsWith('-') && !line.startsWith('---')) cls = styles.diffRemoved;
-        else if (line.startsWith('@@')) cls = styles.diffHunk;
-        else if (line.startsWith('+++') || line.startsWith('---')) cls = styles.diffFile;
-        return (
-          <div key={`${index}-${line.slice(0, 12)}`} className={`${styles.diffLine} ${cls}`}>
-            {line}
-          </div>
-        );
-      })}
-    </div>
+    <>
+      {additions > 0 ? <span className="diff-additions">+{additions}</span> : null}
+      {additions > 0 && removals > 0 ? <span className="tool-diff-separator">/</span> : null}
+      {removals > 0 ? <span className="diff-removals">-{removals}</span> : null}
+      {additions <= 0 && removals <= 0 ? <span className="diff-additions">+0</span> : null}
+    </>
+  );
+}
+
+function DiffStatsPill({ item, compact = false }: { item: ToolRenderItem; compact?: boolean }) {
+  return (
+    <span className={compact ? 'tool-diff-pill compact' : 'tool-diff-pill'}>
+      <DiffStatsText additions={item.additions} removals={item.removals} />
+    </span>
+  );
+}
+
+function DiffStatsButton({ item, onOpen, compact = false }: { item: ToolRenderItem; onOpen: () => void; compact?: boolean }) {
+  return (
+    <button
+      type="button"
+      className="tool-diff-summary"
+      title="View all changes from this round"
+      onClick={(event) => { event.stopPropagation(); onOpen(); }}
+    >
+      <DiffStatsPill item={item} compact={compact} />
+    </button>
   );
 }
 
@@ -379,6 +444,7 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
 
   const anyRunning = items.some((item) => item.status === 'running');
   const anyError = items.some((item) => item.status === 'error');
+  const combinedDiffItem = useMemo(() => createCombinedDiffItem(items), [items]);
 
   // Auto-collapse when tools finish running
   if (wasRunningRef.current && !anyRunning) {
@@ -404,37 +470,40 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
   return (
     <>
       <div className={`tool-group${anyRunning ? ' streaming' : ''}${isOpen ? ' open' : ''} status-${groupStatus}`}>
-        <button
-          type="button"
-          className="tool-group-summary-btn"
-          onClick={toggle}
-        >
-          <span className="tool-group-chevron">›</span>
-          <span className="tool-group-summary-text">
-            {isOpen ? `Tools (${items.length})` : closedLabel}
-          </span>
-          {!isOpen && activityHint ? (
-            <span className="tool-group-summary-activity">{activityHint}</span>
-          ) : null}
-          {anyRunning ? (
-            <span className="thinking-dots" aria-hidden="true">
-              <span /><span /><span />
+        <div className="tool-group-summary-bar">
+          <button
+            type="button"
+            className="tool-group-summary-btn"
+            onClick={toggle}
+          >
+            <span className="tool-group-chevron">›</span>
+            <span className="tool-group-summary-text">
+              {isOpen ? `Tools (${items.length})` : closedLabel}
             </span>
+            {!isOpen && activityHint ? (
+              <span className="tool-group-summary-activity">{activityHint}</span>
+            ) : null}
+            {anyRunning ? (
+              <span className="thinking-dots" aria-hidden="true">
+                <span /><span /><span />
+              </span>
+            ) : null}
+          </button>
+          {combinedDiffItem ? (
+            <DiffStatsButton item={combinedDiffItem} compact onOpen={() => setModalItem(combinedDiffItem)} />
           ) : null}
-        </button>
+        </div>
         <div className={`tool-group-list-wrap${isOpen ? '' : ' collapsed'}`}>
           <div className="tool-group-list-inner">
             <div className="tool-group-list">
               {items.map((item) => {
-                const hasInlineDiff = item.kind === 'edit' && item.diff.length > 0;
-                const hasDetail = !hasInlineDiff && (item.diff.length > 0 || item.output.trim().length > 0);
+                const hasDiff = item.diff.length > 0;
+                const hasDetail = hasDiff || item.output.trim().length > 0;
 
                 const statusNode =
-                  hasInlineDiff ? (
+                  hasDiff ? (
                     <span className={`tool-inline-status ${item.status}`}>
-                      <span className="diff-additions">+{item.additions}</span>
-                      {' / '}
-                      <span className="diff-removals">-{item.removals}</span>
+                      <DiffStatsText additions={item.additions} removals={item.removals} />
                     </span>
                   ) : (
                     <span className={`tool-inline-status ${item.status}`}>
@@ -452,7 +521,7 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
                   <div key={item.id} className="tool-inline">
                     <button
                       type="button"
-                      className={`tool-inline-row${hasDetail ? ' expandable' : ''}${hasInlineDiff ? ' has-inline-diff' : ''}`}
+                      className={`tool-inline-row${hasDetail ? ' expandable' : ''}${hasDiff ? ' has-diff' : ''}`}
                       onClick={() => hasDetail && setModalItem(item)}
                     >
                       <span className={`tool-inline-dot ${item.status}`} />
@@ -471,10 +540,19 @@ function ToolGroupView({ blocks, onOpenPreview }: { blocks: ContentBlock[]; onOp
                         Preview
                       </button>
                     )}
-                    {hasInlineDiff ? <ToolDiffInline diff={item.diff} /> : null}
                   </div>
                 );
               })}
+              {combinedDiffItem ? (
+                <button
+                  type="button"
+                  className="tool-change-summary-row"
+                  onClick={() => setModalItem(combinedDiffItem)}
+                >
+                  <span>View all changes from this round</span>
+                  <DiffStatsPill item={combinedDiffItem} />
+                </button>
+              ) : null}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description

Adds a concise diff summary to desktop chat tool groups so file edits are easier to scan after tool-heavy responses. The summary aggregates added and removed lines for the current tool round and opens a modal with the full combined diff.

## Release Notes

- Added clickable added/removed line summaries for edited and newly written files in desktop chat tool results
- Added a full-change modal for reviewing all file changes from a tool round

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes