### PR TITLE
fix(buyer): enrich incremental discovery peers

### DIFF
--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -250,6 +250,8 @@ export class AntseedNode extends EventEmitter {
   private _sessionTracker: SellerSessionTracker | null = null;
   /** Buyer-side background full discovery sweep, if one is running. */
   private _backgroundPeerDiscoveryPromise: Promise<PeerInfo[]> | null = null;
+  /** Serializes non-blocking on-chain enrichment for incrementally discovered peers. */
+  private _partialPeerEnrichmentChain: Promise<void> = Promise.resolve();
 
   constructor(config: NodeConfig) {
     super();
@@ -536,6 +538,7 @@ export class AntseedNode extends EventEmitter {
           + ` emitted ${peers.length} peer(s) from ${context.endpointCount} endpoint(s)`,
         );
         this.emit("peers:discovered", peers);
+        this._queuePartialPeerEnrichment(peers);
       });
       debugLog(`[Node] Background DHT sweep returned ${results.length} result(s)`);
       const peers = await this._lookupResultsToPeerInfos(results);
@@ -546,6 +549,30 @@ export class AntseedNode extends EventEmitter {
       return [];
     }).finally(() => {
       this._backgroundPeerDiscoveryPromise = null;
+    });
+  }
+
+  private _queuePartialPeerEnrichment(peers: PeerInfo[]): void {
+    if (peers.length === 0 || !this._channelsClient || !this._stakingClient) {
+      return;
+    }
+    const peersToEnrich = peers.map((peer) => ({ ...peer }));
+    this._partialPeerEnrichmentChain = this._partialPeerEnrichmentChain.then(async () => {
+      if (!this._started || !this._channelsClient || !this._stakingClient) {
+        return;
+      }
+      await this._enrichPeersWithOnChainStats(peersToEnrich);
+      if (!this._started) {
+        return;
+      }
+      const enriched = peersToEnrich.filter((peer) => typeof peer.onChainStatsFetchedAt === "number");
+      if (enriched.length === 0) {
+        return;
+      }
+      debugLog(`[Node] Background DHT partial on-chain enrichment emitted ${enriched.length} peer(s)`);
+      this.emit("peers:discovered", enriched);
+    }).catch((err) => {
+      debugWarn(`[Node] Background DHT partial on-chain enrichment failed: ${err instanceof Error ? err.message : err}`);
     });
   }
 

--- a/packages/node/tests/incremental-enrichment.test.ts
+++ b/packages/node/tests/incremental-enrichment.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AntseedNode, type PeerInfo } from '../src/node.js';
+
+function makePeer(peerId = 'a'.repeat(40)): PeerInfo {
+  return {
+    peerId: peerId as PeerInfo['peerId'],
+    providers: ['openai'],
+    lastSeen: Date.now(),
+  };
+}
+
+describe('AntseedNode incremental discovery enrichment', () => {
+  it('emits an enriched peer update after a partial metadata-only discovery event', async () => {
+    const node = new AntseedNode({ role: 'buyer' });
+    const peer = makePeer();
+    const nowSec = Math.floor(Date.now() / 1000);
+    const discovered = vi.fn();
+
+    node.on('peers:discovered', discovered);
+    (node as any)._started = true;
+    (node as any)._stakingClient = {
+      getAgentId: vi.fn().mockResolvedValue(123),
+      getStake: vi.fn().mockResolvedValue(10_000_000n),
+      getStakedAt: vi.fn().mockResolvedValue(nowSec - 86_400),
+    };
+    (node as any)._channelsClient = {
+      getAgentStats: vi.fn().mockResolvedValue({
+        channelCount: 25,
+        ghostCount: 0,
+        totalVolumeUsdc: 50_000_000n,
+        lastSettledAt: nowSec,
+      }),
+    };
+
+    (node as any)._queuePartialPeerEnrichment([peer]);
+    await (node as any)._partialPeerEnrichmentChain;
+
+    expect(discovered).toHaveBeenCalledTimes(1);
+    const [[peers]] = discovered.mock.calls as [[PeerInfo[]]];
+    expect(peers).toHaveLength(1);
+    expect(peers[0]?.peerId).toBe(peer.peerId);
+    expect(peers[0]?.onChainAgentId).toBe(123);
+    expect(peers[0]?.onChainChannelCount).toBe(25);
+    expect(peers[0]?.onChainTotalVolumeUsdcMicros).toBe(50_000_000);
+    expect(peers[0]?.onChainStatsFetchedAt).toEqual(expect.any(Number));
+    expect(peers[0]?.onChainReputationScore).toEqual(expect.any(Number));
+  });
+});


### PR DESCRIPTION
## Summary
- keep fast metadata-only peer discovery emits for first paint
- queue non-blocking on-chain enrichment for each incremental partial peer batch
- emit a second `peers:discovered` update after chain stats/reputation are available so buyer.state.json refreshes sooner
- add a unit test for incremental enrichment emits

## Validation
- corepack pnpm --filter=@antseed/node build
- corepack pnpm --filter=@antseed/node test