### PR TITLE
fix(desktop): detect all-lowercase base58 wallet addresses in chat safety

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/chat-safety.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-safety.ts
@@ -19,8 +19,10 @@ const EVM_ADDRESS_PATTERN = /\b0x[a-fA-F0-9]{40}\b/g;
 const BITCOIN_ADDRESS_PATTERN = /\b(?:bc1[ac-hj-np-z02-9]{25,87}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})\b/gi;
 const COSMOS_ADDRESS_PATTERN = /\b[a-z]{2,16}1[0-9a-z]{38,58}\b/gi;
 // Broad enough to catch common Solana/base58 addresses, but constrained to avoid
-// ordinary prose: base58 only, 32-44 chars, and at least one digit plus both cases.
-const SOLANA_ADDRESS_PATTERN = /\b(?=[1-9A-HJ-NP-Za-km-z]{32,44}\b)(?=[1-9A-HJ-NP-Za-km-z]*\d)(?=[1-9A-HJ-NP-Za-km-z]*[A-Z])(?=[1-9A-HJ-NP-Za-km-z]*[a-z])[1-9A-HJ-NP-Za-km-z]{32,44}\b/g;
+// ordinary prose: base58 only, 32-44 chars, and at least one digit. Case is not
+// required — real base58 addresses with no uppercase letter are valid and must
+// still trigger the safety gate; recall matters more than precision here.
+const SOLANA_ADDRESS_PATTERN = /\b(?=[1-9A-HJ-NP-Za-km-z]{32,44}\b)(?=[1-9A-HJ-NP-Za-km-z]*\d)[1-9A-HJ-NP-Za-km-z]{32,44}\b/g;
 
 const TRAILING_URL_PUNCTUATION = /[),.;:!?]+$/;
 const PAYMENT_INTENT_PATTERN = /\b(?:send|transfer|deposit|top\s*up|fund|funds|pay|payment|required|billing|balance|insufficient|add\s+credits?|add\s+funds?|connect\s+(?:your\s+)?wallet|approve\s+(?:the\s+)?(?:transaction|token|spend|allowance)|claim\s+(?:refund|airdrop|reward)|verify\s+(?:your\s+)?wallet|wallet\s+verification)\b/i;


### PR DESCRIPTION
## Problem

`SOLANA_ADDRESS_PATTERN` in `apps/desktop/src/renderer/ui/components/chat/chat-safety.ts:23` requires **both** an uppercase character and a lowercase character via the two lookaheads `(?=[1-9A-HJ-NP-Za-km-z]*[A-Z])(?=[1-9A-HJ-NP-Za-km-z]*[a-z])`. A valid base58-shape address with no uppercase letter — a normal occurrence — fails to match. It then slips through both safety layers added in #592 / #631 / #642: no `BlockedUnsafePaymentInstruction` overlay, no Reveal gate, the address renders as plain copyable text.

**Repro (one Node line against the current pattern):**

```js
const PAT = /\b(?=[1-9A-HJ-NP-Za-km-z]{32,44}\b)(?=[1-9A-HJ-NP-Za-km-z]*\d)(?=[1-9A-HJ-NP-Za-km-z]*[A-Z])(?=[1-9A-HJ-NP-Za-km-z]*[a-z])[1-9A-HJ-NP-Za-km-z]{32,44}\b/g;
PAT.test('8j3wd6kzgy7v2tahsmwetjhvtekgkfhpyybsuu58foof');  // => false
```

## Fix

Drop both case-class lookaheads. Keep the length (32–44), base58 charset, and at-least-one-digit constraints — those still rule out ordinary English prose (no 32+ char base58-charset word with a digit shows up in normal text), and on a payment-safety surface recall matters more than precision.

After the change, all of these correctly classify:

| input | matches? |
|---|---|
| `8j3wd6kzgy7v2tahsmwetjhvtekgkfhpyybsuu58foof` (lowercase, was the leak) | ✅ now matches |
| `8j3WD6kzGY7v2TAHSmwETjhvTekgkfHpYYbsUU58Foof` (canonical mixedcase) | ✅ still matches |
| `thequickbrownfoxjumpsoverthelazydogagainfox` (no digit, prose) | ❌ rejected |
| `thequickBrownfoxjumpsoverthelazydogagainfox` (mixedcase prose, no digit) | ❌ rejected |
| 31-char or 45-char base58 | ❌ rejected (length bound) |

No behavior change for already-matching addresses. Sibling to the chat-safety bypass closed by #631 and the inline blur shipped in #642 — same threat model established in #592.