### PR TITLE
fix(diem-staking): approve exact stake amount instead of unlimited DIEM allowance

### DIFF
--- a/apps/diem-staking/src/components/StakeCard.tsx
+++ b/apps/diem-staking/src/components/StakeCard.tsx
@@ -325,7 +325,7 @@ function StakePanel(props: StakePanelProps) {
             className="stake-cta"
             disabled={approve.isPending}
             onClick={async () => {
-              await approve.run();
+              await approve.run(props.amt);
               refetchAllowance();
             }}
           >

--- a/apps/diem-staking/src/lib/actions.ts
+++ b/apps/diem-staking/src/lib/actions.ts
@@ -4,21 +4,28 @@
 
 import { useCallback } from 'react';
 import { useWriteContract } from 'wagmi';
-import { parseEther, maxUint256 } from 'viem';
+import { parseEther } from 'viem';
 
 import { DIEM_TOKEN, DIEM_STAKING_PROXY } from './addresses';
 import { DIEM_STAKING_PROXY_ABI, DIEM_TOKEN_ABI } from './abi';
 
 export function useApproveDiem() {
   const { writeContractAsync, isPending, error, reset } = useWriteContract();
-  const run = useCallback(async () => {
-    return writeContractAsync({
-      address: DIEM_TOKEN,
-      abi: DIEM_TOKEN_ABI,
-      functionName: 'approve',
-      args: [DIEM_STAKING_PROXY, maxUint256],
-    });
-  }, [writeContractAsync]);
+  // Approve exactly the amount the user is about to stake. Avoids prompting the
+  // user to ratify an unlimited DIEM allowance — one approve per stake is the
+  // safer pattern if the proxy is ever upgraded or compromised.
+  const run = useCallback(
+    async (amountDiem: string) => {
+      const amt = parseEther(amountDiem);
+      return writeContractAsync({
+        address: DIEM_TOKEN,
+        abi: DIEM_TOKEN_ABI,
+        functionName: 'approve',
+        args: [DIEM_STAKING_PROXY, amt],
+      });
+    },
+    [writeContractAsync],
+  );
   return { run, isPending, error, reset };
 }
 


### PR DESCRIPTION
## Summary

- Replaces maxUint256 in useApproveDiem with the precise amount the user is staking (parseEther(amountDiem))
- Updates the StakeCard.tsx call-site to pass props.amt through to the hook
- Removes the now-unused maxUint256 import from viem

## Why

Unlimited ERC-20 allowances are a known blast-radius amplifier. If the staking proxy is ever upgraded with a bug or a key is compromised, a standing maxUint256 approval gives an attacker full access to every user's DIEM balance. Approving exactly the stake amount eliminates that risk. Users will now see "Approve X DIEM" in their wallet instead of "Approve unlimited".

## Test plan

- [ ] Typecheck passes (pnpm --filter diem-staking exec tsc --noEmit) — verified clean locally
- [ ] Approve button flow: enter an amount, click Approve DIEM, confirm wallet shows the specific amount (not unlimited), allowance refetches, Stake button becomes active
- [ ] Stake-without-prior-allowance regression: fresh wallet session shows approve step correctly
- [ ] No test suite exists for apps/diem-staking yet — a Wagmi-mock unit test asserting approve receives parseEther(amount) rather than maxUint256 is a recommended follow-up

Fixes BUG-155.

Generated with [Claude Code](https://claude.com/claude-code)