### PR TITLE
feat(website): add  link to navbar

### DIFF
--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -176,7 +176,7 @@ const config: Config = {
       },
       items: [
         {to: '/network', label: 'Pricing', position: 'right'},
-        {to: '/integrations', label: 'Integrations hub', position: 'right'},
+        {to: '/integrations', label: 'Integrations', position: 'right'},
         {to: '/providers', label: 'Providers', position: 'right'},
         {
           type: 'docSidebar',
@@ -186,6 +186,7 @@ const config: Config = {
           className: 'header-docs-link',
         },
         {to: '/ants-token', label: '$ANTS', position: 'right'},
+        {href: 'https://diem.antseed.com', label: '$DIEM', position: 'right'},
         {to: '/blog', label: 'Blog', position: 'right'},
         {
           href: 'https://github.com/antseed',


### PR DESCRIPTION
## Summary
- add a `$DIEM` navbar item next to `$ANTS` linking to `https://diem.antseed.com`
- rename `Integrations hub` to `Integrations`
- leave all other website behavior unchanged

## Testing
- ran the current website locally on port 3001
- verified the navbar update in the local preview