### PR TITLE
fix(desktop): Clear stale chat notices

### DIFF
--- a/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
@@ -213,6 +213,225 @@ test('new chat created while previous response is pending sends to its own peer'
   await waitFor(() => uiState.chatSendingConversationIds.length === 0);
 });
 
+
+test('stream errors clear when switching conversations', async () => {
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  uiState.chatServiceOptions = [
+    {
+      id: 'model-a', label: 'Model A', provider: 'openai', protocol: 'openai-chat-completions', count: 1,
+      value: `openai${SEP}model-a${SEP}peer-a`, peerId: 'peer-a', peerDisplayName: 'Peer A', peerLabel: 'Peer A',
+      inputUsdPerMillion: null, outputUsdPerMillion: null, cachedInputUsdPerMillion: null, categories: [], description: '',
+    },
+    {
+      id: 'model-b', label: 'Model B', provider: 'openai', protocol: 'openai-chat-completions', count: 1,
+      value: `openai${SEP}model-b${SEP}peer-b`, peerId: 'peer-b', peerDisplayName: 'Peer B', peerLabel: 'Peer B',
+      inputUsdPerMillion: null, outputUsdPerMillion: null, cachedInputUsdPerMillion: null, categories: [], description: '',
+    },
+  ];
+
+  const conversations: Conversation[] = [
+    {
+      id: 'conv-a',
+      title: 'Conversation A',
+      service: 'model-a',
+      provider: 'openai',
+      peerId: 'peer-a',
+      messages: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+    {
+      id: 'conv-b',
+      title: 'Conversation B',
+      service: 'model-b',
+      provider: 'openai',
+      peerId: 'peer-b',
+      messages: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+  ];
+
+  const streamErrorHandlers: Array<NonNullable<Parameters<NonNullable<DesktopBridge['onChatAiStreamError']>>[0]>> = [];
+  const bridge: DesktopBridge = {
+    chatAiListConversations: async () => ({ ok: true, data: [...conversations] }),
+    chatAiGetConversation: async (id) => {
+      const conversation = conversations.find((c) => c.id === id);
+      return conversation
+        ? { ok: true, data: { ...conversation, messages: [...conversation.messages] } }
+        : { ok: false, error: 'not found' };
+    },
+    onChatAiStreamError: (handler) => {
+      streamErrorHandlers.push(handler);
+      return () => undefined;
+    },
+  };
+
+  const api = initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+  await api.refreshChatConversations();
+  await api.openConversation('conv-a');
+
+  streamErrorHandlers[0]?.({
+    conversationId: 'conv-a',
+    error: 'Upstream refused the request',
+    stopReason: {
+      kind: 'http_error',
+      source: 'upstream',
+      retryable: false,
+      message: 'Upstream refused the request',
+      statusCode: 500,
+    },
+  });
+
+  assert.equal(uiState.chatError, 'Upstream refused the request');
+
+  await api.openConversation('conv-b');
+  assert.equal(uiState.chatError, null);
+
+  await api.openConversation('conv-a');
+  assert.equal(uiState.chatError, null);
+});
+
+test('payment-required card clears when switching conversations or models', async () => {
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  uiState.chatServiceOptions = [
+    {
+      id: 'model-a', label: 'Model A', provider: 'openai', protocol: 'openai-chat-completions', count: 1,
+      value: `openai${SEP}model-a${SEP}peer-a`, peerId: 'peer-a', peerDisplayName: 'Peer A', peerLabel: 'Peer A',
+      inputUsdPerMillion: null, outputUsdPerMillion: null, cachedInputUsdPerMillion: null, categories: [], description: '',
+    },
+    {
+      id: 'model-b', label: 'Model B', provider: 'openai', protocol: 'openai-chat-completions', count: 1,
+      value: `openai${SEP}model-b${SEP}peer-b`, peerId: 'peer-b', peerDisplayName: 'Peer B', peerLabel: 'Peer B',
+      inputUsdPerMillion: null, outputUsdPerMillion: null, cachedInputUsdPerMillion: null, categories: [], description: '',
+    },
+  ];
+
+  const conversations: Conversation[] = [
+    {
+      id: 'conv-a',
+      title: 'Conversation A',
+      service: 'model-a',
+      provider: 'openai',
+      peerId: 'peer-a',
+      messages: [{ role: 'user', content: 'paywalled prompt', createdAt: Date.now() - 1_000 }],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+    {
+      id: 'conv-b',
+      title: 'Conversation B',
+      service: 'model-b',
+      provider: 'openai',
+      peerId: 'peer-b',
+      messages: [],
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+  ];
+
+  let creditsCalls = 0;
+  const sends: Array<{ conversationId: string; message: string; service?: string; provider?: string; peerId?: string }> = [];
+  const streamErrorHandlers: Array<NonNullable<Parameters<NonNullable<DesktopBridge['onChatAiStreamError']>>[0]>> = [];
+  const streamDoneHandlers: Array<(data: { conversationId: string }) => void> = [];
+  const bridge: DesktopBridge = {
+    chatAiListConversations: async () => ({ ok: true, data: [...conversations] }),
+    chatAiGetConversation: async (id) => {
+      const conversation = conversations.find((c) => c.id === id);
+      return conversation
+        ? { ok: true, data: { ...conversation, messages: [...conversation.messages] } }
+        : { ok: false, error: 'not found' };
+    },
+    creditsGetInfo: async () => {
+      creditsCalls += 1;
+      return {
+        ok: true,
+        data: {
+          evmAddress: null,
+          operatorAddress: null,
+          balanceUsdc: '0',
+          reservedUsdc: '0',
+          availableUsdc: '0',
+          creditLimitUsdc: '0',
+        },
+        error: null,
+      };
+    },
+    onChatAiStreamError: (handler) => {
+      streamErrorHandlers.push(handler);
+      return () => undefined;
+    },
+    onChatAiStreamDone: (handler) => {
+      streamDoneHandlers.push(handler);
+      return () => undefined;
+    },
+    chatAiSendStream: async (conversationId, message, service, provider, _attachments, peerId) => {
+      sends.push({ conversationId, message, service, provider, peerId });
+      return { ok: true };
+    },
+    chatAiSelectPeer: async () => ({ ok: true }),
+  };
+
+  const api = initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+  await api.refreshChatConversations();
+  await api.openConversation('conv-a');
+
+  const emitPaymentRequired = () => streamErrorHandlers[0]?.({
+    conversationId: 'conv-a',
+    error: 'payment_required:1000000',
+    stopReason: {
+      kind: 'payment_required',
+      source: 'billing',
+      retryable: false,
+      message: 'Payment required',
+      statusCode: 402,
+      errorCode: 'payment_required',
+    },
+  });
+
+  emitPaymentRequired();
+  await waitFor(() => creditsCalls === 1);
+  await waitFor(() => uiState.chatPaymentApprovalVisible === true);
+  assert.equal(uiState.chatPaymentApprovalPeerId, 'peer-a');
+
+  api.retryAfterPayment();
+  await waitFor(() => sends.length === 1);
+  assert.deepEqual(sends[0], {
+    conversationId: 'conv-a',
+    message: 'paywalled prompt',
+    service: 'model-a',
+    provider: 'openai',
+    peerId: 'peer-a',
+  });
+  assert.equal(uiState.chatPaymentApprovalVisible, true);
+  assert.equal(uiState.chatPaymentApprovalPeerId, 'peer-a');
+
+  streamDoneHandlers[0]?.({ conversationId: 'conv-a' });
+  assert.equal(uiState.chatPaymentApprovalVisible, true);
+  assert.equal(uiState.chatPaymentApprovalPeerId, 'peer-a');
+
+  await api.openConversation('conv-b');
+  assert.equal(uiState.chatPaymentApprovalVisible, false);
+  assert.equal(uiState.chatPaymentApprovalPeerId, null);
+
+  await api.openConversation('conv-a');
+  emitPaymentRequired();
+  await waitFor(() => creditsCalls === 2);
+  await waitFor(() => uiState.chatPaymentApprovalVisible === true);
+
+  api.handleServiceChange(`openai${SEP}model-b${SEP}peer-b`, 'peer-b');
+  assert.equal(uiState.chatPaymentApprovalVisible, false);
+  assert.equal(uiState.chatPaymentApprovalPeerId, null);
+});
+
 test('discover-selected draft keeps its peer if another discover chat is opened before create finishes', async () => {
   installDomTimers();
 

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -213,6 +213,20 @@ export function initChatModule({
     }
   }
 
+  function hidePaymentApprovalCard(): void {
+    uiState.chatPaymentApprovalVisible = false;
+    uiState.chatPaymentApprovalPeerId = null;
+    uiState.chatPaymentApprovalPeerName = null;
+    uiState.chatPaymentApprovalPeerInfo = null;
+    uiState.chatPaymentApprovalLoading = false;
+    uiState.chatPaymentApprovalError = null;
+  }
+
+  function clearTransientChatNotices(): void {
+    uiState.chatError = null;
+    hidePaymentApprovalCard();
+  }
+
   async function refreshAvailableCreditsUsdc(): Promise<number> {
     if (!bridge?.creditsGetInfo) {
       return parseFloat(uiState.creditsAvailableUsdc || '0');
@@ -284,7 +298,6 @@ export function initChatModule({
 
     const timer = setTimeout(() => {
       chatRetryTimers.delete(convId);
-      uiState.chatError = null;
       if (ctx?.content != null) {
         setConversationSending(convId, true);
         dispatchChatRequest(convId, ctx.content, ctx.attachments, ctx.selection);
@@ -306,12 +319,6 @@ export function initChatModule({
       && required > 0
       && available >= required
     ) {
-      uiState.chatPaymentApprovalVisible = false;
-      uiState.chatPaymentApprovalPeerId = null;
-      uiState.chatPaymentApprovalPeerName = null;
-      uiState.chatPaymentApprovalPeerInfo = null;
-      uiState.chatPaymentApprovalError = null;
-      uiState.chatError = null;
       scheduleChatRetry(retryCtx, 'payment');
       notifyUiStateChanged();
       return;
@@ -1500,6 +1507,8 @@ export function initChatModule({
     uiState.chatLifetimeSpentUsdc = '';
     uiState.chatLifetimeTotalTokens = '';
     uiState.chatLifetimeSessions = '';
+    clearTransientChatNotices();
+    notifyUiStateChanged();
 
     try {
       const result = await bridge.chatAiGetConversation(convId);
@@ -1545,7 +1554,7 @@ export function initChatModule({
 
         setLocalConversationMessages(convId, uiState.chatMessages as ChatMessage[]);
         updateThreadMeta(activeConversation);
-        uiState.chatError = null;
+        clearTransientChatNotices();
         notifyUiStateChanged();
 
         const convWorkspacePath = conv.workspacePath;
@@ -1575,7 +1584,7 @@ export function initChatModule({
     activeConversation = null;
     uiState.chatDeleteVisible = false;
     uiState.chatConversationTitle = 'New Chat';
-    uiState.chatError = null;
+    clearTransientChatNotices();
     // Re-derive sending flags from the (now null) active conversation so that
     // the thinking indicator does not leak in from whichever chat the user was
     // previously viewing while it was still streaming. Without this, the
@@ -2173,23 +2182,12 @@ export function initChatModule({
   }
 
   /**
-   * Retry the last user message after a payment failure.  Dismisses the
-   * payment-approval card and re-sends the most recent user message in the
-   * active conversation.  Intended to be called when credits become
-   * available after a 402 was returned.
+   * Retry the last user message after a payment failure. Keeps the
+   * payment-approval card visible while the user stays in the same chat;
+   * context switches are responsible for dismissing transient notices.
    */
   function retryAfterPayment(): void {
     if (!bridge) return;
-
-    // Dismiss payment card
-    uiState.chatPaymentApprovalVisible = false;
-    uiState.chatPaymentApprovalPeerId = null;
-    uiState.chatPaymentApprovalPeerName = null;
-    uiState.chatPaymentApprovalPeerInfo = null;
-    uiState.chatPaymentApprovalLoading = false;
-    uiState.chatPaymentApprovalError = null;
-    uiState.chatError = null;
-    notifyUiStateChanged();
 
     // Find the last user message to resend
     type MsgShape = { role?: string; content?: unknown };
@@ -2239,6 +2237,7 @@ export function initChatModule({
   function handleServiceChange(value: string, explicitPeerId?: string): void {
     uiState.chatSelectedServiceValue = value;
     pendingServiceOptions = null;
+    clearTransientChatNotices();
 
     // Prefer an explicit peerId (e.g. from a Discover card click) so we don't
     // depend on chatServiceOptions.value matching the encoded form exactly.
@@ -2303,6 +2302,7 @@ export function initChatModule({
   function clearPinnedPeer(): void {
     uiState.chatSelectedPeerId = '';
     uiState.chatRoutedPeer = '';
+    clearTransientChatNotices();
     if (activeConversation) {
       delete activeConversation.peerId;
       delete activeConversation.peerLabel;
@@ -2339,10 +2339,10 @@ export function initChatModule({
             }
           });
         } else if (data.conversationId === uiState.chatActiveConversation) {
-            commitAssistantMessage(incomingMessage);
-            uiState.chatError = null;
-            setConversationSending(data.conversationId, false);
-            notifyUiStateChanged();
+          commitAssistantMessage(incomingMessage);
+          uiState.chatError = null;
+          setConversationSending(data.conversationId, false);
+          notifyUiStateChanged();
         }
         void refreshChatConversations();
         void refreshWorkspaceGitStatus();


### PR DESCRIPTION
## Description

Clears transient desktop chat notices whenever the user changes conversations or switches the selected model. This keeps paid-service `payment_required` messages and other chat errors from sticking around after the context changes.

This intentionally uses the simpler behavior: errors/payment requests are dismissed on conversation/model change rather than restored per prior conversation.

## Release Notes

- Fixed payment-required messages and payment cards sticking around after switching chats or models.
- Fixed stale chat error messages remaining visible after moving to a different conversation.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Verification

- `pnpm --filter @antseed/desktop run typecheck:renderer`
- `pnpm exec tsx --test apps/desktop/src/renderer/modules/chat.peer-routing.test.ts`
- `pnpm --filter @antseed/desktop run build:renderer`
