### PR TITLE
fix(payments): Show claimed emission history

### DIFF
--- a/apps/payments/web/src/views/EmissionsView.tsx
+++ b/apps/payments/web/src/views/EmissionsView.tsx
@@ -147,6 +147,13 @@ function getPendingRowReward(row: EmissionsPendingResponse['rows'][number]): str
   return (seller + buyer).toString();
 }
 
+function getHistoryRowReward(
+  row: EmissionsPendingResponse['rows'][number],
+  fallback: SharesType | null | undefined,
+): string {
+  return (safeBigint(getPendingRowReward(row)) + getClaimedRowReward(row, fallback)).toString();
+}
+
 function rowHasClaimableSellerReward(row: EmissionsPendingResponse['rows'][number]): boolean {
   return !row.isCurrent && !row.seller.claimed && safeBigint(row.seller.amount) > 0n;
 }
@@ -468,7 +475,7 @@ export function EmissionsView({ config }: EmissionsViewProps) {
       <section className="portal-content-section" aria-labelledby="emissions-history-title">
         <div className="portal-content-head">
           <h2 className="portal-content-title" id="emissions-history-title">Emission history</h2>
-          <p>Closed-epoch pending amounts returned by the Emissions contract.</p>
+          <p>Closed-epoch reward amounts.</p>
         </div>
 
         <div className="rewards-history">
@@ -479,7 +486,7 @@ export function EmissionsView({ config }: EmissionsViewProps) {
             pastRows.slice().reverse().map((row) => (
               <div className="rewards-history-row" key={row.epoch}>
                 <span>Epoch {row.epoch}</span>
-                <strong>{formatAnts(getPendingRowReward(row))} $ANTS</strong>
+                <strong>{formatAnts(getHistoryRowReward(row, shares))} $ANTS</strong>
                 <em>{getEpochStatus(row)}</em>
               </div>
             ))


### PR DESCRIPTION
## Description

Emission history rows were rendering only the pending amount returned by the Emissions contract. Claimed epochs correctly return zero pending rewards, so rows marked Claimed showed 0  even when the user had earned and claimed rewards.

This updates the history display to show the closed-epoch reward amount by combining unclaimed pending rewards with reconstructed claimed rewards from epoch points.

## Release Notes

- Fixed emission history so claimed  reward epochs display the earned amount instead of 0.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Validation: pnpm --filter=@antseed/payments run build:web