### PR TITLE
Fix/network browse seller 596

### DIFF
--- a/apps/cli/src/cli/commands/network/browse.ts
+++ b/apps/cli/src/cli/commands/network/browse.ts
@@ -219,12 +219,39 @@ function peerReputationScore(peer: PeerInfo): number {
   return effectiveOnChainReputationScore(peer) ?? -1;
 }
 
-type PeerInfoJson = Omit<PeerInfo, 'onChainReputationScore'> & { onChainReputationScore: number | null };
+type PeerInfoJson = Omit<PeerInfo, 'onChainReputationScore'> & {
+  onChainReputationScore: number | null;
+  sellerAddress: string;
+  isDelegatedSeller: boolean;
+};
+
+function normalizeAddressHex(raw: string | undefined): string | null {
+  const normalized = raw?.trim().replace(/^0x/i, '').toLowerCase();
+  return normalized && /^[0-9a-f]{40}$/.test(normalized) ? normalized : null;
+}
+
+/**
+ * Derive the on-chain seller address for a peer. When the peer announces a
+ * `sellerContract` in its metadata (delegated/proxy sellers), that address
+ * is the actual on-chain seller; otherwise the peer's own address is the seller.
+ */
+function sellerAddressForPeer(peer: PeerInfo): string {
+  return normalizeAddressHex(peer.metadata?.sellerContract) ?? peer.peerId;
+}
+
+function delegatedSellerAddress(peer: PeerInfo): string | null {
+  const sellerAddress = sellerAddressForPeer(peer);
+  const peerAddress = normalizeAddressHex(peer.peerId) ?? peer.peerId.toLowerCase();
+  return sellerAddress !== peerAddress ? sellerAddress : null;
+}
 
 function peerWithReputationScore(peer: PeerInfo): PeerInfoJson {
+  const sellerAddress = sellerAddressForPeer(peer);
   return {
     ...peer,
     onChainReputationScore: effectiveOnChainReputationScore(peer),
+    sellerAddress,
+    isDelegatedSeller: delegatedSellerAddress(peer) !== null,
   };
 }
 
@@ -337,6 +364,9 @@ function parseTopLimit(raw: string | undefined): number {
  * The "Free" column is only emitted when at least one displayed peer has
  * free services; otherwise it's omitted so the common-case table stays
  * compact.
+ *
+ * A "Seller" column is added when at least one displayed peer has a
+ * `sellerContract` that differs from its peerId (delegated/proxy sellers).
  */
 function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
   const freeNamesByPeer = new Map(
@@ -344,14 +374,21 @@ function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
   );
   const anyFreeService = Array.from(freeNamesByPeer.values()).some((names) => names.length > 0);
 
+  // Show the "Seller" column when at least one peer has a sellerContract
+  // that differs from its peerId (i.e. a delegated/proxy seller).
+  const anyDelegatedSeller = peers.some((peer) => delegatedSellerAddress(peer) !== null);
+
   const head: string[] = [
     chalk.bold('Peer'),
+  ];
+  if (anyDelegatedSeller) head.push(chalk.bold('On-chain seller'));
+  head.push(
     chalk.bold('Name'),
     chalk.bold('Providers'),
     chalk.bold('Services'),
     chalk.bold('Min In $/1M'),
     chalk.bold('Min Out $/1M'),
-  ];
+  );
   if (anyFreeService) head.push(chalk.bold('Free'));
   head.push(
     chalk.bold('Score'),
@@ -383,6 +420,9 @@ function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
     const badge = isPeerVouched(peer) ? chalk.green(' ✓') : '';
     const peerCell = peer.peerId + badge;
 
+    const sellerAddress = delegatedSellerAddress(peer);
+    const sellerCell = sellerAddress !== null ? chalk.yellow(sellerAddress) : chalk.dim('—');
+
     const freeNames = freeNamesByPeer.get(peer.peerId) ?? [];
     const freeCell = freeNames.length === 0
       ? chalk.dim('—')
@@ -392,12 +432,15 @@ function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
 
     const row: string[] = [
       peerCell,
+    ];
+    if (anyDelegatedSeller) row.push(sellerCell);
+    row.push(
       peer.displayName ?? chalk.dim('—'),
       peer.providers.join(', ') || chalk.dim('—'),
       servicesCell,
       formatUsdPerMillion(pricing.input),
       formatUsdPerMillion(pricing.output),
-    ];
+    );
     if (anyFreeService) row.push(freeCell);
     row.push(
       formatReputationScore(peer),
@@ -421,6 +464,9 @@ function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
   }
   if (anyFreeService) {
     console.log(chalk.dim('  Free column lists services a peer offers at $0 in/out. "Min In/Out $/1M" always reflects the cheapest PAID option.'));
+  }
+  if (anyDelegatedSeller) {
+    console.log(chalk.dim(`  ${chalk.yellow('On-chain seller')} is the contract address that receives payments — differs from Peer when a delegated/proxy operator runs the node.`));
   }
   console.log('');
 }
@@ -454,6 +500,10 @@ function renderExpandedTable(peers: PeerInfo[], requestedTags: Set<string>): voi
   }> = [];
 
   const hasTagFilter = requestedTags.size > 0;
+
+  // Show the "Seller" column when at least one peer has a sellerContract
+  // that differs from its peerId (i.e. a delegated/proxy seller).
+  const anyDelegatedSeller = peers.some((peer) => delegatedSellerAddress(peer) !== null);
 
   for (const peer of peers) {
     const pricing = peer.providerPricing;
@@ -520,6 +570,9 @@ function renderExpandedTable(peers: PeerInfo[], requestedTags: Set<string>): voi
 
   const head: string[] = [
     chalk.bold('Peer'),
+  ];
+  if (anyDelegatedSeller) head.push(chalk.bold('On-chain seller'));
+  head.push(
     chalk.bold('Provider'),
     chalk.bold('Service'),
     chalk.bold('In $/1M'),
@@ -527,7 +580,7 @@ function renderExpandedTable(peers: PeerInfo[], requestedTags: Set<string>): voi
     chalk.bold('Score'),
     chalk.bold('Sessions'),
     chalk.bold('Volume'),
-  ];
+  );
   if (anyTags) head.push(chalk.bold('Tags'));
 
   const table = new Table({ head, wordWrap: true });
@@ -535,6 +588,13 @@ function renderExpandedTable(peers: PeerInfo[], requestedTags: Set<string>): voi
   for (const r of rows) {
     const row: string[] = [
       r.peerId,
+    ];
+    if (anyDelegatedSeller) {
+      const rowPeer = peers.find((p) => p.peerId === r.peerId);
+      const sellerAddress = rowPeer ? delegatedSellerAddress(rowPeer) : null;
+      row.push(sellerAddress !== null ? chalk.yellow(sellerAddress) : chalk.dim('—'));
+    }
+    row.push(
       r.provider,
       r.service === '—' || r.service === '(default)' ? chalk.dim(r.service) : r.service,
       r.input,
@@ -542,7 +602,7 @@ function renderExpandedTable(peers: PeerInfo[], requestedTags: Set<string>): voi
       r.score,
       r.sessions === '—' ? chalk.dim('—') : r.sessions,
       r.volume,
-    ];
+    );
     if (anyTags) {
       row.push(
         r.tags.length === 0
@@ -559,6 +619,9 @@ function renderExpandedTable(peers: PeerInfo[], requestedTags: Set<string>): voi
   console.log(table.toString());
   if (anyTags && requestedTags.size > 0) {
     console.log(chalk.dim(`  Matching tags highlighted green: ${Array.from(requestedTags).sort().join(', ')}`));
+  }
+  if (anyDelegatedSeller) {
+    console.log(chalk.dim(`  ${chalk.yellow('On-chain seller')} is the contract address that receives payments — differs from Peer when a delegated/proxy operator runs the node.`));
   }
   console.log('');
 }

--- a/apps/cli/src/cli/commands/network/peer.ts
+++ b/apps/cli/src/cli/commands/network/peer.ts
@@ -69,6 +69,14 @@ function normalizePeerId(raw: string): string | null {
   return cleaned;
 }
 
+function sellerAddressForPeer(peer: PeerInfo): string {
+  return normalizePeerId(peer.metadata?.sellerContract ?? '') ?? peer.peerId;
+}
+
+function isDelegatedSeller(peer: PeerInfo): boolean {
+  return sellerAddressForPeer(peer) !== peer.peerId.toLowerCase();
+}
+
 /**
  * The detail view doesn't have a column header so it appends `/1M` to make
  * each price self-describing. Precision is adaptive (see `pricing-format.ts`)
@@ -148,6 +156,15 @@ function printPeerDetail(peer: PeerInfo, requestedTags: Set<string>): void {
   console.log(`  ID:              ${peer.peerId}`);
   console.log(`  Display name:    ${peer.displayName ?? chalk.dim('—')}`);
   console.log(`  Public address:  ${peer.publicAddress ?? chalk.dim('—')}`);
+
+  const sellerAddress = sellerAddressForPeer(peer);
+  if (isDelegatedSeller(peer)) {
+    console.log(`  On-chain seller: ${chalk.yellow(sellerAddress)}`);
+    console.log(chalk.dim('    (delegated/proxy seller — channel stats and payments are attributed to the seller address)'));
+  } else {
+    console.log(`  On-chain seller: ${chalk.dim('same as peer')}`);
+  }
+
   if (typeof peer.lastSeen === 'number' && peer.lastSeen > 0) {
     const age = Date.now() - peer.lastSeen;
     console.log(`  Last seen:       ${new Date(peer.lastSeen).toISOString()} ${chalk.dim(`(${Math.max(0, Math.floor(age / 1000))}s ago)`)}`);
@@ -339,9 +356,14 @@ export function registerNetworkPeerCommand(networkCmd: Command): void {
         // filtered list without walking providerPricing themselves. When no
         // tag filter is in effect it simply contains every announced service.
         const matchingServices = collectMatchingServices(match, tagFilter);
+        // Surface the on-chain seller address explicitly so JSON consumers don't
+        // need to dig into `metadata.sellerContract` themselves.
+        const sellerAddress = sellerAddressForPeer(match);
         console.log(JSON.stringify({
           source: sourceLabel,
           filter: tagFilter.size > 0 ? { tags: Array.from(tagFilter).sort() } : null,
+          sellerAddress,
+          isDelegatedSeller: isDelegatedSeller(match),
           peer: match,
           matchingServices,
         }, null, 2));


### PR DESCRIPTION
## What

Adds explicit on-chain seller distinction to `antseed network browse` and `antseed network peer` CLI commands. When a peer operates as a delegated/proxy seller (i.e. `metadata.sellerContract` differs from `peerId`), the actual on-chain seller address is now surfaced separately from the peer/operator identity.

### Changes

**`antseed network browse`**
- New "On-chain seller" column appears when any displayed peer has a `sellerContract` that differs from its `peerId`
- Non-delegated peers show `—` in the column; column is hidden entirely when no delegated sellers are present
- Footer note explains the distinction when the column is shown
- Both compact and expanded (`--services`) tables include the column
- JSON output (`--json`) adds `sellerAddress` and `isDelegatedSeller` per peer

**`antseed network peer <id>`**
- New "On-chain seller" line in the Peer section:
  - Delegated: shows seller contract address with attribution note — *"delegated/proxy seller — channel stats and payments are attributed to the seller address"*
  - Non-delegated: shows *"same as peer"*
- JSON output adds top-level `sellerAddress` and `isDelegatedSeller` fields

All pin/connect semantics (`--peer`, `x-antseed-pin-peer`) remain tied to `peer.peerId` — unchanged.

## Why

Issue #596 — `antseed network browse` previously displayed `peer.peerId` as the visible seller identity. For delegated/proxy sellers (e.g. Venice-style setups), `peerId` is the operator EOA/node identity, while the actual on-chain seller is carried in `peer.metadata.sellerContract`. This made delegated sellers look visually wrong: the browse table showed the operator wallet as the seller, even though channel accounting and payments correctly used the seller contract address. The CLI presentation hid that distinction, making delegated/proxy sellers appear misconfigured.

## Testing

- `pnpm --filter @antseed/cli run typecheck` passes
- `pnpm --filter @antseed/cli run build` passes
- Manual testing against live buyer daemon (49 peers):

| Test | Result |
|------|--------|
| `network browse` — no delegated sellers in top 5 | Column hidden, table compact |
| `network browse` — Venice.ai Proxy in results | "On-chain seller" column shown, Venice row shows `1f228613…dedf18c9`, others show `—` |
| `network browse --services` | Seller column present in expanded table |
| `network browse --json` | `sellerAddress` and `isDelegatedSeller` present on all peers; Venice has `isDelegatedSeller: true` |
| `network peer <venice-id>` | Shows "On-chain seller: 1f228613…" with attribution note |
| `network peer <non-delegated-id>` | Shows "On-chain seller: same as peer" |
| `network peer <id> --json` | `sellerAddress` and `isDelegatedSeller` at top level |
| Pin/connect hints | Still reference `peer.peerId`, unchanged |

No new unit tests added — the network commands currently have no unit test coverage (pre-existing).
## Checklist

- [x] `pnpm run build` passes (`@antseed/cli` typecheck + build verified; full repo build fails on pre-existing native module issue unrelated to this change)
- [x] `pnpm run test` passes (CLI has no test suite; other packages pass)
- [ ] Breaking changes documented — no breaking changes
