### PR TITLE
Add Nix dev shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ See [Metrics](apps/website/docs/guides/metrics.md) for endpoint details, metric 
 
 ## Development
 
+### Optional Nix dev shell
+
+This repository includes a Nix flake for contributors who want a pinned local
+toolchain. The flake provides Node.js, pnpm, Python, native build tools, Git, and
+Linux keychain dependencies used by the workspace. It does not replace the
+normal pnpm workflow.
+
+```bash
+nix develop
+pnpm install
+pnpm run build
+```
+
+If flakes are not enabled globally, run the shell with the required experimental
+features for a single command:
+
+```bash
+nix --extra-experimental-features 'nix-command flakes' develop
+```
+
 ```bash
 pnpm install            # Install all dependencies
 pnpm run build          # Build in dependency order

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779508470,
+        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,45 @@
+{
+  description = "AntSeed development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              cacert
+              cmake
+              git
+              ninja
+              nodejs_22
+              pkg-config
+              pnpm_9
+              python311
+            ] ++ lib.optionals stdenv.isLinux [
+              libsecret
+            ];
+
+            shellHook = ''
+              export PATH="$PWD/node_modules/.bin:$PATH"
+              export npm_config_python="${pkgs.python311}/bin/python3"
+            '';
+          };
+        });
+    };
+}


### PR DESCRIPTION
## Description

Adds an optional Nix flake for contributors who want a pinned development shell. The flake exposes a default dev shell for aarch64/x86_64 Darwin and Linux, pins nixpkgs in flake.lock, and documents the workflow in the root README.

The shell includes the repo-level toolchain needed for the existing pnpm workflow: Node.js 22, pnpm 9, Python 3.11, Git, CMake, Ninja, pkg-config, CA certificates, and Linux-only libsecret support for desktop keychain integration.

This PR is intentionally limited to flake setup and documentation. 
## Release Notes

- Added an optional Nix development shell for contributors.
- Documented how to enter the shell and continue using the existing pnpm workflow.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes, or are not applicable to this docs/tooling-only change

## Verification

- `nix develop --extra-experimental-features "nix-command flakes" --command pnpm --version`
- `nix flake show --extra-experimental-features "nix-command flakes"`
- `nix flake check --extra-experimental-features "nix-command flakes"`
- `git diff --check`
