### PR TITLE
fix(desktop): keep unsafe payment replies visible

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -319,16 +319,18 @@
     }
 
     .chat-sensitive-artifact {
+      appearance: none;
       display: inline-flex;
       align-items: center;
       gap: 6px;
       max-width: 100%;
       margin: 0 2px;
       padding: 2px 6px;
-      border: 1px solid color-mix(in srgb, var(--danger) 26%, var(--border));
+      border: 1px solid var(--border);
       border-radius: 999px;
-      background: color-mix(in srgb, var(--danger) 7%, var(--bg-card-alt));
+      background: color-mix(in srgb, var(--bg-card-alt) 88%, var(--text-muted) 12%);
       color: var(--text-secondary);
+      font: inherit;
       font-size: 0.92em;
       line-height: 1.4;
       vertical-align: baseline;
@@ -345,8 +347,8 @@
       appearance: none;
       border: 0;
       border-radius: 999px;
-      background: color-mix(in srgb, var(--danger) 12%, transparent);
-      color: var(--danger);
+      background: color-mix(in srgb, var(--text-muted) 12%, transparent);
+      color: var(--text-secondary);
       cursor: pointer;
       flex: 0 0 auto;
       font: inherit;
@@ -357,11 +359,12 @@
     }
 
     .chat-sensitive-action:hover {
-      background: color-mix(in srgb, var(--danger) 18%, transparent);
+      background: color-mix(in srgb, var(--text-muted) 18%, transparent);
+      color: var(--text-primary);
     }
 
     .chat-sensitive-action:focus-visible {
-      outline: 2px solid var(--danger);
+      outline: 2px solid var(--accent-blue);
       outline-offset: 2px;
     }
 
@@ -376,45 +379,38 @@
       color: inherit;
     }
 
-    .chat-external-link-gated {
-      border-color: color-mix(in srgb, var(--accent-blue) 28%, var(--border));
-      background: color-mix(in srgb, var(--accent-blue) 7%, var(--bg-card-alt));
-    }
-
     .chat-external-link-gated .chat-sensitive-action {
-      background: color-mix(in srgb, var(--accent-blue) 12%, transparent);
       color: var(--accent-blue);
     }
 
     .chat-external-link-gated .chat-sensitive-action:hover {
-      background: color-mix(in srgb, var(--accent-blue) 18%, transparent);
+      background: color-mix(in srgb, var(--accent-blue) 12%, transparent);
     }
 
-    .chat-payment-link-hidden,
-    .chat-wallet-hidden {
+    .chat-payment-link-hidden {
       font-weight: 600;
     }
 
-    .chat-unsafe-payment-block {
-      margin: 8px 0;
-      padding: 12px 14px;
-      border: 1px solid color-mix(in srgb, var(--danger) 45%, var(--border));
-      border-radius: var(--radius-sm);
-      background: color-mix(in srgb, var(--danger) 10%, var(--bg-card));
-      color: var(--text-primary);
+    .chat-wallet-redaction {
+      color: var(--text-muted);
+      cursor: pointer;
+      font-style: italic;
     }
 
-    .chat-unsafe-payment-title {
-      color: var(--danger);
-      font-size: 13px;
-      font-weight: 800;
-      margin-bottom: 4px;
-    }
-
-    .chat-unsafe-payment-body {
+    .chat-wallet-redaction:hover,
+    .chat-wallet-redaction:focus-visible {
       color: var(--text-secondary);
-      font-size: 13px;
-      line-height: 1.5;
+    }
+
+    .chat-wallet-redaction:focus-visible {
+      outline: 1px solid var(--accent-blue);
+      outline-offset: 2px;
+    }
+
+    .chat-wallet-revealed-text {
+      color: inherit;
+      font: inherit;
+      user-select: text;
     }
 
     .chat-inline-image {

--- a/apps/desktop/src/renderer/ui/components/chat/chat-utils.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-utils.tsx
@@ -1,12 +1,10 @@
 import { Fragment, useMemo, useState } from 'react';
-import type { ReactNode } from 'react';
+import type { KeyboardEvent, ReactNode } from 'react';
 import { Lexer } from 'marked';
 import type { ChatMessage } from './chat-shared';
 import { isToolResultOnlyMessage as isToolResultOnlyMessageShared } from './chat-shared';
 import {
-  findSensitiveChatArtifacts,
   formatArtifactLabel,
-  isLikelyUnsafePaymentInstruction,
   segmentSensitiveChatText,
 } from './chat-safety';
 import type { SensitiveChatArtifact } from './chat-safety';
@@ -106,17 +104,7 @@ function splitHighlightedText(text: string, query: string | undefined, keyPrefix
   return <>{parts}</>;
 }
 
-function securityWarning(): string {
-  return 'This came from untrusted chat content. AntSeed will never ask you to send funds, deposit, top up, connect a wallet, or approve transactions from chat. Use only the official AntSeed wallet screen.';
-}
-
-function confirmUnsafeAction(action: string, target?: string): boolean {
-  const targetLine = target ? `\n\nDestination:\n${target}` : '';
-  return window.confirm(`${securityWarning()}\n\n${action}${targetLine}`);
-}
-
 function safeOpenExternalUrl(url: string): void {
-  if (!confirmUnsafeAction('Open this external destination anyway?', url)) return;
   window.open(url, '_blank', 'noopener,noreferrer');
 }
 
@@ -127,42 +115,35 @@ function firstArtifactFromText(value: string): SensitiveChatArtifact | null {
 
 function HiddenWalletAddress({ artifact }: { artifact: SensitiveChatArtifact }) {
   const [revealed, setRevealed] = useState(false);
-  const [copied, setCopied] = useState(false);
   const value = artifact.value;
   const label = formatArtifactLabel(artifact);
 
   const handleReveal = (): void => {
-    if (!revealed && !confirmUnsafeAction('Reveal this wallet address anyway?')) return;
     setRevealed(true);
   };
 
-  const handleCopy = (): void => {
-    if (!confirmUnsafeAction('Copy this wallet address anyway?')) return;
-    void navigator.clipboard.writeText(value).then(() => {
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
-    }).catch(() => undefined);
+  const handleKeyDown = (event: KeyboardEvent<HTMLSpanElement>): void => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    handleReveal();
   };
 
   if (!revealed) {
     return (
-      <span className="chat-sensitive-artifact chat-wallet-hidden">
-        <span className="chat-sensitive-label">{label}</span>
-        <button type="button" className="chat-sensitive-action" onClick={handleReveal}>
-          Reveal
-        </button>
+      <span
+        className="chat-wallet-redaction"
+        title="Address hidden to keep your funds secure. Click to reveal."
+        role="button"
+        tabIndex={0}
+        onClick={handleReveal}
+        onKeyDown={handleKeyDown}
+      >
+        [address hidden]
       </span>
     );
   }
 
-  return (
-    <span className="chat-sensitive-artifact chat-wallet-revealed">
-      <code className="chat-sensitive-value">{value}</code>
-      <button type="button" className="chat-sensitive-action" onClick={handleCopy}>
-        {copied ? 'Copied' : 'Copy'}
-      </button>
-    </span>
-  );
+  return <code className="chat-wallet-revealed-text">{value}</code>;
 }
 
 function SafeExternalLink({ artifact }: { artifact: SensitiveChatArtifact }) {
@@ -173,7 +154,7 @@ function SafeExternalLink({ artifact }: { artifact: SensitiveChatArtifact }) {
     <span className={`chat-sensitive-artifact${isPaymentLink ? ' chat-payment-link-hidden' : ' chat-external-link-gated'}`}>
       <span className="chat-sensitive-label">{label}</span>
       <button type="button" className="chat-sensitive-action" onClick={() => safeOpenExternalUrl(artifact.value)}>
-        {isPaymentLink ? 'Open anyway' : 'Open with warning'}
+        {isPaymentLink ? 'Open' : 'Open'}
       </button>
     </span>
   );
@@ -203,29 +184,8 @@ function splitSafeHighlightedText(text: string, query: string | undefined, keyPr
   );
 }
 
-function BlockedUnsafePaymentInstruction() {
-  return (
-    <div className="chat-unsafe-payment-block" role="alert">
-      <div className="chat-unsafe-payment-title">Unsafe payment instruction blocked</div>
-      <div className="chat-unsafe-payment-body">
-        A peer response tried to direct you to a payment, deposit, wallet, or external destination.
-        AntSeed will never ask you to send funds, top up, connect a wallet, or approve transactions inside chat.
-        Use only the official AntSeed wallet screen.
-      </div>
-    </div>
-  );
-}
-
-function confirmCopyIfSensitive(text: string): boolean {
-  const artifacts = findSensitiveChatArtifacts(text);
-  if (artifacts.length === 0) return true;
-  const addressCount = artifacts.filter((artifact) => artifact.type === 'wallet-address').length;
-  const linkCount = artifacts.filter((artifact) => artifact.type === 'url').length;
-  const parts = [
-    addressCount > 0 ? `${addressCount} hidden address${addressCount === 1 ? '' : 'es'}` : '',
-    linkCount > 0 ? `${linkCount} gated link${linkCount === 1 ? '' : 's'}` : '',
-  ].filter(Boolean).join(' and ');
-  return confirmUnsafeAction(`This text contains ${parts}. Copy the original text anyway?`);
+function confirmCopyIfSensitive(_text: string): boolean {
+  return true;
 }
 
 function flattenPlainText(tokens: MarkdownToken[] | undefined): string {
@@ -306,7 +266,7 @@ function renderInlineToken(token: MarkdownToken, key: string, highlightQuery?: s
         <span key={key} className="chat-sensitive-artifact chat-external-image-hidden">
           <span className="chat-sensitive-label">External image hidden: {artifact.display}</span>
           <button type="button" className="chat-sensitive-action" onClick={() => safeOpenExternalUrl(artifact.value)}>
-            Open with warning
+            Open
           </button>
         </span>
       );
@@ -466,11 +426,7 @@ function renderBlockToken(token: MarkdownToken, key: string, highlightQuery?: st
   }
 }
 
-export function MarkdownContent({ text, className = 'chat-bubble-content', highlightQuery, activeHighlight, blockUnsafePaymentInstructions = false }: MarkdownContentProps) {
-  const shouldBlock = blockUnsafePaymentInstructions && isLikelyUnsafePaymentInstruction(text);
+export function MarkdownContent({ text, className = 'chat-bubble-content', highlightQuery, activeHighlight }: MarkdownContentProps) {
   const tokens = useMemo(() => Lexer.lex(text, { gfm: true, breaks: true }) as MarkdownToken[], [text]);
-  if (shouldBlock) {
-    return <div className={className}><BlockedUnsafePaymentInstruction /></div>;
-  }
   return <div className={className}>{renderBlockTokens(tokens, 'md', highlightQuery, activeHighlight)}</div>;
 }


### PR DESCRIPTION
## Summary
- stop replacing unsafe payment replies with the full red block
- keep the message text visible and hide only detected wallet addresses inline
- show `[address hidden]` with a tooltip and reveal-on-click behavior

## Notes
- checked the safety detection path; `chat-safety.ts` and the artifact segmentation mechanism were not changed
- EVM, Solana-like, Bitcoin, Cosmos, payment URI, and URL detection remain handled by the existing mechanism

## Verification
- `pnpm --filter=@antseed/desktop run build`