### PR TITLE
fix(desktop): Generate Responses API chat titles

### DIFF
--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -1629,11 +1629,10 @@ async function generateConversationTitleWithModel({
     url = `${LOCALHOST_URL}:${proxyPort}/v1/responses`;
     body = {
       model: serviceId,
-      max_output_tokens: 32,
-      input: [
-        { role: 'system', content: 'You write short, accurate chat titles. Return only the title.' },
-        { role: 'user', content: prompt },
-      ],
+      max_output_tokens: 128,
+      reasoning: { effort: 'minimal' },
+      instructions: 'You write short, accurate chat titles. Return only the title.',
+      input: [{ role: 'user', content: prompt }],
     };
   }
 


### PR DESCRIPTION
## Description

Fixes desktop chat title generation for OpenAI Responses API services. The title request now sends the title-writing system prompt through top-level `instructions` and gives reasoning models enough budget to return visible output.

## Release Notes

- Fixed automatic chat title generation for Responses API models in the desktop app

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Validation

- `pnpm run build:tier0 && pnpm run build:tier3 && pnpm -C apps/desktop run build:main`
- Verified a live `/v1/responses` title-generation call through the local AntSeed buyer proxy returns a non-empty title
