### PR TITLE
fix(node): Skip payment for free services

### DIFF
--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -101,21 +101,20 @@ export class SellerRequestHandler {
         return;
       }
 
+      const requestPricing = this.resolveProviderPricing(provider, request);
+      const isFreeService = this._isFreePricing(requestPricing);
+
       // Reject with 402 if no active payment session and channels client is configured.
       const spm = this._deps.sellerPaymentManager;
       const spmAuthorized = spm?.hasSession(buyerPeerId) ?? false;
       if (this._deps.channelsClient && !spmAuthorized) {
-        const providerPricing = this.resolveProviderPricing(provider, request);
-        // Free services (both input and output priced at 0) skip the payment
-        // channel handshake entirely — no 402, no ReserveAuth, no on-chain reserve.
-        const isFree = providerPricing
-          ? providerPricing.inputUsdPerMillion === 0 && providerPricing.outputUsdPerMillion === 0
-          : false;
-        if (isFree) {
+        // Free services skip the payment channel handshake entirely — no 402,
+        // no ReserveAuth, no on-chain reserve.
+        if (isFreeService) {
           debugLog(`[SellerHandler] Free service for ${buyerPeerId.slice(0, 12)}... — skipping 402 / payment channel`);
         } else {
           const requirements = spm?.getPaymentRequirements(
-            request.requestId, buyerPeerId, providerPricing,
+            request.requestId, buyerPeerId, requestPricing,
           );
           if (requirements) {
             debugLog(`[SellerHandler] No payment session for ${buyerPeerId.slice(0, 12)}... — sending 402 + PaymentRequired`);
@@ -150,8 +149,10 @@ export class SellerRequestHandler {
         }
       }
 
-      // Check budget before routing — reject if buyer hasn't authorized enough
-      if (spm) {
+      // Check budget before routing — reject if buyer hasn't authorized enough.
+      // Free requests must not be blocked by an existing exhausted/blocked paid
+      // payment channel for the same buyer.
+      if (spm && !isFreeService) {
         const initialSession = spm.getChannelByPeer(buyerPeerId);
         if (initialSession) {
           // Drain any in-flight SpendingAuth processing (e.g. an on-chain top-up
@@ -203,9 +204,8 @@ export class SellerRequestHandler {
             }
           }
           if (isBlocked || (spent > 0n && (spent > accepted || isAtExactSpendLimit))) {
-            const providerPricing = this.resolveProviderPricing(provider, request);
             const baseRequirements = spm.getPaymentRequirements(
-              request.requestId, buyerPeerId, providerPricing,
+              request.requestId, buyerPeerId, requestPricing,
             );
             // Tell the buyer exactly how much delivered spend remains unsigned.
             // Do not add forward headroom here: SpendingAuth is claimable
@@ -352,7 +352,6 @@ export class SellerRequestHandler {
 
         // Record metering
         const latencyMs = Date.now() - startTime;
-        const requestPricing = this.resolveProviderPricing(provider, request);
         if (this._deps.sessionTracker) {
           await this._deps.sessionTracker.recordMetering({
             buyerPeerId,
@@ -370,7 +369,7 @@ export class SellerRequestHandler {
 
         // Record spend and send NeedAuth with cost data after every request.
         // The buyer validates the cost independently and responds with SpendingAuth.
-        if (spm?.hasSession(buyerPeerId)) {
+        if (!isFreeService && spm?.hasSession(buyerPeerId)) {
           const usage = responseUsage;
           const costUsdc = computeCostUsdc(usage.freshInputTokens, usage.outputTokens, requestPricing, usage.cachedInputTokens);
           const session = spm.getChannelByPeer(buyerPeerId);
@@ -510,6 +509,13 @@ export class SellerRequestHandler {
   }
 
   // -- Private helpers --
+
+  private _isFreePricing(pricing: import('./interfaces/seller-provider.js').ProviderTokenPricingUsdPerMillion): boolean {
+    const cachedPrice = pricing.cachedInputUsdPerMillion ?? pricing.inputUsdPerMillion;
+    return pricing.inputUsdPerMillion === 0
+      && pricing.outputUsdPerMillion === 0
+      && cachedPrice === 0;
+  }
 
   private _parseJsonBody(body: Uint8Array): unknown | null {
     try {

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -175,7 +175,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     expect(pricing).toEqual({ inputUsdPerMillion: 0.05, outputUsdPerMillion: 0.1 });
   });
 
-  it('does not add a paid auth headroom for zero-cost responses', async () => {
+  it('does not touch payment state for free responses even when a paid session exists', async () => {
     const provider = makeProvider(0, 0, { name: 'free-tier', services: ['local-test'] });
     provider.handleRequest = vi.fn(async (req) => ({
       requestId: req.requestId,
@@ -191,9 +191,10 @@ describe('SellerRequestHandler payment pricing selection', () => {
     }));
 
     const sendNeedAuth = vi.fn();
+    const recordSpend = vi.fn();
     const handler = new SellerRequestHandler({
       providers: [provider],
-      sellerPaymentManager: makeSpmMock({ getPaymentRequirements: () => ({ minBudgetPerRequest: '0', suggestedAmount: '0' }) }),
+      sellerPaymentManager: makeSpmMock({ recordSpend, getPaymentRequirements: () => ({ minBudgetPerRequest: '0', suggestedAmount: '0' }) }),
       sessionTracker: null,
       channelsClient: {} as any,
       announcer: null,
@@ -207,9 +208,10 @@ describe('SellerRequestHandler payment pricing selection', () => {
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
     await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-zero-cost', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })) }) });
 
+    expect(provider.handleRequest).toHaveBeenCalledOnce();
     expect(sentFrames.length).toBeGreaterThan(0);
-    expect(sendNeedAuth).toHaveBeenCalledOnce();
-    expect(sendNeedAuth).toHaveBeenCalledWith(expect.objectContaining({ requestId: 'req-zero-cost', lastRequestCost: '0', currentAcceptedCumulative: '0', requiredCumulativeAmount: '0' }));
+    expect(recordSpend).not.toHaveBeenCalled();
+    expect(sendNeedAuth).not.toHaveBeenCalled();
   });
 
   it('uses cumulative spend as NeedAuth required amount without double-counting the latest request', async () => {
@@ -303,7 +305,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     expect(BigInt(sendNeedAuth.mock.calls[0]![0].requiredCumulativeAmount)).toBeLessThanOrEqual(reserveMax);
   });
 
-  it('skips the 402 / ReserveAuth handshake when the service is free', async () => {
+  it('skips the 402 / ReserveAuth handshake when a first-time buyer requests a free service', async () => {
     const provider = makeProvider(0, 0, { name: 'free-tier', services: ['local-test'] });
     provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
 
@@ -328,6 +330,75 @@ describe('SellerRequestHandler payment pricing selection', () => {
     expect(provider.handleRequest).toHaveBeenCalledOnce();
     expect(sendPaymentRequired).not.toHaveBeenCalled();
     expect(sendNeedAuth).not.toHaveBeenCalled();
+    const responseFrames = sentFrames.map((f) => decodeFrame(f)).filter((d) => d?.message.type === MessageType.HttpResponse);
+    expect(responseFrames).toHaveLength(1);
+    const response = decodeHttpResponse(responseFrames[0]!.message.payload);
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('skips the first-time buyer 402 when the requested service has a free override on a paid provider', async () => {
+    const provider = makeProvider(10, 20, {
+      name: 'mixed-tier',
+      services: ['free-model'],
+      servicePricing: { 'free-model': { inputUsdPerMillion: 0, outputUsdPerMillion: 0 } },
+    });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
+
+    const sendPaymentRequired = vi.fn();
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: makeSpmMock({ hasSession: () => false, getChannelByPeer: () => undefined }),
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired } as any;
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-free-override', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'free-model' })) }) });
+
+    expect(provider.handleRequest).toHaveBeenCalledOnce();
+    expect(sendPaymentRequired).not.toHaveBeenCalled();
+    const response = decodeHttpResponse(decodeFrame(sentFrames[0]!)!.message.payload);
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('continues serving a free service even when an existing paid channel is exhausted', async () => {
+    const provider = makeProvider(0, 0, { name: 'free-tier', services: ['local-test'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
+
+    const sendPaymentRequired = vi.fn();
+    const sendNeedAuth = vi.fn();
+    const settleSession = vi.fn(async () => {});
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: makeSpmMock({
+        getCumulativeSpend: () => 1_000_000n,
+        getAcceptedCumulative: () => 1_000_000n,
+        getReserveMax: () => 1_000_000n,
+        settleSession,
+      }),
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-free-exhausted-channel', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })) }) });
+
+    expect(provider.handleRequest).toHaveBeenCalledOnce();
+    expect(sendPaymentRequired).not.toHaveBeenCalled();
+    expect(sendNeedAuth).not.toHaveBeenCalled();
+    expect(settleSession).not.toHaveBeenCalled();
     const responseFrames = sentFrames.map((f) => decodeFrame(f)).filter((d) => d?.message.type === MessageType.HttpResponse);
     expect(responseFrames).toHaveLength(1);
     const response = decodeHttpResponse(responseFrames[0]!.message.payload);


### PR DESCRIPTION
## Description

Fixes seller-side payment gating so requests for resolved-free services bypass all payment checks. This prevents free services from returning 402 Payment Required when payments are enabled or when a buyer has an existing exhausted paid channel with the peer.

## Release Notes

- Fixed free peer services incorrectly returning 402 Payment Required in some payment-enabled seller flows.
- Added regression coverage for first-time buyers using free services without deposits.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
