### PR TITLE
fix(desktop): Block unsafe chat payment prompts

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -207,6 +207,105 @@
       text-decoration: line-through;
     }
 
+    .chat-sensitive-artifact {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      max-width: 100%;
+      margin: 0 2px;
+      padding: 2px 6px;
+      border: 1px solid color-mix(in srgb, var(--danger) 26%, var(--border));
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--danger) 7%, var(--bg-card-alt));
+      color: var(--text-secondary);
+      font-size: 0.92em;
+      line-height: 1.4;
+      vertical-align: baseline;
+    }
+
+    .chat-sensitive-label {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .chat-sensitive-action {
+      appearance: none;
+      border: 0;
+      border-radius: 999px;
+      background: color-mix(in srgb, var(--danger) 12%, transparent);
+      color: var(--danger);
+      cursor: pointer;
+      flex: 0 0 auto;
+      font: inherit;
+      font-size: 0.86em;
+      font-weight: 700;
+      line-height: 1.2;
+      padding: 2px 6px;
+    }
+
+    .chat-sensitive-action:hover {
+      background: color-mix(in srgb, var(--danger) 18%, transparent);
+    }
+
+    .chat-sensitive-action:focus-visible {
+      outline: 2px solid var(--danger);
+      outline-offset: 2px;
+    }
+
+    .chat-sensitive-value {
+      max-width: min(420px, 70vw);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      background: transparent;
+      border: 0;
+      padding: 0;
+      color: inherit;
+    }
+
+    .chat-external-link-gated {
+      border-color: color-mix(in srgb, var(--accent-blue) 28%, var(--border));
+      background: color-mix(in srgb, var(--accent-blue) 7%, var(--bg-card-alt));
+    }
+
+    .chat-external-link-gated .chat-sensitive-action {
+      background: color-mix(in srgb, var(--accent-blue) 12%, transparent);
+      color: var(--accent-blue);
+    }
+
+    .chat-external-link-gated .chat-sensitive-action:hover {
+      background: color-mix(in srgb, var(--accent-blue) 18%, transparent);
+    }
+
+    .chat-payment-link-hidden,
+    .chat-wallet-hidden {
+      font-weight: 600;
+    }
+
+    .chat-unsafe-payment-block {
+      margin: 8px 0;
+      padding: 12px 14px;
+      border: 1px solid color-mix(in srgb, var(--danger) 45%, var(--border));
+      border-radius: var(--radius-sm);
+      background: color-mix(in srgb, var(--danger) 10%, var(--bg-card));
+      color: var(--text-primary);
+    }
+
+    .chat-unsafe-payment-title {
+      color: var(--danger);
+      font-size: 13px;
+      font-weight: 800;
+      margin-bottom: 4px;
+    }
+
+    .chat-unsafe-payment-body {
+      color: var(--text-secondary);
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
     .chat-inline-image {
       max-width: 100%;
       border-radius: var(--radius-sm);

--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.tsx
@@ -5,6 +5,7 @@ import { Copy01Icon, Tick02Icon, BrowserIcon } from '@hugeicons/core-free-icons'
 import * as Tooltip from '@radix-ui/react-tooltip';
 import type { ReactNode } from 'react';
 import { MarkdownContent } from './chat-utils.js';
+import { findSensitiveChatArtifacts } from './chat-safety';
 import styles from './ChatBubble.module.scss';
 import { AttachmentViewer, type ViewerAttachment } from './AttachmentViewer';
 import type { ChatMessage, ContentBlock } from './chat-shared';
@@ -161,7 +162,7 @@ function getBlockRenderKey(block: ContentBlock, index: number, messagePrefix = '
 }
 
 
-function StreamingMarkdown({ text, highlightQuery, activeHighlight }: { text: string; highlightQuery?: string; activeHighlight?: boolean }) {
+function StreamingMarkdown({ text, highlightQuery, activeHighlight, blockUnsafePaymentInstructions = false }: { text: string; highlightQuery?: string; activeHighlight?: boolean; blockUnsafePaymentInstructions?: boolean }) {
   const [visibleText, setVisibleText] = useState(text);
   const frameRef = useRef<number | null>(null);
   const lastFrameAtRef = useRef(0);
@@ -222,12 +223,12 @@ function StreamingMarkdown({ text, highlightQuery, activeHighlight }: { text: st
 
   return (
     <div className="chat-bubble-content streaming-cursor">
-      <MarkdownContent text={visibleText} highlightQuery={highlightQuery} activeHighlight={activeHighlight} />
+      <MarkdownContent text={visibleText} highlightQuery={highlightQuery} activeHighlight={activeHighlight} blockUnsafePaymentInstructions={blockUnsafePaymentInstructions} />
     </div>
   );
 }
 
-function ThinkingBlockView({ block, highlightQuery, activeHighlight }: { block: ContentBlock; highlightQuery?: string; activeHighlight?: boolean }) {
+function ThinkingBlockView({ block, highlightQuery, activeHighlight, blockUnsafePaymentInstructions = false }: { block: ContentBlock; highlightQuery?: string; activeHighlight?: boolean; blockUnsafePaymentInstructions?: boolean }) {
   const [manualToggle, setManualToggle] = useState<boolean | null>(null);
   const isOpen = manualToggle ?? false;
   const thinkingText = String(block.thinking || '');
@@ -258,7 +259,7 @@ function ThinkingBlockView({ block, highlightQuery, activeHighlight }: { block: 
         <span className="thinking-block-label">Internal Thoughts</span>
         {!isOpen && (
           <span className="thinking-block-preview">
-            <MarkdownContent text={preview} className="thinking-block-preview-md" highlightQuery={highlightQuery} activeHighlight={activeHighlight} />
+            <MarkdownContent text={preview} className="thinking-block-preview-md" highlightQuery={highlightQuery} activeHighlight={activeHighlight} blockUnsafePaymentInstructions={blockUnsafePaymentInstructions} />
           </span>
         )}
         {block.streaming ? (
@@ -274,8 +275,8 @@ function ThinkingBlockView({ block, highlightQuery, activeHighlight }: { block: 
           <div className="thinking-block-body">
             {hasThinkingText ? (
               block.streaming
-                ? <StreamingMarkdown text={thinkingText} highlightQuery={highlightQuery} activeHighlight={activeHighlight} />
-                : <MarkdownContent text={thinkingText} className="thinking-block-markdown" highlightQuery={highlightQuery} activeHighlight={activeHighlight} />
+                ? <StreamingMarkdown text={thinkingText} highlightQuery={highlightQuery} activeHighlight={activeHighlight} blockUnsafePaymentInstructions={blockUnsafePaymentInstructions} />
+                : <MarkdownContent text={thinkingText} className="thinking-block-markdown" highlightQuery={highlightQuery} activeHighlight={activeHighlight} blockUnsafePaymentInstructions={blockUnsafePaymentInstructions} />
             ) : (
               <div className="chat-bubble-content streaming-cursor">Thinking...</div>
             )}
@@ -590,6 +591,7 @@ function renderAssistantBlocks(
   conversationId?: string,
   highlightQuery?: string,
   activeHighlight?: boolean,
+  blockUnsafePaymentInstructions = false,
 ): ReactNode[] {
   const nodes: ReactNode[] = [];
   let toolGroup: ContentBlock[] = [];
@@ -607,6 +609,7 @@ function renderAssistantBlocks(
       conversationId,
       highlightQuery,
       activeHighlight,
+      blockUnsafePaymentInstructions,
     ));
     thinkingGroup = [];
   };
@@ -643,7 +646,7 @@ function renderAssistantBlocks(
     }
 
     flushGroups();
-    nodes.push(renderBlock(block, index, streaming, messagePrefix, conversationId, highlightQuery, activeHighlight));
+    nodes.push(renderBlock(block, index, streaming, messagePrefix, conversationId, highlightQuery, activeHighlight, blockUnsafePaymentInstructions));
   });
 
   flushGroups();
@@ -765,18 +768,19 @@ function renderBlock(
   conversationId?: string,
   highlightQuery?: string,
   activeHighlight?: boolean,
+  blockUnsafePaymentInstructions = false,
 ): ReactNode {
   const blockKey = getBlockRenderKey(block, index, messagePrefix);
 
   if (block.type === 'text') {
     if (block.streaming) {
-      return <StreamingMarkdown key={blockKey} text={String(block.text || '')} highlightQuery={highlightQuery} activeHighlight={activeHighlight} />;
+      return <StreamingMarkdown key={blockKey} text={String(block.text || '')} highlightQuery={highlightQuery} activeHighlight={activeHighlight} blockUnsafePaymentInstructions={blockUnsafePaymentInstructions} />;
     }
-    return <MarkdownContent key={blockKey} text={String(block.text || '')} highlightQuery={highlightQuery} activeHighlight={activeHighlight} />;
+    return <MarkdownContent key={blockKey} text={String(block.text || '')} highlightQuery={highlightQuery} activeHighlight={activeHighlight} blockUnsafePaymentInstructions={blockUnsafePaymentInstructions} />;
   }
 
   if (block.type === 'thinking') {
-    return <ThinkingBlockView key={blockKey} block={block} highlightQuery={highlightQuery} activeHighlight={activeHighlight} />;
+    return <ThinkingBlockView key={blockKey} block={block} highlightQuery={highlightQuery} activeHighlight={activeHighlight} blockUnsafePaymentInstructions={blockUnsafePaymentInstructions} />;
   }
 
   if (block.type === 'file') {
@@ -842,6 +846,13 @@ function CopyResponseButton({ content }: { content: unknown }) {
   const handleCopy = useCallback(() => {
     const text = extractPlainText(content);
     if (!text) return;
+    const artifacts = findSensitiveChatArtifacts(text);
+    if (artifacts.length > 0) {
+      const shouldCopy = window.confirm(
+        'This response contains hidden addresses or gated links. AntSeed will never ask you to send funds, deposit, top up, connect a wallet, or approve transactions from chat. Copy the original response anyway?',
+      );
+      if (!shouldCopy) return;
+    }
     navigator.clipboard.writeText(text).then(() => {
       setCopied(true);
       if (timerRef.current !== null) window.clearTimeout(timerRef.current);
@@ -911,9 +922,9 @@ export function ChatBubble({ message, streaming = false, onOpenPreview, conversa
   const content = useMemo(() => {
     if (message.role === 'assistant') {
       if (Array.isArray(message.content)) {
-        return renderAssistantBlocks(message.content as ContentBlock[], isStreamingBubble, messagePrefix, onOpenPreview, conversationId, searchQuery, searchActive);
+        return renderAssistantBlocks(message.content as ContentBlock[], isStreamingBubble, messagePrefix, onOpenPreview, conversationId, searchQuery, searchActive, true);
       }
-      return <MarkdownContent text={String(message.content)} highlightQuery={searchQuery} activeHighlight={searchActive} />;
+      return <MarkdownContent text={String(message.content)} highlightQuery={searchQuery} activeHighlight={searchActive} blockUnsafePaymentInstructions />;
     }
 
     if (typeof message.content === 'string') {
@@ -921,7 +932,7 @@ export function ChatBubble({ message, streaming = false, onOpenPreview, conversa
     }
 
     if (Array.isArray(message.content)) {
-      return (message.content as ContentBlock[]).map((block, index) => renderBlock(block, index, isStreamingBubble, messagePrefix, conversationId, searchQuery, searchActive));
+      return (message.content as ContentBlock[]).map((block, index) => renderBlock(block, index, isStreamingBubble, messagePrefix, conversationId, searchQuery, searchActive, false));
     }
 
     return <div className="chat-bubble-content">{JSON.stringify(message.content)}</div>;

--- a/apps/desktop/src/renderer/ui/components/chat/chat-safety.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-safety.ts
@@ -1,0 +1,170 @@
+export type SensitiveChatArtifact =
+  | { type: 'url'; value: string; scheme: string; display: string }
+  | { type: 'wallet-address'; value: string; chainHint: string };
+
+export type ChatTextSegment =
+  | { type: 'text'; text: string }
+  | { type: 'artifact'; artifact: SensitiveChatArtifact };
+
+type MatchCandidate = {
+  start: number;
+  end: number;
+  artifact: SensitiveChatArtifact;
+  priority: number;
+};
+
+const ZERO_WIDTH_CHARS = /[\u200B-\u200D\uFEFF]/g;
+const URL_OR_PAYMENT_URI_PATTERN = /\b(?:(?:https?:\/\/|www\.)[^\s<>{}|\\^`"']+|(?:ethereum|bitcoin|solana|wc):[^\s<>{}|\\^`"']+)/giu;
+const EVM_ADDRESS_PATTERN = /\b0x[a-fA-F0-9]{40}\b/g;
+const BITCOIN_ADDRESS_PATTERN = /\b(?:bc1[ac-hj-np-z02-9]{25,87}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})\b/gi;
+const COSMOS_ADDRESS_PATTERN = /\b[a-z]{2,16}1[0-9a-z]{38,58}\b/gi;
+// Broad enough to catch common Solana/base58 addresses, but constrained to avoid
+// ordinary prose: base58 only, 32-44 chars, and at least one digit plus both cases.
+const SOLANA_ADDRESS_PATTERN = /\b(?=[1-9A-HJ-NP-Za-km-z]{32,44}\b)(?=[1-9A-HJ-NP-Za-km-z]*\d)(?=[1-9A-HJ-NP-Za-km-z]*[A-Z])(?=[1-9A-HJ-NP-Za-km-z]*[a-z])[1-9A-HJ-NP-Za-km-z]{32,44}\b/g;
+
+const TRAILING_URL_PUNCTUATION = /[),.;:!?]+$/;
+const PAYMENT_INTENT_PATTERN = /\b(?:send|transfer|deposit|top\s*up|fund|funds|pay|payment|required|billing|balance|insufficient|add\s+credits?|add\s+funds?|connect\s+(?:your\s+)?wallet|approve\s+(?:the\s+)?(?:transaction|token|spend|allowance)|claim\s+(?:refund|airdrop|reward)|verify\s+(?:your\s+)?wallet|wallet\s+verification)\b/i;
+
+function normalizeForDetection(text: string): string {
+  return text
+    .normalize('NFKC')
+    .replace(ZERO_WIDTH_CHARS, '')
+    .replace(/[._\-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function trimUrlPunctuation(value: string): string {
+  let next = value;
+  while (TRAILING_URL_PUNCTUATION.test(next)) {
+    const candidate = next.replace(TRAILING_URL_PUNCTUATION, '');
+    if (candidate.length === next.length || candidate.length === 0) break;
+    next = candidate;
+  }
+  return next;
+}
+
+function urlArtifact(rawValue: string): SensitiveChatArtifact | null {
+  const trimmed = trimUrlPunctuation(rawValue.trim());
+  if (!trimmed) return null;
+  const withProtocol = trimmed.toLowerCase().startsWith('www.') ? `https://${trimmed}` : trimmed;
+
+  try {
+    const parsed = new URL(withProtocol);
+    const scheme = parsed.protocol.replace(/:$/, '').toLowerCase();
+    if (!scheme) return null;
+
+    let display = scheme;
+    if (scheme === 'http' || scheme === 'https') {
+      display = parsed.hostname.replace(/^www\./i, '') || 'external link';
+    } else if (scheme === 'mailto') {
+      display = 'email link';
+    } else if (scheme === 'wc') {
+      display = 'WalletConnect link';
+    } else if (scheme === 'ethereum' || scheme === 'bitcoin' || scheme === 'solana') {
+      display = `${scheme} payment link`;
+    }
+
+    return { type: 'url', value: withProtocol, scheme, display };
+  } catch {
+    return null;
+  }
+}
+
+function pushRegexMatches(
+  candidates: MatchCandidate[],
+  text: string,
+  pattern: RegExp,
+  chainHint: string,
+  priority: number,
+): void {
+  pattern.lastIndex = 0;
+  for (const match of text.matchAll(pattern)) {
+    const value = match[0];
+    if (!value || match.index === undefined) continue;
+    candidates.push({
+      start: match.index,
+      end: match.index + value.length,
+      artifact: { type: 'wallet-address', value, chainHint },
+      priority,
+    });
+  }
+}
+
+function collectSensitiveArtifacts(text: string): MatchCandidate[] {
+  const candidates: MatchCandidate[] = [];
+
+  URL_OR_PAYMENT_URI_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(URL_OR_PAYMENT_URI_PATTERN)) {
+    const raw = match[0];
+    if (!raw || match.index === undefined) continue;
+    const artifact = urlArtifact(raw);
+    if (!artifact) continue;
+    candidates.push({
+      start: match.index,
+      end: match.index + trimUrlPunctuation(raw).length,
+      artifact,
+      priority: 10,
+    });
+  }
+
+  pushRegexMatches(candidates, text, EVM_ADDRESS_PATTERN, 'EVM', 5);
+  pushRegexMatches(candidates, text, BITCOIN_ADDRESS_PATTERN, 'Bitcoin', 4);
+  pushRegexMatches(candidates, text, COSMOS_ADDRESS_PATTERN, 'Cosmos', 3);
+  pushRegexMatches(candidates, text, SOLANA_ADDRESS_PATTERN, 'wallet-like', 2);
+
+  candidates.sort((a, b) => a.start - b.start || b.priority - a.priority || (b.end - b.start) - (a.end - a.start));
+
+  const selected: MatchCandidate[] = [];
+  let cursor = 0;
+  for (const candidate of candidates) {
+    if (candidate.start < cursor) continue;
+    selected.push(candidate);
+    cursor = candidate.end;
+  }
+  return selected;
+}
+
+export function segmentSensitiveChatText(text: string): ChatTextSegment[] {
+  if (!text) return [{ type: 'text', text: '' }];
+  const matches = collectSensitiveArtifacts(text);
+  if (matches.length === 0) return [{ type: 'text', text }];
+
+  const segments: ChatTextSegment[] = [];
+  let cursor = 0;
+  for (const match of matches) {
+    if (match.start > cursor) {
+      segments.push({ type: 'text', text: text.slice(cursor, match.start) });
+    }
+    segments.push({ type: 'artifact', artifact: match.artifact });
+    cursor = match.end;
+  }
+  if (cursor < text.length) {
+    segments.push({ type: 'text', text: text.slice(cursor) });
+  }
+  return segments;
+}
+
+export function findSensitiveChatArtifacts(text: string): SensitiveChatArtifact[] {
+  return collectSensitiveArtifacts(text).map((match) => match.artifact);
+}
+
+export function hasSensitiveChatArtifact(text: string): boolean {
+  return collectSensitiveArtifacts(text).length > 0;
+}
+
+export function isLikelyUnsafePaymentInstruction(text: string): boolean {
+  if (!hasSensitiveChatArtifact(text)) return false;
+  return PAYMENT_INTENT_PATTERN.test(normalizeForDetection(text));
+}
+
+export function formatArtifactLabel(artifact: SensitiveChatArtifact): string {
+  if (artifact.type === 'wallet-address') {
+    return `${artifact.chainHint} address hidden`;
+  }
+  if (artifact.scheme === 'wc') return 'WalletConnect link hidden';
+  if (artifact.scheme === 'ethereum' || artifact.scheme === 'bitcoin' || artifact.scheme === 'solana') {
+    return `${artifact.scheme} payment link hidden`;
+  }
+  return `External link: ${artifact.display}`;
+}

--- a/apps/desktop/src/renderer/ui/components/chat/chat-utils.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-utils.tsx
@@ -3,12 +3,20 @@ import type { ReactNode } from 'react';
 import { Lexer } from 'marked';
 import type { ChatMessage } from './chat-shared';
 import { isToolResultOnlyMessage as isToolResultOnlyMessageShared } from './chat-shared';
+import {
+  findSensitiveChatArtifacts,
+  formatArtifactLabel,
+  isLikelyUnsafePaymentInstruction,
+  segmentSensitiveChatText,
+} from './chat-safety';
+import type { SensitiveChatArtifact } from './chat-safety';
 
 type MarkdownContentProps = {
   text: string;
   className?: string;
   highlightQuery?: string;
   activeHighlight?: boolean;
+  blockUnsafePaymentInstructions?: boolean;
 };
 
 type MarkdownToken = {
@@ -31,18 +39,6 @@ type MarkdownToken = {
 };
 
 export const isToolResultOnlyMessage = isToolResultOnlyMessageShared;
-
-function isSafeHref(rawHref: string): boolean {
-  const trimmed = rawHref.trim();
-  if (!trimmed) return false;
-  try {
-    const parsed = new URL(trimmed, 'https://antseed.invalid');
-    const protocol = parsed.protocol.toLowerCase();
-    return protocol === 'http:' || protocol === 'https:' || protocol === 'mailto:';
-  } catch {
-    return false;
-  }
-}
 
 function normalizeText(value: unknown): string {
   return typeof value === 'string' ? value : String(value ?? '');
@@ -109,6 +105,128 @@ function splitHighlightedText(text: string, query: string | undefined, keyPrefix
   return <>{parts}</>;
 }
 
+function securityWarning(): string {
+  return 'This came from untrusted chat content. AntSeed will never ask you to send funds, deposit, top up, connect a wallet, or approve transactions from chat. Use only the official AntSeed wallet screen.';
+}
+
+function confirmUnsafeAction(action: string, target?: string): boolean {
+  const targetLine = target ? `\n\nDestination:\n${target}` : '';
+  return window.confirm(`${securityWarning()}\n\n${action}${targetLine}`);
+}
+
+function safeOpenExternalUrl(url: string): void {
+  if (!confirmUnsafeAction('Open this external destination anyway?', url)) return;
+  window.open(url, '_blank', 'noopener,noreferrer');
+}
+
+function firstArtifactFromText(value: string): SensitiveChatArtifact | null {
+  const segment = segmentSensitiveChatText(value).find((part) => part.type === 'artifact');
+  return segment?.type === 'artifact' ? segment.artifact : null;
+}
+
+function HiddenWalletAddress({ artifact }: { artifact: SensitiveChatArtifact }) {
+  const [revealed, setRevealed] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const value = artifact.value;
+  const label = formatArtifactLabel(artifact);
+
+  const handleReveal = (): void => {
+    if (!revealed && !confirmUnsafeAction('Reveal this wallet address anyway?')) return;
+    setRevealed(true);
+  };
+
+  const handleCopy = (): void => {
+    if (!confirmUnsafeAction('Copy this wallet address anyway?')) return;
+    void navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    }).catch(() => undefined);
+  };
+
+  if (!revealed) {
+    return (
+      <span className="chat-sensitive-artifact chat-wallet-hidden">
+        <span className="chat-sensitive-label">{label}</span>
+        <button type="button" className="chat-sensitive-action" onClick={handleReveal}>
+          Reveal
+        </button>
+      </span>
+    );
+  }
+
+  return (
+    <span className="chat-sensitive-artifact chat-wallet-revealed">
+      <code className="chat-sensitive-value">{value}</code>
+      <button type="button" className="chat-sensitive-action" onClick={handleCopy}>
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </span>
+  );
+}
+
+function SafeExternalLink({ artifact }: { artifact: SensitiveChatArtifact }) {
+  const label = formatArtifactLabel(artifact);
+  const isPaymentLink = artifact.type === 'url' && ['ethereum', 'bitcoin', 'solana', 'wc'].includes(artifact.scheme);
+
+  return (
+    <span className={`chat-sensitive-artifact${isPaymentLink ? ' chat-payment-link-hidden' : ' chat-external-link-gated'}`}>
+      <span className="chat-sensitive-label">{label}</span>
+      <button type="button" className="chat-sensitive-action" onClick={() => safeOpenExternalUrl(artifact.value)}>
+        {isPaymentLink ? 'Open anyway' : 'Open with warning'}
+      </button>
+    </span>
+  );
+}
+
+function SafeArtifact({ artifact }: { artifact: SensitiveChatArtifact; children?: ReactNode }) {
+  if (artifact.type === 'wallet-address') return <HiddenWalletAddress artifact={artifact} />;
+  return <SafeExternalLink artifact={artifact} />;
+}
+
+function splitSafeHighlightedText(text: string, query: string | undefined, keyPrefix: string, activeHighlight = false): ReactNode {
+  const segments = segmentSensitiveChatText(text);
+  if (segments.length === 1 && segments[0]?.type === 'text') {
+    return splitHighlightedText(segments[0].text, query, keyPrefix, activeHighlight);
+  }
+
+  return (
+    <>
+      {segments.map((segment, index) => {
+        const key = `${keyPrefix}-safe-${index}`;
+        if (segment.type === 'text') {
+          return <Fragment key={key}>{splitHighlightedText(segment.text, query, key, activeHighlight)}</Fragment>;
+        }
+        return <SafeArtifact key={key} artifact={segment.artifact} />;
+      })}
+    </>
+  );
+}
+
+function BlockedUnsafePaymentInstruction() {
+  return (
+    <div className="chat-unsafe-payment-block" role="alert">
+      <div className="chat-unsafe-payment-title">Unsafe payment instruction blocked</div>
+      <div className="chat-unsafe-payment-body">
+        A peer response tried to direct you to a payment, deposit, wallet, or external destination.
+        AntSeed will never ask you to send funds, top up, connect a wallet, or approve transactions inside chat.
+        Use only the official AntSeed wallet screen.
+      </div>
+    </div>
+  );
+}
+
+function confirmCopyIfSensitive(text: string): boolean {
+  const artifacts = findSensitiveChatArtifacts(text);
+  if (artifacts.length === 0) return true;
+  const addressCount = artifacts.filter((artifact) => artifact.type === 'wallet-address').length;
+  const linkCount = artifacts.filter((artifact) => artifact.type === 'url').length;
+  const parts = [
+    addressCount > 0 ? `${addressCount} hidden address${addressCount === 1 ? '' : 'es'}` : '',
+    linkCount > 0 ? `${linkCount} gated link${linkCount === 1 ? '' : 's'}` : '',
+  ].filter(Boolean).join(' and ');
+  return confirmUnsafeAction(`This text contains ${parts}. Copy the original text anyway?`);
+}
+
 function flattenPlainText(tokens: MarkdownToken[] | undefined): string {
   if (!Array.isArray(tokens) || tokens.length === 0) return '';
   let output = '';
@@ -137,9 +255,9 @@ function renderInlineToken(token: MarkdownToken, key: string, highlightQuery?: s
       if (Array.isArray(token.tokens) && token.tokens.length > 0) {
         return <Fragment key={key}>{renderInlineTokens(token.tokens, key, highlightQuery, activeHighlight)}</Fragment>;
       }
-      return <Fragment key={key}>{splitHighlightedText(normalizeText(token.text), highlightQuery, key, activeHighlight)}</Fragment>;
+      return <Fragment key={key}>{splitSafeHighlightedText(normalizeText(token.text), highlightQuery, key, activeHighlight)}</Fragment>;
     case 'escape':
-      return <Fragment key={key}>{splitHighlightedText(normalizeText(token.text), highlightQuery, key, activeHighlight)}</Fragment>;
+      return <Fragment key={key}>{splitSafeHighlightedText(normalizeText(token.text), highlightQuery, key, activeHighlight)}</Fragment>;
     case 'strong':
       return <strong key={key}>{renderInlineTokens(token.tokens, key, highlightQuery, activeHighlight)}</strong>;
     case 'em':
@@ -147,7 +265,7 @@ function renderInlineToken(token: MarkdownToken, key: string, highlightQuery?: s
     case 'codespan':
       return (
         <code key={key} className="chat-inline-code">
-          {splitHighlightedText(normalizeText(token.text), highlightQuery, key, activeHighlight)}
+          {splitSafeHighlightedText(normalizeText(token.text), highlightQuery, key, activeHighlight)}
         </code>
       );
     case 'br':
@@ -157,43 +275,41 @@ function renderInlineToken(token: MarkdownToken, key: string, highlightQuery?: s
     case 'link': {
       const href = normalizeText(token.href);
       const content = renderInlineTokens(token.tokens, key, highlightQuery, activeHighlight);
-      if (!isSafeHref(href)) {
+      const artifact = firstArtifactFromText(href);
+      if (!artifact || artifact.type !== 'url') {
         return (
           <span key={key} className="chat-inline-link-invalid">
             {content}
           </span>
         );
       }
-      return (
-        <a
-          key={key}
-          href={href}
-          style={{ color: 'var(--accent-blue)', textDecoration: 'underline' }}
-          target="_blank"
-          rel="noopener noreferrer"
-          title={token.title ?? undefined}
-        >
-          {content}
-        </a>
-      );
+      return <SafeArtifact key={key} artifact={artifact}>{content}</SafeArtifact>;
     }
     case 'image': {
       const href = normalizeText(token.href);
       const alt = flattenPlainText(token.tokens) || normalizeText(token.text) || 'Image';
-      if (!isSafeHref(href)) {
+      const artifact = firstArtifactFromText(href);
+      if (!artifact || artifact.type !== 'url') {
         return (
           <span key={key} className="chat-inline-link-invalid">
             {alt}
           </span>
         );
       }
-      return <img key={key} src={href} alt={alt} className="chat-inline-image" />;
+      return (
+        <span key={key} className="chat-sensitive-artifact chat-external-image-hidden">
+          <span className="chat-sensitive-label">External image hidden: {artifact.display}</span>
+          <button type="button" className="chat-sensitive-action" onClick={() => safeOpenExternalUrl(artifact.value)}>
+            Open with warning
+          </button>
+        </span>
+      );
     }
     default:
       if (Array.isArray(token.tokens) && token.tokens.length > 0) {
         return <Fragment key={key}>{renderInlineTokens(token.tokens, key, highlightQuery, activeHighlight)}</Fragment>;
       }
-      return <Fragment key={key}>{splitHighlightedText(normalizeText(token.text ?? token.raw), highlightQuery, key, activeHighlight)}</Fragment>;
+      return <Fragment key={key}>{splitSafeHighlightedText(normalizeText(token.text ?? token.raw), highlightQuery, key, activeHighlight)}</Fragment>;
   }
 }
 
@@ -205,7 +321,7 @@ function renderTableCell(token: MarkdownToken, key: string, highlightQuery?: str
   if (Array.isArray(token.tokens) && token.tokens.length > 0) {
     return <Fragment key={key}>{renderInlineTokens(token.tokens, key, highlightQuery, activeHighlight)}</Fragment>;
   }
-  return <Fragment key={key}>{splitHighlightedText(normalizeText(token.text ?? token.raw), highlightQuery, key, activeHighlight)}</Fragment>;
+  return <Fragment key={key}>{splitSafeHighlightedText(normalizeText(token.text ?? token.raw), highlightQuery, key, activeHighlight)}</Fragment>;
 }
 
 function renderListItemContent(token: MarkdownToken, key: string, highlightQuery?: string, activeHighlight = false): ReactNode {
@@ -217,7 +333,7 @@ function renderListItemContent(token: MarkdownToken, key: string, highlightQuery
     }
     return <>{renderInlineTokens(token.tokens, key, highlightQuery, activeHighlight)}</>;
   }
-  return splitHighlightedText(normalizeText(token.text ?? token.raw), highlightQuery, key, activeHighlight);
+  return splitSafeHighlightedText(normalizeText(token.text ?? token.raw), highlightQuery, key, activeHighlight);
 }
 
 function CodeBlock({ code, lang, highlightQuery, activeHighlight }: { code: string; lang?: string; highlightQuery?: string; activeHighlight?: boolean }) {
@@ -225,6 +341,7 @@ function CodeBlock({ code, lang, highlightQuery, activeHighlight }: { code: stri
   const langLabel = normalizeText(lang).trim() || 'code';
 
   const handleCopy = (): void => {
+    if (!confirmCopyIfSensitive(code)) return;
     void navigator.clipboard.writeText(code).then(() => {
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);
@@ -240,7 +357,7 @@ function CodeBlock({ code, lang, highlightQuery, activeHighlight }: { code: stri
         </button>
       </div>
       <pre>
-        <code>{splitHighlightedText(code, highlightQuery, 'code', activeHighlight)}</code>
+        <code>{splitSafeHighlightedText(code, highlightQuery, 'code', activeHighlight)}</code>
       </pre>
     </div>
   );
@@ -256,7 +373,7 @@ function renderBlockToken(token: MarkdownToken, key: string, highlightQuery?: st
       if (Array.isArray(token.tokens) && token.tokens.length > 0) {
         return <p key={key}>{renderInlineTokens(token.tokens, key, highlightQuery, activeHighlight)}</p>;
       }
-      return <p key={key}>{splitHighlightedText(normalizeText(token.text), highlightQuery, key, activeHighlight)}</p>;
+      return <p key={key}>{splitSafeHighlightedText(normalizeText(token.text), highlightQuery, key, activeHighlight)}</p>;
     case 'heading': {
       const depth = Math.min(Math.max(Number(token.depth) || 1, 1), 6);
       const children = renderInlineTokens(token.tokens, key, highlightQuery, activeHighlight);
@@ -323,11 +440,15 @@ function renderBlockToken(token: MarkdownToken, key: string, highlightQuery?: st
       if (Array.isArray(token.tokens) && token.tokens.length > 0) {
         return <Fragment key={key}>{renderBlockTokens(token.tokens, key, highlightQuery, activeHighlight)}</Fragment>;
       }
-      return <p key={key}>{splitHighlightedText(normalizeText(token.text ?? token.raw), highlightQuery, key, activeHighlight)}</p>;
+      return <p key={key}>{splitSafeHighlightedText(normalizeText(token.text ?? token.raw), highlightQuery, key, activeHighlight)}</p>;
   }
 }
 
-export function MarkdownContent({ text, className = 'chat-bubble-content', highlightQuery, activeHighlight }: MarkdownContentProps) {
+export function MarkdownContent({ text, className = 'chat-bubble-content', highlightQuery, activeHighlight, blockUnsafePaymentInstructions = false }: MarkdownContentProps) {
+  const shouldBlock = blockUnsafePaymentInstructions && isLikelyUnsafePaymentInstruction(text);
   const tokens = useMemo(() => Lexer.lex(text, { gfm: true, breaks: true }) as MarkdownToken[], [text]);
+  if (shouldBlock) {
+    return <div className={className}><BlockedUnsafePaymentInstruction /></div>;
+  }
   return <div className={className}>{renderBlockTokens(tokens, 'md', highlightQuery, activeHighlight)}</div>;
 }


### PR DESCRIPTION
## Description

Adds buyer-side safety rendering in AntStation chat so peer-generated content cannot directly present wallet addresses, payment links, or external destinations as trusted actions. Assistant responses with obvious payment/deposit instructions plus an actionable target are blocked before display.

## Release Notes

- Hidden wallet addresses in AntStation chat behind an explicit safety warning
- Gated external links and payment URI schemes with an interstitial warning
- Blocked assistant responses that combine payment/deposit language with links or wallet addresses

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Verification

- pnpm --filter @antseed/desktop run typecheck:renderer
- pnpm --filter @antseed/desktop run build:renderer
