### PR TITLE
fix(payments): Use epoch emission params

### DIFF
--- a/apps/payments/src/routes.ts
+++ b/apps/payments/src/routes.ts
@@ -293,7 +293,7 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
 
       const rows = await Promise.all(
         epochList.map(async (epoch) => {
-          const [pending, v2UserSP, v2UserBP, v2SellerClaimed, v2BuyerClaimed, v2TotalSP, v2TotalBP, epEmission] = await Promise.all([
+          const [pending, v2UserSP, v2UserBP, v2SellerClaimed, v2BuyerClaimed, v2TotalSP, v2TotalBP, epEmission, params] = await Promise.all([
             retryRead(() => client.pendingEmissions(address, [epoch])),
             retryRead(() => client.userSellerPoints(address, epoch)),
             retryRead(() => client.userBuyerPoints(address, epoch)),
@@ -302,6 +302,7 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
             retryRead(() => client.epochTotalSellerPoints(epoch)),
             retryRead(() => client.epochTotalBuyerPoints(epoch)),
             retryRead(() => client.getEpochEmission(epoch)),
+            retryRead(() => client.getEpochParams(epoch)),
           ]);
 
           let userSP = v2UserSP;
@@ -338,6 +339,7 @@ export function registerRoutes(fastify: FastifyInstance, ctx: RouteContext): voi
           return {
             epoch,
             epochEmission: epEmission.toString(),
+            params,
             seller: {
               amount: pending.seller.toString(),
               userPoints: userSP.toString(),

--- a/apps/payments/web/src/api.ts
+++ b/apps/payments/web/src/api.ts
@@ -95,9 +95,20 @@ export interface EmissionsEpochInfo {
   halvingInterval: number;
 }
 
+export interface EmissionsEpochParams {
+  sellerSharePct: number;
+  buyerSharePct: number;
+  reserveSharePct: number;
+  teamSharePct: number;
+  maxSellerSharePct: number;
+  maxBuyerSharePct: number;
+  initialized: boolean;
+}
+
 export interface EmissionsPendingRow {
   epoch: number;
   epochEmission: string;
+  params: EmissionsEpochParams;
   seller: { amount: string; userPoints: string; totalPoints: string; claimed: boolean };
   buyer:  { amount: string; userPoints: string; totalPoints: string; claimed: boolean };
   isCurrent: boolean;
@@ -108,13 +119,7 @@ export interface EmissionsPendingResponse {
   rows: EmissionsPendingRow[];
 }
 
-export interface EmissionsShares {
-  sellerSharePct: number;
-  buyerSharePct: number;
-  reserveSharePct: number;
-  teamSharePct: number;
-  maxSellerSharePct: number;
-}
+export interface EmissionsShares extends EmissionsEpochParams {}
 
 export async function getEmissionsInfo(): Promise<EmissionsEpochInfo> {
   return fetchJson('/api/emissions');

--- a/apps/payments/web/src/views/EmissionsView.tsx
+++ b/apps/payments/web/src/views/EmissionsView.tsx
@@ -8,6 +8,7 @@ import {
   getEmissionsShares,
   getTransfersEnabled,
   type EmissionsEpochInfo,
+  type EmissionsEpochParams,
   type EmissionsPendingResponse,
   type EmissionsShares as SharesType,
 } from '../api';
@@ -40,48 +41,66 @@ function formatAnts(amountWei: string): string {
   }
 }
 
-function estimateSideReward(epochEmission: string, sharePct: number, userPts: string, totalPts: string): bigint {
+function getEffectiveParams(
+  row: EmissionsPendingResponse['rows'][number] | undefined,
+  fallback: SharesType | null | undefined,
+): EmissionsEpochParams | null {
+  if (row?.params?.initialized) return row.params;
+  return fallback ?? row?.params ?? null;
+}
+
+function estimateSideReward(
+  epochEmission: string,
+  sharePct: number,
+  maxSharePct: number,
+  userPts: string,
+  totalPts: string,
+): bigint {
   const emission = safeBigint(epochEmission);
   const user = safeBigint(userPts);
   const total = safeBigint(totalPts);
-  if (total === 0n) return 0n;
-  return emission * BigInt(Math.round(sharePct * 100)) * user / (10000n * total);
+  if (emission === 0n || total === 0n || user === 0n) return 0n;
+
+  const bucket = emission * BigInt(Math.round(sharePct * 100)) / 10000n;
+  const reward = bucket * user / total;
+  const maxReward = bucket * BigInt(Math.round(maxSharePct * 100)) / 10000n;
+  return reward > maxReward ? maxReward : reward;
 }
 
 function estimateRowReward(
   row: EmissionsPendingResponse['rows'][number],
-  epochEmission: string,
-  shares: SharesType,
+  fallback: SharesType | null | undefined,
 ): string {
-  const emission = safeBigint(epochEmission);
-  const userSP = safeBigint(row.seller.userPoints);
-  const totalSP = safeBigint(row.seller.totalPoints);
-  const userBP = safeBigint(row.buyer.userPoints);
-  const totalBP = safeBigint(row.buyer.totalPoints);
+  const params = getEffectiveParams(row, fallback);
+  if (!params) return '0';
 
-  let est = 0n;
-  if (totalSP > 0n) {
-    est += emission * BigInt(Math.round(shares.sellerSharePct * 100)) * userSP / (10000n * totalSP);
-  }
-  if (totalBP > 0n) {
-    est += emission * BigInt(Math.round(shares.buyerSharePct * 100)) * userBP / (10000n * totalBP);
-  }
-  return est.toString();
+  const sellerReward = estimateSideReward(
+    row.epochEmission,
+    params.sellerSharePct,
+    params.maxSellerSharePct,
+    row.seller.userPoints,
+    row.seller.totalPoints,
+  );
+  const buyerReward = estimateSideReward(
+    row.epochEmission,
+    params.buyerSharePct,
+    params.maxBuyerSharePct,
+    row.buyer.userPoints,
+    row.buyer.totalPoints,
+  );
+  return (sellerReward + buyerReward).toString();
 }
 
 function computeEpochShare(
   row: EmissionsPendingResponse['rows'][number] | undefined,
-  shares: SharesType,
+  fallback: SharesType | null | undefined,
 ): number {
   if (!row) return 0;
-  const userSP = safeBigint(row.seller.userPoints);
-  const totalSP = safeBigint(row.seller.totalPoints);
-  const userBP = safeBigint(row.buyer.userPoints);
-  const totalBP = safeBigint(row.buyer.totalPoints);
-  let pct = 0;
-  if (totalSP > 0n) pct += shares.sellerSharePct * Number((userSP * 10000n) / totalSP) / 10000;
-  if (totalBP > 0n) pct += shares.buyerSharePct * Number((userBP * 10000n) / totalBP) / 10000;
-  return pct;
+  const emission = safeBigint(row.epochEmission);
+  if (emission === 0n) return 0;
+
+  const reward = safeBigint(estimateRowReward(row, fallback));
+  return Number((reward * 10000n) / emission) / 100;
 }
 
 function formatTimeRemaining(seconds: number): string {
@@ -252,31 +271,37 @@ export function EmissionsView({ config }: EmissionsViewProps) {
 
   const rows = pending?.rows ?? [];
   const currentRow = rows.find((r) => r.isCurrent);
-  const currentSellerPts = currentRow?.seller.userPoints ?? '0';
-  const currentBuyerPts = currentRow?.buyer.userPoints ?? '0';
-  const totalSellerPts = currentRow?.seller.totalPoints ?? '0';
-  const totalBuyerPts = currentRow?.buyer.totalPoints ?? '0';
-  const currentEstimate = currentRow && info && shares
-    ? estimateRowReward(currentRow, info.epochEmission, shares)
-    : '0';
-
-  const epochSharePct = shares
-    ? computeEpochShare(currentRow, shares)
-    : 0;
+  const currentParams = getEffectiveParams(currentRow, shares);
+  const currentEstimate = currentRow ? estimateRowReward(currentRow, shares) : '0';
+  const epochSharePct = computeEpochShare(currentRow, shares);
 
   let totalClaimable = 0n;
   let totalClaimed = 0n;
   for (const r of rows) {
     if (r.isCurrent) continue;
-    const ep = r.epochEmission ?? info.epochEmission;
-    // Per-side: pendingEmissions returns 0 for claimed sides, so estimate from points
-    if (r.seller.claimed && shares) {
-      totalClaimed += estimateSideReward(ep, shares.sellerSharePct, r.seller.userPoints, r.seller.totalPoints);
+    const params = getEffectiveParams(r, shares);
+    // Per-side: pendingEmissions returns 0 for claimed sides, so estimate from points.
+    // Use the epoch's snapshotted params so historical rows don't change when
+    // owner-controlled global shares are updated for future epochs.
+    if (r.seller.claimed && params) {
+      totalClaimed += estimateSideReward(
+        r.epochEmission,
+        params.sellerSharePct,
+        params.maxSellerSharePct,
+        r.seller.userPoints,
+        r.seller.totalPoints,
+      );
     } else {
       totalClaimable += safeBigint(r.seller.amount);
     }
-    if (r.buyer.claimed && shares) {
-      totalClaimed += estimateSideReward(ep, shares.buyerSharePct, r.buyer.userPoints, r.buyer.totalPoints);
+    if (r.buyer.claimed && params) {
+      totalClaimed += estimateSideReward(
+        r.epochEmission,
+        params.buyerSharePct,
+        params.maxBuyerSharePct,
+        r.buyer.userPoints,
+        r.buyer.totalPoints,
+      );
     } else {
       totalClaimable += safeBigint(r.buyer.amount);
     }
@@ -288,10 +313,10 @@ export function EmissionsView({ config }: EmissionsViewProps) {
         <header className="dashboard-section-head">
           <div className="dashboard-section-eyebrow">Current epoch</div>
           <h2 className="dashboard-section-title">Epoch #{info.currentEpoch}</h2>
-          {shares && (
+          {currentParams && (
             <p className="dashboard-section-sub">
-              Split: {shares.sellerSharePct}% sellers · {shares.buyerSharePct}% buyers ·{' '}
-              {shares.reserveSharePct}% reserve · {shares.teamSharePct}% team
+              Split: {currentParams.sellerSharePct}% sellers · {currentParams.buyerSharePct}% buyers ·{' '}
+              {currentParams.reserveSharePct}% reserve · {currentParams.teamSharePct}% team
             </p>
           )}
         </header>
@@ -361,7 +386,7 @@ export function EmissionsView({ config }: EmissionsViewProps) {
           </p>
         </header>
         <div className="dashboard-chart-card">
-          <EmissionsTable rows={pending?.rows ?? []} epochEmission={info.epochEmission} shares={shares} />
+          <EmissionsTable rows={pending?.rows ?? []} shares={shares} />
           {(sellerClaimError || buyerClaimError) && (
             <div className="status-msg status-error">{sellerClaimError || buyerClaimError}</div>
           )}
@@ -441,9 +466,8 @@ export function EmissionsView({ config }: EmissionsViewProps) {
   );
 }
 
-function EmissionsTable({ rows, epochEmission, shares }: {
+function EmissionsTable({ rows, shares }: {
   rows: EmissionsPendingResponse['rows'];
-  epochEmission?: string;
   shares?: SharesType | null;
 }) {
   if (rows.length === 0) {
@@ -462,11 +486,10 @@ function EmissionsTable({ rows, epochEmission, shares }: {
         </thead>
         <tbody>
           {rows.slice().reverse().map((row) => {
-            const ep = row.epochEmission ?? epochEmission ?? '0';
-            const total = (row.isCurrent || row.seller.claimed || row.buyer.claimed) && shares
-              ? estimateRowReward(row, ep, shares)
+            const total = row.isCurrent || row.seller.claimed || row.buyer.claimed
+              ? estimateRowReward(row, shares)
               : addWei(row.seller.amount, row.buyer.amount);
-            const share = shares ? computeEpochShare(row, shares) : 0;
+            const share = computeEpochShare(row, shares);
             // "Fully resolved" = each side is either claimed or has no points
             const sellerDone = row.seller.claimed || row.seller.userPoints === '0';
             const buyerDone = row.buyer.claimed || row.buyer.userPoints === '0';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -41,7 +41,7 @@ export { DepositsClient, type DepositsClientConfig, type BuyerBalanceInfo } from
 export { ChannelsClient, type ChannelsClientConfig, type ChannelInfo, type AgentStats } from './payments/evm/channels-client.js';
 export { IdentityClient, type IdentityClientConfig } from './payments/evm/identity-client.js';
 export { StakingClient, type StakingClientConfig } from './payments/evm/staking-client.js';
-export { EmissionsClient, type EmissionsClientConfig } from './payments/evm/emissions-client.js';
+export { EmissionsClient, type EmissionsClientConfig, type EmissionsEpochParams } from './payments/evm/emissions-client.js';
 export { ANTSTokenClient, type ANTSTokenClientConfig } from './payments/evm/ants-token-client.js';
 export {
   StatsClient,

--- a/packages/node/src/payments/evm/emissions-client.ts
+++ b/packages/node/src/payments/evm/emissions-client.ts
@@ -32,8 +32,10 @@ const EMISSIONS_ABI = [
   'function RESERVE_SHARE_PCT() external view returns (uint256)',
   'function TEAM_SHARE_PCT() external view returns (uint256)',
   'function MAX_SELLER_SHARE_PCT() external view returns (uint256)',
+  'function MAX_BUYER_SHARE_PCT() external view returns (uint256)',
   'function reserveAccumulated() external view returns (uint256)',
   // Reads — mappings exposed as auto-generated getters
+  'function epochParams(uint256 epoch) external view returns (uint256 sellerSharePct, uint256 buyerSharePct, uint256 reserveSharePct, uint256 teamSharePct, uint256 maxSellerSharePct, uint256 maxBuyerSharePct, bool initialized)',
   'function epochTotalSellerPoints(uint256 epoch) external view returns (uint256)',
   'function epochTotalBuyerPoints(uint256 epoch) external view returns (uint256)',
   'function userSellerPoints(address account, uint256 epoch) external view returns (uint256)',
@@ -41,6 +43,20 @@ const EMISSIONS_ABI = [
   'function sellerEpochClaimed(address account, uint256 epoch) external view returns (bool)',
   'function buyerEpochClaimed(address account, uint256 epoch) external view returns (bool)',
 ] as const;
+
+const LEGACY_EPOCH_PARAMS_ABI = [
+  'function epochParams(uint256 epoch) external view returns (uint256 sellerSharePct, uint256 buyerSharePct, uint256 reserveSharePct, uint256 teamSharePct, uint256 maxSellerSharePct, bool initialized)',
+] as const;
+
+export interface EmissionsEpochParams {
+  sellerSharePct: number;
+  buyerSharePct: number;
+  reserveSharePct: number;
+  teamSharePct: number;
+  maxSellerSharePct: number;
+  maxBuyerSharePct: number;
+  initialized: boolean;
+}
 
 export class EmissionsClient extends BaseEvmClient {
   constructor(config: EmissionsClientConfig) {
@@ -98,20 +114,15 @@ export class EmissionsClient extends BaseEvmClient {
     return Number(v);
   }
 
-  async getShares(): Promise<{
-    sellerSharePct: number;
-    buyerSharePct: number;
-    reserveSharePct: number;
-    teamSharePct: number;
-    maxSellerSharePct: number;
-  }> {
+  async getShares(): Promise<EmissionsEpochParams> {
     const contract = new Contract(this._contractAddress, EMISSIONS_ABI, this._provider);
-    const [seller, buyer, reserve, team, maxSeller] = await Promise.all([
+    const [seller, buyer, reserve, team, maxSeller, maxBuyer] = await Promise.all([
       contract.getFunction('SELLER_SHARE_PCT')(),
       contract.getFunction('BUYER_SHARE_PCT')(),
       contract.getFunction('RESERVE_SHARE_PCT')(),
       contract.getFunction('TEAM_SHARE_PCT')(),
       contract.getFunction('MAX_SELLER_SHARE_PCT')(),
+      contract.getFunction('MAX_BUYER_SHARE_PCT')().catch(() => 100n),
     ]);
     return {
       sellerSharePct: Number(seller),
@@ -119,7 +130,37 @@ export class EmissionsClient extends BaseEvmClient {
       reserveSharePct: Number(reserve),
       teamSharePct: Number(team),
       maxSellerSharePct: Number(maxSeller),
+      maxBuyerSharePct: Number(maxBuyer),
+      initialized: true,
     };
+  }
+
+  async getEpochParams(epoch: number): Promise<EmissionsEpochParams> {
+    const contract = new Contract(this._contractAddress, EMISSIONS_ABI, this._provider);
+    try {
+      const [seller, buyer, reserve, team, maxSeller, maxBuyer, initialized] = await contract.getFunction('epochParams')(epoch);
+      return {
+        sellerSharePct: Number(seller),
+        buyerSharePct: Number(buyer),
+        reserveSharePct: Number(reserve),
+        teamSharePct: Number(team),
+        maxSellerSharePct: Number(maxSeller),
+        maxBuyerSharePct: Number(maxBuyer),
+        initialized,
+      };
+    } catch {
+      const legacyContract = new Contract(this._contractAddress, LEGACY_EPOCH_PARAMS_ABI, this._provider);
+      const [seller, buyer, reserve, team, maxSeller, initialized] = await legacyContract.getFunction('epochParams')(epoch);
+      return {
+        sellerSharePct: Number(seller),
+        buyerSharePct: Number(buyer),
+        reserveSharePct: Number(reserve),
+        teamSharePct: Number(team),
+        maxSellerSharePct: Number(maxSeller),
+        maxBuyerSharePct: 100,
+        initialized,
+      };
+    }
   }
 
   async epochTotalSellerPoints(epoch: number): Promise<bigint> {

--- a/packages/node/src/payments/index.ts
+++ b/packages/node/src/payments/index.ts
@@ -56,7 +56,7 @@ export type { ANTSTokenClientConfig } from './evm/ants-token-client.js';
 
 // Emissions
 export { EmissionsClient } from './evm/emissions-client.js';
-export type { EmissionsClientConfig } from './evm/emissions-client.js';
+export type { EmissionsClientConfig, EmissionsEpochParams } from './evm/emissions-client.js';
 
 // Subscription Pool
 export { SubPoolClient } from './evm/subpool-client.js';

--- a/packages/node/tests/emissions-client.test.ts
+++ b/packages/node/tests/emissions-client.test.ts
@@ -42,6 +42,7 @@ describe('EmissionsClient', () => {
     expect(typeof client.getGenesis).toBe('function');
     expect(typeof client.getHalvingInterval).toBe('function');
     expect(typeof client.getShares).toBe('function');
+    expect(typeof client.getEpochParams).toBe('function');
     expect(typeof client.epochTotalSellerPoints).toBe('function');
     expect(typeof client.epochTotalBuyerPoints).toBe('function');
     expect(typeof client.userSellerPoints).toBe('function');


### PR DESCRIPTION
## Description

Fixes the payments portal emissions dashboard to use each epoch's snapshotted emissions params instead of only the current global share params. This keeps the current epoch and historical estimates accurate when seller/buyer split settings are changed for future epochs.

The API now includes per-epoch params with pending emissions rows, and the UI uses those params for reward/share estimates and claimed totals.

## Release Notes

- Fixed emissions dashboard estimates so they reflect each epoch's snapshotted buyer/seller reward split
- Fixed current epoch display after emissions share settings are changed for future epochs

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
