### PR TITLE
Fix/identity hex 0x prefix

### DIFF
--- a/apps/cli/src/cli/commands/payments.ts
+++ b/apps/cli/src/cli/commands/payments.ts
@@ -12,7 +12,8 @@ export function registerPaymentsCommand(program: Command): void {
 
       try {
         const { createServer } = await import('@antseed/payments');
-        const identityHex = process.env['ANTSEED_IDENTITY_HEX'] || undefined;
+        const rawHex = process.env['ANTSEED_IDENTITY_HEX'] || undefined;
+  const identityHex = rawHex ? rawHex.replace(/^0x/i, '') : undefined;
         const server = await createServer({ port, dataDir: globalOpts.dataDir, identityHex });
         await server.listen({ port, host: '127.0.0.1' });
 

--- a/apps/cli/src/cli/commands/payments.ts
+++ b/apps/cli/src/cli/commands/payments.ts
@@ -13,7 +13,7 @@ export function registerPaymentsCommand(program: Command): void {
       try {
         const { createServer } = await import('@antseed/payments');
         const rawHex = process.env['ANTSEED_IDENTITY_HEX'] || undefined;
-  const identityHex = rawHex ? rawHex.replace(/^0x/i, '') : undefined;
+        const identityHex = rawHex ? rawHex.replace(/^0x/i, '') : undefined;
         const server = await createServer({ port, dataDir: globalOpts.dataDir, identityHex });
         await server.listen({ port, host: '127.0.0.1' });
 

--- a/apps/payments/src/crypto-context.ts
+++ b/apps/payments/src/crypto-context.ts
@@ -27,7 +27,9 @@ export async function loadCryptoContext(options: {
   let identity: Identity;
 
   if (options.identityHex) {
-    identity = identityFromPrivateKeyHex(options.identityHex);
+    // Normalize: accept both raw hex and 0x-prefixed values
+const normalizedHex = options.identityHex.replace(/^0x/i, '');
+identity = identityFromPrivateKeyHex(normalizedHex);
   } else {
     const { homedir } = await import('node:os');
     const dataDir = options.dataDir || `${homedir()}/.antseed`;

--- a/apps/payments/src/crypto-context.ts
+++ b/apps/payments/src/crypto-context.ts
@@ -28,8 +28,8 @@ export async function loadCryptoContext(options: {
 
   if (options.identityHex) {
     // Normalize: accept both raw hex and 0x-prefixed values
-const normalizedHex = options.identityHex.replace(/^0x/i, '');
-identity = identityFromPrivateKeyHex(normalizedHex);
+    const normalizedHex = options.identityHex.replace(/^0x/i, '');
+    identity = identityFromPrivateKeyHex(normalizedHex);
   } else {
     const { homedir } = await import('node:os');
     const dataDir = options.dataDir || `${homedir()}/.antseed`;


### PR DESCRIPTION
  ## What                                                                                           
                                                                                                    
  Normalize `ANTSEED_IDENTITY_HEX` environment variable to accept both `0x`-prefixed and raw hex    
values.                                                                                             
                                                                                                    
  ## Why                                                                                            
                                                                                                    
  Previously the code only accepted raw 64-character hex strings. Users who set                     
`ANTSEED_IDENTITY_HEX=0x...` (with the common `0x` prefix) would get an `INVALID_ARGUMENT` error    
from ethers when loading the crypto context, especially in the payments portal.                     
                                                                                                    
  This change makes the CLI and payments module accept both forms for better UX and compatibility   
with common key export formats.                                                                     
                                                                                                    
  ## Testing                                                                                        
                                                                                                    
  - Manually verified that both `ANTSEED_IDENTITY_HEX=abcdef...` and                                
`ANTSEED_IDENTITY_HEX=0xabcdef...` now load the identity without error.                             
  - Existing behavior for raw hex values is preserved (no prefix → unchanged).                      
  - The `metrics` command already handled the prefix correctly; no change was needed there.         
                                                                                                    
  ## Checklist                                                                                      
                                                                                                    
  - [ ] `pnpm run build` passes                                                                     
  - [ ] `pnpm run test` passes                                                                      
  - [ ] Breaking changes documented  
