### PR TITLE
fix(app): Allow desktop microphone access

### DIFF
--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -17,5 +17,8 @@
     <!-- Embedded Fastify dashboard server -->
     <key>com.apple.security.network.server</key>
     <true/>
+    <!-- Microphone access for local voice transcription -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
   </dict>
 </plist>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed Desktop",
-  "version": "0.1.91",
+  "version": "0.1.92",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",


### PR DESCRIPTION
## Description

Adds the macOS audio-input entitlement required for microphone access in signed AntStation builds. Also bumps the desktop app version to 0.1.92 for a follow-up release.

## Release Notes

- Fixed microphone recording permission in the signed macOS desktop app
- Bumped AntSeed Desktop to version 0.1.92

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Validation run locally:

```txt
plutil -lint apps/desktop/build/entitlements.mac.plist
pnpm -C apps/desktop run build:main
```
