### PR TITLE
fix(metering): zero-cost receipts for failed requests

### DIFF
--- a/packages/node/src/metering/seller-session-tracker.ts
+++ b/packages/node/src/metering/seller-session-tracker.ts
@@ -209,10 +209,15 @@ export class SellerSessionTracker {
     }
 
     if (this._receiptGenerator) {
+      // Only charge for successful requests (2xx/3xx status codes)
+      // Failed requests (4xx/5xx) get zero-cost receipts for audit trail
+      const isSuccess = statusCode >= 200 && statusCode < 400;
       const estimatedCostUsd =
-        (tokens.inputTokens * providerPricingUsdPerMillion.inputUsdPerMillion +
-          tokens.outputTokens * providerPricingUsdPerMillion.outputUsdPerMillion) /
-        1_000_000;
+        isSuccess
+          ? (tokens.inputTokens * providerPricingUsdPerMillion.inputUsdPerMillion +
+              tokens.outputTokens * providerPricingUsdPerMillion.outputUsdPerMillion) /
+            1_000_000
+          : 0;
       const effectiveUsdPerThousandTokens =
         tokens.totalTokens > 0 ? (estimatedCostUsd / tokens.totalTokens) * 1000 : 0;
       const unitPriceCentsPerThousandTokens = Math.max(0, effectiveUsdPerThousandTokens * 100);
@@ -226,7 +231,10 @@ export class SellerSessionTracker {
       );
       try {
         metering.insertReceipt(receipt);
-        session.totalCostCents += receipt.costCents;
+        // Only add to session total for successful requests
+        if (receipt.costCents > 0) {
+          session.totalCostCents += receipt.costCents;
+        }
       } catch (err) {
         debugWarn(`[SessionTracker] Failed to record usage receipt: ${err instanceof Error ? err.message : err}`);
       }


### PR DESCRIPTION
Fixes #614

## Problem
`recordMetering()` generates `UsageReceipt` with `costCents > 0` even for failed requests (4xx/5xx). This inflates seller revenue and charges buyers for failed work.

## Solution
Gate receipt cost calculation on `statusCode >= 200 && statusCode < 400`. Failed requests get zero-cost receipts (preserving audit trail).

## Changes
- Added `isSuccess` check based on statusCode
- `estimatedCostUsd` is 0 for failed requests (4xx/5xx)
- `session.totalCostCents` only incremented for successful requests
- Receipts are still inserted for all requests (audit trail preserved)

## Testing
Manual verification that:
- `costCents === 0` for 4xx/5xx responses
- `costCents > 0` for 2xx responses
- Receipts are inserted for all requests

Recommended: Add unit tests for 4xx/5xx scenarios.