### PR TITLE
feat(cli): Add model peer pinning

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -246,34 +246,24 @@ antseed buyer start --metadata-fetch-timeout-ms 1500
 
 For production sellers, prefer a dedicated Base JSON-RPC endpoint over public defaults. You can set it durably with `payments.crypto.rpcUrl`, at runtime with `ANTSEED_BASE_RPC_URL`, or for one run with `antseed seller start --base-rpc-url <url>`.
 
-### Session overrides (live, while proxy is running)
+### Peer pinning (live, while proxy is running)
 
-After `antseed buyer start` is running, you can override the service or peer for all subsequent requests without restarting:
+After `antseed buyer start` is running, you can pin all subsequent requests to a peer without restarting:
 
 ```bash
-# Pin all requests to a specific service (overrides whatever the tool sends)
-antseed buyer connection set --service claude-opus-4-6
-
 # Pin all requests to a specific peer (bypasses router for peer selection)
 antseed buyer connection set --peer <40-char-hex-peer-id>
-
-# Combine both in one command
-antseed buyer connection set --service claude-sonnet-4-6 --peer <peer-id>
 
 # Check current session state
 antseed buyer connection get
 
-# Clear individual overrides
-antseed buyer connection clear --service
-antseed buyer connection clear --peer
-
-# Clear all overrides at once
+# Clear the session pin
 antseed buyer connection clear
 ```
 
-Session overrides are stored in `~/.antseed/buyer.state.json` and picked up by the running proxy immediately via file-watching. The desktop app reads and writes the same file to expose service/peer selection in its UI.
+Session peer pins are stored in `~/.antseed/buyer.state.json` and picked up by the running proxy immediately via file-watching. The desktop app reads and writes the same file to expose peer selection in its UI.
 
-The service override rewrites the `model` field in the request body **before routing**, so peer selection, pricing, and the forwarded request all reflect the overridden service — regardless of what the tool (e.g. Claude Code) originally requested.
+For tools that can only set a model name, use `<peerId>/<model>` as the model. The proxy strips the peer prefix before provider matching and forwards only `<model>` to the seller. If both this model prefix and `x-antseed-pin-peer` are sent, the header selects the peer and the model prefix is still stripped.
 
 ## Payments
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -263,7 +263,7 @@ antseed buyer connection clear
 
 Session peer pins are stored in `~/.antseed/buyer.state.json` and picked up by the running proxy immediately via file-watching. The desktop app reads and writes the same file to expose peer selection in its UI.
 
-For tools that can only set a model name, use `<peerId>/<model>` as the model. The proxy strips the peer prefix before provider matching and forwards only `<model>` to the seller. If both this model prefix and `x-antseed-pin-peer` are sent, the header selects the peer and the model prefix is still stripped.
+For tools that can only set a model name, use `<peerId>@<model>` as the model. The proxy strips the peer prefix before provider matching and forwards only `<model>` to the seller. If both this model prefix and `x-antseed-pin-peer` are sent, the header selects the peer and the model prefix is still stripped.
 
 ## Payments
 

--- a/apps/cli/src/cli/commands/buyer/connection.ts
+++ b/apps/cli/src/cli/commands/buyer/connection.ts
@@ -9,7 +9,6 @@ interface BuyerStateFile {
   state: 'connected' | 'stopped'
   pid: number
   port: number
-  pinnedService: string | null
   pinnedPeerId: string | null
   [key: string]: unknown
 }
@@ -30,6 +29,7 @@ async function readStateFile(dataDir: string): Promise<BuyerStateFile | null> {
 async function writeStateFile(dataDir: string, data: BuyerStateFile): Promise<void> {
   const tmp = join(dataDir, `.buyer.state.${randomUUID()}.json.tmp`)
   try {
+    delete (data as Record<string, unknown>).pinnedService
     await writeFile(tmp, JSON.stringify(data, null, 2))
     await rename(tmp, stateFilePath(dataDir))
   } catch (err) {
@@ -67,7 +67,7 @@ export function registerBuyerConnectionCommand(buyerCmd: Command): void {
 
   connection
     .command('get')
-    .description('Show current session state (pinned service, pinned peer)')
+    .description('Show current session state (pinned peer)')
     .action(async () => {
       const globalOpts = getGlobalOptions(buyerCmd)
       const state = await readStateFile(globalOpts.dataDir)
@@ -79,31 +79,20 @@ export function registerBuyerConnectionCommand(buyerCmd: Command): void {
       console.log(`State:         ${alive ? chalk.green('connected') : chalk.red(state.state ?? 'stopped')}`)
       console.log(`PID:           ${state.pid}`)
       console.log(`Port:          ${state.port}`)
-      console.log(`Pinned service: ${state.pinnedService ? chalk.cyan(state.pinnedService) : chalk.dim('none')}`)
       console.log(`Pinned peer:   ${state.pinnedPeerId ? chalk.cyan(state.pinnedPeerId) : chalk.dim('none')}`)
     })
 
   connection
     .command('set')
-    .description('Update session overrides on the running buyer proxy')
-    .option('--service <service>', 'override service ID for all routed requests')
+    .description('Update the session peer pin on the running buyer proxy')
     .option('--peer <peerId>', 'pin all requests to a specific peer ID (40-char hex EVM address)')
     .action(async (options) => {
       const globalOpts = getGlobalOptions(buyerCmd)
       const state = await requireRunningBuyer(globalOpts.dataDir)
 
-      if (options.service === undefined && options.peer === undefined) {
-        console.error(chalk.red('Error: specify at least --service or --peer.'))
+      if (options.peer === undefined) {
+        console.error(chalk.red('Error: specify --peer.'))
         process.exit(1)
-      }
-
-      if (options.service !== undefined) {
-        const service = String(options.service).trim()
-        if (service.length === 0) {
-          console.error(chalk.red('Error: --service must not be empty.'))
-          process.exit(1)
-        }
-        state.pinnedService = service
       }
 
       if (options.peer !== undefined) {
@@ -117,34 +106,20 @@ export function registerBuyerConnectionCommand(buyerCmd: Command): void {
 
       await writeStateFile(globalOpts.dataDir, state)
 
-      if (options.service !== undefined) console.log(chalk.green(`Pinned service set to: ${state.pinnedService}`))
       if (options.peer !== undefined) console.log(chalk.green(`Pinned peer set to: ${state.pinnedPeerId}`))
     })
 
   connection
     .command('clear')
-    .description('Clear session overrides (defaults to clearing both service and peer)')
-    .option('--service', 'clear only the service override')
-    .option('--peer', 'clear only the peer pin')
-    .action(async (options) => {
+    .description('Clear the session peer pin')
+    .action(async () => {
       const globalOpts = getGlobalOptions(buyerCmd)
       const state = await requireRunningBuyer(globalOpts.dataDir)
 
-      const clearAll = !options.service && !options.peer
-      const clearService = clearAll || Boolean(options.service)
-      const clearPeer = clearAll || Boolean(options.peer)
-
-      if (clearService) state.pinnedService = null
-      if (clearPeer) state.pinnedPeerId = null
+      state.pinnedPeerId = null
 
       await writeStateFile(globalOpts.dataDir, state)
 
-      if (clearService && clearPeer) {
-        console.log(chalk.green('All session overrides cleared.'))
-      } else if (clearService) {
-        console.log(chalk.green('Service override cleared.'))
-      } else {
-        console.log(chalk.green('Peer pin cleared.'))
-      }
+      console.log(chalk.green('Peer pin cleared.'))
     })
 }

--- a/apps/cli/src/cli/commands/buyer/connection.ts
+++ b/apps/cli/src/cli/commands/buyer/connection.ts
@@ -29,7 +29,6 @@ async function readStateFile(dataDir: string): Promise<BuyerStateFile | null> {
 async function writeStateFile(dataDir: string, data: BuyerStateFile): Promise<void> {
   const tmp = join(dataDir, `.buyer.state.${randomUUID()}.json.tmp`)
   try {
-    delete (data as Record<string, unknown>).pinnedService
     await writeFile(tmp, JSON.stringify(data, null, 2))
     await rename(tmp, stateFilePath(dataDir))
   } catch (err) {

--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -342,9 +342,10 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
       if (pinnedPeerId) {
         console.log(chalk.yellow(`  pinned peer: ${pinnedPeerId} (router bypassed)`))
       } else {
-        console.log(chalk.yellow('  pinned peer: none — auto-selection is disabled, requests will 409 until a peer is pinned'))
+        console.log(chalk.yellow('  pinned peer: none — auto-selection is disabled, requests will fail until a peer is pinned'))
         console.log(chalk.dim('    Pin a peer with:  antseed network browse → antseed buyer connection set --peer <peerId>'))
         console.log(chalk.dim('    Or per-request:   x-antseed-pin-peer: <peerId> header'))
+        console.log(chalk.dim('    Or in model:      <peerId>/<model>'))
       }
       console.log('')
 

--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -345,7 +345,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
         console.log(chalk.yellow('  pinned peer: none — auto-selection is disabled, requests will fail until a peer is pinned'))
         console.log(chalk.dim('    Pin a peer with:  antseed network browse → antseed buyer connection set --peer <peerId>'))
         console.log(chalk.dim('    Or per-request:   x-antseed-pin-peer: <peerId> header'))
-        console.log(chalk.dim('    Or in model:      <peerId>/<model>'))
+        console.log(chalk.dim('    Or in model:      <peerId>@<model>'))
       }
       console.log('')
 

--- a/apps/cli/src/cli/commands/buyer/status.ts
+++ b/apps/cli/src/cli/commands/buyer/status.ts
@@ -12,7 +12,6 @@ interface BuyerStateFile {
   state?: string;
   pid?: number;
   port?: number;
-  pinnedService?: string | null;
   pinnedPeerId?: string | null;
 }
 
@@ -66,7 +65,6 @@ export function registerBuyerStatusCommand(buyerCmd: Command): void {
           console.log(JSON.stringify({
             connectionState: nodeStatus.state,
             proxyPort: nodeStatus.proxyPort,
-            pinnedService: buyerState?.pinnedService ?? null,
             pinnedPeerId: buyerState?.pinnedPeerId ?? null,
             depositsAvailable,
             depositsReserved,
@@ -84,7 +82,6 @@ export function registerBuyerStatusCommand(buyerCmd: Command): void {
         table.push(
           ['Connection state', nodeStatus.state === 'connected' ? chalk.green('connected') : chalk.gray('idle')],
           ['Proxy port', nodeStatus.proxyPort ? String(nodeStatus.proxyPort) : chalk.dim('n/a')],
-          ['Pinned service', buyerState?.pinnedService ? chalk.cyan(buyerState.pinnedService) : chalk.dim('none')],
           ['Pinned peer', buyerState?.pinnedPeerId ? chalk.cyan(buyerState.pinnedPeerId) : chalk.dim('none')],
           ['Deposits available', depositsAvailable ? chalk.green(`${depositsAvailable} USDC`) : chalk.dim('unavailable')],
           ['Deposits reserved', depositsReserved ? chalk.yellow(`${depositsReserved} USDC`) : chalk.dim('unavailable')],

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -390,7 +390,7 @@ test('model peer prefix pins the request peer and strips the routed model', asyn
   }
   const proxy = makeBuyerProxyWithPeers([pinnedPeer], [pinnedPeer], router)
   const req = makeProxyRequest({
-    body: { model: `${pinnedPeer.peerId}/gpt-4o`, messages: [] },
+    body: { model: `${pinnedPeer.peerId}@gpt-4o`, messages: [] },
   })
 
   const res = await invokeProxy(proxy, req)
@@ -418,7 +418,7 @@ test('x-antseed-pin-peer header takes precedence over model peer prefix', async 
     headers: {
       'x-antseed-pin-peer': headerPinnedPeer.peerId,
     },
-    body: { model: `${modelPinnedPeer.peerId}/gpt-4o`, messages: [] },
+    body: { model: `${modelPinnedPeer.peerId}@gpt-4o`, messages: [] },
   })
 
   const res = await invokeProxy(proxy, req)
@@ -665,11 +665,11 @@ function parseJsonBody(body: Uint8Array): Record<string, unknown> {
 const jsonHeaders: Record<string, string> = { 'content-type': 'application/json' }
 
 test('parsePeerPinnedService parses 40-char hex peer prefixes', () => {
-  assert.deepEqual(parsePeerPinnedService(`${validPeerId}/claude-sonnet-4-5`), {
+  assert.deepEqual(parsePeerPinnedService(`${validPeerId}@claude-sonnet-4-5`), {
     peerId: validPeerId,
     service: 'claude-sonnet-4-5',
   })
-  assert.deepEqual(parsePeerPinnedService(`0x${validPeerId.toUpperCase()}/gpt-4o`), {
+  assert.deepEqual(parsePeerPinnedService(`0x${validPeerId.toUpperCase()}@gpt-4o`), {
     peerId: validPeerId,
     service: 'gpt-4o',
   })
@@ -677,12 +677,13 @@ test('parsePeerPinnedService parses 40-char hex peer prefixes', () => {
 
 test('parsePeerPinnedService ignores non-peer model paths', () => {
   assert.equal(parsePeerPinnedService('openai/gpt-4o'), null)
-  assert.equal(parsePeerPinnedService(`${validPeerId}/`), null)
-  assert.equal(parsePeerPinnedService(`/${validPeerId}`), null)
+  assert.equal(parsePeerPinnedService('openai@gpt-4o'), null)
+  assert.equal(parsePeerPinnedService(`${validPeerId}@`), null)
+  assert.equal(parsePeerPinnedService(`@${validPeerId}`), null)
 })
 
 test('rewritePeerPinnedServiceInBody strips model peer prefix and sets service', () => {
-  const body = makeJsonBody({ model: `${validPeerId}/gpt-4o`, messages: [] })
+  const body = makeJsonBody({ model: `${validPeerId}@gpt-4o`, messages: [] })
   const result = rewritePeerPinnedServiceInBody(body, jsonHeaders)
   const parsed = parseJsonBody(result.body)
   assert.equal(result.pinnedPeerId, validPeerId)
@@ -691,7 +692,7 @@ test('rewritePeerPinnedServiceInBody strips model peer prefix and sets service',
 })
 
 test('rewritePeerPinnedServiceInBody strips service peer prefix when model is absent', () => {
-  const body = makeJsonBody({ service: `${validPeerId}/gpt-4o`, messages: [] })
+  const body = makeJsonBody({ service: `${validPeerId}@gpt-4o`, messages: [] })
   const result = rewritePeerPinnedServiceInBody(body, jsonHeaders)
   const parsed = parseJsonBody(result.body)
   assert.equal(result.pinnedPeerId, validPeerId)
@@ -700,7 +701,7 @@ test('rewritePeerPinnedServiceInBody strips service peer prefix when model is ab
 })
 
 test('rewritePeerPinnedServiceInBody preserves explicit unprefixed service when model is prefixed', () => {
-  const body = makeJsonBody({ model: `${validPeerId}/gpt-4o`, service: 'custom-service', messages: [] })
+  const body = makeJsonBody({ model: `${validPeerId}@gpt-4o`, service: 'custom-service', messages: [] })
   const result = rewritePeerPinnedServiceInBody(body, jsonHeaders)
   const parsed = parseJsonBody(result.body)
   assert.equal(result.pinnedPeerId, validPeerId)
@@ -709,7 +710,7 @@ test('rewritePeerPinnedServiceInBody preserves explicit unprefixed service when 
 })
 
 test('rewritePeerPinnedServiceInBody preserves all other fields', () => {
-  const body = makeJsonBody({ model: `${validPeerId}/gpt-4o`, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1024 })
+  const body = makeJsonBody({ model: `${validPeerId}@gpt-4o`, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1024 })
   const result = rewritePeerPinnedServiceInBody(body, jsonHeaders)
   const parsed = parseJsonBody(result.body)
   assert.equal(parsed['service'], 'gpt-4o')
@@ -719,14 +720,14 @@ test('rewritePeerPinnedServiceInBody preserves all other fields', () => {
 })
 
 test('rewritePeerPinnedServiceInBody updates content-length header when present', () => {
-  const original = makeJsonBody({ model: `${validPeerId}/gpt-4o`, messages: [] })
+  const original = makeJsonBody({ model: `${validPeerId}@gpt-4o`, messages: [] })
   const headers = { 'content-type': 'application/json', 'content-length': String(original.length) }
   const result = rewritePeerPinnedServiceInBody(original, headers)
   assert.equal(result.headers['content-length'], String(result.body.length))
 })
 
 test('rewritePeerPinnedServiceInBody returns original when body is not JSON content-type', () => {
-  const body = makeJsonBody({ model: `${validPeerId}/gpt-4o` })
+  const body = makeJsonBody({ model: `${validPeerId}@gpt-4o` })
   const headers = { 'content-type': 'text/plain' }
   const result = rewritePeerPinnedServiceInBody(body, headers)
   assert.equal(result.body, body)

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -6,7 +6,13 @@ import { Readable } from 'node:stream'
 import test from 'node:test'
 import type { PeerInfo } from '@antseed/node'
 import { DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS } from '../config/defaults.js'
-import { BuyerProxy, parsePersistedPeers, selectCandidatePeersForRouting, rewriteServiceInBody } from './buyer-proxy.js'
+import {
+  BuyerProxy,
+  parsePeerPinnedService,
+  parsePersistedPeers,
+  rewritePeerPinnedServiceInBody,
+  selectCandidatePeersForRouting,
+} from './buyer-proxy.js'
 
 function makePeer(seed: string, providers: string[]): PeerInfo {
   const repeated = (seed.repeat(40) + 'a'.repeat(40)).slice(0, 40)
@@ -371,6 +377,58 @@ test('pinned proxy request enforces buyer routing policy', async () => {
   assert.match(res.body, /pricing\/reputation limits/)
 })
 
+test('model peer prefix pins the request peer and strips the routed model', async () => {
+  const pinnedPeer = makePeer('a', ['openai'])
+  let capturedRequestBody: Record<string, unknown> | null = null
+  let capturedPeerId: string | null = null
+  const router = {
+    allowsPeerForPolicy: (req: { body: Uint8Array }, peer: PeerInfo) => {
+      capturedRequestBody = parseJsonBody(req.body)
+      capturedPeerId = peer.peerId
+      return false
+    },
+  }
+  const proxy = makeBuyerProxyWithPeers([pinnedPeer], [pinnedPeer], router)
+  const req = makeProxyRequest({
+    body: { model: `${pinnedPeer.peerId}/gpt-4o`, messages: [] },
+  })
+
+  const res = await invokeProxy(proxy, req)
+
+  assert.equal(res.statusCode, 502)
+  assert.equal(capturedPeerId, pinnedPeer.peerId)
+  assert.equal(capturedRequestBody?.['model'], 'gpt-4o')
+  assert.equal(capturedRequestBody?.['service'], 'gpt-4o')
+})
+
+test('x-antseed-pin-peer header takes precedence over model peer prefix', async () => {
+  const modelPinnedPeer = makePeer('a', ['openai'])
+  const headerPinnedPeer = makePeer('b', ['openai'])
+  let capturedRequestBody: Record<string, unknown> | null = null
+  let capturedPeerId: string | null = null
+  const router = {
+    allowsPeerForPolicy: (req: { body: Uint8Array }, peer: PeerInfo) => {
+      capturedRequestBody = parseJsonBody(req.body)
+      capturedPeerId = peer.peerId
+      return false
+    },
+  }
+  const proxy = makeBuyerProxyWithPeers([modelPinnedPeer, headerPinnedPeer], [modelPinnedPeer, headerPinnedPeer], router)
+  const req = makeProxyRequest({
+    headers: {
+      'x-antseed-pin-peer': headerPinnedPeer.peerId,
+    },
+    body: { model: `${modelPinnedPeer.peerId}/gpt-4o`, messages: [] },
+  })
+
+  const res = await invokeProxy(proxy, req)
+
+  assert.equal(res.statusCode, 502)
+  assert.equal(capturedPeerId, headerPinnedPeer.peerId)
+  assert.equal(capturedRequestBody?.['model'], 'gpt-4o')
+  assert.equal(capturedRequestBody?.['service'], 'gpt-4o')
+})
+
 // parsePersistedPeers — hydrates _cachedPeers from buyer.state.json at startup
 // so the first request after launch can route from the warm cache without
 // blocking on DHT discovery.
@@ -594,7 +652,7 @@ test('parsePersistedPeers filters non-string entries out of providers', () => {
   assert.deepEqual(result[0]?.providers, ['openai', 'claude-oauth'])
 })
 
-// rewriteServiceInBody tests
+// peer-pinned model syntax tests
 
 function makeJsonBody(obj: Record<string, unknown>): Uint8Array {
   return new TextEncoder().encode(JSON.stringify(obj))
@@ -606,55 +664,86 @@ function parseJsonBody(body: Uint8Array): Record<string, unknown> {
 
 const jsonHeaders: Record<string, string> = { 'content-type': 'application/json' }
 
-test('rewriteServiceInBody replaces existing model field and sets service', () => {
-  const body = makeJsonBody({ model: 'claude-sonnet-4-5', messages: [] })
-  const result = rewriteServiceInBody(body, jsonHeaders, 'claude-opus-4-6')
-  const parsed = parseJsonBody(result.body)
-  assert.equal(parsed['service'], 'claude-opus-4-6')
-  assert.equal(parsed['model'], 'claude-opus-4-6')
+test('parsePeerPinnedService parses 40-char hex peer prefixes', () => {
+  assert.deepEqual(parsePeerPinnedService(`${validPeerId}/claude-sonnet-4-5`), {
+    peerId: validPeerId,
+    service: 'claude-sonnet-4-5',
+  })
+  assert.deepEqual(parsePeerPinnedService(`0x${validPeerId.toUpperCase()}/gpt-4o`), {
+    peerId: validPeerId,
+    service: 'gpt-4o',
+  })
 })
 
-test('rewriteServiceInBody adds service and model fields when absent', () => {
-  const body = makeJsonBody({ messages: [] })
-  const result = rewriteServiceInBody(body, jsonHeaders, 'claude-opus-4-6')
-  const parsed = parseJsonBody(result.body)
-  assert.equal(parsed['service'], 'claude-opus-4-6')
-  assert.equal(parsed['model'], 'claude-opus-4-6')
+test('parsePeerPinnedService ignores non-peer model paths', () => {
+  assert.equal(parsePeerPinnedService('openai/gpt-4o'), null)
+  assert.equal(parsePeerPinnedService(`${validPeerId}/`), null)
+  assert.equal(parsePeerPinnedService(`/${validPeerId}`), null)
 })
 
-test('rewriteServiceInBody preserves all other fields', () => {
-  const body = makeJsonBody({ model: 'old', messages: [{ role: 'user', content: 'hi' }], max_tokens: 1024 })
-  const result = rewriteServiceInBody(body, jsonHeaders, 'new-model')
+test('rewritePeerPinnedServiceInBody strips model peer prefix and sets service', () => {
+  const body = makeJsonBody({ model: `${validPeerId}/gpt-4o`, messages: [] })
+  const result = rewritePeerPinnedServiceInBody(body, jsonHeaders)
   const parsed = parseJsonBody(result.body)
-  assert.equal(parsed['service'], 'new-model')
-  assert.equal(parsed['model'], 'new-model')
+  assert.equal(result.pinnedPeerId, validPeerId)
+  assert.equal(parsed['service'], 'gpt-4o')
+  assert.equal(parsed['model'], 'gpt-4o')
+})
+
+test('rewritePeerPinnedServiceInBody strips service peer prefix when model is absent', () => {
+  const body = makeJsonBody({ service: `${validPeerId}/gpt-4o`, messages: [] })
+  const result = rewritePeerPinnedServiceInBody(body, jsonHeaders)
+  const parsed = parseJsonBody(result.body)
+  assert.equal(result.pinnedPeerId, validPeerId)
+  assert.equal(parsed['service'], 'gpt-4o')
+  assert.equal(parsed['model'], 'gpt-4o')
+})
+
+test('rewritePeerPinnedServiceInBody preserves explicit unprefixed service when model is prefixed', () => {
+  const body = makeJsonBody({ model: `${validPeerId}/gpt-4o`, service: 'custom-service', messages: [] })
+  const result = rewritePeerPinnedServiceInBody(body, jsonHeaders)
+  const parsed = parseJsonBody(result.body)
+  assert.equal(result.pinnedPeerId, validPeerId)
+  assert.equal(parsed['model'], 'gpt-4o')
+  assert.equal(parsed['service'], 'custom-service')
+})
+
+test('rewritePeerPinnedServiceInBody preserves all other fields', () => {
+  const body = makeJsonBody({ model: `${validPeerId}/gpt-4o`, messages: [{ role: 'user', content: 'hi' }], max_tokens: 1024 })
+  const result = rewritePeerPinnedServiceInBody(body, jsonHeaders)
+  const parsed = parseJsonBody(result.body)
+  assert.equal(parsed['service'], 'gpt-4o')
+  assert.equal(parsed['model'], 'gpt-4o')
   assert.deepEqual(parsed['messages'], [{ role: 'user', content: 'hi' }])
   assert.equal(parsed['max_tokens'], 1024)
 })
 
-test('rewriteServiceInBody updates content-length header when present', () => {
-  const original = makeJsonBody({ model: 'a', messages: [] })
+test('rewritePeerPinnedServiceInBody updates content-length header when present', () => {
+  const original = makeJsonBody({ model: `${validPeerId}/gpt-4o`, messages: [] })
   const headers = { 'content-type': 'application/json', 'content-length': String(original.length) }
-  const result = rewriteServiceInBody(original, headers, 'claude-opus-4-6-20251201')
+  const result = rewritePeerPinnedServiceInBody(original, headers)
   assert.equal(result.headers['content-length'], String(result.body.length))
 })
 
-test('rewriteServiceInBody returns original when body is not JSON content-type', () => {
-  const body = makeJsonBody({ model: 'old' })
+test('rewritePeerPinnedServiceInBody returns original when body is not JSON content-type', () => {
+  const body = makeJsonBody({ model: `${validPeerId}/gpt-4o` })
   const headers = { 'content-type': 'text/plain' }
-  const result = rewriteServiceInBody(body, headers, 'new-model')
+  const result = rewritePeerPinnedServiceInBody(body, headers)
   assert.equal(result.body, body)
   assert.equal(result.headers, headers)
+  assert.equal(result.pinnedPeerId, null)
 })
 
-test('rewriteServiceInBody returns original when body is empty', () => {
+test('rewritePeerPinnedServiceInBody returns original when body is empty', () => {
   const body = new Uint8Array(0)
-  const result = rewriteServiceInBody(body, jsonHeaders, 'new-model')
+  const result = rewritePeerPinnedServiceInBody(body, jsonHeaders)
   assert.equal(result.body, body)
+  assert.equal(result.pinnedPeerId, null)
 })
 
-test('rewriteServiceInBody returns original when body is not a JSON object', () => {
+test('rewritePeerPinnedServiceInBody returns original when body is not a JSON object', () => {
   const body = new TextEncoder().encode('"just a string"')
-  const result = rewriteServiceInBody(body, jsonHeaders, 'new-model')
+  const result = rewritePeerPinnedServiceInBody(body, jsonHeaders)
   assert.equal(result.body, body)
+  assert.equal(result.pinnedPeerId, null)
 })

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -1019,7 +1019,7 @@ export class BuyerProxy {
 
     // Auto peer selection is disabled. Every request MUST target a specific
     // peer, either via the per-request `x-antseed-pin-peer` header, a
-    // `<peerId>/<model>` model prefix, or a session-wide pin set by
+    // `<peerId>@<model>` model prefix, or a session-wide pin set by
     // `antseed buyer connection set --peer <peerId>`.
     //
     // Surface the error in the structured shape OpenAI/Anthropic SDKs expect
@@ -1034,7 +1034,7 @@ export class BuyerProxy {
         'No peer pinned. Auto-selection is disabled.\n'
         + 'Pin a peer one of three ways:\n'
         + '  • Per-request header:   x-antseed-pin-peer: <peerId>    (40-char hex EVM address)\n'
-        + '  • Model name prefix:    <peerId>/<model>\n'
+        + '  • Model name prefix:    <peerId>@<model>\n'
         + '  • Session pin:          antseed buyer connection set --peer <peerId>\n'
         + 'Discover peers with:       antseed network browse'
       res.writeHead(400, { 'content-type': 'application/json' })
@@ -1046,7 +1046,7 @@ export class BuyerProxy {
           param: 'x-antseed-pin-peer',
           help: {
             perRequestHeader: 'x-antseed-pin-peer: <peerId>',
-            modelPrefix: '<peerId>/<model>',
+            modelPrefix: '<peerId>@<model>',
             sessionPin: 'antseed buyer connection set --peer <peerId>',
             discoverPeers: 'antseed network browse',
           },

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -35,7 +35,7 @@ import {
   summarizeRequestShape,
   summarizeErrorResponse,
   requestWantsStreaming,
-  rewriteServiceInBody,
+  rewritePeerPinnedServiceInBody,
   isConnectionChurnError,
   isConnectionHealthy,
 } from './request-utils.js'
@@ -56,12 +56,12 @@ import { DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS } from '../config/defaults.js'
 
 // Re-export for backward compatibility (used by tests and other consumers)
 export { selectCandidatePeersForRouting, type CandidatePeerRouteSelection } from './routing.js'
-export { rewriteServiceInBody } from './request-utils.js'
+export { parsePeerPinnedService, rewritePeerPinnedServiceInBody } from './request-utils.js'
 
 export interface BuyerProxyConfig {
   port: number
   node: AntseedNode
-  /** Data directory used to persist buyer.state.json (discovered peers, session overrides). */
+  /** Data directory used to persist buyer.state.json (discovered peers, session peer pin). */
   dataDir: string
   /** How often to refresh the peer list from DHT in the background (ms). Default: 300000 (5 min) */
   backgroundRefreshIntervalMs?: number
@@ -78,12 +78,6 @@ export interface BuyerProxyConfig {
    * and allowed by the buyer's pricing policy. A 502 is returned if the peer cannot be reached.
    */
   pinnedPeerId?: string
-  /**
-   * Pin all requests to a specific service ID for this session.
-   * Overrides the service field in the request body before routing and forwarding.
-   * Can be updated at runtime via `antseed buyer connection set --service`.
-   */
-  pinnedService?: string
 }
 
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504])
@@ -348,7 +342,6 @@ export class BuyerProxy {
   private readonly _stateFile: string
   private _stateFileWatching = false
   private _pinnedPeer: string | null
-  private _pinnedService: string | null
   private _stateWatchDebounce: ReturnType<typeof setTimeout> | null = null
 
   private _stateWriteChain: Promise<void> = Promise.resolve()
@@ -376,7 +369,6 @@ export class BuyerProxy {
     this._stateDir = config.dataDir
     this._stateFile = join(config.dataDir, 'buyer.state.json')
     this._pinnedPeer = config.pinnedPeerId?.toLowerCase() ?? null
-    this._pinnedService = config.pinnedService?.trim() ?? null
     this._server = createServer((req, res) => {
       this._handleRequest(req, res).catch((err) => {
         log('Unhandled error:', err)
@@ -405,10 +397,10 @@ export class BuyerProxy {
     // startup route from the warm cache without blocking on DHT discovery.
     // The background refresh still runs to pick up fresh peers and IP changes.
     await this._hydratePeersFromStateFile()
-    // If the CLI didn't pass --peer/--service, adopt whatever a previous
-    // `antseed buyer connection set` wrote to buyer.state.json so the pin
-    // survives daemon restart.
-    if (this._pinnedPeer === null && this._pinnedService === null) {
+    // If the CLI didn't pass --peer, adopt whatever a previous
+    // `antseed buyer connection set --peer` wrote to buyer.state.json so the
+    // pin survives daemon restart.
+    if (this._pinnedPeer === null) {
       await this._reloadSessionOverrides()
     }
     await new Promise<void>((resolve, reject) => {
@@ -495,15 +487,11 @@ export class BuyerProxy {
     try {
       const raw = await readFile(this._stateFile, 'utf-8')
       const parsed = JSON.parse(raw) as Record<string, unknown>
-      const pinnedService = typeof parsed.pinnedService === 'string' && parsed.pinnedService.trim().length > 0
-        ? parsed.pinnedService.trim()
-        : null
       const pinnedPeer = typeof parsed.pinnedPeerId === 'string' && parsed.pinnedPeerId.trim().length > 0
         ? parsed.pinnedPeerId.trim().toLowerCase()
         : null
-      this._pinnedService = pinnedService
       this._pinnedPeer = pinnedPeer
-      log(`Session overrides reloaded: service=${pinnedService ?? 'none'} peer=${pinnedPeer ?? 'none'}`)
+      log(`Session overrides reloaded: peer=${pinnedPeer ?? 'none'}`)
     } catch {
       // state file unreadable; keep current values
     }
@@ -533,11 +521,11 @@ export class BuyerProxy {
   }
 
   private async _writeStateFile(state: 'connected' | 'stopped'): Promise<void> {
-    // When stopping, preserve whatever pinnedService/pinnedPeerId is already
+    // When stopping, preserve whatever pinnedPeerId is already
     // in the file — the debounce may have been cancelled before
     // _reloadSessionOverrides could commit the latest CLI-written values.
     const sessionOverrides = state === 'connected'
-      ? { pinnedService: this._pinnedService, pinnedPeerId: this._pinnedPeer }
+      ? { pinnedPeerId: this._pinnedPeer, pinnedService: undefined }
       : {}
     await this._mergeStateFile({
       state,
@@ -988,19 +976,18 @@ export class BuyerProxy {
       body: new Uint8Array(body),
     }
 
-    // Snapshot both session overrides together before any await so a concurrent
-    // _reloadSessionOverrides() cannot produce a service/peer mismatch mid-request.
-    const effectivePinnedService = this._pinnedService
+    // Snapshot the session peer pin before any await so a concurrent
+    // _reloadSessionOverrides() cannot change routing mid-request.
     const effectivePinnedPeer = this._pinnedPeer
-    if (effectivePinnedService) {
-      const { body: rewrittenBody, headers: rewrittenHeaders } = rewriteServiceInBody(
-        serializedReq.body,
-        serializedReq.headers,
-        effectivePinnedService,
-      )
-      if (rewrittenBody !== serializedReq.body) {
-        serializedReq = { ...serializedReq, body: rewrittenBody, headers: rewrittenHeaders }
-        log(`Service override applied: ${effectivePinnedService}`)
+    const {
+      body: servicePinBody,
+      headers: servicePinHeaders,
+      pinnedPeerId: bodyPinnedPeer,
+    } = rewritePeerPinnedServiceInBody(serializedReq.body, serializedReq.headers)
+    if (servicePinBody !== serializedReq.body) {
+      serializedReq = { ...serializedReq, body: servicePinBody, headers: servicePinHeaders }
+      if (bodyPinnedPeer) {
+        log(`Model peer pin applied: peer=${bodyPinnedPeer.slice(0, 12)}...`)
       }
     }
 
@@ -1027,12 +1014,13 @@ export class BuyerProxy {
     const requestedService = extractRequestedService(serializedReq)
     log(`Routing: protocol=${requestProtocol ?? 'null'} service=${requestedService ?? 'null'}`)
     const explicitProvider = getExplicitProviderOverride(serializedReq)
-    const explicitPeerId = getExplicitPeerIdOverride(serializedReq, effectivePinnedPeer ?? undefined)
+    const explicitPeerId = getExplicitPeerIdOverride(serializedReq, effectivePinnedPeer ?? undefined, bodyPinnedPeer)
     log(`Routing hints: provider=${explicitProvider ?? 'auto'} pin-peer=${explicitPeerId ?? 'none'}`)
 
     // Auto peer selection is disabled. Every request MUST target a specific
-    // peer, either via the per-request `x-antseed-pin-peer` header or via a
-    // session-wide pin set by `antseed buyer connection set --peer <peerId>`.
+    // peer, either via the per-request `x-antseed-pin-peer` header, a
+    // `<peerId>/<model>` model prefix, or a session-wide pin set by
+    // `antseed buyer connection set --peer <peerId>`.
     //
     // Surface the error in the structured shape OpenAI/Anthropic SDKs expect
     // (`{ error: { type, code, message, ... } }`) so callers see a proper
@@ -1044,8 +1032,9 @@ export class BuyerProxy {
       log('Request rejected: no peer pinned')
       const errorMessage =
         'No peer pinned. Auto-selection is disabled.\n'
-        + 'Pin a peer one of two ways:\n'
+        + 'Pin a peer one of three ways:\n'
         + '  • Per-request header:   x-antseed-pin-peer: <peerId>    (40-char hex EVM address)\n'
+        + '  • Model name prefix:    <peerId>/<model>\n'
         + '  • Session pin:          antseed buyer connection set --peer <peerId>\n'
         + 'Discover peers with:       antseed network browse'
       res.writeHead(400, { 'content-type': 'application/json' })
@@ -1057,6 +1046,7 @@ export class BuyerProxy {
           param: 'x-antseed-pin-peer',
           help: {
             perRequestHeader: 'x-antseed-pin-peer: <peerId>',
+            modelPrefix: '<peerId>/<model>',
             sessionPin: 'antseed buyer connection set --peer <peerId>',
             discoverPeers: 'antseed network browse',
           },
@@ -1129,7 +1119,11 @@ export class BuyerProxy {
     }
 
     if (!pinnedDiscovered) {
-      const logSource = serializedReq.headers['x-antseed-pin-peer'] ? 'x-antseed-pin-peer header' : '--peer flag or session pin'
+      const logSource = serializedReq.headers['x-antseed-pin-peer']
+        ? 'x-antseed-pin-peer header'
+        : bodyPinnedPeer
+          ? 'model peer prefix'
+          : '--peer flag or session pin'
       const diagnostics = this._formatPeerSelectionDiagnostics(discoveredPeers)
       log(`Pinned peer ${explicitPeerId.slice(0, 12)}... not discoverable in DHT (${logSource})`)
       res.writeHead(502, { 'content-type': 'text/plain' })

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -525,7 +525,7 @@ export class BuyerProxy {
     // in the file — the debounce may have been cancelled before
     // _reloadSessionOverrides could commit the latest CLI-written values.
     const sessionOverrides = state === 'connected'
-      ? { pinnedPeerId: this._pinnedPeer, pinnedService: undefined }
+      ? { pinnedPeerId: this._pinnedPeer }
       : {}
     await this._mergeStateFile({
       state,

--- a/apps/cli/src/proxy/request-utils.ts
+++ b/apps/cli/src/proxy/request-utils.ts
@@ -24,13 +24,13 @@ export function normalizePeerId(value: string): string | null {
 }
 
 export function parsePeerPinnedService(value: string): { peerId: string; service: string } | null {
-  const slashIndex = value.indexOf('/')
-  if (slashIndex <= 0 || slashIndex === value.length - 1) {
+  const separatorIndex = value.indexOf('@')
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
     return null
   }
 
-  const peerId = normalizePeerId(value.slice(0, slashIndex))
-  const service = value.slice(slashIndex + 1).trim()
+  const peerId = normalizePeerId(value.slice(0, separatorIndex))
+  const service = value.slice(separatorIndex + 1).trim()
   if (!peerId || service.length === 0) {
     return null
   }

--- a/apps/cli/src/proxy/request-utils.ts
+++ b/apps/cli/src/proxy/request-utils.ts
@@ -17,6 +17,26 @@ function getHeader(headers: Record<string, string>, name: string): string {
   return headers[name] ?? headers[name.charAt(0).toUpperCase() + name.slice(1)] ?? ''
 }
 
+export function normalizePeerId(value: string): string | null {
+  const trimmed = value.trim().toLowerCase()
+  const withoutPrefix = trimmed.startsWith('0x') ? trimmed.slice(2) : trimmed
+  return /^[0-9a-f]{40}$/.test(withoutPrefix) ? withoutPrefix : null
+}
+
+export function parsePeerPinnedService(value: string): { peerId: string; service: string } | null {
+  const slashIndex = value.indexOf('/')
+  if (slashIndex <= 0 || slashIndex === value.length - 1) {
+    return null
+  }
+
+  const peerId = normalizePeerId(value.slice(0, slashIndex))
+  const service = value.slice(slashIndex + 1).trim()
+  if (!peerId || service.length === 0) {
+    return null
+  }
+  return { peerId, service }
+}
+
 export function extractRequestedService(request: SerializedHttpRequest): string | null {
   if (!getHeader(request.headers, 'content-type').toLowerCase().includes('application/json')) {
     return null
@@ -248,26 +268,39 @@ export function isLoopbackPeer(peer: PeerInfo): boolean {
   return isLoopbackHost(host)
 }
 
-/**
- * Rewrite the `service` (and `model` for upstream LLM API compat) fields in a JSON request body.
- * Also updates `content-length` if present in headers.
- * Returns the original body/headers unchanged if the body is not JSON,
- * is empty, or cannot be parsed.
- */
-export function rewriteServiceInBody(
+export function rewritePeerPinnedServiceInBody(
   body: Uint8Array,
   headers: Record<string, string>,
-  service: string,
-): { body: Uint8Array; headers: Record<string, string> } {
+): { body: Uint8Array; headers: Record<string, string>; pinnedPeerId: string | null } {
   if (!getHeader(headers, 'content-type').toLowerCase().includes('application/json') || body.length === 0) {
-    return { body, headers }
+    return { body, headers, pinnedPeerId: null }
   }
   const obj = parseJsonObject(body)
   if (!obj) {
-    return { body, headers }
+    return { body, headers, pinnedPeerId: null }
   }
-  obj['service'] = service
-  obj['model'] = service
+
+  const rawModel = typeof obj['model'] === 'string' ? obj['model'].trim() : ''
+  const rawService = typeof obj['service'] === 'string' ? obj['service'].trim() : ''
+  const parsedModel = rawModel ? parsePeerPinnedService(rawModel) : null
+  const parsedService = rawService ? parsePeerPinnedService(rawService) : null
+  const parsed = parsedModel ?? parsedService
+  if (!parsed) {
+    return { body, headers, pinnedPeerId: null }
+  }
+
+  if (parsedModel) {
+    obj['model'] = parsedModel.service
+    if (obj['service'] === undefined || obj['service'] === rawModel) {
+      obj['service'] = parsedModel.service
+    }
+  } else if (parsedService) {
+    obj['service'] = parsedService.service
+    if (obj['model'] === undefined || obj['model'] === rawService) {
+      obj['model'] = parsedService.service
+    }
+  }
+
   const rewritten = new TextEncoder().encode(JSON.stringify(obj))
   const updatedHeaders = { ...headers }
   if ('content-length' in updatedHeaders) {
@@ -275,5 +308,5 @@ export function rewriteServiceInBody(
   } else if ('Content-Length' in updatedHeaders) {
     updatedHeaders['Content-Length'] = String(rewritten.length)
   }
-  return { body: rewritten, headers: updatedHeaders }
+  return { body: rewritten, headers: updatedHeaders, pinnedPeerId: parsed.peerId }
 }

--- a/apps/cli/src/proxy/routing.ts
+++ b/apps/cli/src/proxy/routing.ts
@@ -5,7 +5,7 @@ import {
   type ServiceApiProtocol,
   type TargetProtocolSelection,
 } from './service-api-adapter.js'
-import { log } from './request-utils.js'
+import { log, normalizePeerId } from './request-utils.js'
 
 export type PeerProtocolRoutePlan = {
   provider: string
@@ -30,10 +30,12 @@ export function getExplicitProviderOverride(request: SerializedHttpRequest): str
 export function getExplicitPeerIdOverride(
   request: SerializedHttpRequest,
   sessionPinnedPeerId: string | undefined,
+  requestPinnedPeerId?: string | null,
 ): string | null {
   // Per-request header takes priority over session pin
-  const header = request.headers['x-antseed-pin-peer']?.trim().toLowerCase()
-  if (header && header.length > 0) return header
+  const header = request.headers['x-antseed-pin-peer']?.trim()
+  if (header && header.length > 0) return normalizePeerId(header) ?? header.toLowerCase()
+  if (requestPinnedPeerId) return requestPinnedPeerId.toLowerCase()
   return sessionPinnedPeerId?.toLowerCase() ?? null
 }
 

--- a/apps/website/docs/guides/using-the-api.md
+++ b/apps/website/docs/guides/using-the-api.md
@@ -143,14 +143,13 @@ antseed network peer <40-char-hex-peer-id>
 # Pin a peer for the session (survives daemon restart)
 antseed buyer connection set --peer <40-char-hex-peer-id>
 
-# Pin a service too — overrides the `model` field in all requests
-antseed buyer connection set --service claude-opus-4-6
-
 # Clear pins
 antseed buyer connection clear
 ```
 
-You can also pin per-request by sending the `x-antseed-pin-peer: <peerId>` header — useful when different calls should go to different peers.
+You can also pin per-request by sending the `x-antseed-pin-peer: <peerId>` header, or by encoding the peer in the model field as `<peerId>/<model>`. The proxy strips the peer prefix before provider matching and forwarding, so `4668854ba3e8b094e6f48fbeb59cec1cfde162f2/gpt-5.5` routes to that peer as model `gpt-5.5`.
+
+Precedence: `x-antseed-pin-peer` selects the peer when both a header pin and model prefix are present. The model prefix is still stripped before the request is routed.
 
 ## How Routing Works
 

--- a/apps/website/docs/guides/using-the-api.md
+++ b/apps/website/docs/guides/using-the-api.md
@@ -147,7 +147,7 @@ antseed buyer connection set --peer <40-char-hex-peer-id>
 antseed buyer connection clear
 ```
 
-You can also pin per-request by sending the `x-antseed-pin-peer: <peerId>` header, or by encoding the peer in the model field as `<peerId>/<model>`. The proxy strips the peer prefix before provider matching and forwarding, so `4668854ba3e8b094e6f48fbeb59cec1cfde162f2/gpt-5.5` routes to that peer as model `gpt-5.5`.
+You can also pin per-request by sending the `x-antseed-pin-peer: <peerId>` header, or by encoding the peer in the model field as `<peerId>@<model>`. The proxy strips the peer prefix before provider matching and forwarding, so `4668854ba3e8b094e6f48fbeb59cec1cfde162f2@gpt-5.5` routes to that peer as model `gpt-5.5`.
 
 Precedence: `x-antseed-pin-peer` selects the peer when both a header pin and model prefix are present. The model prefix is still stripped before the request is routed.
 

--- a/apps/website/plugins/integrations-pages.ts
+++ b/apps/website/plugins/integrations-pages.ts
@@ -280,7 +280,11 @@ function renderSkillMarkdown(): string {
   out.push('    `~/.antseed/buyer.state.json` and applies to every request until you change it.');
   out.push('  - **Per-request header**: `x-antseed-pin-peer: <peerId>` on each call. Overrides');
   out.push('    the session pin for that request, and works *without* any session pin at all.');
+  out.push('  - **Model prefix**: set `model` to `<peerId>/<service>`. The proxy uses the');
+  out.push('    prefix as the peer pin and forwards only `<service>` to the seller.');
   out.push('  ');
+  out.push('  If both header and model-prefix pins are present, the header selects the peer;');
+  out.push('  the model prefix is still stripped before routing.');
   out.push('  Until at least one of these is in effect, every request returns `no_peer_pinned`.');
   out.push('');
 
@@ -424,7 +428,7 @@ function renderSkillMarkdown(): string {
   out.push('| `identity.key` | Raw 32-byte EVM private key for the buyer wallet. Fallback when `ANTSEED_IDENTITY_HEX` is not set. | yes | NO — deleting loses access to your USDC deposits. Back this up. |');
   out.push('| `identity.enc` | Encrypted copy of `identity.key` (when the desktop app sets a passphrase). | yes | only if `identity.key` is also intact |');
   out.push('| `config.json` | Static settings: chain id, proxy port, max-pricing caps, bootstrap nodes, payments preferences. Hand-editable. | yes | yes (defaults are sane) |');
-  out.push('| `buyer.state.json` | Live runtime state: `pinnedPeerId`, `pinnedService`, the discovered-peers cache (`discoveredPeers`), on-chain stats, the proxy `pid` and `port`. Re-built from the network on next start. | yes (the pin survives restart) | yes (you lose the pin and the cached peer list — next browse will repopulate) |');
+  out.push('| `buyer.state.json` | Live runtime state: `pinnedPeerId`, the discovered-peers cache (`discoveredPeers`), on-chain stats, the proxy `pid` and `port`. Re-built from the network on next start. | yes (the pin survives restart) | yes (you lose the pin and the cached peer list — next browse will repopulate) |');
   out.push('| `metering.db` | SQLite log of every request the proxy served (model, peer, tokens, USDC). Used by `antseed buyer status` and the payments portal. | yes | yes (you lose request history; settlement is unaffected) |');
   out.push('| `payments/` | Per-channel state used by the seller-side settlement flow (only relevant if you also run `antseed seller`). | yes | only if you do not run a seller |');
   out.push('| `plugins/` | Cache of downloaded provider plugins. | yes | yes (re-downloaded on next use) |');
@@ -458,7 +462,6 @@ function renderSkillMarkdown(): string {
   out.push('Top-level fields that an agent might want to inspect:');
   out.push('');
   out.push('- `pinnedPeerId` — the currently pinned peer (or `null`).');
-  out.push('- `pinnedService` — the service id pinned with `antseed buyer connection set --service <id>` (rare).');
   out.push('- `pid` / `port` — the running proxy. If `pid` is non-null but the process is gone, `antseed buyer start` will detect the stale lockfile and clean up.');
   out.push('- `discoveredPeers` — cached peer list from the last DHT browse. Refreshed on `antseed network browse`.');
   out.push('- `peersUpdatedAt`, `onChainStatsRefreshedAt` — cache timestamps (epoch millis).');

--- a/apps/website/plugins/integrations-pages.ts
+++ b/apps/website/plugins/integrations-pages.ts
@@ -275,12 +275,12 @@ function renderSkillMarkdown(): string {
   out.push('- **Pin** — telling the buyer proxy "route requests to *this* peer." In the');
   out.push('  default manual flow, there is no peer auto-selection; you must choose a peer,');
   out.push('  send a per-request pin header, or start the proxy with a router plugin that');
-  out.push('  performs selection. Two common explicit routes:');
+  out.push('  performs selection. Common explicit routes:');
   out.push('  - **Session pin**: `antseed buyer connection set --peer <peerId>`. Persists in');
   out.push('    `~/.antseed/buyer.state.json` and applies to every request until you change it.');
   out.push('  - **Per-request header**: `x-antseed-pin-peer: <peerId>` on each call. Overrides');
   out.push('    the session pin for that request, and works *without* any session pin at all.');
-  out.push('  - **Model prefix**: set `model` to `<peerId>/<service>`. The proxy uses the');
+  out.push('  - **Model prefix**: set `model` to `<peerId>@<service>`. The proxy uses the');
   out.push('    prefix as the peer pin and forwards only `<service>` to the seller.');
   out.push('  ');
   out.push('  If both header and model-prefix pins are present, the header selects the peer;');


### PR DESCRIPTION
## Description

Adds request-level peer pinning via OpenAI-compatible model names in the form `<peerId>@<model>`. The buyer proxy applies the peer prefix as the per-request pin, strips it before routing/provider matching, and keeps `x-antseed-pin-peer` as the highest-precedence peer selector.

Removes the session-wide service pin implementation from the buyer connection/status commands. Existing `pinnedService` values in buyer state are ignored but left untouched.

Closes #622

## Release Notes

- Added `<peerId>@<model>` model syntax for per-request seller pinning without custom headers
- Removed the buyer session service-pin command and runtime handling
- Documented peer-pin precedence between request headers, model prefixes, and session pins

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
