### PR TITLE
Fix network browse service matching

### DIFF
--- a/apps/cli/src/cli/commands/network/browse.test.ts
+++ b/apps/cli/src/cli/commands/network/browse.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { peerMatchesServiceFilter } from './browse.js';
+import type { PeerInfo } from '@antseed/node';
+
+function peerWithServices(services: string[], providers: string[] = ['minimax']): PeerInfo {
+  return {
+    peerId: '0000000000000000000000000000000000000001' as PeerInfo['peerId'],
+    lastSeen: Date.now(),
+    providers,
+    providerPricing: {
+      minimax: {
+        defaults: { inputUsdPerMillion: 0, outputUsdPerMillion: 0 },
+        services: Object.fromEntries(
+          services.map((service) => [service, { inputUsdPerMillion: 1, outputUsdPerMillion: 1 }]),
+        ),
+      },
+    },
+  };
+}
+
+test('network browse service filter matches canonical service ids exactly', () => {
+  assert.equal(peerMatchesServiceFilter(peerWithServices(['minimax-m3']), 'minimax-m3'), true);
+});
+
+test('network browse service filter matches punctuation and model-prefix variants', () => {
+  const peer = peerWithServices(['minimax-m3']);
+  assert.equal(peerMatchesServiceFilter(peer, 'minimax-3'), true);
+  assert.equal(peerMatchesServiceFilter(peer, 'MiniMax M3'), true);
+  assert.equal(peerMatchesServiceFilter(peer, 'minimax_m3'), true);
+});
+
+test('network browse service filter still matches providers', () => {
+  assert.equal(peerMatchesServiceFilter(peerWithServices(['gpt-5.5'], ['market-router']), 'market router'), true);
+});
+
+test('network browse service filter rejects unrelated services', () => {
+  assert.equal(peerMatchesServiceFilter(peerWithServices(['minimax-m3']), 'claude'), false);
+});

--- a/apps/cli/src/cli/commands/network/browse.ts
+++ b/apps/cli/src/cli/commands/network/browse.ts
@@ -138,15 +138,37 @@ function collectFreeServiceNames(peer: PeerInfo): string[] {
   return Array.from(names).sort((a, b) => a.localeCompare(b));
 }
 
+function normalizeServiceSearchTerm(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+    .replace(/([a-z])m(?=\d)/g, '$1');
+}
+
+function serviceSearchTerms(value: string): string[] {
+  const raw = value.trim().toLowerCase();
+  const normalized = normalizeServiceSearchTerm(value);
+  return Array.from(new Set([raw, normalized].filter((term) => term.length > 0)));
+}
+
+function serviceNameMatchesFilter(name: string, filter: string): boolean {
+  const haystackTerms = serviceSearchTerms(name);
+  const needleTerms = serviceSearchTerms(filter);
+  if (needleTerms.length === 0) return true;
+  return needleTerms.some((needle) => haystackTerms.some((haystack) => haystack.includes(needle)));
+}
+
 /**
  * Check whether the peer matches a `--service` filter. Matches on provider
- * name OR any announced service name (case-insensitive).
+ * name OR any announced service name using a forgiving normalized substring
+ * comparison so common spelling variants like `minimax-3`, `minimax m3`, and
+ * `MiniMax M3` match the canonical `minimax-m3` service id.
  */
-function peerMatchesServiceFilter(peer: PeerInfo, filter: string): boolean {
-  const needle = filter.trim().toLowerCase();
-  if (needle.length === 0) return true;
-  if (peer.providers.some((p) => p.toLowerCase() === needle)) return true;
-  return collectServiceNames(peer).some((name) => name.toLowerCase() === needle);
+export function peerMatchesServiceFilter(peer: PeerInfo, filter: string): boolean {
+  if (filter.trim().length === 0) return true;
+  if (peer.providers.some((p) => serviceNameMatchesFilter(p, filter))) return true;
+  return collectServiceNames(peer).some((name) => serviceNameMatchesFilter(name, filter));
 }
 
 /**


### PR DESCRIPTION
Fixes #628.

## Summary
- Normalize service filter matching for `antseed network browse --service`
- Match common service spelling variants like `minimax-3`, `minimax m3`, and `MiniMax M3` against canonical IDs such as `minimax-m3`
- Keep provider matching working with the same normalized comparison
- Add unit coverage for exact, variant, provider, and unrelated-service cases

## Verification
- `corepack pnpm --filter=@antseed/cli run build`
- `node --test apps/cli/dist/cli/commands/network/browse.test.js`