### PR TITLE
fix(app): Bound payments RPC reads

### DIFF
--- a/apps/payments/src/routes.ts
+++ b/apps/payments/src/routes.ts
@@ -30,16 +30,18 @@ interface RouteContext {
 
 // Use shared utilities from @antseed/node
 const formatUsdc6 = formatUsdc;
+const RPC_READ_ATTEMPTS = 2;
+const RPC_READ_TIMEOUT_MS = 2_500;
 
 // Retry helper for on-chain view calls. Base RPC occasionally returns an
 // unparseable response (ethers surfaces it as CALL_EXCEPTION with null
 // revert data even though the call didn't actually revert); view calls are
 // idempotent, so retrying clears these transient failures.
-async function retryRead<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
+async function retryRead<T>(fn: () => Promise<T>, attempts = RPC_READ_ATTEMPTS): Promise<T> {
   let lastErr: unknown;
   for (let i = 0; i < attempts; i++) {
     try {
-      return await fn();
+      return await withReadTimeout(fn());
     } catch (err) {
       lastErr = err;
       if (i < attempts - 1) {
@@ -48,6 +50,20 @@ async function retryRead<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
     }
   }
   throw lastErr;
+}
+
+async function withReadTimeout<T>(promise: Promise<T>): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      reject(new Error(`RPC read timed out after ${RPC_READ_TIMEOUT_MS}ms`));
+    }, RPC_READ_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
 }
 
 function createClient(config: PaymentCryptoConfig, evmChainId?: number): DepositsClient {

--- a/packages/node/src/payments/evm/base-evm-client.ts
+++ b/packages/node/src/payments/evm/base-evm-client.ts
@@ -10,6 +10,8 @@ import {
   type TransactionResponse,
 } from 'ethers';
 
+const FALLBACK_STALL_TIMEOUT_MS = 750;
+
 function buildProvider(rpcUrl: string, fallbackRpcUrls?: string[], evmChainId?: number): AbstractProvider {
   const network = evmChainId ? Network.from(evmChainId) : undefined;
   const opts = { batchMaxCount: 1, staticNetwork: network ? true : undefined };
@@ -20,7 +22,7 @@ function buildProvider(rpcUrl: string, fallbackRpcUrls?: string[], evmChainId?: 
   const configs = urls.map((url, i) => ({
     provider: new JsonRpcProvider(url, network, opts),
     priority: i + 1,
-    stallTimeout: 2000,
+    stallTimeout: FALLBACK_STALL_TIMEOUT_MS,
     weight: 1,
   }));
   return new FallbackProvider(configs, network, { quorum: 1 });


### PR DESCRIPTION
## Description

Reduces long payments portal stalls caused by slow Base RPC contract reads without changing the configured RPC endpoint list. The payments API now bounds server-side view-call retries, and the shared EVM fallback provider starts failover sooner when a provider stalls.

This keeps the existing Base RPC defaults intact while making payments API behavior predictable when public RPCs are slow.

## Release Notes

- Fixed payments portal RPC reads that could stall balance, operator, and emissions loading for around 20 seconds.
- Improved timeout handling for payments-related Base contract reads.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
