### PR TITLE
Fix payments portal dev port fallback

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -344,11 +344,11 @@ ipcMain.handle('payments:open-portal', async (_event, tab?: string) => {
       params.set('tab', tab);
     }
     const qs = params.toString();
-    // In dev mode, open the Vite HMR dev server (which proxies /api to the Fastify port).
-    // Set ANTSEED_PAYMENTS_DEV_URL to override (default: http://localhost:5175).
-    // When dev mode is detected but the dev server is not reachable, we still fall back to the Fastify URL.
-    const devUrl = isDev ? (process.env['ANTSEED_PAYMENTS_DEV_URL'] || 'http://localhost:5175') : null;
-    const base = devUrl ?? `${LOCALHOST_URL}:${PAYMENTS_PORT}`;
+    // In dev mode, open the Vite HMR dev server (which proxies /api to the Fastify port) when configured.
+    // Set ANTSEED_PAYMENTS_DEV_URL to override (default: the Fastify URL).
+    // When dev mode is detected but no dev server URL is configured, we still fall back to the Fastify URL.
+    const devUrl = isDev ? process.env['ANTSEED_PAYMENTS_DEV_URL']?.trim() : undefined;
+    const base = devUrl || `${LOCALHOST_URL}:${PAYMENTS_PORT}`;
     const url = qs ? `${base}?${qs}` : base;
     const { default: open } = await import('open');
     await open(url);

--- a/apps/payments/vite.config.ts
+++ b/apps/payments/vite.config.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const paymentsBackendPort = Number(process.env['ANTSEED_PAYMENTS_PORT']) || 3118;
+const paymentsProxyTarget = process.env['ANTSEED_PAYMENTS_PROXY_TARGET'] || `http://127.0.0.1:${paymentsBackendPort}`;
 
 export default defineConfig({
   plugins: [react()],
@@ -18,7 +20,7 @@ export default defineConfig({
       // Forward all backend calls to the Fastify server spawned by the desktop app.
       // Override the target with ANTSEED_PAYMENTS_PROXY_TARGET if the server is on a different port.
       '/api': {
-        target: process.env['ANTSEED_PAYMENTS_PROXY_TARGET'] || 'http://127.0.0.1:3118',
+        target: paymentsProxyTarget,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

Fixes the payments portal URL that AntStation opens in desktop dev mode.

In the normal `apps/desktop` dev flow, AntStation starts the payments Fastify server on `ANTSEED_PAYMENTS_PORT` / `3118`, but it was still opening the optional payments Vite HMR URL at `http://localhost:5175` by default. That port is only valid when the payments web dev server is started separately, so the portal link could fail even though the payments server was running.

This PR changes desktop dev behavior to:

- open the Fastify payments portal by default using `ANTSEED_PAYMENTS_PORT` / `3118`
- keep `ANTSEED_PAYMENTS_DEV_URL` as an explicit override for the optional payments Vite HMR server
- make the payments Vite proxy default derive from `ANTSEED_PAYMENTS_PORT`, so both sides use the same backend port setting

Production behavior is unchanged.

## Verification

- `pnpm -C apps/desktop run build:main`
- `pnpm -C apps/payments run build:web`