### PR TITLE
fix(cli): Warn on public Base RPC

### DIFF
--- a/apps/cli/src/cli/commands/seller/start.test.ts
+++ b/apps/cli/src/cli/commands/seller/start.test.ts
@@ -7,6 +7,7 @@ import {
   assertSellerPrerequisites,
   buildSellerRuntimeOverridesFromFlags,
   buildSellerPluginRuntimeEnv,
+  isPublicRpcUrl,
   mergeSellerRuntimeEnv,
   parseOptionalPositiveIntegerEnv,
   selectSellerProviderNames,
@@ -243,6 +244,22 @@ test('parseOptionalPositiveIntegerEnv accepts positive integer env values', () =
   assert.equal(parseOptionalPositiveIntegerEnv('0'), undefined);
   assert.equal(parseOptionalPositiveIntegerEnv('123abc'), undefined);
   assert.equal(parseOptionalPositiveIntegerEnv('not-a-number'), undefined);
+});
+
+test('isPublicRpcUrl detects built-in public Base RPC endpoints', () => {
+  assert.equal(isPublicRpcUrl('https://base.publicnode.com'), true);
+  assert.equal(isPublicRpcUrl('https://base.drpc.org'), true);
+  assert.equal(isPublicRpcUrl('https://base.llamarpc.com'), true);
+  assert.equal(isPublicRpcUrl('https://mainnet.base.org'), true);
+  assert.equal(isPublicRpcUrl('https://sepolia.base.org'), true);
+});
+
+test('isPublicRpcUrl matches host only and ignores invalid or dedicated RPC URLs', () => {
+  assert.equal(isPublicRpcUrl('https://BASE.PUBLICNODE.COM/path'), true);
+  assert.equal(isPublicRpcUrl('https://base.publicnode.com:443'), true);
+  assert.equal(isPublicRpcUrl('https://rpc.example.com/base.publicnode.com'), false);
+  assert.equal(isPublicRpcUrl('https://dedicated-base-rpc.example'), false);
+  assert.equal(isPublicRpcUrl('not a url'), false);
 });
 
 test('resolveBaseRpcUrlOverride uses flag before ANTSEED_BASE_RPC_URL', () => {

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -49,6 +49,23 @@ function parseOptionalBoolEnv(value: string | undefined): boolean | null {
   return null
 }
 
+const PUBLIC_BASE_RPC_HOSTS = new Set([
+  'base.publicnode.com',
+  'base.drpc.org',
+  'base.llamarpc.com',
+  'mainnet.base.org',
+  'sepolia.base.org',
+])
+
+export function isPublicRpcUrl(rpcUrl: string): boolean {
+  try {
+    const host = new URL(rpcUrl).hostname.toLowerCase()
+    return PUBLIC_BASE_RPC_HOSTS.has(host)
+  } catch {
+    return false
+  }
+}
+
 /**
  * Gate `antseed seller start` on required prerequisites:
  *   1. At least one service is configured for the selected provider.
@@ -518,6 +535,9 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
       if (paymentConfig?.crypto?.rpcUrl) {
         const rpcSource = baseRpcUrlOverride ? 'runtime override' : 'config/default'
         console.log(chalk.dim(`  Base RPC URL: ${paymentConfig.crypto.rpcUrl} (${rpcSource})`))
+        if (isPublicRpcUrl(paymentConfig.crypto.rpcUrl)) {
+          console.log(chalk.yellow('  Warning: using a public Base RPC. Public RPCs can be rate-limited or lag on event/log polling; sellers should use a dedicated RPC for reliable payment channel settlement. Learn how to configure one: https://antseed.com/docs/config#base-rpc-url'))
+        }
       }
       // CLI flag (decimal USDC) overrides config JSON (base-unit string).
       const minSettleDeltaFlag = options.minSettleDelta as string | undefined


### PR DESCRIPTION
## Description

Adds a seller startup warning when the effective Base RPC URL points at a known public/default endpoint. The warning appears immediately after the effective Base RPC URL is printed so operators can switch to a dedicated RPC before relying on payment channel settlement polling.

Closes #634.

## Release Notes

- Warn sellers at startup when using known public Base RPC endpoints that may be rate-limited or lag on event/log polling.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
