### PR TITLE
feat(payments): Add verified usage manifests

### DIFF
--- a/apps/network-stats/src/index.ts
+++ b/apps/network-stats/src/index.ts
@@ -7,6 +7,7 @@ import { NetworkPoller } from './poller.js';
 import { createServer } from './server.js';
 import { SqliteStore } from './store.js';
 import { MetadataIndexer } from './indexer.js';
+import { UsageManifestFetcher } from './usage-manifest-fetcher.js';
 
 const PORT = parseInt(process.env['PORT'] ?? '4000', 10);
 const CACHE_PATH = process.env['CACHE_PATH'];
@@ -39,6 +40,7 @@ if (chainConfig.statsContractAddress && typeof chainConfig.statsDeployBlock === 
   indexer = new MetadataIndexer({
     store,
     statsClient,
+    usageManifestFetcher: new UsageManifestFetcher(),
     chainId: CHAIN_ID,
     contractAddress: chainConfig.statsContractAddress.toLowerCase(),
     deployBlock: chainConfig.statsDeployBlock,

--- a/apps/network-stats/src/indexer.test.ts
+++ b/apps/network-stats/src/indexer.test.ts
@@ -1,9 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import type { DecodedMetadataRecorded } from '@antseed/node';
+import type { DecodedMetadataPointerRecorded, DecodedMetadataRecorded, UsageManifest } from '@antseed/node';
 import { SqliteStore } from './store.js';
 import { MetadataIndexer } from './indexer.js';
+import type { UsageManifestFetcher } from './usage-manifest-fetcher.js';
 
 type MockStatsClient = Pick<
   import('@antseed/node').StatsClient,
@@ -15,6 +16,7 @@ type MockStatsClient = Pick<
 function makeMockClient(opts: {
   blockNumber: number;
   events?: DecodedMetadataRecorded[];
+  pointerEvents?: DecodedMetadataPointerRecorded[];
   throwOnFetch?: boolean;
 }): {
   client: MockStatsClient;
@@ -31,7 +33,7 @@ function makeMockClient(opts: {
       return opts.events ?? [];
     },
     async getMetadataPointerRecordedEvents() {
-      return [];
+      return opts.pointerEvents ?? [];
     },
   };
   return { client, fetchCalls };
@@ -49,6 +51,49 @@ function makeEvent(overrides: Partial<DecodedMetadataRecorded> = {}): DecodedMet
     inputTokens: 0n,
     outputTokens: 0n,
     requestCount: 0n,
+    ...overrides,
+  };
+}
+
+function makePointerEvent(overrides: Partial<DecodedMetadataPointerRecorded> = {}): DecodedMetadataPointerRecorded {
+  return {
+    blockNumber: 1,
+    txHash: '0x' + '9'.repeat(64),
+    logIndex: 0,
+    agentId: 1n,
+    buyer: '0x' + '0'.repeat(40),
+    channelId: '0x' + '1'.repeat(64),
+    metadataHash: '0x' + '2'.repeat(64),
+    cid: 'bafkreitest',
+    cidBytes: '0x6261666b72656974657374',
+    usageRoot: '0x' + '3'.repeat(64),
+    ...overrides,
+  };
+}
+
+function makeManifest(channelId: string, overrides: Partial<UsageManifest> = {}): UsageManifest {
+  return {
+    version: 1,
+    channelId,
+    records: [],
+    totals: {
+      costUsdc: '1000',
+      inputTokens: '100',
+      cachedInputTokens: '0',
+      freshInputTokens: '100',
+      outputTokens: '50',
+      requestCount: '1',
+    },
+    services: {
+      'gpt-5.5': {
+        costUsdc: '1000',
+        inputTokens: '100',
+        cachedInputTokens: '0',
+        freshInputTokens: '100',
+        outputTokens: '50',
+        requestCount: '1',
+      },
+    },
     ...overrides,
   };
 }
@@ -278,6 +323,58 @@ describe('MetadataIndexer', () => {
     assert.equal(fetchCalls.length, 1);
     assert.equal(fetchCalls[0]!.fromBlock, 0);
     assert.equal(store.getCheckpoint(CHAIN_ID, CONTRACT), 188);
+
+    store.close();
+  });
+
+  it('retries usage manifest pointers after transient fetch failure even after checkpoint advances', async () => {
+    const store = makeStore();
+    const channelId = '0x' + 'c'.repeat(64);
+    const pointer = makePointerEvent({ blockNumber: 10, channelId, agentId: 7n });
+    const manifest = makeManifest(channelId);
+    let fetchAttempts = 0;
+    const fetcher = {
+      async fetch(cid: string, usageRoot: string) {
+        fetchAttempts += 1;
+        assert.equal(cid, pointer.cid);
+        assert.equal(usageRoot, pointer.usageRoot.toLowerCase());
+        if (fetchAttempts === 1) throw new Error('gateway unavailable');
+        return manifest;
+      },
+    } as unknown as UsageManifestFetcher;
+
+    const { client, fetchCalls } = makeMockClient({
+      blockNumber: 100,
+      pointerEvents: [pointer],
+    });
+    const indexer = new MetadataIndexer({
+      store,
+      statsClient: client,
+      usageManifestFetcher: fetcher,
+      chainId: CHAIN_ID,
+      contractAddress: CONTRACT,
+      deployBlock: 0,
+      tickIntervalMs: 60_000,
+      reorgSafetyBlocks: 12,
+    });
+
+    await indexer.tick();
+
+    assert.equal(fetchAttempts, 1);
+    assert.equal(store.getCheckpoint(CHAIN_ID, CONTRACT), 88);
+    assert.equal(store.getPendingUsageManifestPointers(CHAIN_ID, CONTRACT).length, 1);
+    assert.equal(store.getSellerTotals(7), null);
+
+    await indexer.tick();
+
+    assert.equal(fetchAttempts, 2);
+    assert.equal(fetchCalls.length, 1);
+    assert.equal(store.getPendingUsageManifestPointers(CHAIN_ID, CONTRACT).length, 0);
+    const totals = store.getSellerTotals(7);
+    assert.ok(totals !== null);
+    assert.equal(totals.totalInputTokens, 100n);
+    assert.equal(totals.totalOutputTokens, 50n);
+    assert.equal(totals.totalRequests, 1n);
 
     store.close();
   });

--- a/apps/network-stats/src/indexer.test.ts
+++ b/apps/network-stats/src/indexer.test.ts
@@ -1,7 +1,13 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import type { DecodedMetadataPointerRecorded, DecodedMetadataRecorded, UsageManifest } from '@antseed/node';
+import {
+  ZERO_USAGE_ROOT,
+  computeUsageRoot,
+  type DecodedMetadataPointerRecorded,
+  type DecodedMetadataRecorded,
+  type UsageLeafBatch,
+} from '@antseed/node';
 import { SqliteStore } from './store.js';
 import { MetadataIndexer } from './indexer.js';
 import type { UsageManifestFetcher } from './usage-manifest-fetcher.js';
@@ -71,29 +77,26 @@ function makePointerEvent(overrides: Partial<DecodedMetadataPointerRecorded> = {
   };
 }
 
-function makeManifest(channelId: string, overrides: Partial<UsageManifest> = {}): UsageManifest {
+function makeUsageLeafBatch(overrides: Partial<UsageLeafBatch> = {}): UsageLeafBatch {
+  const leaves = overrides.leaves ?? [{
+    requestId: 'req-1',
+    service: 'gpt-5.5',
+    costUsdc: '1000',
+    cumulativeCostUsdc: '1000',
+    inputTokens: '100',
+    cachedInputTokens: '0',
+    freshInputTokens: '100',
+    outputTokens: '50',
+    inputSha256: '0'.repeat(64),
+    outputSha256: '1'.repeat(64),
+  }];
+  const prevRoot = overrides.prevRoot ?? ZERO_USAGE_ROOT;
+  const usageRoot = overrides.usageRoot ?? computeUsageRoot(prevRoot, leaves);
   return {
     version: 1,
-    channelId,
-    records: [],
-    totals: {
-      costUsdc: '1000',
-      inputTokens: '100',
-      cachedInputTokens: '0',
-      freshInputTokens: '100',
-      outputTokens: '50',
-      requestCount: '1',
-    },
-    services: {
-      'gpt-5.5': {
-        costUsdc: '1000',
-        inputTokens: '100',
-        cachedInputTokens: '0',
-        freshInputTokens: '100',
-        outputTokens: '50',
-        requestCount: '1',
-      },
-    },
+    prevRoot,
+    usageRoot,
+    leaves,
     ...overrides,
   };
 }
@@ -330,8 +333,8 @@ describe('MetadataIndexer', () => {
   it('retries usage manifest pointers after transient fetch failure even after checkpoint advances', async () => {
     const store = makeStore();
     const channelId = '0x' + 'c'.repeat(64);
-    const pointer = makePointerEvent({ blockNumber: 10, channelId, agentId: 7n });
-    const manifest = makeManifest(channelId);
+    const batch = makeUsageLeafBatch();
+    const pointer = makePointerEvent({ blockNumber: 10, channelId, agentId: 7n, usageRoot: batch.usageRoot });
     let fetchAttempts = 0;
     const fetcher = {
       async fetch(cid: string, usageRoot: string) {
@@ -339,7 +342,7 @@ describe('MetadataIndexer', () => {
         assert.equal(cid, pointer.cid);
         assert.equal(usageRoot, pointer.usageRoot.toLowerCase());
         if (fetchAttempts === 1) throw new Error('gateway unavailable');
-        return manifest;
+        return batch;
       },
     } as unknown as UsageManifestFetcher;
 

--- a/apps/network-stats/src/indexer.test.ts
+++ b/apps/network-stats/src/indexer.test.ts
@@ -5,6 +5,11 @@ import type { DecodedMetadataRecorded } from '@antseed/node';
 import { SqliteStore } from './store.js';
 import { MetadataIndexer } from './indexer.js';
 
+type MockStatsClient = Pick<
+  import('@antseed/node').StatsClient,
+  'getMetadataRecordedEvents' | 'getMetadataPointerRecordedEvents' | 'getBlockNumber'
+>;
+
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 function makeMockClient(opts: {
@@ -12,7 +17,7 @@ function makeMockClient(opts: {
   events?: DecodedMetadataRecorded[];
   throwOnFetch?: boolean;
 }): {
-  client: Pick<import('@antseed/node').StatsClient, 'getMetadataRecordedEvents' | 'getBlockNumber'>;
+  client: MockStatsClient;
   fetchCalls: Array<{ fromBlock: number; toBlock: number }>;
 } {
   const fetchCalls: Array<{ fromBlock: number; toBlock: number }> = [];
@@ -24,6 +29,9 @@ function makeMockClient(opts: {
       fetchCalls.push(p);
       if (opts.throwOnFetch) throw new Error('forced');
       return opts.events ?? [];
+    },
+    async getMetadataPointerRecordedEvents() {
+      return [];
     },
   };
   return { client, fetchCalls };

--- a/apps/network-stats/src/indexer.ts
+++ b/apps/network-stats/src/indexer.ts
@@ -98,6 +98,7 @@ export class MetadataIndexer {
       const safeTo = latest - this._reorgSafetyBlocks;
 
       if (safeTo < this._deployBlock) {
+        await this._processPendingUsageManifests();
         return;
       }
 
@@ -105,6 +106,7 @@ export class MetadataIndexer {
       const fromBlock = checkpoint === null ? this._deployBlock : checkpoint + 1;
 
       if (fromBlock > safeTo) {
+        await this._processPendingUsageManifests();
         return;
       }
 
@@ -151,32 +153,37 @@ export class MetadataIndexer {
         toBlock,
         blockTimestamps,
         newCheckpointTimestamp,
+        pointerEvents,
       );
 
-      if (this._usageManifestFetcher) {
-        for (const event of pointerEvents) {
-          try {
-            const manifest = await this._usageManifestFetcher.fetch(event.cid, event.usageRoot);
-            this._store.applyUsageManifest(
-              this._chainId,
-              this._contractAddress,
-              event,
-              manifest,
-              blockTimestamps?.get(event.blockNumber) ?? null,
-            );
-          } catch (err) {
-            console.error(
-              `[indexer] usage manifest skipped cid=${event.cid}: ${err instanceof Error ? err.message : err}`,
-            );
-          }
-        }
-      }
+      await this._processPendingUsageManifests(blockTimestamps);
 
       console.log(`[indexer] ${fromBlock}..${toBlock} events=${events.length} pointers=${pointerEvents.length}`);
     } catch (err) {
       console.error('[indexer] tick error:', err);
     } finally {
       this._running = false;
+    }
+  }
+
+  private async _processPendingUsageManifests(blockTimestamps?: Map<number, number>): Promise<void> {
+    if (!this._usageManifestFetcher) return;
+    const pending = this._store.getPendingUsageManifestPointers(this._chainId, this._contractAddress);
+    for (const event of pending) {
+      try {
+        const manifest = await this._usageManifestFetcher.fetch(event.cid, event.usageRoot);
+        this._store.applyUsageManifest(
+          this._chainId,
+          this._contractAddress,
+          event,
+          manifest,
+          blockTimestamps?.get(event.blockNumber) ?? null,
+        );
+      } catch (err) {
+        console.error(
+          `[indexer] usage manifest pending cid=${event.cid}: ${err instanceof Error ? err.message : err}`,
+        );
+      }
     }
   }
 }

--- a/apps/network-stats/src/indexer.ts
+++ b/apps/network-stats/src/indexer.ts
@@ -1,10 +1,12 @@
 import { ethers } from 'ethers';
 import type { StatsClient } from '@antseed/node';
 import type { SqliteStore } from './store.js';
+import type { UsageManifestFetcher } from './usage-manifest-fetcher.js';
 
 export interface MetadataIndexerOptions {
   store: SqliteStore;
-  statsClient: Pick<StatsClient, 'getMetadataRecordedEvents' | 'getBlockNumber'>;
+  statsClient: Pick<StatsClient, 'getMetadataRecordedEvents' | 'getMetadataPointerRecordedEvents' | 'getBlockNumber'>;
+  usageManifestFetcher?: UsageManifestFetcher;
   chainId: string;              // e.g. 'base-mainnet'
   contractAddress: string;      // lowercased externally — indexer stores as-is
   deployBlock: number;          // one-time seed for cold start
@@ -23,7 +25,8 @@ function logError(err: unknown): void {
 
 export class MetadataIndexer {
   private readonly _store: SqliteStore;
-  private readonly _statsClient: Pick<StatsClient, 'getMetadataRecordedEvents' | 'getBlockNumber'>;
+  private readonly _statsClient: Pick<StatsClient, 'getMetadataRecordedEvents' | 'getMetadataPointerRecordedEvents' | 'getBlockNumber'>;
+  private readonly _usageManifestFetcher: UsageManifestFetcher | undefined;
   private readonly _chainId: string;
   private readonly _contractAddress: string;
   private readonly _deployBlock: number;
@@ -45,6 +48,7 @@ export class MetadataIndexer {
 
     this._store = options.store;
     this._statsClient = options.statsClient;
+    this._usageManifestFetcher = options.usageManifestFetcher;
     this._chainId = options.chainId;
     this._contractAddress = options.contractAddress;
     this._deployBlock = options.deployBlock;
@@ -106,14 +110,18 @@ export class MetadataIndexer {
 
       const toBlock = Math.min(safeTo, fromBlock + this._maxBlocksPerTick - 1);
 
-      const events = await this._statsClient.getMetadataRecordedEvents({ fromBlock, toBlock });
+      const [events, pointerEvents] = await Promise.all([
+        this._statsClient.getMetadataRecordedEvents({ fromBlock, toBlock }),
+        this._statsClient.getMetadataPointerRecordedEvents({ fromBlock, toBlock }),
+      ]);
 
       // Fetch block timestamps for each distinct block that carried an event,
       // so applyBatch can stamp first_seen_at with on-chain wall clock. Only
       // distinct blocks matter — a block with N events costs one getBlock call.
       let blockTimestamps: Map<number, number> | undefined;
-      if (this._provider && events.length > 0) {
-        const uniqueBlocks = Array.from(new Set(events.map((e) => e.blockNumber)));
+      const eventBlocks = [...events.map((e) => e.blockNumber), ...pointerEvents.map((e) => e.blockNumber)];
+      if (this._provider && eventBlocks.length > 0) {
+        const uniqueBlocks = Array.from(new Set(eventBlocks));
         const blocks = await Promise.all(uniqueBlocks.map((b) => this._provider!.getBlock(b)));
         blockTimestamps = new Map();
         for (let i = 0; i < uniqueBlocks.length; i++) {
@@ -145,7 +153,26 @@ export class MetadataIndexer {
         newCheckpointTimestamp,
       );
 
-      console.log(`[indexer] ${fromBlock}..${toBlock} events=${events.length}`);
+      if (this._usageManifestFetcher) {
+        for (const event of pointerEvents) {
+          try {
+            const manifest = await this._usageManifestFetcher.fetch(event.cid, event.usageRoot);
+            this._store.applyUsageManifest(
+              this._chainId,
+              this._contractAddress,
+              event,
+              manifest,
+              blockTimestamps?.get(event.blockNumber) ?? null,
+            );
+          } catch (err) {
+            console.error(
+              `[indexer] usage manifest skipped cid=${event.cid}: ${err instanceof Error ? err.message : err}`,
+            );
+          }
+        }
+      }
+
+      console.log(`[indexer] ${fromBlock}..${toBlock} events=${events.length} pointers=${pointerEvents.length}`);
     } catch (err) {
       console.error('[indexer] tick error:', err);
     } finally {

--- a/apps/network-stats/src/store.test.ts
+++ b/apps/network-stats/src/store.test.ts
@@ -49,8 +49,11 @@ describe('SqliteStore', () => {
     assert.deepEqual(tables, [
       'indexer_checkpoint',
       'seller_buyer_totals',
+      'seller_channel_service_totals',
       'seller_channel_totals',
       'seller_metadata_totals',
+      'seller_service_totals',
+      'usage_manifest_pointers',
     ]);
     store.close();
   });
@@ -283,4 +286,3 @@ describe('SqliteStore', () => {
     store.close();
   });
 });
-

--- a/apps/network-stats/src/store.ts
+++ b/apps/network-stats/src/store.ts
@@ -1,5 +1,12 @@
 import Database from 'better-sqlite3';
-import type { DecodedMetadataPointerRecorded, DecodedMetadataRecorded, UsageManifest } from '@antseed/node';
+import {
+  ZERO_USAGE_ROOT,
+  computeUsageRoot,
+  type DecodedMetadataPointerRecorded,
+  type DecodedMetadataRecorded,
+  type UsageLeaf,
+  type UsageLeafBatch,
+} from '@antseed/node';
 
 export type StoredUsageManifestPointer = Omit<DecodedMetadataPointerRecorded, 'metadataHash'>;
 
@@ -44,6 +51,7 @@ interface BuyerOrChannelRow {
   total_request_count: string;
   settlement_count: number;
   first_settled_block: number;
+  usage_root?: string;
 }
 
 interface SellerTotalsRow {
@@ -83,7 +91,7 @@ export class SqliteStore {
   private _selectBuyer!: Database.Statement<[number, string], BuyerOrChannelRow>;
   private _upsertBuyer!: Database.Statement<[number, string, string, string, string, number, number, number]>;
   private _selectChannel!: Database.Statement<[number, string], BuyerOrChannelRow & { buyer: string }>;
-  private _upsertChannel!: Database.Statement<[number, string, string, string, string, string, number, number, number]>;
+  private _upsertChannel!: Database.Statement<[number, string, string, string, string, string, number, number, number, string]>;
   private _selectSellerTotals!: Database.Statement<[number], SellerTotalsRow>;
   private _selectAllSellerTotals!: Database.Statement<[], SellerTotalsRow>;
   private _countBuyers!: Database.Statement<[number], { c: number }>;
@@ -135,6 +143,7 @@ export class SqliteStore {
         settlement_count INTEGER NOT NULL DEFAULT 0,
         first_settled_block INTEGER NOT NULL,
         last_settled_block INTEGER NOT NULL,
+        usage_root TEXT NOT NULL DEFAULT '${ZERO_USAGE_ROOT}',
         PRIMARY KEY (agent_id, channel_id)
       );
 
@@ -188,6 +197,12 @@ export class SqliteStore {
       );
     `);
 
+    try {
+      this.db.exec(`ALTER TABLE seller_channel_totals ADD COLUMN usage_root TEXT NOT NULL DEFAULT '${ZERO_USAGE_ROOT}'`);
+    } catch {
+      // Column already exists on databases initialized by this branch.
+    }
+
     this._selectCheckpoint = this.db.prepare(
       'SELECT last_block, last_block_timestamp FROM indexer_checkpoint WHERE chain_id = ? AND contract_address = ?',
     );
@@ -224,14 +239,14 @@ export class SqliteStore {
     );
 
     this._selectChannel = this.db.prepare(
-      'SELECT buyer, total_input_tokens, total_output_tokens, total_request_count, settlement_count, first_settled_block FROM seller_channel_totals WHERE agent_id = ? AND channel_id = ?',
+      'SELECT buyer, total_input_tokens, total_output_tokens, total_request_count, settlement_count, first_settled_block, usage_root FROM seller_channel_totals WHERE agent_id = ? AND channel_id = ?',
     );
 
     this._upsertChannel = this.db.prepare(
       `INSERT OR REPLACE INTO seller_channel_totals
          (agent_id, channel_id, buyer, total_input_tokens, total_output_tokens, total_request_count,
-          settlement_count, first_settled_block, last_settled_block)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          settlement_count, first_settled_block, last_settled_block, usage_root)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     );
 
     this._selectSellerTotals = this.db.prepare(
@@ -384,6 +399,7 @@ export class SqliteStore {
           prevChannelSettlements + 1,
           prevChannelFirstBlock,
           event.blockNumber,
+          existingChannel?.usage_root ?? ZERO_USAGE_ROOT,
         );
       }
 
@@ -424,7 +440,7 @@ export class SqliteStore {
     chainId: string,
     contractAddress: string,
     event: DecodedMetadataPointerRecorded | StoredUsageManifestPointer,
-    manifest: UsageManifest,
+    batch: UsageLeafBatch,
     blockTimestamp?: number | null,
   ): void {
     this.db.transaction(() => {
@@ -436,8 +452,17 @@ export class SqliteStore {
       const buyer = event.buyer.toLowerCase();
       const channelId = event.channelId.toLowerCase();
       const now = Math.floor(Date.now() / 1000);
-      if (manifest.version !== 1 || manifest.channelId.toLowerCase() !== channelId) {
-        throw new Error(`usage manifest does not match pointer channel ${channelId}`);
+      if (batch.version !== 1) {
+        throw new Error(`unsupported usage leaf batch version`);
+      }
+      const existingChannel = this._selectChannel.get(agentId, channelId);
+      const prevUsageRoot = existingChannel?.usage_root ?? ZERO_USAGE_ROOT;
+      if (batch.prevRoot.toLowerCase() !== prevUsageRoot.toLowerCase()) {
+        throw new Error(`usage leaf batch prevRoot does not match channel root ${channelId}`);
+      }
+      const computedRoot = computeUsageRoot(batch.prevRoot, batch.leaves);
+      if (computedRoot.toLowerCase() !== event.usageRoot.toLowerCase() || computedRoot.toLowerCase() !== batch.usageRoot.toLowerCase()) {
+        throw new Error(`usage leaf batch root mismatch for channel ${channelId}`);
       }
 
       const inserted = this._insertPointerEvent(chainId, contractAddress, event);
@@ -452,20 +477,20 @@ export class SqliteStore {
         if (row?.processed_at != null) return;
       }
 
-      const existingChannel = this._selectChannel.get(agentId, channelId);
       const prevChannelInput = existingChannel ? BigInt(existingChannel.total_input_tokens) : 0n;
       const prevChannelOutput = existingChannel ? BigInt(existingChannel.total_output_tokens) : 0n;
       const prevChannelCount = existingChannel ? BigInt(existingChannel.total_request_count) : 0n;
-      const nextChannelInput = BigInt(manifest.totals.inputTokens);
-      const nextChannelOutput = BigInt(manifest.totals.outputTokens);
-      const nextChannelCount = BigInt(manifest.totals.requestCount);
-      if (nextChannelInput < prevChannelInput || nextChannelOutput < prevChannelOutput || nextChannelCount < prevChannelCount) {
-        throw new Error(`usage manifest regression for channel ${channelId}`);
+      let deltaInput = 0n;
+      let deltaOutput = 0n;
+      let deltaCount = 0n;
+      for (const leaf of batch.leaves) {
+        deltaInput += BigInt(leaf.inputTokens);
+        deltaOutput += BigInt(leaf.outputTokens);
+        deltaCount += 1n;
       }
-
-      const deltaInput = nextChannelInput - prevChannelInput;
-      const deltaOutput = nextChannelOutput - prevChannelOutput;
-      const deltaCount = nextChannelCount - prevChannelCount;
+      const nextChannelInput = prevChannelInput + deltaInput;
+      const nextChannelOutput = prevChannelOutput + deltaOutput;
+      const nextChannelCount = prevChannelCount + deltaCount;
       const eventTimestamp = blockTimestamp ?? null;
 
       // v1 MetadataRecorded and v2 usage manifests are intended to be mutually
@@ -508,10 +533,11 @@ export class SqliteStore {
         (existingChannel?.settlement_count ?? 0) + 1,
         existingChannel?.first_settled_block ?? event.blockNumber,
         event.blockNumber,
+        computedRoot,
       );
 
-      for (const [service, totals] of Object.entries(manifest.services)) {
-        this._applyServiceManifestTotals(agentId, channelId, service, totals);
+      for (const leaf of batch.leaves) {
+        this._applyServiceLeafDelta(agentId, channelId, leaf);
       }
 
       this._markUsageManifestPointerProcessed.run(
@@ -548,12 +574,17 @@ export class SqliteStore {
     );
   }
 
-  private _applyServiceManifestTotals(
-    agentId: number,
-    channelId: string,
-    service: string,
-    totals: UsageManifest['services'][string],
-  ): void {
+  private _applyServiceLeafDelta(agentId: number, channelId: string, leaf: UsageLeaf): void {
+    const service = leaf.service ?? 'unknown';
+    const delta = {
+      cost: BigInt(leaf.costUsdc),
+      input: BigInt(leaf.inputTokens),
+      cached: BigInt(leaf.cachedInputTokens),
+      fresh: BigInt(leaf.freshInputTokens),
+      output: BigInt(leaf.outputTokens),
+      count: 1n,
+    };
+
     const selectChannelService = this.db.prepare(
       `SELECT total_cost_usdc, total_input_tokens, total_cached_input_tokens, total_fresh_input_tokens,
               total_output_tokens, total_request_count
@@ -569,37 +600,21 @@ export class SqliteStore {
       total_request_count: string;
     } | undefined;
 
-    const next = {
-      cost: BigInt(totals.costUsdc),
-      input: BigInt(totals.inputTokens),
-      cached: BigInt(totals.cachedInputTokens),
-      fresh: BigInt(totals.freshInputTokens),
-      output: BigInt(totals.outputTokens),
-      count: BigInt(totals.requestCount),
-    };
-    const previous = {
-      cost: prev ? BigInt(prev.total_cost_usdc) : 0n,
-      input: prev ? BigInt(prev.total_input_tokens) : 0n,
-      cached: prev ? BigInt(prev.total_cached_input_tokens) : 0n,
-      fresh: prev ? BigInt(prev.total_fresh_input_tokens) : 0n,
-      output: prev ? BigInt(prev.total_output_tokens) : 0n,
-      count: prev ? BigInt(prev.total_request_count) : 0n,
-    };
-    if (
-      next.cost < previous.cost || next.input < previous.input || next.cached < previous.cached
-      || next.fresh < previous.fresh || next.output < previous.output || next.count < previous.count
-    ) {
-      throw new Error(`usage manifest regression for service ${service}`);
-    }
-
     this.db.prepare(
       `INSERT OR REPLACE INTO seller_channel_service_totals
         (agent_id, channel_id, service, total_cost_usdc, total_input_tokens,
          total_cached_input_tokens, total_fresh_input_tokens, total_output_tokens, total_request_count)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
-      agentId, channelId, service, next.cost.toString(), next.input.toString(),
-      next.cached.toString(), next.fresh.toString(), next.output.toString(), next.count.toString(),
+      agentId,
+      channelId,
+      service,
+      ((prev ? BigInt(prev.total_cost_usdc) : 0n) + delta.cost).toString(),
+      ((prev ? BigInt(prev.total_input_tokens) : 0n) + delta.input).toString(),
+      ((prev ? BigInt(prev.total_cached_input_tokens) : 0n) + delta.cached).toString(),
+      ((prev ? BigInt(prev.total_fresh_input_tokens) : 0n) + delta.fresh).toString(),
+      ((prev ? BigInt(prev.total_output_tokens) : 0n) + delta.output).toString(),
+      ((prev ? BigInt(prev.total_request_count) : 0n) + delta.count).toString(),
     );
 
     const aggregate = this.db.prepare(
@@ -617,12 +632,12 @@ export class SqliteStore {
     ).run(
       agentId,
       service,
-      ((aggregate ? BigInt(aggregate.total_cost_usdc) : 0n) + next.cost - previous.cost).toString(),
-      ((aggregate ? BigInt(aggregate.total_input_tokens) : 0n) + next.input - previous.input).toString(),
-      ((aggregate ? BigInt(aggregate.total_cached_input_tokens) : 0n) + next.cached - previous.cached).toString(),
-      ((aggregate ? BigInt(aggregate.total_fresh_input_tokens) : 0n) + next.fresh - previous.fresh).toString(),
-      ((aggregate ? BigInt(aggregate.total_output_tokens) : 0n) + next.output - previous.output).toString(),
-      ((aggregate ? BigInt(aggregate.total_request_count) : 0n) + next.count - previous.count).toString(),
+      ((aggregate ? BigInt(aggregate.total_cost_usdc) : 0n) + delta.cost).toString(),
+      ((aggregate ? BigInt(aggregate.total_input_tokens) : 0n) + delta.input).toString(),
+      ((aggregate ? BigInt(aggregate.total_cached_input_tokens) : 0n) + delta.cached).toString(),
+      ((aggregate ? BigInt(aggregate.total_fresh_input_tokens) : 0n) + delta.fresh).toString(),
+      ((aggregate ? BigInt(aggregate.total_output_tokens) : 0n) + delta.output).toString(),
+      ((aggregate ? BigInt(aggregate.total_request_count) : 0n) + delta.count).toString(),
     );
   }
 

--- a/apps/network-stats/src/store.ts
+++ b/apps/network-stats/src/store.ts
@@ -1,5 +1,5 @@
 import Database from 'better-sqlite3';
-import type { DecodedMetadataRecorded } from '@antseed/node';
+import type { DecodedMetadataPointerRecorded, DecodedMetadataRecorded, UsageManifest } from '@antseed/node';
 
 export interface SellerTotals {
   totalRequests: bigint;
@@ -126,6 +126,47 @@ export class SqliteStore {
         last_block INTEGER NOT NULL,
         last_block_timestamp INTEGER,
         PRIMARY KEY (chain_id, contract_address)
+      );
+
+      CREATE TABLE IF NOT EXISTS usage_manifest_pointers (
+        chain_id TEXT NOT NULL,
+        contract_address TEXT NOT NULL,
+        tx_hash TEXT NOT NULL,
+        log_index INTEGER NOT NULL,
+        agent_id INTEGER NOT NULL,
+        buyer TEXT NOT NULL,
+        channel_id TEXT NOT NULL,
+        cid TEXT NOT NULL,
+        cid_bytes TEXT NOT NULL,
+        usage_root TEXT NOT NULL,
+        block_number INTEGER NOT NULL,
+        processed_at INTEGER,
+        PRIMARY KEY (chain_id, contract_address, tx_hash, log_index)
+      );
+
+      CREATE TABLE IF NOT EXISTS seller_service_totals (
+        agent_id INTEGER NOT NULL,
+        service TEXT NOT NULL,
+        total_cost_usdc TEXT NOT NULL DEFAULT '0',
+        total_input_tokens TEXT NOT NULL DEFAULT '0',
+        total_cached_input_tokens TEXT NOT NULL DEFAULT '0',
+        total_fresh_input_tokens TEXT NOT NULL DEFAULT '0',
+        total_output_tokens TEXT NOT NULL DEFAULT '0',
+        total_request_count TEXT NOT NULL DEFAULT '0',
+        PRIMARY KEY (agent_id, service)
+      );
+
+      CREATE TABLE IF NOT EXISTS seller_channel_service_totals (
+        agent_id INTEGER NOT NULL,
+        channel_id TEXT NOT NULL,
+        service TEXT NOT NULL,
+        total_cost_usdc TEXT NOT NULL DEFAULT '0',
+        total_input_tokens TEXT NOT NULL DEFAULT '0',
+        total_cached_input_tokens TEXT NOT NULL DEFAULT '0',
+        total_fresh_input_tokens TEXT NOT NULL DEFAULT '0',
+        total_output_tokens TEXT NOT NULL DEFAULT '0',
+        total_request_count TEXT NOT NULL DEFAULT '0',
+        PRIMARY KEY (agent_id, channel_id, service)
       );
     `);
 
@@ -307,6 +348,201 @@ export class SqliteStore {
         newCheckpointTimestamp ?? null,
       );
     })();
+  }
+
+  applyUsageManifest(
+    chainId: string,
+    contractAddress: string,
+    event: DecodedMetadataPointerRecorded,
+    manifest: UsageManifest,
+    blockTimestamp?: number | null,
+  ): void {
+    this.db.transaction(() => {
+      if (event.agentId > BigInt(Number.MAX_SAFE_INTEGER)) {
+        console.warn(`[store] agentId ${event.agentId} exceeds MAX_SAFE_INTEGER — skipping usage manifest`);
+        return;
+      }
+      const agentId = Number(event.agentId);
+      const buyer = event.buyer.toLowerCase();
+      const channelId = event.channelId.toLowerCase();
+      const now = Math.floor(Date.now() / 1000);
+      if (manifest.version !== 1 || manifest.channelId.toLowerCase() !== channelId) {
+        throw new Error(`usage manifest does not match pointer channel ${channelId}`);
+      }
+
+      const inserted = this.db.prepare(
+        `INSERT OR IGNORE INTO usage_manifest_pointers
+          (chain_id, contract_address, tx_hash, log_index, agent_id, buyer, channel_id,
+           cid, cid_bytes, usage_root, block_number, processed_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+      ).run(
+        chainId,
+        contractAddress.toLowerCase(),
+        event.txHash.toLowerCase(),
+        event.logIndex,
+        agentId,
+        buyer,
+        channelId,
+        event.cid,
+        event.cidBytes,
+        event.usageRoot.toLowerCase(),
+        event.blockNumber,
+      );
+
+      if (inserted.changes === 0) {
+        const row = this.db.prepare(
+          `SELECT processed_at FROM usage_manifest_pointers
+           WHERE chain_id = ? AND contract_address = ? AND tx_hash = ? AND log_index = ?`,
+        ).get(chainId, contractAddress.toLowerCase(), event.txHash.toLowerCase(), event.logIndex) as { processed_at: number | null } | undefined;
+        if (row?.processed_at != null) return;
+      }
+
+      const existingChannel = this._selectChannel.get(agentId, channelId);
+      const prevChannelInput = existingChannel ? BigInt(existingChannel.total_input_tokens) : 0n;
+      const prevChannelOutput = existingChannel ? BigInt(existingChannel.total_output_tokens) : 0n;
+      const prevChannelCount = existingChannel ? BigInt(existingChannel.total_request_count) : 0n;
+      const nextChannelInput = BigInt(manifest.totals.inputTokens);
+      const nextChannelOutput = BigInt(manifest.totals.outputTokens);
+      const nextChannelCount = BigInt(manifest.totals.requestCount);
+      if (nextChannelInput < prevChannelInput || nextChannelOutput < prevChannelOutput || nextChannelCount < prevChannelCount) {
+        throw new Error(`usage manifest regression for channel ${channelId}`);
+      }
+
+      const deltaInput = nextChannelInput - prevChannelInput;
+      const deltaOutput = nextChannelOutput - prevChannelOutput;
+      const deltaCount = nextChannelCount - prevChannelCount;
+      const eventTimestamp = blockTimestamp ?? null;
+
+      // v1 MetadataRecorded and v2 usage manifests are intended to be mutually
+      // exclusive per settlement/channel. If a deployment emits both for the
+      // same payment, token and settlement totals can double count unless the
+      // indexer is taught a deployment-specific de-dup policy.
+      const existingSeller = this._selectSeller.get(agentId);
+      this._upsertSeller.run(
+        agentId,
+        ((existingSeller ? BigInt(existingSeller.total_input_tokens) : 0n) + deltaInput).toString(),
+        ((existingSeller ? BigInt(existingSeller.total_output_tokens) : 0n) + deltaOutput).toString(),
+        ((existingSeller ? BigInt(existingSeller.total_request_count) : 0n) + deltaCount).toString(),
+        (existingSeller?.settlement_count ?? 0) + 1,
+        existingSeller?.first_settled_block ?? event.blockNumber,
+        event.blockNumber,
+        existingSeller?.first_seen_at ?? eventTimestamp,
+        eventTimestamp ?? existingSeller?.last_seen_at ?? null,
+        now,
+      );
+
+      const existingBuyer = this._selectBuyer.get(agentId, buyer);
+      this._upsertBuyer.run(
+        agentId,
+        buyer,
+        ((existingBuyer ? BigInt(existingBuyer.total_input_tokens) : 0n) + deltaInput).toString(),
+        ((existingBuyer ? BigInt(existingBuyer.total_output_tokens) : 0n) + deltaOutput).toString(),
+        ((existingBuyer ? BigInt(existingBuyer.total_request_count) : 0n) + deltaCount).toString(),
+        (existingBuyer?.settlement_count ?? 0) + 1,
+        existingBuyer?.first_settled_block ?? event.blockNumber,
+        event.blockNumber,
+      );
+
+      this._upsertChannel.run(
+        agentId,
+        channelId,
+        buyer,
+        nextChannelInput.toString(),
+        nextChannelOutput.toString(),
+        nextChannelCount.toString(),
+        (existingChannel?.settlement_count ?? 0) + 1,
+        existingChannel?.first_settled_block ?? event.blockNumber,
+        event.blockNumber,
+      );
+
+      for (const [service, totals] of Object.entries(manifest.services)) {
+        this._applyServiceManifestTotals(agentId, channelId, service, totals);
+      }
+
+      this.db.prepare(
+        `UPDATE usage_manifest_pointers
+         SET processed_at = ?
+         WHERE chain_id = ? AND contract_address = ? AND tx_hash = ? AND log_index = ?`,
+      ).run(now, chainId, contractAddress.toLowerCase(), event.txHash.toLowerCase(), event.logIndex);
+    })();
+  }
+
+  private _applyServiceManifestTotals(
+    agentId: number,
+    channelId: string,
+    service: string,
+    totals: UsageManifest['services'][string],
+  ): void {
+    const selectChannelService = this.db.prepare(
+      `SELECT total_cost_usdc, total_input_tokens, total_cached_input_tokens, total_fresh_input_tokens,
+              total_output_tokens, total_request_count
+       FROM seller_channel_service_totals
+       WHERE agent_id = ? AND channel_id = ? AND service = ?`,
+    );
+    const prev = selectChannelService.get(agentId, channelId, service) as {
+      total_cost_usdc: string;
+      total_input_tokens: string;
+      total_cached_input_tokens: string;
+      total_fresh_input_tokens: string;
+      total_output_tokens: string;
+      total_request_count: string;
+    } | undefined;
+
+    const next = {
+      cost: BigInt(totals.costUsdc),
+      input: BigInt(totals.inputTokens),
+      cached: BigInt(totals.cachedInputTokens),
+      fresh: BigInt(totals.freshInputTokens),
+      output: BigInt(totals.outputTokens),
+      count: BigInt(totals.requestCount),
+    };
+    const previous = {
+      cost: prev ? BigInt(prev.total_cost_usdc) : 0n,
+      input: prev ? BigInt(prev.total_input_tokens) : 0n,
+      cached: prev ? BigInt(prev.total_cached_input_tokens) : 0n,
+      fresh: prev ? BigInt(prev.total_fresh_input_tokens) : 0n,
+      output: prev ? BigInt(prev.total_output_tokens) : 0n,
+      count: prev ? BigInt(prev.total_request_count) : 0n,
+    };
+    if (
+      next.cost < previous.cost || next.input < previous.input || next.cached < previous.cached
+      || next.fresh < previous.fresh || next.output < previous.output || next.count < previous.count
+    ) {
+      throw new Error(`usage manifest regression for service ${service}`);
+    }
+
+    this.db.prepare(
+      `INSERT OR REPLACE INTO seller_channel_service_totals
+        (agent_id, channel_id, service, total_cost_usdc, total_input_tokens,
+         total_cached_input_tokens, total_fresh_input_tokens, total_output_tokens, total_request_count)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      agentId, channelId, service, next.cost.toString(), next.input.toString(),
+      next.cached.toString(), next.fresh.toString(), next.output.toString(), next.count.toString(),
+    );
+
+    const aggregate = this.db.prepare(
+      `SELECT total_cost_usdc, total_input_tokens, total_cached_input_tokens, total_fresh_input_tokens,
+              total_output_tokens, total_request_count
+       FROM seller_service_totals
+       WHERE agent_id = ? AND service = ?`,
+    ).get(agentId, service) as typeof prev;
+
+    this.db.prepare(
+      `INSERT OR REPLACE INTO seller_service_totals
+        (agent_id, service, total_cost_usdc, total_input_tokens, total_cached_input_tokens,
+         total_fresh_input_tokens, total_output_tokens, total_request_count)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      agentId,
+      service,
+      ((aggregate ? BigInt(aggregate.total_cost_usdc) : 0n) + next.cost - previous.cost).toString(),
+      ((aggregate ? BigInt(aggregate.total_input_tokens) : 0n) + next.input - previous.input).toString(),
+      ((aggregate ? BigInt(aggregate.total_cached_input_tokens) : 0n) + next.cached - previous.cached).toString(),
+      ((aggregate ? BigInt(aggregate.total_fresh_input_tokens) : 0n) + next.fresh - previous.fresh).toString(),
+      ((aggregate ? BigInt(aggregate.total_output_tokens) : 0n) + next.output - previous.output).toString(),
+      ((aggregate ? BigInt(aggregate.total_request_count) : 0n) + next.count - previous.count).toString(),
+    );
   }
 
   /** Returns last indexed block + block timestamp, or null if no checkpoint. */

--- a/apps/network-stats/src/store.ts
+++ b/apps/network-stats/src/store.ts
@@ -1,6 +1,8 @@
 import Database from 'better-sqlite3';
 import type { DecodedMetadataPointerRecorded, DecodedMetadataRecorded, UsageManifest } from '@antseed/node';
 
+export type StoredUsageManifestPointer = Omit<DecodedMetadataPointerRecorded, 'metadataHash'>;
+
 export interface SellerTotals {
   totalRequests: bigint;
   totalInputTokens: bigint;
@@ -56,6 +58,18 @@ interface SellerTotalsRow {
   last_updated_at: number;
 }
 
+interface UsageManifestPointerRow {
+  tx_hash: string;
+  log_index: number;
+  agent_id: number;
+  buyer: string;
+  channel_id: string;
+  cid: string;
+  cid_bytes: string;
+  usage_root: string;
+  block_number: number;
+}
+
 export class SqliteStore {
   private db: Database.Database;
 
@@ -74,6 +88,10 @@ export class SqliteStore {
   private _selectAllSellerTotals!: Database.Statement<[], SellerTotalsRow>;
   private _countBuyers!: Database.Statement<[number], { c: number }>;
   private _countChannels!: Database.Statement<[number], { c: number }>;
+  private _insertUsageManifestPointer!: Database.Statement<[string, string, string, number, number, string, string, string, string, string, number]>;
+  private _selectUsageManifestPointerProcessed!: Database.Statement<[string, string, string, number], { processed_at: number | null }>;
+  private _selectPendingUsageManifestPointers!: Database.Statement<[string, string, number], UsageManifestPointerRow>;
+  private _markUsageManifestPointerProcessed!: Database.Statement<[number, string, string, string, number]>;
 
   constructor(dbPath: string) {
     this.db = new Database(dbPath);
@@ -231,6 +249,32 @@ export class SqliteStore {
     this._countChannels = this.db.prepare(
       'SELECT COUNT(*) AS c FROM seller_channel_totals WHERE agent_id = ?',
     );
+
+    this._insertUsageManifestPointer = this.db.prepare(
+      `INSERT OR IGNORE INTO usage_manifest_pointers
+        (chain_id, contract_address, tx_hash, log_index, agent_id, buyer, channel_id,
+         cid, cid_bytes, usage_root, block_number, processed_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+    );
+
+    this._selectUsageManifestPointerProcessed = this.db.prepare(
+      `SELECT processed_at FROM usage_manifest_pointers
+       WHERE chain_id = ? AND contract_address = ? AND tx_hash = ? AND log_index = ?`,
+    );
+
+    this._selectPendingUsageManifestPointers = this.db.prepare(
+      `SELECT tx_hash, log_index, agent_id, buyer, channel_id, cid, cid_bytes, usage_root, block_number
+       FROM usage_manifest_pointers
+       WHERE chain_id = ? AND contract_address = ? AND processed_at IS NULL
+       ORDER BY block_number ASC, log_index ASC
+       LIMIT ?`,
+    );
+
+    this._markUsageManifestPointerProcessed = this.db.prepare(
+      `UPDATE usage_manifest_pointers
+       SET processed_at = ?
+       WHERE chain_id = ? AND contract_address = ? AND tx_hash = ? AND log_index = ?`,
+    );
   }
 
   /** Returns last indexed block for (chainId, contractAddress), or null if no checkpoint. */
@@ -244,7 +288,8 @@ export class SqliteStore {
    *   1. For each event, upsert seller_metadata_totals (add deltas, track first/last block, bump count).
    *   2. Upsert seller_buyer_totals for (agentId, buyer) with the same deltas.
    *   3. Upsert seller_channel_totals for (agentId, channelId) with the same deltas.
-   *   4. Advance indexer_checkpoint.last_block = newCheckpoint for this (chainId, contractAddress).
+   *   4. Insert v2 usage manifest pointer events as unprocessed retry work.
+   *   5. Advance indexer_checkpoint.last_block = newCheckpoint for this (chainId, contractAddress).
    * If any step throws, the transaction is rolled back — next tick re-fetches the same range.
    *
    * Events MUST be sorted ascending by (blockNumber, logIndex) — StatsClient guarantees this.
@@ -258,6 +303,7 @@ export class SqliteStore {
     newCheckpoint: number,
     blockTimestamps?: Map<number, number>,
     newCheckpointTimestamp?: number | null,
+    pointerEvents: DecodedMetadataPointerRecorded[] = [],
   ): void {
     this.db.transaction(() => {
       for (const event of events) {
@@ -341,6 +387,10 @@ export class SqliteStore {
         );
       }
 
+      for (const event of pointerEvents) {
+        this._insertPointerEvent(chainId, contractAddress, event);
+      }
+
       this._upsertCheckpoint.run(
         chainId,
         contractAddress.toLowerCase(),
@@ -350,10 +400,30 @@ export class SqliteStore {
     })();
   }
 
+  getPendingUsageManifestPointers(
+    chainId: string,
+    contractAddress: string,
+    limit = 100,
+  ): StoredUsageManifestPointer[] {
+    return this._selectPendingUsageManifestPointers
+      .all(chainId, contractAddress.toLowerCase(), limit)
+      .map((row) => ({
+        blockNumber: row.block_number,
+        txHash: row.tx_hash,
+        logIndex: row.log_index,
+        agentId: BigInt(row.agent_id),
+        buyer: row.buyer,
+        channelId: row.channel_id,
+        cid: row.cid,
+        cidBytes: row.cid_bytes,
+        usageRoot: row.usage_root,
+      }));
+  }
+
   applyUsageManifest(
     chainId: string,
     contractAddress: string,
-    event: DecodedMetadataPointerRecorded,
+    event: DecodedMetadataPointerRecorded | StoredUsageManifestPointer,
     manifest: UsageManifest,
     blockTimestamp?: number | null,
   ): void {
@@ -370,30 +440,15 @@ export class SqliteStore {
         throw new Error(`usage manifest does not match pointer channel ${channelId}`);
       }
 
-      const inserted = this.db.prepare(
-        `INSERT OR IGNORE INTO usage_manifest_pointers
-          (chain_id, contract_address, tx_hash, log_index, agent_id, buyer, channel_id,
-           cid, cid_bytes, usage_root, block_number, processed_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
-      ).run(
-        chainId,
-        contractAddress.toLowerCase(),
-        event.txHash.toLowerCase(),
-        event.logIndex,
-        agentId,
-        buyer,
-        channelId,
-        event.cid,
-        event.cidBytes,
-        event.usageRoot.toLowerCase(),
-        event.blockNumber,
-      );
+      const inserted = this._insertPointerEvent(chainId, contractAddress, event);
 
       if (inserted.changes === 0) {
-        const row = this.db.prepare(
-          `SELECT processed_at FROM usage_manifest_pointers
-           WHERE chain_id = ? AND contract_address = ? AND tx_hash = ? AND log_index = ?`,
-        ).get(chainId, contractAddress.toLowerCase(), event.txHash.toLowerCase(), event.logIndex) as { processed_at: number | null } | undefined;
+        const row = this._selectUsageManifestPointerProcessed.get(
+          chainId,
+          contractAddress.toLowerCase(),
+          event.txHash.toLowerCase(),
+          event.logIndex,
+        );
         if (row?.processed_at != null) return;
       }
 
@@ -459,12 +514,38 @@ export class SqliteStore {
         this._applyServiceManifestTotals(agentId, channelId, service, totals);
       }
 
-      this.db.prepare(
-        `UPDATE usage_manifest_pointers
-         SET processed_at = ?
-         WHERE chain_id = ? AND contract_address = ? AND tx_hash = ? AND log_index = ?`,
-      ).run(now, chainId, contractAddress.toLowerCase(), event.txHash.toLowerCase(), event.logIndex);
+      this._markUsageManifestPointerProcessed.run(
+        now,
+        chainId,
+        contractAddress.toLowerCase(),
+        event.txHash.toLowerCase(),
+        event.logIndex,
+      );
     })();
+  }
+
+  private _insertPointerEvent(
+    chainId: string,
+    contractAddress: string,
+    event: DecodedMetadataPointerRecorded | StoredUsageManifestPointer,
+  ): Database.RunResult {
+    if (event.agentId > BigInt(Number.MAX_SAFE_INTEGER)) {
+      console.warn(`[store] agentId ${event.agentId} exceeds MAX_SAFE_INTEGER — skipping usage manifest pointer`);
+      return { changes: 0, lastInsertRowid: 0 };
+    }
+    return this._insertUsageManifestPointer.run(
+      chainId,
+      contractAddress.toLowerCase(),
+      event.txHash.toLowerCase(),
+      event.logIndex,
+      Number(event.agentId),
+      event.buyer.toLowerCase(),
+      event.channelId.toLowerCase(),
+      event.cid,
+      event.cidBytes,
+      event.usageRoot.toLowerCase(),
+      event.blockNumber,
+    );
   }
 
   private _applyServiceManifestTotals(

--- a/apps/network-stats/src/usage-manifest-fetcher.test.ts
+++ b/apps/network-stats/src/usage-manifest-fetcher.test.ts
@@ -1,0 +1,87 @@
+import { createHash } from 'node:crypto';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { UsageManifestFetcher } from './usage-manifest-fetcher.js';
+
+const enc = new TextEncoder();
+
+function manifestBytes(): Uint8Array {
+  return enc.encode(JSON.stringify({
+    version: 1,
+    channelId: '0x' + '1'.repeat(64),
+    records: [],
+    totals: {
+      costUsdc: '0',
+      inputTokens: '0',
+      cachedInputTokens: '0',
+      freshInputTokens: '0',
+      outputTokens: '0',
+      requestCount: '0',
+    },
+    services: {},
+  }));
+}
+
+function sha256Root(bytes: Uint8Array): string {
+  return `0x${createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+describe('UsageManifestFetcher', () => {
+  const originalFetch = globalThis.fetch;
+
+  it('fetches and verifies a bounded usage manifest', async () => {
+    const bytes = manifestBytes();
+    globalThis.fetch = async () => new Response(bytes, { status: 200 });
+    try {
+      const fetcher = new UsageManifestFetcher({
+        gatewayUrl: 'https://example.test/ipfs',
+        maxBytes: bytes.byteLength,
+      });
+      const manifest = await fetcher.fetch('bafkreitest', sha256Root(bytes));
+      assert.equal(manifest.version, 1);
+      assert.equal(manifest.channelId, '0x' + '1'.repeat(64));
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('rejects streamed usage manifests that exceed the byte limit', async () => {
+    globalThis.fetch = async () => new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(4));
+          controller.enqueue(new Uint8Array(4));
+          controller.close();
+        },
+      }),
+      { status: 200 },
+    );
+    try {
+      const fetcher = new UsageManifestFetcher({ maxBytes: 5 });
+      await assert.rejects(
+        () => fetcher.fetch('bafkreitest', '0x' + '0'.repeat(64)),
+        /exceeds max size/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('aborts usage manifest fetches after the configured timeout', async () => {
+    globalThis.fetch = ((_url: string | URL | Request, init?: RequestInit) => new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener('abort', () => {
+        reject(new DOMException('Aborted', 'AbortError'));
+      });
+    })) as typeof fetch;
+    try {
+      const fetcher = new UsageManifestFetcher({ timeoutMs: 1 });
+      await assert.rejects(
+        () => fetcher.fetch('bafkreitest', '0x' + '0'.repeat(64)),
+        /timed out/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/apps/network-stats/src/usage-manifest-fetcher.test.ts
+++ b/apps/network-stats/src/usage-manifest-fetcher.test.ts
@@ -1,46 +1,34 @@
-import { createHash } from 'node:crypto';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { ZERO_USAGE_ROOT } from '@antseed/node';
 
 import { UsageManifestFetcher } from './usage-manifest-fetcher.js';
 
 const enc = new TextEncoder();
 
-function manifestBytes(): Uint8Array {
+function batchBytes(): Uint8Array {
   return enc.encode(JSON.stringify({
     version: 1,
-    channelId: '0x' + '1'.repeat(64),
-    records: [],
-    totals: {
-      costUsdc: '0',
-      inputTokens: '0',
-      cachedInputTokens: '0',
-      freshInputTokens: '0',
-      outputTokens: '0',
-      requestCount: '0',
-    },
-    services: {},
+    prevRoot: ZERO_USAGE_ROOT,
+    usageRoot: ZERO_USAGE_ROOT,
+    leaves: [],
   }));
-}
-
-function sha256Root(bytes: Uint8Array): string {
-  return `0x${createHash('sha256').update(bytes).digest('hex')}`;
 }
 
 describe('UsageManifestFetcher', () => {
   const originalFetch = globalThis.fetch;
 
-  it('fetches and verifies a bounded usage manifest', async () => {
-    const bytes = manifestBytes();
+  it('fetches and verifies a bounded usage leaf batch', async () => {
+    const bytes = batchBytes();
     globalThis.fetch = async () => new Response(bytes, { status: 200 });
     try {
       const fetcher = new UsageManifestFetcher({
         gatewayUrl: 'https://example.test/ipfs',
         maxBytes: bytes.byteLength,
       });
-      const manifest = await fetcher.fetch('bafkreitest', sha256Root(bytes));
-      assert.equal(manifest.version, 1);
-      assert.equal(manifest.channelId, '0x' + '1'.repeat(64));
+      const batch = await fetcher.fetch('bafkreitest', ZERO_USAGE_ROOT);
+      assert.equal(batch.version, 1);
+      assert.equal(batch.usageRoot, ZERO_USAGE_ROOT);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/apps/network-stats/src/usage-manifest-fetcher.ts
+++ b/apps/network-stats/src/usage-manifest-fetcher.ts
@@ -1,0 +1,27 @@
+import { createHash } from 'node:crypto';
+import type { UsageManifest } from '@antseed/node';
+
+export interface UsageManifestFetcherOptions {
+  gatewayUrl?: string;
+}
+
+export class UsageManifestFetcher {
+  private readonly _gatewayUrl: string;
+
+  constructor(options: UsageManifestFetcherOptions = {}) {
+    this._gatewayUrl = options.gatewayUrl ?? process.env['NETWORK_STATS_IPFS_GATEWAY_URL'] ?? 'https://ipfs.io/ipfs';
+  }
+
+  async fetch(cid: string, expectedRoot: string): Promise<UsageManifest> {
+    const res = await fetch(`${this._gatewayUrl.replace(/\/$/, '')}/${encodeURIComponent(cid)}`);
+    if (!res.ok) {
+      throw new Error(`failed to fetch usage manifest ${cid}: HTTP ${res.status}`);
+    }
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    const root = `0x${createHash('sha256').update(bytes).digest('hex')}`;
+    if (root.toLowerCase() !== expectedRoot.toLowerCase()) {
+      throw new Error(`usage manifest root mismatch for ${cid}`);
+    }
+    return JSON.parse(new TextDecoder().decode(bytes)) as UsageManifest;
+  }
+}

--- a/apps/network-stats/src/usage-manifest-fetcher.ts
+++ b/apps/network-stats/src/usage-manifest-fetcher.ts
@@ -1,5 +1,4 @@
-import { createHash } from 'node:crypto';
-import type { UsageManifest } from '@antseed/node';
+import { computeUsageRoot, type UsageLeafBatch } from '@antseed/node';
 
 export interface UsageManifestFetcherOptions {
   gatewayUrl?: string;
@@ -18,7 +17,7 @@ export class UsageManifestFetcher {
     this._maxBytes = options.maxBytes ?? readPositiveIntEnv('NETWORK_STATS_USAGE_MANIFEST_MAX_BYTES') ?? 16 * 1024 * 1024;
   }
 
-  async fetch(cid: string, expectedRoot: string): Promise<UsageManifest> {
+  async fetch(cid: string, expectedRoot: string): Promise<UsageLeafBatch> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this._timeoutMs);
     try {
@@ -29,11 +28,12 @@ export class UsageManifestFetcher {
         throw new Error(`failed to fetch usage manifest ${cid}: HTTP ${res.status}`);
       }
       const bytes = await this._readBoundedBody(res, cid);
-      const root = `0x${createHash('sha256').update(bytes).digest('hex')}`;
-      if (root.toLowerCase() !== expectedRoot.toLowerCase()) {
+      const batch = JSON.parse(new TextDecoder().decode(bytes)) as UsageLeafBatch;
+      const root = computeUsageRoot(batch.prevRoot, batch.leaves);
+      if (batch.version !== 1 || root.toLowerCase() !== batch.usageRoot.toLowerCase() || root.toLowerCase() !== expectedRoot.toLowerCase()) {
         throw new Error(`usage manifest root mismatch for ${cid}`);
       }
-      return JSON.parse(new TextDecoder().decode(bytes)) as UsageManifest;
+      return batch;
     } catch (err) {
       if (controller.signal.aborted) {
         throw new Error(`timed out fetching usage manifest ${cid}`);

--- a/apps/network-stats/src/usage-manifest-fetcher.ts
+++ b/apps/network-stats/src/usage-manifest-fetcher.ts
@@ -3,25 +3,91 @@ import type { UsageManifest } from '@antseed/node';
 
 export interface UsageManifestFetcherOptions {
   gatewayUrl?: string;
+  timeoutMs?: number;
+  maxBytes?: number;
 }
 
 export class UsageManifestFetcher {
   private readonly _gatewayUrl: string;
+  private readonly _timeoutMs: number;
+  private readonly _maxBytes: number;
 
   constructor(options: UsageManifestFetcherOptions = {}) {
     this._gatewayUrl = options.gatewayUrl ?? process.env['NETWORK_STATS_IPFS_GATEWAY_URL'] ?? 'https://ipfs.io/ipfs';
+    this._timeoutMs = options.timeoutMs ?? readPositiveIntEnv('NETWORK_STATS_IPFS_FETCH_TIMEOUT_MS') ?? 10_000;
+    this._maxBytes = options.maxBytes ?? readPositiveIntEnv('NETWORK_STATS_USAGE_MANIFEST_MAX_BYTES') ?? 16 * 1024 * 1024;
   }
 
   async fetch(cid: string, expectedRoot: string): Promise<UsageManifest> {
-    const res = await fetch(`${this._gatewayUrl.replace(/\/$/, '')}/${encodeURIComponent(cid)}`);
-    if (!res.ok) {
-      throw new Error(`failed to fetch usage manifest ${cid}: HTTP ${res.status}`);
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this._timeoutMs);
+    try {
+      const res = await fetch(`${this._gatewayUrl.replace(/\/$/, '')}/${encodeURIComponent(cid)}`, {
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        throw new Error(`failed to fetch usage manifest ${cid}: HTTP ${res.status}`);
+      }
+      const bytes = await this._readBoundedBody(res, cid);
+      const root = `0x${createHash('sha256').update(bytes).digest('hex')}`;
+      if (root.toLowerCase() !== expectedRoot.toLowerCase()) {
+        throw new Error(`usage manifest root mismatch for ${cid}`);
+      }
+      return JSON.parse(new TextDecoder().decode(bytes)) as UsageManifest;
+    } catch (err) {
+      if (controller.signal.aborted) {
+        throw new Error(`timed out fetching usage manifest ${cid}`);
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
     }
-    const bytes = new Uint8Array(await res.arrayBuffer());
-    const root = `0x${createHash('sha256').update(bytes).digest('hex')}`;
-    if (root.toLowerCase() !== expectedRoot.toLowerCase()) {
-      throw new Error(`usage manifest root mismatch for ${cid}`);
-    }
-    return JSON.parse(new TextDecoder().decode(bytes)) as UsageManifest;
   }
+
+  private async _readBoundedBody(res: Response, cid: string): Promise<Uint8Array> {
+    const contentLength = res.headers.get('content-length');
+    if (contentLength) {
+      const length = Number(contentLength);
+      if (Number.isFinite(length) && length > this._maxBytes) {
+        throw new Error(`usage manifest ${cid} exceeds max size ${this._maxBytes} bytes`);
+      }
+    }
+
+    if (!res.body) {
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      if (bytes.byteLength > this._maxBytes) {
+        throw new Error(`usage manifest ${cid} exceeds max size ${this._maxBytes} bytes`);
+      }
+      return bytes;
+    }
+
+    const reader = res.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > this._maxBytes) {
+        await reader.cancel();
+        throw new Error(`usage manifest ${cid} exceeds max size ${this._maxBytes} bytes`);
+      }
+      chunks.push(value);
+    }
+
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      out.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return out;
+  }
+}
+
+function readPositiveIntEnv(name: string): number | undefined {
+  const raw = process.env[name];
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
 }

--- a/packages/contracts/AntseedStats.sol
+++ b/packages/contracts/AntseedStats.sol
@@ -37,8 +37,18 @@ contract AntseedStats is IAntseedStats, Ownable {
         uint256 requestCount
     );
 
+    event MetadataPointerRecorded(
+        uint256 indexed agentId,
+        address indexed buyer,
+        bytes32 indexed channelId,
+        bytes32 metadataHash,
+        bytes cid,
+        bytes32 usageRoot
+    );
+
     // ─── Custom Errors ──────────────────────────────────────────────
     error InvalidAddress();
+    error InvalidMetadata();
     error NotAuthorized();
 
     // ─── Constructor ────────────────────────────────────────────────
@@ -59,7 +69,16 @@ contract AntseedStats is IAntseedStats, Ownable {
         if (!writers[msg.sender]) revert NotAuthorized();
         if (buyer == address(0)) revert InvalidAddress();
 
-        (uint256 cumulativeInputTokens, uint256 cumulativeOutputTokens, uint256 cumulativeRequestCount) = _decodeMetadata(metadata);
+        uint256 version = _decodeVersion(metadata);
+        if (version == 2) {
+            (, bytes memory cid, bytes32 usageRoot) = abi.decode(metadata, (uint256, bytes, bytes32));
+            emit MetadataPointerRecorded(agentId, buyer, channelId, keccak256(metadata), cid, usageRoot);
+            return;
+        }
+        if (version != 1) revert InvalidMetadata();
+
+        (uint256 cumulativeInputTokens, uint256 cumulativeOutputTokens, uint256 cumulativeRequestCount) =
+            _decodeV1Metadata(metadata);
 
         ChannelMetadataSnapshot storage snapshot = _channelSnapshots[channelId];
         if (
@@ -96,7 +115,12 @@ contract AntseedStats is IAntseedStats, Ownable {
     }
 
     // ─── Internal Helpers ───────────────────────────────────────────
-    function _decodeMetadata(bytes calldata metadata)
+    function _decodeVersion(bytes calldata metadata) internal pure returns (uint256 version) {
+        if (metadata.length < 32) revert InvalidMetadata();
+        version = abi.decode(metadata[:32], (uint256));
+    }
+
+    function _decodeV1Metadata(bytes calldata metadata)
         internal
         pure
         returns (uint256 cumulativeInputTokens, uint256 cumulativeOutputTokens, uint256 cumulativeRequestCount)

--- a/packages/contracts/interfaces/IAntseedStats.sol
+++ b/packages/contracts/interfaces/IAntseedStats.sol
@@ -10,6 +10,7 @@ interface IAntseedStats {
     }
 
     function getBuyerMetadataStats(uint256 agentId, address buyer) external view returns (BuyerMetadataStats memory);
+
     function recordMetadata(
         uint256 agentId,
         address buyer,

--- a/packages/contracts/test/AntseedStats.t.sol
+++ b/packages/contracts/test/AntseedStats.t.sol
@@ -17,6 +17,15 @@ contract AntseedStatsTest is Test {
 
     uint256 public tokenId;
 
+    event MetadataPointerRecorded(
+        uint256 indexed agentId,
+        address indexed buyer,
+        bytes32 indexed channelId,
+        bytes32 metadataHash,
+        bytes cid,
+        bytes32 usageRoot
+    );
+
     function setUp() public {
         registry = new AntseedRegistry();
         identityRegistry = new MockERC8004Registry();
@@ -78,6 +87,23 @@ contract AntseedStatsTest is Test {
         assertEq(buyerStats.totalInputTokens, 275);
         assertEq(buyerStats.totalOutputTokens, 130);
         assertEq(buyerStats.totalRequestCount, 7);
+    }
+
+    function test_recordMetadata_v2EmitsPointerOnly() public {
+        stats.setWriter(writer, true);
+
+        bytes memory metadata = abi.encode(uint256(2), bytes("bafkreihash"), bytes32(uint256(0x1234)));
+
+        vm.expectEmit(true, true, true, true);
+        emit MetadataPointerRecorded(tokenId, buyer, bytes32("chan-1"), keccak256(metadata), bytes("bafkreihash"), bytes32(uint256(0x1234)));
+
+        vm.prank(writer);
+        stats.recordMetadata(tokenId, buyer, bytes32("chan-1"), metadata);
+
+        IAntseedStats.BuyerMetadataStats memory buyerStats = stats.getBuyerMetadataStats(tokenId, buyer);
+        assertEq(buyerStats.totalInputTokens, 0);
+        assertEq(buyerStats.totalOutputTokens, 0);
+        assertEq(buyerStats.totalRequestCount, 0);
     }
 
     function test_recordMetadata_revert_invalidShape() public {

--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -277,12 +277,12 @@ export class BuyerRequestHandler {
       if (result.action === 'return') return result.response;
       startTime = Date.now();
       const retriedResponse = await executeRequest();
-      negotiator.estimateCostFromResponse(peer, retriedResponse, requestedService);
+      negotiator.estimateCostFromResponse(peer, retriedResponse, requestedService, req);
       return retriedResponse;
     }
 
     if (negotiator) {
-      negotiator.estimateCostFromResponse(peer, response, requestedService);
+      negotiator.estimateCostFromResponse(peer, response, requestedService, req);
     }
 
     return response;

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -76,6 +76,8 @@ export {
   UsageManifestStore,
   publishUsageManifestBestEffort,
 } from './payments/usage-manifest.js';
+export { BuyerUsageVerifier } from './payments/buyer-usage-verifier.js';
+export { SellerUsageWriter } from './payments/seller-usage-writer.js';
 export type {
   UsageManifest,
   UsageManifestPointer,
@@ -83,6 +85,8 @@ export type {
   UsageManifestRecordInput,
   UsageManifestServiceTotals,
 } from './payments/usage-manifest.js';
+export type { UsageObservationInput, VerifiedUsagePointer } from './payments/buyer-usage-verifier.js';
+export type { SellerUsagePointer, SellerUsageWriteInput } from './payments/seller-usage-writer.js';
 export { NatTraversal, type NatMapping, type NatTraversalResult } from './p2p/nat-traversal.js';
 export { BuyerPaymentManager } from './payments/buyer-payment-manager.js';
 export type { BuyerPaymentConfig } from './payments/buyer-payment-manager.js';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -71,21 +71,29 @@ export {
 export type { SpendingAuthMessage, ReserveAuthMessage, SetOperatorMessage, SpendingAuthMetadata } from './payments/evm/signatures.js';
 export {
   buildUsageManifest,
+  buildUsageLeafBatch,
   buildUsageManifestRecord,
+  computeUsageLeafBatchPointer,
   computeUsageManifestPointer,
+  computeUsageRoot,
   UsageManifestStore,
+  publishUsageLeafBatchBestEffort,
   publishUsageManifestBestEffort,
+  ZERO_USAGE_ROOT,
 } from './payments/usage-manifest.js';
 export { BuyerUsageVerifier } from './payments/buyer-usage-verifier.js';
 export { SellerUsageWriter } from './payments/seller-usage-writer.js';
 export type {
   UsageManifest,
+  UsageLeaf,
+  UsageLeafBatch,
+  UsageLeafBatchPointer,
   UsageManifestPointer,
   UsageManifestRecord,
   UsageManifestRecordInput,
   UsageManifestServiceTotals,
 } from './payments/usage-manifest.js';
-export type { UsageObservationInput, VerifiedUsagePointer } from './payments/buyer-usage-verifier.js';
+export type { PendingUsageBatch, UsageObservationInput } from './payments/buyer-usage-verifier.js';
 export type { SellerUsagePointer, SellerUsageWriteInput } from './payments/seller-usage-writer.js';
 export { NatTraversal, type NatMapping, type NatTraversalResult } from './p2p/nat-traversal.js';
 export { BuyerPaymentManager } from './payments/buyer-payment-manager.js';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -47,6 +47,7 @@ export {
   StatsClient,
   type StatsClientConfig,
   type DecodedMetadataRecorded,
+  type DecodedMetadataPointerRecorded,
 } from './payments/evm/stats-client.js';
 export { signData, verifySignature, signUtf8, verifyUtf8 } from './p2p/identity.js';
 export {
@@ -59,12 +60,29 @@ export {
   RESERVE_AUTH_TYPES,
   SET_OPERATOR_TYPES,
   computeMetadataHash,
+  computePointerMetadataHash,
   encodeMetadata,
+  encodePointerMetadata,
   computeChannelId,
   ZERO_METADATA,
   ZERO_METADATA_HASH,
+  POINTER_METADATA_VERSION,
 } from './payments/evm/signatures.js';
 export type { SpendingAuthMessage, ReserveAuthMessage, SetOperatorMessage, SpendingAuthMetadata } from './payments/evm/signatures.js';
+export {
+  buildUsageManifest,
+  buildUsageManifestRecord,
+  computeUsageManifestPointer,
+  UsageManifestStore,
+  publishUsageManifestBestEffort,
+} from './payments/usage-manifest.js';
+export type {
+  UsageManifest,
+  UsageManifestPointer,
+  UsageManifestRecord,
+  UsageManifestRecordInput,
+  UsageManifestServiceTotals,
+} from './payments/usage-manifest.js';
 export { NatTraversal, type NatMapping, type NatTraversalResult } from './p2p/nat-traversal.js';
 export { BuyerPaymentManager } from './payments/buyer-payment-manager.js';
 export type { BuyerPaymentConfig } from './payments/buyer-payment-manager.js';

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1449,7 +1449,7 @@ export class AntseedNode extends EventEmitter {
         ...(payments.minBudgetPerRequest ? { minBudgetPerRequest: payments.minBudgetPerRequest } : {}),
         ...(payments.minSettleDelta ? { minSettleDelta: payments.minSettleDelta } : {}),
       };
-      this._sellerPaymentManager = new SellerPaymentManager(this._identity, sellerConfig, this._channelStore);
+      this._sellerPaymentManager = new SellerPaymentManager(this._identity, sellerConfig, this._channelStore, this._sellerUsageWriter);
       debugLog(`[Node] SellerPaymentManager initialized`);
 
       // Startup recovery: validate hydrated channels against on-chain state, then check timeouts

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -63,6 +63,7 @@ import {
   StakingClient,
   ChannelStore,
   CHANNEL_STATUS,
+  UsageManifestStore,
 } from "./payments/index.js";
 import { debugLog, debugWarn } from "./utils/debug.js";
 import { parsePublicAddress } from "./discovery/public-address.js";
@@ -240,6 +241,8 @@ export class AntseedNode extends EventEmitter {
   private _buyerHandler: BuyerRequestHandler | null = null;
   /** Seller-side payment manager (initialized when seller has payment config). */
   private _sellerPaymentManager: SellerPaymentManager | null = null;
+  /** Seller-side cumulative usage manifests for buyer-verified stats pointers. */
+  private _usageManifestStore: UsageManifestStore | null = null;
   /** Shared channel store for payment persistence. */
   private _channelStore: ChannelStore | null = null;
   /** Periodic timeout checker interval. */
@@ -1193,6 +1196,7 @@ export class AntseedNode extends EventEmitter {
       sessionTracker: this._sessionTracker,
       channelsClient: this._channelsClient,
       announcer: this._announcer,
+      usageManifestStore: this._usageManifestStore,
       maxUploadBodyBytes: this._config.maxUploadBodyBytes,
       emit: (event, ...args) => this.emit(event, ...args),
     });
@@ -1278,7 +1282,7 @@ export class AntseedNode extends EventEmitter {
           this._depositsClient,
           this._channelsClient,
           this._channelStore,
-          {},
+          { usageManifestStore: new UsageManifestStore(join(paymentsDir, "buyer-usage-manifests")) },
           this,
           this._sellerAddressResolver ?? undefined,
         );
@@ -1417,6 +1421,10 @@ export class AntseedNode extends EventEmitter {
 
     // Initialize ChannelStore for persistent payment channels (shared instance)
     const paymentsDir = join(dataDir, "payments");
+    if (this._config.role === 'seller' && !this._usageManifestStore) {
+      this._usageManifestStore = new UsageManifestStore(join(paymentsDir, "usage-manifests"));
+      debugLog("[Node] UsageManifestStore initialized");
+    }
     if (!this._channelStore) {
       try {
         this._channelStore = new ChannelStore(paymentsDir);

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -72,6 +72,7 @@ import { BuyerPaymentNegotiator } from "./payments/buyer-payment-negotiator.js";
 import { SellerAddressResolver } from "./discovery/seller-address-resolver.js";
 import { Contract as EthersContract } from "ethers";
 import { SellerPaymentManager, type SellerPaymentConfig } from "./payments/seller-payment-manager.js";
+import { SellerUsageWriter } from "./payments/seller-usage-writer.js";
 import { IdentityClient } from "./payments/evm/identity-client.js";
 import { SellerRequestHandler } from "./seller-request-handler.js";
 import {
@@ -243,6 +244,7 @@ export class AntseedNode extends EventEmitter {
   private _sellerPaymentManager: SellerPaymentManager | null = null;
   /** Seller-side cumulative usage manifests for buyer-verified stats pointers. */
   private _usageManifestStore: UsageManifestStore | null = null;
+  private _sellerUsageWriter: SellerUsageWriter | null = null;
   /** Shared channel store for payment persistence. */
   private _channelStore: ChannelStore | null = null;
   /** Periodic timeout checker interval. */
@@ -1196,7 +1198,7 @@ export class AntseedNode extends EventEmitter {
       sessionTracker: this._sessionTracker,
       channelsClient: this._channelsClient,
       announcer: this._announcer,
-      usageManifestStore: this._usageManifestStore,
+      usageWriter: this._sellerUsageWriter,
       maxUploadBodyBytes: this._config.maxUploadBodyBytes,
       emit: (event, ...args) => this.emit(event, ...args),
     });
@@ -1423,6 +1425,7 @@ export class AntseedNode extends EventEmitter {
     const paymentsDir = join(dataDir, "payments");
     if (this._config.role === 'seller' && !this._usageManifestStore) {
       this._usageManifestStore = new UsageManifestStore(join(paymentsDir, "usage-manifests"));
+      this._sellerUsageWriter = new SellerUsageWriter(this._usageManifestStore);
       debugLog("[Node] UsageManifestStore initialized");
     }
     if (!this._channelStore) {

--- a/packages/node/src/p2p/payment-codec.ts
+++ b/packages/node/src/p2p/payment-codec.ts
@@ -109,5 +109,7 @@ export function decodeNeedAuth(data: Uint8Array): NeedAuthPayload {
   if (typeof obj.cachedInputTokens === 'string') result.cachedInputTokens = obj.cachedInputTokens;
   if (typeof obj.freshInputTokens === 'string') result.freshInputTokens = obj.freshInputTokens;
   if (typeof obj.service === 'string') result.service = obj.service;
+  if (typeof obj.usageCid === 'string') result.usageCid = obj.usageCid;
+  if (typeof obj.usageRoot === 'string') result.usageRoot = obj.usageRoot;
   return result;
 }

--- a/packages/node/src/p2p/payment-codec.ts
+++ b/packages/node/src/p2p/payment-codec.ts
@@ -65,6 +65,24 @@ export function decodeSpendingAuth(data: Uint8Array): SpendingAuthPayload {
   if (typeof obj.reserveSalt === 'string') result.reserveSalt = obj.reserveSalt;
   if (typeof obj.reserveMaxAmount === 'string') result.reserveMaxAmount = obj.reserveMaxAmount;
   if (typeof obj.reserveDeadline === 'number') result.reserveDeadline = obj.reserveDeadline;
+  if (typeof obj.usageCid === 'string') result.usageCid = obj.usageCid;
+  if (typeof obj.usageRoot === 'string') result.usageRoot = obj.usageRoot;
+  if (Array.isArray(obj.usageLeaves)) {
+    result.usageLeaves = obj.usageLeaves
+      .filter((entry): entry is Record<string, unknown> => typeof entry === 'object' && entry !== null && !Array.isArray(entry))
+      .map((entry) => ({
+        requestId: requireString(entry, 'requestId'),
+        ...(typeof entry.service === 'string' ? { service: entry.service } : {}),
+        costUsdc: requireString(entry, 'costUsdc'),
+        cumulativeCostUsdc: requireString(entry, 'cumulativeCostUsdc'),
+        inputTokens: requireString(entry, 'inputTokens'),
+        cachedInputTokens: requireString(entry, 'cachedInputTokens'),
+        freshInputTokens: requireString(entry, 'freshInputTokens'),
+        outputTokens: requireString(entry, 'outputTokens'),
+        inputSha256: requireString(entry, 'inputSha256'),
+        outputSha256: requireString(entry, 'outputSha256'),
+      }));
+  }
   return result;
 }
 

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -63,10 +63,13 @@ export interface PerRequestAuthResult {
 }
 
 export interface NeedAuthHandlingOptions {
-  verifiedMetadata?: {
+  usageMetadata?: {
     encodedMetadata: string;
     metadataHash: string;
     requiredCumulativeAmount: bigint;
+    usageCid: string;
+    usageRoot: string;
+    usageLeaves: SpendingAuthPayload['usageLeaves'];
   };
 }
 
@@ -389,7 +392,13 @@ export class BuyerPaymentManager {
     cumulativeAmount: bigint,
     metadata: SpendingAuthMetadata,
     paymentMux: PaymentMux,
-    metadataOverride?: { metadataHash: string; encodedMetadata: string },
+    metadataOverride?: {
+      metadataHash: string;
+      encodedMetadata: string;
+      usageCid?: string;
+      usageRoot?: string;
+      usageLeaves?: SpendingAuthPayload['usageLeaves'];
+    },
   ): Promise<void> {
     const metadataHashHex = metadataOverride?.metadataHash ?? computeMetadataHash(metadata);
     const encodedMetadata = metadataOverride?.encodedMetadata ?? encodeMetadata(metadata);
@@ -413,6 +422,9 @@ export class BuyerPaymentManager {
       metadataHash: metadataHashHex,
       metadata: encodedMetadata,
       spendingAuthSig,
+      ...(metadataOverride?.usageCid ? { usageCid: metadataOverride.usageCid } : {}),
+      ...(metadataOverride?.usageRoot ? { usageRoot: metadataOverride.usageRoot } : {}),
+      ...(metadataOverride?.usageLeaves ? { usageLeaves: metadataOverride.usageLeaves } : {}),
     });
   }
 
@@ -679,6 +691,13 @@ export class BuyerPaymentManager {
       reportedOutputTokens?: bigint;
       reportedCachedInputTokens?: bigint;
       service?: string;
+      usageMetadata?: {
+        encodedMetadata: string;
+        metadataHash: string;
+        usageCid: string;
+        usageRoot: string;
+        usageLeaves: SpendingAuthPayload['usageLeaves'];
+      };
     },
   ): Promise<PerRequestAuthResult> {
     const session = this.getActiveSession(sellerPeerId);
@@ -791,8 +810,8 @@ export class BuyerPaymentManager {
     );
 
     // Compute metadata hash and encode metadata
-    const metadataHashHex = computeMetadataHash(newMeta);
-    const encodedMetadata = encodeMetadata(newMeta);
+    const metadataHashHex = responseStats.usageMetadata?.metadataHash ?? computeMetadataHash(newMeta);
+    const encodedMetadata = responseStats.usageMetadata?.encodedMetadata ?? encodeMetadata(newMeta);
 
     // Sign EIP-712 SpendingAuth
     const channelsDomain = this._channelsDomain;
@@ -817,6 +836,9 @@ export class BuyerPaymentManager {
       metadataHash: metadataHashHex,
       metadata: encodedMetadata,
       spendingAuthSig,
+      ...(responseStats.usageMetadata?.usageCid ? { usageCid: responseStats.usageMetadata.usageCid } : {}),
+      ...(responseStats.usageMetadata?.usageRoot ? { usageRoot: responseStats.usageMetadata.usageRoot } : {}),
+      ...(responseStats.usageMetadata?.usageLeaves ? { usageLeaves: responseStats.usageMetadata.usageLeaves } : {}),
     };
 
     const topUpNeeded = this._needsTopUp(sellerPeerId);
@@ -951,10 +973,13 @@ export class BuyerPaymentManager {
       cumulativeRequestCount: prevMeta.cumulativeRequestCount + 1n,
     };
     this._metadata.set(sellerPeerId, newMeta);
-    const verifiedMetadata = options.verifiedMetadata?.requiredCumulativeAmount === effectiveAmount
+    const verifiedMetadata = options.usageMetadata?.requiredCumulativeAmount === effectiveAmount
       ? {
-          encodedMetadata: options.verifiedMetadata.encodedMetadata,
-          metadataHash: options.verifiedMetadata.metadataHash,
+          encodedMetadata: options.usageMetadata.encodedMetadata,
+          metadataHash: options.usageMetadata.metadataHash,
+          usageCid: options.usageMetadata.usageCid,
+          usageRoot: options.usageMetadata.usageRoot,
+          usageLeaves: options.usageMetadata.usageLeaves,
         }
       : null;
 

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto';
-import { type AbstractSigner } from 'ethers';
+import { type AbstractSigner, keccak256 } from 'ethers';
 import type { Identity } from '../p2p/identity.js';
 import type { PaymentMux } from '../p2p/payment-mux.js';
 import type {
@@ -14,6 +14,7 @@ import {
   makeChannelsDomain,
   computeMetadataHash,
   encodeMetadata,
+  encodePointerMetadata,
   ZERO_METADATA,
   ZERO_METADATA_HASH,
   computeChannelId,
@@ -60,6 +61,15 @@ export interface BuyerPaymentConfig {
 export interface PerRequestAuthResult {
   payload: SpendingAuthPayload;
   topUpNeeded: boolean;
+}
+
+export interface NeedAuthHandlingOptions {
+  usagePointerVerified?: boolean;
+}
+
+export interface NeedAuthHandlingResult {
+  signed: boolean;
+  signedUsagePointer: boolean;
 }
 
 /**
@@ -376,9 +386,10 @@ export class BuyerPaymentManager {
     cumulativeAmount: bigint,
     metadata: SpendingAuthMetadata,
     paymentMux: PaymentMux,
+    metadataOverride?: { metadataHash: string; encodedMetadata: string },
   ): Promise<void> {
-    const metadataHashHex = computeMetadataHash(metadata);
-    const encodedMetadata = encodeMetadata(metadata);
+    const metadataHashHex = metadataOverride?.metadataHash ?? computeMetadataHash(metadata);
+    const encodedMetadata = metadataOverride?.encodedMetadata ?? encodeMetadata(metadata);
     const metadataMsg: SpendingAuthMessage = {
       channelId: session.sessionId,
       cumulativeAmount,
@@ -822,11 +833,12 @@ export class BuyerPaymentManager {
     sellerPeerId: string,
     payload: NeedAuthPayload,
     paymentMux: PaymentMux,
-  ): Promise<void> {
+    options: NeedAuthHandlingOptions = {},
+  ): Promise<NeedAuthHandlingResult> {
     const session = this.getActiveSession(sellerPeerId);
     if (!session) {
       debugWarn(`[BuyerPayment] NeedAuth for unknown seller: ${sellerPeerId.slice(0, 12)}...`);
-      return;
+      return { signed: false, signedUsagePointer: false };
     }
 
     const buyerService = payload.requestId ? this._requestService.get(payload.requestId) : undefined;
@@ -839,7 +851,7 @@ export class BuyerPaymentManager {
       debugLog(
         `[BuyerPayment] NeedAuth stale: required=${requiredCumulativeAmount} <= current=${currentCumulative} — ignoring`,
       );
-      return;
+      return { signed: false, signedUsagePointer: false };
     }
     if (payload.requestId) this._requestService.delete(payload.requestId);
 
@@ -870,7 +882,7 @@ export class BuyerPaymentManager {
           debugWarn(
             `[BuyerPayment] NeedAuth: seller claimed cost ${sellerCost} exceeds ${this._costTolerance}x buyer estimate ${buyerEstimate} — rejecting`,
           );
-          return;
+          return { signed: false, signedUsagePointer: false };
         }
         debugLog(
           `[BuyerPayment] NeedAuth: seller cost=${sellerCost} buyer estimate=${buyerEstimate} (in=${sellerIn} cached=${sellerCached} out=${sellerOut}) — validated`,
@@ -901,7 +913,7 @@ export class BuyerPaymentManager {
         debugWarn(
           `[BuyerPayment] NeedAuth: maxSignable=${maxSignable} <= currentCumulative=${currentCumulative} — overdraft limit reached`,
         );
-        return;
+        return { signed: false, signedUsagePointer: false };
       }
     }
 
@@ -921,7 +933,7 @@ export class BuyerPaymentManager {
       debugWarn(
         `[BuyerPayment] NeedAuth: effectiveAmount=${effectiveAmount} <= currentCumulative=${currentCumulative} — cannot advance`,
       );
-      return;
+      return { signed: false, signedUsagePointer: false };
     }
 
     debugLog(`[BuyerPayment] NeedAuth: channel=${session.sessionId.slice(0, 18)}... required=${requiredCumulativeAmount} effective=${effectiveAmount}`);
@@ -936,13 +948,29 @@ export class BuyerPaymentManager {
       cumulativeRequestCount: prevMeta.cumulativeRequestCount + 1n,
     };
     this._metadata.set(sellerPeerId, newMeta);
+    const canSignUsagePointer = Boolean(payload.usageCid && payload.usageRoot)
+      && options.usagePointerVerified === true
+      && effectiveAmount === requiredCumulativeAmount;
+    const encodedPointerMetadata = canSignUsagePointer
+      ? encodePointerMetadata(payload.usageCid!, payload.usageRoot!)
+      : null;
 
     // Send via PaymentMux
     try {
-      await this._sendUpdatedSpendingAuth(session, sellerPeerId, effectiveAmount, newMeta, paymentMux);
+      await this._sendUpdatedSpendingAuth(
+        session,
+        sellerPeerId,
+        effectiveAmount,
+        newMeta,
+        paymentMux,
+        encodedPointerMetadata
+          ? { encodedMetadata: encodedPointerMetadata, metadataHash: keccak256(encodedPointerMetadata) }
+          : undefined,
+      );
       debugLog(`[BuyerPayment] NeedAuth responded: new cumulativeAmount=${effectiveAmount}`);
     } catch {
       debugLog(`[BuyerPayment] NeedAuth: connection closed before SpendingAuth could be sent`);
+      return { signed: false, signedUsagePointer: false };
     }
 
     // Send topUp AFTER the SpendingAuth so the seller processes the higher
@@ -954,6 +982,7 @@ export class BuyerPaymentManager {
     if (needsTopUp || this._needsTopUp(sellerPeerId)) {
       await this._topUpAfterSpendAuthBestEffort(sellerPeerId, paymentMux, 'handleNeedAuth');
     }
+    return { signed: true, signedUsagePointer: canSignUsagePointer };
   }
 
   // ── Reserve top-up ─────────────────────────────────────────────

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto';
-import { type AbstractSigner, keccak256 } from 'ethers';
+import { type AbstractSigner } from 'ethers';
 import type { Identity } from '../p2p/identity.js';
 import type { PaymentMux } from '../p2p/payment-mux.js';
 import type {
@@ -14,7 +14,6 @@ import {
   makeChannelsDomain,
   computeMetadataHash,
   encodeMetadata,
-  encodePointerMetadata,
   ZERO_METADATA,
   ZERO_METADATA_HASH,
   computeChannelId,
@@ -64,12 +63,16 @@ export interface PerRequestAuthResult {
 }
 
 export interface NeedAuthHandlingOptions {
-  usagePointerVerified?: boolean;
+  verifiedMetadata?: {
+    encodedMetadata: string;
+    metadataHash: string;
+    requiredCumulativeAmount: bigint;
+  };
 }
 
 export interface NeedAuthHandlingResult {
   signed: boolean;
-  signedUsagePointer: boolean;
+  signedVerifiedMetadata: boolean;
 }
 
 /**
@@ -838,7 +841,7 @@ export class BuyerPaymentManager {
     const session = this.getActiveSession(sellerPeerId);
     if (!session) {
       debugWarn(`[BuyerPayment] NeedAuth for unknown seller: ${sellerPeerId.slice(0, 12)}...`);
-      return { signed: false, signedUsagePointer: false };
+      return { signed: false, signedVerifiedMetadata: false };
     }
 
     const buyerService = payload.requestId ? this._requestService.get(payload.requestId) : undefined;
@@ -851,7 +854,7 @@ export class BuyerPaymentManager {
       debugLog(
         `[BuyerPayment] NeedAuth stale: required=${requiredCumulativeAmount} <= current=${currentCumulative} — ignoring`,
       );
-      return { signed: false, signedUsagePointer: false };
+      return { signed: false, signedVerifiedMetadata: false };
     }
     if (payload.requestId) this._requestService.delete(payload.requestId);
 
@@ -882,7 +885,7 @@ export class BuyerPaymentManager {
           debugWarn(
             `[BuyerPayment] NeedAuth: seller claimed cost ${sellerCost} exceeds ${this._costTolerance}x buyer estimate ${buyerEstimate} — rejecting`,
           );
-          return { signed: false, signedUsagePointer: false };
+          return { signed: false, signedVerifiedMetadata: false };
         }
         debugLog(
           `[BuyerPayment] NeedAuth: seller cost=${sellerCost} buyer estimate=${buyerEstimate} (in=${sellerIn} cached=${sellerCached} out=${sellerOut}) — validated`,
@@ -913,7 +916,7 @@ export class BuyerPaymentManager {
         debugWarn(
           `[BuyerPayment] NeedAuth: maxSignable=${maxSignable} <= currentCumulative=${currentCumulative} — overdraft limit reached`,
         );
-        return { signed: false, signedUsagePointer: false };
+        return { signed: false, signedVerifiedMetadata: false };
       }
     }
 
@@ -933,7 +936,7 @@ export class BuyerPaymentManager {
       debugWarn(
         `[BuyerPayment] NeedAuth: effectiveAmount=${effectiveAmount} <= currentCumulative=${currentCumulative} — cannot advance`,
       );
-      return { signed: false, signedUsagePointer: false };
+      return { signed: false, signedVerifiedMetadata: false };
     }
 
     debugLog(`[BuyerPayment] NeedAuth: channel=${session.sessionId.slice(0, 18)}... required=${requiredCumulativeAmount} effective=${effectiveAmount}`);
@@ -948,11 +951,11 @@ export class BuyerPaymentManager {
       cumulativeRequestCount: prevMeta.cumulativeRequestCount + 1n,
     };
     this._metadata.set(sellerPeerId, newMeta);
-    const canSignUsagePointer = Boolean(payload.usageCid && payload.usageRoot)
-      && options.usagePointerVerified === true
-      && effectiveAmount === requiredCumulativeAmount;
-    const encodedPointerMetadata = canSignUsagePointer
-      ? encodePointerMetadata(payload.usageCid!, payload.usageRoot!)
+    const verifiedMetadata = options.verifiedMetadata?.requiredCumulativeAmount === effectiveAmount
+      ? {
+          encodedMetadata: options.verifiedMetadata.encodedMetadata,
+          metadataHash: options.verifiedMetadata.metadataHash,
+        }
       : null;
 
     // Send via PaymentMux
@@ -963,14 +966,12 @@ export class BuyerPaymentManager {
         effectiveAmount,
         newMeta,
         paymentMux,
-        encodedPointerMetadata
-          ? { encodedMetadata: encodedPointerMetadata, metadataHash: keccak256(encodedPointerMetadata) }
-          : undefined,
+        verifiedMetadata ?? undefined,
       );
       debugLog(`[BuyerPayment] NeedAuth responded: new cumulativeAmount=${effectiveAmount}`);
     } catch {
       debugLog(`[BuyerPayment] NeedAuth: connection closed before SpendingAuth could be sent`);
-      return { signed: false, signedUsagePointer: false };
+      return { signed: false, signedVerifiedMetadata: false };
     }
 
     // Send topUp AFTER the SpendingAuth so the seller processes the higher
@@ -982,7 +983,7 @@ export class BuyerPaymentManager {
     if (needsTopUp || this._needsTopUp(sellerPeerId)) {
       await this._topUpAfterSpendAuthBestEffort(sellerPeerId, paymentMux, 'handleNeedAuth');
     }
-    return { signed: true, signedUsagePointer: canSignUsagePointer };
+    return { signed: true, signedVerifiedMetadata: verifiedMetadata !== null };
   }
 
   // ── Reserve top-up ─────────────────────────────────────────────

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -649,8 +649,11 @@ export class BuyerPaymentNegotiator {
       : null;
     if (payload.usageCid || payload.usageRoot) {
       if (!verifiedPointer) {
+        const diverged = this._usageVerifier?.isChannelDiverged(payload.channelId) ?? false;
         debugWarn(
-          `[BuyerNegotiator] Usage pointer verification failed for ${peerId.slice(0, 12)}...; signing legacy metadata only`,
+          diverged
+            ? `[BuyerNegotiator] Usage manifest diverged for channel ${payload.channelId.slice(0, 18)}...; signing legacy metadata only`
+            : `[BuyerNegotiator] Usage pointer verification failed for ${peerId.slice(0, 12)}...; signing legacy metadata only`,
         );
       }
     }

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -96,6 +96,8 @@ export class BuyerPaymentNegotiator {
   private readonly _firstRequestSent = new Set<string>();
   /** Per-peer last response cost, raw content, and latency from the seller. */
   private readonly _lastResponseCost = new Map<string, LastResponseCost>();
+  /** Per-peer cumulative cost used for buyer-authored usage leaves. */
+  private readonly _usageCumulativeCost = new Map<string, bigint>();
   /** Buyer-side payment muxes keyed by seller peerId. */
   private readonly _muxes = new Map<PeerId, PaymentMux>();
   /** In-flight NeedAuth handlers keyed by seller peerId. */
@@ -216,12 +218,38 @@ export class BuyerPaymentNegotiator {
     const reportedOutputTokens = lastCost?.outputTokens;
     const reportedCachedInputTokens = lastCost?.cachedInputTokens;
     const service = lastCost?.service;
+    const session = this._bpm.getActiveSession(peer.peerId);
+    const pendingUsage = session
+      ? this._usageVerifier?.buildPendingBatch(peer.peerId, session.sessionId) ?? null
+      : null;
     try {
       const { payload, topUpNeeded } = await this._bpm.signPerRequestAuth(
         peer.peerId,
-        { inputBytes, outputBytes, sellerClaimedCost, reportedInputTokens, reportedOutputTokens, reportedCachedInputTokens, service },
+        {
+          inputBytes,
+          outputBytes,
+          sellerClaimedCost,
+          reportedInputTokens,
+          reportedOutputTokens,
+          reportedCachedInputTokens,
+          service,
+          ...(pendingUsage
+            ? {
+                usageMetadata: {
+                  encodedMetadata: pendingUsage.encodedMetadata,
+                  metadataHash: pendingUsage.metadataHash,
+                  usageCid: pendingUsage.usageCid,
+                  usageRoot: pendingUsage.usageRoot,
+                  usageLeaves: pendingUsage.leaves,
+                },
+              }
+            : {}),
+        },
       );
       pmux.sendSpendingAuth(payload);
+      if (pendingUsage && session) {
+        this._usageVerifier?.commitBatch(peer.peerId, session.sessionId, pendingUsage.batch);
+      }
       // Release held content to free memory — no longer needed after signing
       this._lastResponseCost.delete(peer.peerId);
       debugLog(`[BuyerNegotiator] Per-request SpendingAuth sent to ${peer.peerId.slice(0, 12)}... cumulative=${payload.cumulativeAmount}`);
@@ -471,13 +499,18 @@ export class BuyerPaymentNegotiator {
       cachedInputUsdPerMillion: sessionPricing?.cachedInputUsdPerMillion,
     };
     const costUsdc = computeCostUsdc(usage.freshInputTokens, usage.outputTokens, pricing, usage.cachedInputTokens);
+    const activeSession = this._bpm.getActiveSession(peer.peerId);
+    const previousCumulativeCost = this._usageCumulativeCost.get(peer.peerId)
+      ?? (activeSession ? this._usageVerifier?.getCommittedCumulativeCost(activeSession.sessionId) ?? 0n : 0n);
+    const cumulativeCost = previousCumulativeCost + costUsdc;
+    this._usageCumulativeCost.set(peer.peerId, cumulativeCost);
 
     this._lastResponseCost.set(peer.peerId, {
       costUsdc,
       inputTokens: BigInt(usage.inputTokens),
       outputTokens: BigInt(usage.outputTokens),
       cachedInputTokens: BigInt(usage.cachedInputTokens),
-      cumulativeCost: 0n,
+      cumulativeCost,
       inputContent: new Uint8Array(0),
       outputContent: response.body,
       latencyMs: 0,
@@ -496,6 +529,7 @@ export class BuyerPaymentNegotiator {
         requestId: request.requestId,
         service,
         costUsdc,
+        cumulativeCostUsdc: cumulativeCost,
         inputTokens: usage.inputTokens,
         cachedInputTokens: usage.cachedInputTokens,
         freshInputTokens: usage.freshInputTokens,
@@ -616,6 +650,7 @@ export class BuyerPaymentNegotiator {
     this._lockedPeers.delete(peerId);
     this._firstRequestSent.delete(peerId);
     this._lastResponseCost.delete(peerId);
+    this._usageCumulativeCost.delete(peerId);
     this._usageVerifier?.clearPeer(peerId);
   }
 
@@ -631,6 +666,7 @@ export class BuyerPaymentNegotiator {
     this._lockedPeers.clear();
     this._firstRequestSent.clear();
     this._lastResponseCost.clear();
+    this._usageCumulativeCost.clear();
     this._muxes.clear();
 
     for (const [, pending] of this._pendingPaymentRequired) {
@@ -644,33 +680,24 @@ export class BuyerPaymentNegotiator {
   }
 
   async handleNeedAuth(peerId: PeerId, payload: NeedAuthPayload, pmux: PaymentMux): Promise<void> {
-    const verifiedPointer = payload.usageCid || payload.usageRoot
-      ? await this._usageVerifier?.verifyPointer(peerId, payload) ?? null
-      : null;
-    if (payload.usageCid || payload.usageRoot) {
-      if (!verifiedPointer) {
-        const diverged = this._usageVerifier?.isChannelDiverged(payload.channelId) ?? false;
-        debugWarn(
-          diverged
-            ? `[BuyerNegotiator] Usage manifest diverged for channel ${payload.channelId.slice(0, 18)}...; signing legacy metadata only`
-            : `[BuyerNegotiator] Usage pointer verification failed for ${peerId.slice(0, 12)}...; signing legacy metadata only`,
-        );
-      }
-    }
+    const pendingUsage = this._usageVerifier?.buildPendingBatch(peerId, payload.channelId) ?? null;
 
     const result = await this._bpm.handleNeedAuth(peerId, payload, pmux, {
-      ...(verifiedPointer
+      ...(pendingUsage
         ? {
-            verifiedMetadata: {
-              encodedMetadata: verifiedPointer.encodedMetadata,
-              metadataHash: verifiedPointer.metadataHash,
-              requiredCumulativeAmount: verifiedPointer.requiredCumulativeAmount,
+            usageMetadata: {
+              encodedMetadata: pendingUsage.encodedMetadata,
+              metadataHash: pendingUsage.metadataHash,
+              requiredCumulativeAmount: BigInt(payload.requiredCumulativeAmount),
+              usageCid: pendingUsage.usageCid,
+              usageRoot: pendingUsage.usageRoot,
+              usageLeaves: pendingUsage.leaves,
             },
           }
         : {}),
     });
-    if (result.signedVerifiedMetadata && verifiedPointer) {
-      this._usageVerifier?.commit(payload.channelId, verifiedPointer.record);
+    if (result.signedVerifiedMetadata && pendingUsage) {
+      this._usageVerifier?.commitBatch(peerId, payload.channelId, pendingUsage.batch);
     }
   }
 

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -16,13 +16,8 @@ import { SellerAuthorizationError } from '../discovery/seller-address-resolver.j
 import { parseResponseUsage } from '../utils/response-usage.js';
 import { computeCostUsdc, type ServicePricing } from './pricing.js';
 import { formatUsdc } from './usdc-utils.js';
-import {
-  buildUsageManifest,
-  buildUsageManifestRecord,
-  computeUsageManifestPointer,
-  type UsageManifestStore,
-  type UsageManifestRecord,
-} from './usage-manifest.js';
+import type { UsageManifestStore } from './usage-manifest.js';
+import { BuyerUsageVerifier } from './buyer-usage-verifier.js';
 
 export interface BuyerNegotiatorConfig {
   usageManifestStore?: UsageManifestStore | null;
@@ -49,18 +44,6 @@ interface LastResponseCost {
   outputContent: Uint8Array;
   latencyMs: number;
   service?: string;
-}
-
-interface UsageObservation {
-  requestId: string;
-  service?: string;
-  costUsdc: bigint;
-  inputTokens: number;
-  cachedInputTokens: number;
-  freshInputTokens: number;
-  outputTokens: number;
-  inputBody: Uint8Array;
-  outputBody: Uint8Array;
 }
 
 function parsePaymentRequiredBody(body: Uint8Array): Record<string, unknown> | null {
@@ -94,7 +77,7 @@ export class BuyerPaymentNegotiator {
   private readonly _channelStore: ChannelStore | null;
   private readonly _identity: Identity;
   private readonly _emit: NegotiationEmitter;
-  private readonly _usageManifestStore: UsageManifestStore | null;
+  private readonly _usageVerifier: BuyerUsageVerifier | null;
   private readonly _sellerAddressResolver?: SellerAddressResolver;
 
   /** Tracks which seller peers the buyer has already negotiated payment for. */
@@ -117,9 +100,6 @@ export class BuyerPaymentNegotiator {
   private readonly _muxes = new Map<PeerId, PaymentMux>();
   /** In-flight NeedAuth handlers keyed by seller peerId. */
   private readonly _pendingNeedAuth = new Map<string, Promise<void>>();
-  private readonly _usageObservations = new Map<string, UsageObservation>();
-  private readonly _usageObservationWaiters = new Map<string, Array<(value: UsageObservation | null) => void>>();
-  private readonly _verifiedUsageRecordsByChannel = new Map<string, UsageManifestRecord[]>();
 
   constructor(
     identity: Identity,
@@ -137,7 +117,7 @@ export class BuyerPaymentNegotiator {
     this._channelsClient = channelsClient;
     this._channelStore = channelStore;
     this._emit = emitter;
-    this._usageManifestStore = config.usageManifestStore ?? null;
+    this._usageVerifier = config.usageManifestStore ? new BuyerUsageVerifier(config.usageManifestStore) : null;
     this._sellerAddressResolver = sellerAddressResolver;
   }
 
@@ -512,7 +492,7 @@ export class BuyerPaymentNegotiator {
     this._bpm.recordAndPersistTokens(peer.peerId, usage.inputTokens, usage.outputTokens);
 
     if (request?.requestId) {
-      this._recordUsageObservation(peer.peerId, {
+      this._usageVerifier?.recordObservation(peer.peerId, {
         requestId: request.requestId,
         service,
         costUsdc,
@@ -636,7 +616,7 @@ export class BuyerPaymentNegotiator {
     this._lockedPeers.delete(peerId);
     this._firstRequestSent.delete(peerId);
     this._lastResponseCost.delete(peerId);
-    this._clearUsageStateForPeer(peerId);
+    this._usageVerifier?.clearPeer(peerId);
   }
 
   /** Wait for in-flight NeedAuth handlers to complete (settlement safety). */
@@ -660,19 +640,15 @@ export class BuyerPaymentNegotiator {
     this._pendingPaymentRequired.clear();
     this._bufferedPaymentRequired.clear();
     this._negotiationLocks.clear();
-    this._usageObservations.clear();
-    for (const waiters of this._usageObservationWaiters.values()) {
-      for (const resolve of waiters) resolve(null);
-    }
-    this._usageObservationWaiters.clear();
-    this._verifiedUsageRecordsByChannel.clear();
+    this._usageVerifier?.cleanup();
   }
 
   async handleNeedAuth(peerId: PeerId, payload: NeedAuthPayload, pmux: PaymentMux): Promise<void> {
-    let verifiedRecord: UsageManifestRecord | null = null;
+    const verifiedPointer = payload.usageCid || payload.usageRoot
+      ? await this._usageVerifier?.verifyPointer(peerId, payload) ?? null
+      : null;
     if (payload.usageCid || payload.usageRoot) {
-      verifiedRecord = await this._verifyUsagePointer(peerId, payload);
-      if (!verifiedRecord) {
+      if (!verifiedPointer) {
         debugWarn(
           `[BuyerNegotiator] Usage pointer verification failed for ${peerId.slice(0, 12)}...; signing legacy metadata only`,
         );
@@ -680,97 +656,19 @@ export class BuyerPaymentNegotiator {
     }
 
     const result = await this._bpm.handleNeedAuth(peerId, payload, pmux, {
-      usagePointerVerified: verifiedRecord !== null,
+      ...(verifiedPointer
+        ? {
+            verifiedMetadata: {
+              encodedMetadata: verifiedPointer.encodedMetadata,
+              metadataHash: verifiedPointer.metadataHash,
+              requiredCumulativeAmount: verifiedPointer.requiredCumulativeAmount,
+            },
+          }
+        : {}),
     });
-    if (result.signed && verifiedRecord) {
-      this._commitVerifiedUsageRecord(payload.channelId, verifiedRecord);
+    if (result.signedVerifiedMetadata && verifiedPointer) {
+      this._usageVerifier?.commit(payload.channelId, verifiedPointer.record);
     }
-  }
-
-  private _recordUsageObservation(peerId: PeerId, observation: UsageObservation): void {
-    const key = this._usageObservationKey(peerId, observation.requestId);
-    this._usageObservations.set(key, observation);
-    const waiters = this._usageObservationWaiters.get(key);
-    if (!waiters) return;
-    this._usageObservationWaiters.delete(key);
-    for (const resolve of waiters) resolve(observation);
-  }
-
-  private async _verifyUsagePointer(peerId: PeerId, payload: NeedAuthPayload): Promise<UsageManifestRecord | null> {
-    if (!payload.requestId || !payload.usageCid || !payload.usageRoot) return null;
-    const key = this._usageObservationKey(peerId, payload.requestId);
-    const observation = await this._waitForUsageObservation(key, 2_000);
-    this._usageObservations.delete(key);
-    if (!observation) return null;
-
-    const record = buildUsageManifestRecord({
-      requestId: observation.requestId,
-      service: observation.service,
-      costUsdc: BigInt(payload.lastRequestCost ?? observation.costUsdc),
-      cumulativeCostUsdc: BigInt(payload.requiredCumulativeAmount),
-      inputTokens: observation.inputTokens,
-      cachedInputTokens: observation.cachedInputTokens,
-      freshInputTokens: observation.freshInputTokens,
-      outputTokens: observation.outputTokens,
-      inputBody: observation.inputBody,
-      outputBody: observation.outputBody,
-    });
-    const previous = this._getVerifiedUsageRecords(payload.channelId);
-    const pointer = computeUsageManifestPointer(buildUsageManifest(payload.channelId, [...previous, record]));
-    const rootMatches = pointer.usageRoot.toLowerCase() === payload.usageRoot.toLowerCase();
-    const cidMatches = pointer.cid === payload.usageCid;
-    return rootMatches && cidMatches ? record : null;
-  }
-
-  private async _waitForUsageObservation(key: string, timeoutMs: number): Promise<UsageObservation | null> {
-    const existing = this._usageObservations.get(key);
-    if (existing) return existing;
-    return await new Promise((resolve) => {
-      const timer = setTimeout(() => {
-        const waiters = this._usageObservationWaiters.get(key)?.filter((entry) => entry !== wrapped);
-        if (waiters && waiters.length > 0) this._usageObservationWaiters.set(key, waiters);
-        else this._usageObservationWaiters.delete(key);
-        resolve(null);
-      }, timeoutMs);
-      const wrapped = (value: UsageObservation | null): void => {
-        clearTimeout(timer);
-        resolve(value);
-      };
-      const waiters = this._usageObservationWaiters.get(key) ?? [];
-      waiters.push(wrapped);
-      this._usageObservationWaiters.set(key, waiters);
-    });
-  }
-
-  private _commitVerifiedUsageRecord(channelId: string, record: UsageManifestRecord): void {
-    const records = this._getVerifiedUsageRecords(channelId);
-    records.push(record);
-    this._verifiedUsageRecordsByChannel.set(channelId, records);
-    this._usageManifestStore?.replace(channelId, records);
-  }
-
-  private _getVerifiedUsageRecords(channelId: string): UsageManifestRecord[] {
-    const existing = this._verifiedUsageRecordsByChannel.get(channelId);
-    if (existing) return existing;
-    const records = this._usageManifestStore?.getRecords(channelId) ?? [];
-    this._verifiedUsageRecordsByChannel.set(channelId, records);
-    return records;
-  }
-
-  private _clearUsageStateForPeer(peerId: PeerId): void {
-    const prefix = `${peerId}:`;
-    for (const key of this._usageObservations.keys()) {
-      if (key.startsWith(prefix)) this._usageObservations.delete(key);
-    }
-    for (const [key, waiters] of this._usageObservationWaiters) {
-      if (!key.startsWith(prefix)) continue;
-      this._usageObservationWaiters.delete(key);
-      for (const resolve of waiters) resolve(null);
-    }
-  }
-
-  private _usageObservationKey(peerId: PeerId, requestId: string): string {
-    return `${peerId}:${requestId}`;
   }
 
   /**

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -3,7 +3,7 @@ import type { PeerConnection } from '../p2p/connection-manager.js';
 import { PaymentMux } from '../p2p/payment-mux.js';
 import type { PeerInfo, PeerId } from '../types/peer.js';
 import type { SerializedHttpRequest, SerializedHttpResponse } from '../types/http.js';
-import { PAYMENT_CODE_CHANNEL_EXHAUSTED, type PaymentRequiredPayload } from '../types/protocol.js';
+import { PAYMENT_CODE_CHANNEL_EXHAUSTED, type NeedAuthPayload, type PaymentRequiredPayload } from '../types/protocol.js';
 import type { BuyerPaymentManager } from './buyer-payment-manager.js';
 import type { DepositsClient } from './evm/deposits-client.js';
 import type { ChannelsClient } from './evm/channels-client.js';
@@ -16,8 +16,17 @@ import { SellerAuthorizationError } from '../discovery/seller-address-resolver.j
 import { parseResponseUsage } from '../utils/response-usage.js';
 import { computeCostUsdc, type ServicePricing } from './pricing.js';
 import { formatUsdc } from './usdc-utils.js';
+import {
+  buildUsageManifest,
+  buildUsageManifestRecord,
+  computeUsageManifestPointer,
+  type UsageManifestStore,
+  type UsageManifestRecord,
+} from './usage-manifest.js';
 
-export interface BuyerNegotiatorConfig {}
+export interface BuyerNegotiatorConfig {
+  usageManifestStore?: UsageManifestStore | null;
+}
 
 /** Emitter interface — subset of EventEmitter used by the negotiator. */
 export interface NegotiationEmitter {
@@ -40,6 +49,18 @@ interface LastResponseCost {
   outputContent: Uint8Array;
   latencyMs: number;
   service?: string;
+}
+
+interface UsageObservation {
+  requestId: string;
+  service?: string;
+  costUsdc: bigint;
+  inputTokens: number;
+  cachedInputTokens: number;
+  freshInputTokens: number;
+  outputTokens: number;
+  inputBody: Uint8Array;
+  outputBody: Uint8Array;
 }
 
 function parsePaymentRequiredBody(body: Uint8Array): Record<string, unknown> | null {
@@ -73,6 +94,7 @@ export class BuyerPaymentNegotiator {
   private readonly _channelStore: ChannelStore | null;
   private readonly _identity: Identity;
   private readonly _emit: NegotiationEmitter;
+  private readonly _usageManifestStore: UsageManifestStore | null;
   private readonly _sellerAddressResolver?: SellerAddressResolver;
 
   /** Tracks which seller peers the buyer has already negotiated payment for. */
@@ -95,6 +117,9 @@ export class BuyerPaymentNegotiator {
   private readonly _muxes = new Map<PeerId, PaymentMux>();
   /** In-flight NeedAuth handlers keyed by seller peerId. */
   private readonly _pendingNeedAuth = new Map<string, Promise<void>>();
+  private readonly _usageObservations = new Map<string, UsageObservation>();
+  private readonly _usageObservationWaiters = new Map<string, Array<(value: UsageObservation | null) => void>>();
+  private readonly _verifiedUsageRecordsByChannel = new Map<string, UsageManifestRecord[]>();
 
   constructor(
     identity: Identity,
@@ -102,7 +127,7 @@ export class BuyerPaymentNegotiator {
     depositsClient: DepositsClient | null,
     channelsClient: ChannelsClient | null,
     channelStore: ChannelStore | null,
-    _config: BuyerNegotiatorConfig,
+    config: BuyerNegotiatorConfig,
     emitter: NegotiationEmitter,
     sellerAddressResolver?: SellerAddressResolver,
   ) {
@@ -112,6 +137,7 @@ export class BuyerPaymentNegotiator {
     this._channelsClient = channelsClient;
     this._channelStore = channelStore;
     this._emit = emitter;
+    this._usageManifestStore = config.usageManifestStore ?? null;
     this._sellerAddressResolver = sellerAddressResolver;
   }
 
@@ -143,7 +169,7 @@ export class BuyerPaymentNegotiator {
     });
 
     pmux.onNeedAuth((payload) => {
-      const p = this._bpm.handleNeedAuth(peerId, payload, pmux);
+      const p = this.handleNeedAuth(peerId, payload, pmux);
       this._pendingNeedAuth.set(peerId, p);
       p.finally(() => {
         if (this._pendingNeedAuth.get(peerId) === p) this._pendingNeedAuth.delete(peerId);
@@ -442,7 +468,12 @@ export class BuyerPaymentNegotiator {
     }
   }
 
-  estimateCostFromResponse(peer: PeerInfo, response: SerializedHttpResponse, service?: string): void {
+  estimateCostFromResponse(
+    peer: PeerInfo,
+    response: SerializedHttpResponse,
+    service?: string,
+    request?: SerializedHttpRequest,
+  ): void {
     // Prefer session pricing (from PaymentRequired negotiation, includes service-specific rates)
     // over peer-level defaults which may be different from the actual service pricing.
     const sessionPricing = this._bpm.getSessionPricing(peer.peerId, service);
@@ -479,6 +510,20 @@ export class BuyerPaymentNegotiator {
     );
 
     this._bpm.recordAndPersistTokens(peer.peerId, usage.inputTokens, usage.outputTokens);
+
+    if (request?.requestId) {
+      this._recordUsageObservation(peer.peerId, {
+        requestId: request.requestId,
+        service,
+        costUsdc,
+        inputTokens: usage.inputTokens,
+        cachedInputTokens: usage.cachedInputTokens,
+        freshInputTokens: usage.freshInputTokens,
+        outputTokens: usage.outputTokens,
+        inputBody: request.body,
+        outputBody: response.body,
+      });
+    }
   }
 
   // parseCostHeaders removed — cost data now flows through NeedAuth on PaymentMux.
@@ -591,6 +636,7 @@ export class BuyerPaymentNegotiator {
     this._lockedPeers.delete(peerId);
     this._firstRequestSent.delete(peerId);
     this._lastResponseCost.delete(peerId);
+    this._clearUsageStateForPeer(peerId);
   }
 
   /** Wait for in-flight NeedAuth handlers to complete (settlement safety). */
@@ -614,6 +660,117 @@ export class BuyerPaymentNegotiator {
     this._pendingPaymentRequired.clear();
     this._bufferedPaymentRequired.clear();
     this._negotiationLocks.clear();
+    this._usageObservations.clear();
+    for (const waiters of this._usageObservationWaiters.values()) {
+      for (const resolve of waiters) resolve(null);
+    }
+    this._usageObservationWaiters.clear();
+    this._verifiedUsageRecordsByChannel.clear();
+  }
+
+  async handleNeedAuth(peerId: PeerId, payload: NeedAuthPayload, pmux: PaymentMux): Promise<void> {
+    let verifiedRecord: UsageManifestRecord | null = null;
+    if (payload.usageCid || payload.usageRoot) {
+      verifiedRecord = await this._verifyUsagePointer(peerId, payload);
+      if (!verifiedRecord) {
+        debugWarn(
+          `[BuyerNegotiator] Usage pointer verification failed for ${peerId.slice(0, 12)}...; signing legacy metadata only`,
+        );
+      }
+    }
+
+    const result = await this._bpm.handleNeedAuth(peerId, payload, pmux, {
+      usagePointerVerified: verifiedRecord !== null,
+    });
+    if (result.signed && verifiedRecord) {
+      this._commitVerifiedUsageRecord(payload.channelId, verifiedRecord);
+    }
+  }
+
+  private _recordUsageObservation(peerId: PeerId, observation: UsageObservation): void {
+    const key = this._usageObservationKey(peerId, observation.requestId);
+    this._usageObservations.set(key, observation);
+    const waiters = this._usageObservationWaiters.get(key);
+    if (!waiters) return;
+    this._usageObservationWaiters.delete(key);
+    for (const resolve of waiters) resolve(observation);
+  }
+
+  private async _verifyUsagePointer(peerId: PeerId, payload: NeedAuthPayload): Promise<UsageManifestRecord | null> {
+    if (!payload.requestId || !payload.usageCid || !payload.usageRoot) return null;
+    const key = this._usageObservationKey(peerId, payload.requestId);
+    const observation = await this._waitForUsageObservation(key, 2_000);
+    this._usageObservations.delete(key);
+    if (!observation) return null;
+
+    const record = buildUsageManifestRecord({
+      requestId: observation.requestId,
+      service: observation.service,
+      costUsdc: BigInt(payload.lastRequestCost ?? observation.costUsdc),
+      cumulativeCostUsdc: BigInt(payload.requiredCumulativeAmount),
+      inputTokens: observation.inputTokens,
+      cachedInputTokens: observation.cachedInputTokens,
+      freshInputTokens: observation.freshInputTokens,
+      outputTokens: observation.outputTokens,
+      inputBody: observation.inputBody,
+      outputBody: observation.outputBody,
+    });
+    const previous = this._getVerifiedUsageRecords(payload.channelId);
+    const pointer = computeUsageManifestPointer(buildUsageManifest(payload.channelId, [...previous, record]));
+    const rootMatches = pointer.usageRoot.toLowerCase() === payload.usageRoot.toLowerCase();
+    const cidMatches = pointer.cid === payload.usageCid;
+    return rootMatches && cidMatches ? record : null;
+  }
+
+  private async _waitForUsageObservation(key: string, timeoutMs: number): Promise<UsageObservation | null> {
+    const existing = this._usageObservations.get(key);
+    if (existing) return existing;
+    return await new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        const waiters = this._usageObservationWaiters.get(key)?.filter((entry) => entry !== wrapped);
+        if (waiters && waiters.length > 0) this._usageObservationWaiters.set(key, waiters);
+        else this._usageObservationWaiters.delete(key);
+        resolve(null);
+      }, timeoutMs);
+      const wrapped = (value: UsageObservation | null): void => {
+        clearTimeout(timer);
+        resolve(value);
+      };
+      const waiters = this._usageObservationWaiters.get(key) ?? [];
+      waiters.push(wrapped);
+      this._usageObservationWaiters.set(key, waiters);
+    });
+  }
+
+  private _commitVerifiedUsageRecord(channelId: string, record: UsageManifestRecord): void {
+    const records = this._getVerifiedUsageRecords(channelId);
+    records.push(record);
+    this._verifiedUsageRecordsByChannel.set(channelId, records);
+    this._usageManifestStore?.replace(channelId, records);
+  }
+
+  private _getVerifiedUsageRecords(channelId: string): UsageManifestRecord[] {
+    const existing = this._verifiedUsageRecordsByChannel.get(channelId);
+    if (existing) return existing;
+    const records = this._usageManifestStore?.getRecords(channelId) ?? [];
+    this._verifiedUsageRecordsByChannel.set(channelId, records);
+    return records;
+  }
+
+  private _clearUsageStateForPeer(peerId: PeerId): void {
+    const prefix = `${peerId}:`;
+    for (const key of this._usageObservations.keys()) {
+      if (key.startsWith(prefix)) this._usageObservations.delete(key);
+    }
+    for (const [key, waiters] of this._usageObservationWaiters) {
+      if (!key.startsWith(prefix)) continue;
+      this._usageObservationWaiters.delete(key);
+      for (const resolve of waiters) resolve(null);
+    }
+  }
+
+  private _usageObservationKey(peerId: PeerId, requestId: string): string {
+    return `${peerId}:${requestId}`;
   }
 
   /**

--- a/packages/node/src/payments/buyer-usage-verifier.ts
+++ b/packages/node/src/payments/buyer-usage-verifier.ts
@@ -1,0 +1,148 @@
+import { keccak256 } from 'ethers';
+import type { NeedAuthPayload } from '../types/protocol.js';
+import type { PeerId } from '../types/peer.js';
+import {
+  buildUsageManifest,
+  buildUsageManifestRecord,
+  computeUsageManifestPointer,
+  type UsageManifestStore,
+  type UsageManifestRecord,
+} from './usage-manifest.js';
+import { encodePointerMetadata } from './evm/signatures.js';
+
+export interface UsageObservationInput {
+  requestId: string;
+  service?: string;
+  costUsdc: bigint;
+  inputTokens: number;
+  cachedInputTokens: number;
+  freshInputTokens: number;
+  outputTokens: number;
+  inputBody: Uint8Array;
+  outputBody: Uint8Array;
+}
+
+interface UsageObservation extends UsageObservationInput {}
+
+export interface VerifiedUsagePointer {
+  record: UsageManifestRecord;
+  encodedMetadata: string;
+  metadataHash: string;
+  requiredCumulativeAmount: bigint;
+}
+
+export class BuyerUsageVerifier {
+  private readonly _observations = new Map<string, UsageObservation>();
+  private readonly _observationWaiters = new Map<string, Array<(value: UsageObservation | null) => void>>();
+  private readonly _verifiedRecordsByChannel = new Map<string, UsageManifestRecord[]>();
+
+  constructor(private readonly _store: UsageManifestStore | null = null) {}
+
+  get pendingObservationCount(): number {
+    return this._observations.size;
+  }
+
+  recordObservation(peerId: PeerId, observation: UsageObservationInput): void {
+    const key = this._observationKey(peerId, observation.requestId);
+    this._observations.set(key, observation);
+    const waiters = this._observationWaiters.get(key);
+    if (!waiters) return;
+    this._observationWaiters.delete(key);
+    for (const resolve of waiters) resolve(observation);
+  }
+
+  async verifyPointer(peerId: PeerId, payload: NeedAuthPayload): Promise<VerifiedUsagePointer | null> {
+    if (!payload.requestId || !payload.usageCid || !payload.usageRoot) return null;
+    const key = this._observationKey(peerId, payload.requestId);
+    const observation = await this._waitForObservation(key, 2_000);
+    this._observations.delete(key);
+    if (!observation) return null;
+
+    const requiredCumulativeAmount = BigInt(payload.requiredCumulativeAmount);
+    const record = buildUsageManifestRecord({
+      requestId: observation.requestId,
+      service: observation.service,
+      costUsdc: BigInt(payload.lastRequestCost ?? observation.costUsdc),
+      cumulativeCostUsdc: requiredCumulativeAmount,
+      inputTokens: observation.inputTokens,
+      cachedInputTokens: observation.cachedInputTokens,
+      freshInputTokens: observation.freshInputTokens,
+      outputTokens: observation.outputTokens,
+      inputBody: observation.inputBody,
+      outputBody: observation.outputBody,
+    });
+    const previous = this._getVerifiedRecords(payload.channelId);
+    const pointer = computeUsageManifestPointer(buildUsageManifest(payload.channelId, [...previous, record]));
+    const rootMatches = pointer.usageRoot.toLowerCase() === payload.usageRoot.toLowerCase();
+    const cidMatches = pointer.cid === payload.usageCid;
+    if (!rootMatches || !cidMatches) return null;
+
+    const encodedMetadata = encodePointerMetadata(payload.usageCid, payload.usageRoot);
+    return {
+      record,
+      encodedMetadata,
+      metadataHash: keccak256(encodedMetadata),
+      requiredCumulativeAmount,
+    };
+  }
+
+  commit(channelId: string, record: UsageManifestRecord): void {
+    const records = this._getVerifiedRecords(channelId);
+    records.push(record);
+    this._verifiedRecordsByChannel.set(channelId, records);
+    this._store?.replace(channelId, records);
+  }
+
+  clearPeer(peerId: PeerId): void {
+    const prefix = `${peerId}:`;
+    for (const key of this._observations.keys()) {
+      if (key.startsWith(prefix)) this._observations.delete(key);
+    }
+    for (const [key, waiters] of this._observationWaiters) {
+      if (!key.startsWith(prefix)) continue;
+      this._observationWaiters.delete(key);
+      for (const resolve of waiters) resolve(null);
+    }
+  }
+
+  cleanup(): void {
+    this._observations.clear();
+    for (const waiters of this._observationWaiters.values()) {
+      for (const resolve of waiters) resolve(null);
+    }
+    this._observationWaiters.clear();
+    this._verifiedRecordsByChannel.clear();
+  }
+
+  private _getVerifiedRecords(channelId: string): UsageManifestRecord[] {
+    const existing = this._verifiedRecordsByChannel.get(channelId);
+    if (existing) return existing;
+    const records = this._store?.getRecords(channelId) ?? [];
+    this._verifiedRecordsByChannel.set(channelId, records);
+    return records;
+  }
+
+  private async _waitForObservation(key: string, timeoutMs: number): Promise<UsageObservation | null> {
+    const existing = this._observations.get(key);
+    if (existing) return existing;
+    return await new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        const waiters = this._observationWaiters.get(key)?.filter((entry) => entry !== wrapped);
+        if (waiters && waiters.length > 0) this._observationWaiters.set(key, waiters);
+        else this._observationWaiters.delete(key);
+        resolve(null);
+      }, timeoutMs);
+      const wrapped = (value: UsageObservation | null): void => {
+        clearTimeout(timer);
+        resolve(value);
+      };
+      const waiters = this._observationWaiters.get(key) ?? [];
+      waiters.push(wrapped);
+      this._observationWaiters.set(key, waiters);
+    });
+  }
+
+  private _observationKey(peerId: PeerId, requestId: string): string {
+    return `${peerId}:${requestId}`;
+  }
+}

--- a/packages/node/src/payments/buyer-usage-verifier.ts
+++ b/packages/node/src/payments/buyer-usage-verifier.ts
@@ -1,12 +1,12 @@
 import { keccak256 } from 'ethers';
-import type { NeedAuthPayload } from '../types/protocol.js';
 import type { PeerId } from '../types/peer.js';
 import {
-  buildUsageManifest,
+  buildUsageLeafBatch,
   buildUsageManifestRecord,
-  computeUsageManifestPointer,
+  computeUsageLeafBatchPointer,
+  type UsageLeaf,
+  type UsageLeafBatch,
   type UsageManifestStore,
-  type UsageManifestRecord,
 } from './usage-manifest.js';
 import { encodePointerMetadata } from './evm/signatures.js';
 
@@ -14,6 +14,7 @@ export interface UsageObservationInput {
   requestId: string;
   service?: string;
   costUsdc: bigint;
+  cumulativeCostUsdc: bigint;
   inputTokens: number;
   cachedInputTokens: number;
   freshInputTokens: number;
@@ -22,52 +23,33 @@ export interface UsageObservationInput {
   outputBody: Uint8Array;
 }
 
-interface UsageObservation extends UsageObservationInput {}
-
-export interface VerifiedUsagePointer {
-  record: UsageManifestRecord;
+export interface PendingUsageBatch {
+  batch: UsageLeafBatch;
   encodedMetadata: string;
   metadataHash: string;
-  requiredCumulativeAmount: bigint;
+  usageRoot: string;
+  usageCid: string;
+  leaves: UsageLeaf[];
 }
 
 export class BuyerUsageVerifier {
-  private readonly _observations = new Map<string, UsageObservation>();
-  private readonly _observationWaiters = new Map<string, Array<(value: UsageObservation | null) => void>>();
-  private readonly _verifiedRecordsByChannel = new Map<string, UsageManifestRecord[]>();
-  private readonly _divergedChannels = new Set<string>();
+  private readonly _pendingLeavesByPeer = new Map<string, UsageLeaf[]>();
+  private readonly _usageRootsByChannel = new Map<string, string>();
 
   constructor(private readonly _store: UsageManifestStore | null = null) {}
 
   get pendingObservationCount(): number {
-    return this._observations.size;
+    let count = 0;
+    for (const leaves of this._pendingLeavesByPeer.values()) count += leaves.length;
+    return count;
   }
 
   recordObservation(peerId: PeerId, observation: UsageObservationInput): void {
-    const key = this._observationKey(peerId, observation.requestId);
-    this._observations.set(key, observation);
-    const waiters = this._observationWaiters.get(key);
-    if (!waiters) return;
-    this._observationWaiters.delete(key);
-    for (const resolve of waiters) resolve(observation);
-  }
-
-  async verifyPointer(peerId: PeerId, payload: NeedAuthPayload): Promise<VerifiedUsagePointer | null> {
-    if (!payload.requestId || !payload.usageCid || !payload.usageRoot) return null;
-    const key = this._observationKey(peerId, payload.requestId);
-    const observation = await this._waitForObservation(key, 2_000);
-    this._observations.delete(key);
-    if (!observation) {
-      this._markDiverged(payload.channelId);
-      return null;
-    }
-
-    const requiredCumulativeAmount = BigInt(payload.requiredCumulativeAmount);
-    const record = buildUsageManifestRecord({
+    const leaf = buildUsageManifestRecord({
       requestId: observation.requestId,
       service: observation.service,
-      costUsdc: BigInt(payload.lastRequestCost ?? observation.costUsdc),
-      cumulativeCostUsdc: requiredCumulativeAmount,
+      costUsdc: observation.costUsdc,
+      cumulativeCostUsdc: observation.cumulativeCostUsdc,
       inputTokens: observation.inputTokens,
       cachedInputTokens: observation.cachedInputTokens,
       freshInputTokens: observation.freshInputTokens,
@@ -75,90 +57,57 @@ export class BuyerUsageVerifier {
       inputBody: observation.inputBody,
       outputBody: observation.outputBody,
     });
-    const previous = this._getVerifiedRecords(payload.channelId);
-    const pointer = computeUsageManifestPointer(buildUsageManifest(payload.channelId, [...previous, record]));
-    const rootMatches = pointer.usageRoot.toLowerCase() === payload.usageRoot.toLowerCase();
-    const cidMatches = pointer.cid === payload.usageCid;
-    if (!rootMatches || !cidMatches) {
-      this._markDiverged(payload.channelId);
-      return null;
-    }
+    const pending = this._pendingLeavesByPeer.get(peerId) ?? [];
+    pending.push(leaf);
+    this._pendingLeavesByPeer.set(peerId, pending);
+  }
 
-    const encodedMetadata = encodePointerMetadata(payload.usageCid, payload.usageRoot);
+  buildPendingBatch(peerId: PeerId, channelId: string): PendingUsageBatch | null {
+    const leaves = this._pendingLeavesByPeer.get(peerId);
+    if (!leaves || leaves.length === 0) return null;
+    const prevRoot = this._getUsageRoot(channelId);
+    const batch = buildUsageLeafBatch(prevRoot, leaves);
+    const pointer = computeUsageLeafBatchPointer(batch);
+    const encodedMetadata = encodePointerMetadata(pointer.cid, pointer.usageRoot);
     return {
-      record,
+      batch,
       encodedMetadata,
       metadataHash: keccak256(encodedMetadata),
-      requiredCumulativeAmount,
+      usageRoot: pointer.usageRoot,
+      usageCid: pointer.cid,
+      leaves: [...leaves],
     };
   }
 
-  commit(channelId: string, record: UsageManifestRecord): void {
-    const records = this._getVerifiedRecords(channelId);
-    records.push(record);
-    this._verifiedRecordsByChannel.set(channelId, records);
-    this._store?.replace(channelId, records);
+  commitBatch(peerId: PeerId, channelId: string, batch: UsageLeafBatch): void {
+    this._store?.appendLeafBatch(channelId, batch);
+    this._usageRootsByChannel.set(channelId, batch.usageRoot);
+    const pending = this._pendingLeavesByPeer.get(peerId) ?? [];
+    const remaining = pending.slice(batch.leaves.length);
+    if (remaining.length > 0) this._pendingLeavesByPeer.set(peerId, remaining);
+    else this._pendingLeavesByPeer.delete(peerId);
   }
 
-  isChannelDiverged(channelId: string): boolean {
-    return this._divergedChannels.has(channelId.toLowerCase());
+  getCommittedCumulativeCost(channelId: string): bigint {
+    const records = this._store?.getRecords(channelId) ?? [];
+    const last = records.at(-1);
+    return last ? BigInt(last.cumulativeCostUsdc) : 0n;
   }
 
   clearPeer(peerId: PeerId): void {
-    const prefix = `${peerId}:`;
-    for (const key of this._observations.keys()) {
-      if (key.startsWith(prefix)) this._observations.delete(key);
-    }
-    for (const [key, waiters] of this._observationWaiters) {
-      if (!key.startsWith(prefix)) continue;
-      this._observationWaiters.delete(key);
-      for (const resolve of waiters) resolve(null);
-    }
+    this._pendingLeavesByPeer.delete(peerId);
   }
 
   cleanup(): void {
-    this._observations.clear();
-    for (const waiters of this._observationWaiters.values()) {
-      for (const resolve of waiters) resolve(null);
-    }
-    this._observationWaiters.clear();
-    this._verifiedRecordsByChannel.clear();
-    this._divergedChannels.clear();
+    this._pendingLeavesByPeer.clear();
+    this._usageRootsByChannel.clear();
   }
 
-  private _getVerifiedRecords(channelId: string): UsageManifestRecord[] {
-    const existing = this._verifiedRecordsByChannel.get(channelId);
+  private _getUsageRoot(channelId: string): string {
+    const existing = this._usageRootsByChannel.get(channelId);
     if (existing) return existing;
-    const records = this._store?.getRecords(channelId) ?? [];
-    this._verifiedRecordsByChannel.set(channelId, records);
-    return records;
-  }
-
-  private async _waitForObservation(key: string, timeoutMs: number): Promise<UsageObservation | null> {
-    const existing = this._observations.get(key);
-    if (existing) return existing;
-    return await new Promise((resolve) => {
-      const timer = setTimeout(() => {
-        const waiters = this._observationWaiters.get(key)?.filter((entry) => entry !== wrapped);
-        if (waiters && waiters.length > 0) this._observationWaiters.set(key, waiters);
-        else this._observationWaiters.delete(key);
-        resolve(null);
-      }, timeoutMs);
-      const wrapped = (value: UsageObservation | null): void => {
-        clearTimeout(timer);
-        resolve(value);
-      };
-      const waiters = this._observationWaiters.get(key) ?? [];
-      waiters.push(wrapped);
-      this._observationWaiters.set(key, waiters);
-    });
-  }
-
-  private _observationKey(peerId: PeerId, requestId: string): string {
-    return `${peerId}:${requestId}`;
-  }
-
-  private _markDiverged(channelId: string): void {
-    this._divergedChannels.add(channelId.toLowerCase());
+    const root = this._store?.getUsageRoot(channelId) ?? `0x${'00'.repeat(32)}`;
+    this._usageRootsByChannel.set(channelId, root);
+    return root;
   }
 }

--- a/packages/node/src/payments/buyer-usage-verifier.ts
+++ b/packages/node/src/payments/buyer-usage-verifier.ts
@@ -35,6 +35,7 @@ export class BuyerUsageVerifier {
   private readonly _observations = new Map<string, UsageObservation>();
   private readonly _observationWaiters = new Map<string, Array<(value: UsageObservation | null) => void>>();
   private readonly _verifiedRecordsByChannel = new Map<string, UsageManifestRecord[]>();
+  private readonly _divergedChannels = new Set<string>();
 
   constructor(private readonly _store: UsageManifestStore | null = null) {}
 
@@ -56,7 +57,10 @@ export class BuyerUsageVerifier {
     const key = this._observationKey(peerId, payload.requestId);
     const observation = await this._waitForObservation(key, 2_000);
     this._observations.delete(key);
-    if (!observation) return null;
+    if (!observation) {
+      this._markDiverged(payload.channelId);
+      return null;
+    }
 
     const requiredCumulativeAmount = BigInt(payload.requiredCumulativeAmount);
     const record = buildUsageManifestRecord({
@@ -75,7 +79,10 @@ export class BuyerUsageVerifier {
     const pointer = computeUsageManifestPointer(buildUsageManifest(payload.channelId, [...previous, record]));
     const rootMatches = pointer.usageRoot.toLowerCase() === payload.usageRoot.toLowerCase();
     const cidMatches = pointer.cid === payload.usageCid;
-    if (!rootMatches || !cidMatches) return null;
+    if (!rootMatches || !cidMatches) {
+      this._markDiverged(payload.channelId);
+      return null;
+    }
 
     const encodedMetadata = encodePointerMetadata(payload.usageCid, payload.usageRoot);
     return {
@@ -91,6 +98,10 @@ export class BuyerUsageVerifier {
     records.push(record);
     this._verifiedRecordsByChannel.set(channelId, records);
     this._store?.replace(channelId, records);
+  }
+
+  isChannelDiverged(channelId: string): boolean {
+    return this._divergedChannels.has(channelId.toLowerCase());
   }
 
   clearPeer(peerId: PeerId): void {
@@ -112,6 +123,7 @@ export class BuyerUsageVerifier {
     }
     this._observationWaiters.clear();
     this._verifiedRecordsByChannel.clear();
+    this._divergedChannels.clear();
   }
 
   private _getVerifiedRecords(channelId: string): UsageManifestRecord[] {
@@ -144,5 +156,9 @@ export class BuyerUsageVerifier {
 
   private _observationKey(peerId: PeerId, requestId: string): string {
     return `${peerId}:${requestId}`;
+  }
+
+  private _markDiverged(channelId: string): void {
+    this._divergedChannels.add(channelId.toLowerCase());
   }
 }

--- a/packages/node/src/payments/evm/signatures.ts
+++ b/packages/node/src/payments/evm/signatures.ts
@@ -59,6 +59,7 @@ export interface SpendingAuthMetadata {
 }
 
 export const METADATA_VERSION = 1n;
+export const POINTER_METADATA_VERSION = 2n;
 
 export function encodeMetadata(metadata: SpendingAuthMetadata): string {
   const coder = AbiCoder.defaultAbiCoder();
@@ -70,6 +71,16 @@ export function encodeMetadata(metadata: SpendingAuthMetadata): string {
 
 export function computeMetadataHash(metadata: SpendingAuthMetadata): string {
   return keccak256(encodeMetadata(metadata));
+}
+
+export function encodePointerMetadata(cid: string | Uint8Array, usageRoot: string): string {
+  const coder = AbiCoder.defaultAbiCoder();
+  const cidBytes = typeof cid === 'string' ? new TextEncoder().encode(cid) : cid;
+  return coder.encode(['uint256', 'bytes', 'bytes32'], [POINTER_METADATA_VERSION, cidBytes, usageRoot]);
+}
+
+export function computePointerMetadataHash(cid: string | Uint8Array, usageRoot: string): string {
+  return keccak256(encodePointerMetadata(cid, usageRoot));
 }
 
 export const ZERO_METADATA: SpendingAuthMetadata = {

--- a/packages/node/src/payments/evm/stats-client.ts
+++ b/packages/node/src/payments/evm/stats-client.ts
@@ -21,8 +21,22 @@ export interface DecodedMetadataRecorded {
   requestCount: bigint; // delta
 }
 
+export interface DecodedMetadataPointerRecorded {
+  blockNumber: number;
+  txHash: string;
+  logIndex: number;
+  agentId: bigint;
+  buyer: string;
+  channelId: string;
+  metadataHash: string;
+  cid: string;
+  cidBytes: string;
+  usageRoot: string;
+}
+
 const STATS_ABI = [
   'event MetadataRecorded(uint256 indexed agentId, address indexed buyer, bytes32 indexed channelId, bytes32 metadataHash, uint256 inputTokens, uint256 outputTokens, uint256 requestCount)',
+  'event MetadataPointerRecorded(uint256 indexed agentId, address indexed buyer, bytes32 indexed channelId, bytes32 metadataHash, bytes cid, bytes32 usageRoot)',
 ] as const;
 
 export class StatsClient extends BaseEvmClient {
@@ -71,7 +85,55 @@ export class StatsClient extends BaseEvmClient {
     return out;
   }
 
+  async getMetadataPointerRecordedEvents(params: {
+    fromBlock: number;
+    toBlock: number;
+  }): Promise<DecodedMetadataPointerRecorded[]> {
+    const iface = new ethers.Interface(STATS_ABI);
+    const topic = iface.getEvent('MetadataPointerRecorded')!.topicHash;
+
+    const logs = await this._provider.getLogs({
+      address: this._contractAddress,
+      fromBlock: params.fromBlock,
+      toBlock: params.toBlock,
+      topics: [topic],
+    });
+
+    const out: DecodedMetadataPointerRecorded[] = [];
+    for (const log of logs) {
+      const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
+      if (!parsed || parsed.name !== 'MetadataPointerRecorded') continue;
+      const cidBytes = parsed.args[4] as string;
+      out.push({
+        blockNumber: log.blockNumber,
+        txHash: log.transactionHash,
+        logIndex: log.index,
+        agentId: parsed.args[0] as bigint,
+        buyer: (parsed.args[1] as string).toLowerCase(),
+        channelId: parsed.args[2] as string,
+        metadataHash: parsed.args[3] as string,
+        cid: decodeCid(cidBytes),
+        cidBytes,
+        usageRoot: parsed.args[5] as string,
+      });
+    }
+    out.sort((a, b) =>
+      a.blockNumber !== b.blockNumber ? a.blockNumber - b.blockNumber : a.logIndex - b.logIndex,
+    );
+    return out;
+  }
+
   async getBlockNumber(): Promise<number> {
     return this._provider.getBlockNumber();
   }
+}
+
+function decodeCid(cidBytes: string): string {
+  try {
+    const bytes = ethers.getBytes(cidBytes);
+    const decoded = new TextDecoder().decode(bytes);
+    // Advisory display value only; indexers should preserve cidBytes as canonical.
+    if (/^[\x21-\x7e]+$/.test(decoded)) return decoded;
+  } catch { /* fall through */ }
+  return cidBytes;
 }

--- a/packages/node/src/payments/index.ts
+++ b/packages/node/src/payments/index.ts
@@ -81,10 +81,14 @@ export type {
 // Buyer payment negotiator (402 handling, SpendingAuth flow, cost tracking)
 export { BuyerPaymentNegotiator } from './buyer-payment-negotiator.js';
 export type { BuyerNegotiatorConfig, Handle402Result, NegotiationEmitter } from './buyer-payment-negotiator.js';
+export { BuyerUsageVerifier } from './buyer-usage-verifier.js';
+export type { UsageObservationInput, VerifiedUsagePointer } from './buyer-usage-verifier.js';
 
 // Seller payment manager
 export { SellerPaymentManager, DEFAULT_MIN_SETTLE_DELTA_STR } from './seller-payment-manager.js';
 export type { SellerPaymentConfig } from './seller-payment-manager.js';
+export { SellerUsageWriter } from './seller-usage-writer.js';
+export type { SellerUsagePointer, SellerUsageWriteInput } from './seller-usage-writer.js';
 
 // Pricing utilities
 export { computeCostUsdc, estimateCostFromBytes, estimateTokensFromBytes } from './pricing.js';

--- a/packages/node/src/payments/index.ts
+++ b/packages/node/src/payments/index.ts
@@ -82,7 +82,7 @@ export type {
 export { BuyerPaymentNegotiator } from './buyer-payment-negotiator.js';
 export type { BuyerNegotiatorConfig, Handle402Result, NegotiationEmitter } from './buyer-payment-negotiator.js';
 export { BuyerUsageVerifier } from './buyer-usage-verifier.js';
-export type { UsageObservationInput, VerifiedUsagePointer } from './buyer-usage-verifier.js';
+export type { PendingUsageBatch, UsageObservationInput } from './buyer-usage-verifier.js';
 
 // Seller payment manager
 export { SellerPaymentManager, DEFAULT_MIN_SETTLE_DELTA_STR } from './seller-payment-manager.js';
@@ -96,13 +96,21 @@ export type { ServicePricing } from './pricing.js';
 
 export {
   buildUsageManifest,
+  buildUsageLeafBatch,
   buildUsageManifestRecord,
+  computeUsageLeafBatchPointer,
   computeUsageManifestPointer,
+  computeUsageRoot,
   UsageManifestStore,
+  publishUsageLeafBatchBestEffort,
   publishUsageManifestBestEffort,
+  ZERO_USAGE_ROOT,
 } from './usage-manifest.js';
 export type {
   UsageManifest,
+  UsageLeaf,
+  UsageLeafBatch,
+  UsageLeafBatchPointer,
   UsageManifestPointer,
   UsageManifestRecord,
   UsageManifestRecordInput,

--- a/packages/node/src/payments/index.ts
+++ b/packages/node/src/payments/index.ts
@@ -42,8 +42,11 @@ export {
   RESERVE_AUTH_TYPES,
   SET_OPERATOR_TYPES,
   computeMetadataHash,
+  computePointerMetadataHash,
   encodeMetadata,
+  encodePointerMetadata,
   METADATA_VERSION,
+  POINTER_METADATA_VERSION,
   computeChannelId,
   ZERO_METADATA,
   ZERO_METADATA_HASH,
@@ -68,7 +71,12 @@ export type { StoredChannel, StoredReceipt } from './channel-store.js';
 
 // Buyer payment manager
 export { BuyerPaymentManager } from './buyer-payment-manager.js';
-export type { BuyerPaymentConfig, PerRequestAuthResult } from './buyer-payment-manager.js';
+export type {
+  BuyerPaymentConfig,
+  NeedAuthHandlingOptions,
+  NeedAuthHandlingResult,
+  PerRequestAuthResult,
+} from './buyer-payment-manager.js';
 
 // Buyer payment negotiator (402 handling, SpendingAuth flow, cost tracking)
 export { BuyerPaymentNegotiator } from './buyer-payment-negotiator.js';
@@ -81,6 +89,21 @@ export type { SellerPaymentConfig } from './seller-payment-manager.js';
 // Pricing utilities
 export { computeCostUsdc, estimateCostFromBytes, estimateTokensFromBytes } from './pricing.js';
 export type { ServicePricing } from './pricing.js';
+
+export {
+  buildUsageManifest,
+  buildUsageManifestRecord,
+  computeUsageManifestPointer,
+  UsageManifestStore,
+  publishUsageManifestBestEffort,
+} from './usage-manifest.js';
+export type {
+  UsageManifest,
+  UsageManifestPointer,
+  UsageManifestRecord,
+  UsageManifestRecordInput,
+  UsageManifestServiceTotals,
+} from './usage-manifest.js';
 
 // Readiness checks
 export { checkSellerReadiness, checkBuyerReadiness } from './readiness.js';

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -17,6 +17,7 @@ import { debugLog, debugWarn } from '../utils/debug.js';
 import { peerIdToAddress } from '../types/peer.js';
 import { ChannelStore, type StoredChannel } from './channel-store.js';
 import { classifyOnChainChannel, matchesChannelParties } from './channel-session-state.js';
+import type { SellerUsageWriter } from './seller-usage-writer.js';
 
 export interface SellerPaymentConfig {
   rpcUrl: string;
@@ -139,7 +140,7 @@ export class SellerPaymentManager {
   /** Max close() retries before giving up (buyer must requestClose on-chain) */
   private static readonly MAX_CLOSE_RETRIES = 3;
 
-  constructor(identity: Identity, config: SellerPaymentConfig, channelStore: ChannelStore) {
+  constructor(identity: Identity, config: SellerPaymentConfig, channelStore: ChannelStore, private readonly _usageWriter: SellerUsageWriter | null = null) {
     this._config = config;
     this._signer = identity.wallet;
     const channelsClient = new ChannelsClient({
@@ -608,6 +609,9 @@ export class SellerPaymentManager {
           return 'rejected';
         }
         if (cumulativeAmount === existingCumulative) {
+          if (!this._acceptUsageBatch(channelId, payload, cumulativeAmount)) {
+            return 'rejected';
+          }
           debugLog(`[SellerPayment] Idempotent SpendingAuth (same cumulative=${cumulativeAmount}) — accepted`);
           return 'accepted';
         }
@@ -634,6 +638,10 @@ export class SellerPaymentManager {
             `cumulative=${cumulativeAmount} > reserveMax=${currentReserveMax}` +
             `${pendingTopUpForCheck ? ` (pending topUp to ${pendingTopUpForCheck.newMaxAmount})` : ''} channel=${channelId.slice(0, 18)}...`,
           );
+          return 'rejected';
+        }
+
+        if (!this._acceptUsageBatch(channelId, payload, cumulativeAmount)) {
           return 'rejected';
         }
 
@@ -994,6 +1002,10 @@ export class SellerPaymentManager {
       return false;
     }
 
+    if (!this._acceptUsageBatch(channelId, auth, newCumulative)) {
+      return false;
+    }
+
     this._hydratedChannelIds.delete(channelId);
 
     // Update if strictly greater
@@ -1042,6 +1054,18 @@ export class SellerPaymentManager {
 
     // Persist spent amount to ChannelStore (using tokensDelivered field)
     this._channelStore.updateTokensDelivered(sessionId, newSpent.toString(), 0);
+  }
+
+  private _acceptUsageBatch(channelId: string, payload: SpendingAuthPayload, cumulativeAmount: bigint): boolean {
+    const hasUsageBatch = Boolean(payload.usageLeaves?.length || payload.usageRoot || payload.usageCid);
+    if (!hasUsageBatch) return true;
+    const pointer = this._usageWriter?.acceptSignedBatch(channelId, payload, cumulativeAmount);
+    if (!pointer) {
+      debugWarn(`[SellerPayment] Rejecting SpendingAuth with invalid usage batch for channel=${channelId.slice(0, 18)}...`);
+      return false;
+    }
+    debugLog(`[SellerPayment] Accepted usage batch for channel=${channelId.slice(0, 18)}... cid=${pointer.cid} root=${pointer.usageRoot.slice(0, 18)}...`);
+    return true;
   }
 
   // ── Settlement ──────────────────────────────────────────────

--- a/packages/node/src/payments/seller-usage-writer.ts
+++ b/packages/node/src/payments/seller-usage-writer.ts
@@ -1,0 +1,45 @@
+import type { SerializedHttpRequest } from '../types/http.js';
+import type { parseResponseUsage } from '../utils/response-usage.js';
+import {
+  buildUsageManifestRecord,
+  publishUsageManifestBestEffort,
+  type UsageManifestStore,
+} from './usage-manifest.js';
+
+export interface SellerUsageWriteInput {
+  channelId: string;
+  request: SerializedHttpRequest;
+  responseBody: Uint8Array;
+  service?: string;
+  costUsdc: bigint;
+  cumulativeSpend: bigint;
+  usage: ReturnType<typeof parseResponseUsage>;
+}
+
+export interface SellerUsagePointer {
+  cid: string;
+  usageRoot: string;
+}
+
+export class SellerUsageWriter {
+  constructor(private readonly _store: UsageManifestStore | null = null) {}
+
+  write(input: SellerUsageWriteInput): SellerUsagePointer | null {
+    if (!this._store) return null;
+    const record = buildUsageManifestRecord({
+      requestId: input.request.requestId,
+      service: input.service,
+      costUsdc: input.costUsdc,
+      cumulativeCostUsdc: input.cumulativeSpend,
+      inputTokens: input.usage.inputTokens,
+      cachedInputTokens: input.usage.cachedInputTokens,
+      freshInputTokens: input.usage.freshInputTokens,
+      outputTokens: input.usage.outputTokens,
+      inputBody: input.request.body,
+      outputBody: input.responseBody,
+    });
+    const pointer = this._store.append(input.channelId, record);
+    publishUsageManifestBestEffort(pointer);
+    return { cid: pointer.cid, usageRoot: pointer.usageRoot };
+  }
+}

--- a/packages/node/src/payments/seller-usage-writer.ts
+++ b/packages/node/src/payments/seller-usage-writer.ts
@@ -1,10 +1,17 @@
+import { keccak256 } from 'ethers';
 import type { SerializedHttpRequest } from '../types/http.js';
+import type { SpendingAuthPayload } from '../types/protocol.js';
 import type { parseResponseUsage } from '../utils/response-usage.js';
 import {
+  buildUsageLeafBatch,
   buildUsageManifestRecord,
+  computeUsageLeafBatchPointer,
   publishUsageManifestBestEffort,
+  publishUsageLeafBatchBestEffort,
+  type UsageLeaf,
   type UsageManifestStore,
 } from './usage-manifest.js';
+import { encodePointerMetadata } from './evm/signatures.js';
 
 export interface SellerUsageWriteInput {
   channelId: string;
@@ -21,12 +28,77 @@ export interface SellerUsagePointer {
   usageRoot: string;
 }
 
+interface PendingSellerUsage {
+  expected: UsageLeaf;
+  minCostUsdc: bigint;
+}
+
 export class SellerUsageWriter {
+  private readonly _pendingByChannel = new Map<string, Map<string, PendingSellerUsage>>();
+
   constructor(private readonly _store: UsageManifestStore | null = null) {}
+
+  recordObservation(input: SellerUsageWriteInput): void {
+    const record = this._buildRecord(input);
+    const channel = this._pendingByChannel.get(input.channelId) ?? new Map<string, PendingSellerUsage>();
+    channel.set(input.request.requestId, {
+      expected: record,
+      minCostUsdc: input.costUsdc,
+    });
+    this._pendingByChannel.set(input.channelId, channel);
+  }
+
+  acceptSignedBatch(
+    channelId: string,
+    payload: SpendingAuthPayload,
+    signedCumulativeAmount: bigint,
+  ): SellerUsagePointer | null {
+    if (!this._store) return null;
+    if (!payload.usageLeaves || payload.usageLeaves.length === 0 || !payload.usageRoot || !payload.usageCid) {
+      return null;
+    }
+
+    const pending = this._pendingByChannel.get(channelId);
+    if (!pending) return null;
+
+    for (const leaf of payload.usageLeaves) {
+      const observed = pending.get(leaf.requestId);
+      if (!observed || !this._leafMatchesObservation(leaf, observed, signedCumulativeAmount)) {
+        return null;
+      }
+    }
+
+    const prevRoot = this._store.getUsageRoot(channelId);
+    const batch = buildUsageLeafBatch(prevRoot, payload.usageLeaves);
+    const pointer = computeUsageLeafBatchPointer(batch);
+    if (pointer.usageRoot.toLowerCase() !== payload.usageRoot.toLowerCase() || pointer.cid !== payload.usageCid) {
+      return null;
+    }
+    const encodedMetadata = encodePointerMetadata(pointer.cid, pointer.usageRoot);
+    if (encodedMetadata.toLowerCase() !== payload.metadata.toLowerCase()) {
+      return null;
+    }
+    if (keccak256(encodedMetadata).toLowerCase() !== payload.metadataHash.toLowerCase()) {
+      return null;
+    }
+
+    const stored = this._store.appendLeafBatch(channelId, batch);
+    publishUsageLeafBatchBestEffort(stored);
+    for (const leaf of payload.usageLeaves) pending.delete(leaf.requestId);
+    if (pending.size === 0) this._pendingByChannel.delete(channelId);
+    return { cid: pointer.cid, usageRoot: pointer.usageRoot };
+  }
 
   write(input: SellerUsageWriteInput): SellerUsagePointer | null {
     if (!this._store) return null;
-    const record = buildUsageManifestRecord({
+    const record = this._buildRecord(input);
+    const pointer = this._store.append(input.channelId, record);
+    publishUsageManifestBestEffort(pointer);
+    return { cid: pointer.cid, usageRoot: pointer.usageRoot };
+  }
+
+  private _buildRecord(input: SellerUsageWriteInput): UsageLeaf {
+    return buildUsageManifestRecord({
       requestId: input.request.requestId,
       service: input.service,
       costUsdc: input.costUsdc,
@@ -38,8 +110,28 @@ export class SellerUsageWriter {
       inputBody: input.request.body,
       outputBody: input.responseBody,
     });
-    const pointer = this._store.append(input.channelId, record);
-    publishUsageManifestBestEffort(pointer);
-    return { cid: pointer.cid, usageRoot: pointer.usageRoot };
+  }
+
+  private _leafMatchesObservation(
+    leaf: UsageLeaf,
+    observed: PendingSellerUsage,
+    signedCumulativeAmount: bigint,
+  ): boolean {
+    const expected = observed.expected;
+    if (leaf.requestId !== expected.requestId) return false;
+    if ((leaf.service ?? '') !== (expected.service ?? '')) return false;
+    if (leaf.inputSha256.toLowerCase() !== expected.inputSha256.toLowerCase()) return false;
+    if (leaf.outputSha256.toLowerCase() !== expected.outputSha256.toLowerCase()) return false;
+    if (leaf.inputTokens !== expected.inputTokens) return false;
+    if (leaf.cachedInputTokens !== expected.cachedInputTokens) return false;
+    if (leaf.freshInputTokens !== expected.freshInputTokens) return false;
+    if (leaf.outputTokens !== expected.outputTokens) return false;
+    try {
+      if (BigInt(leaf.costUsdc) < observed.minCostUsdc) return false;
+      if (BigInt(leaf.cumulativeCostUsdc) > signedCumulativeAmount) return false;
+    } catch {
+      return false;
+    }
+    return true;
   }
 }

--- a/packages/node/src/payments/usage-manifest.ts
+++ b/packages/node/src/payments/usage-manifest.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { keccak256 } from 'ethers';
 
 const encoder = new TextEncoder();
 const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
@@ -29,6 +30,17 @@ export interface UsageManifestRecord {
   outputTokens: string;
   inputSha256: string;
   outputSha256: string;
+}
+
+export type UsageLeaf = UsageManifestRecord;
+
+export const ZERO_USAGE_ROOT = `0x${'00'.repeat(32)}`;
+
+export interface UsageLeafBatch {
+  version: 1;
+  prevRoot: string;
+  usageRoot: string;
+  leaves: UsageLeaf[];
 }
 
 export interface UsageManifestServiceTotals {
@@ -60,6 +72,13 @@ export interface UsageManifestPointer {
   usageRoot: string;
   bytes: Uint8Array;
   manifest: UsageManifest;
+}
+
+export interface UsageLeafBatchPointer {
+  cid: string;
+  usageRoot: string;
+  bytes: Uint8Array;
+  batch: UsageLeafBatch;
 }
 
 export function sha256Hex(bytes: Uint8Array): string {
@@ -146,6 +165,46 @@ export function canonicalJson(value: unknown): string {
   return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`).join(',')}}`;
 }
 
+export function computeUsageLeafHash(leaf: UsageLeaf): Uint8Array {
+  return createHash('sha256').update(encoder.encode(canonicalJson(leaf))).digest();
+}
+
+export function extendUsageRoot(prevRoot: string, leaf: UsageLeaf): string {
+  const normalizedPrevRoot = normalizeBytes32(prevRoot);
+  const prev = Buffer.from(normalizedPrevRoot.slice(2), 'hex');
+  const leafHash = computeUsageLeafHash(leaf);
+  return keccak256(Buffer.concat([prev, leafHash]));
+}
+
+export function computeUsageRoot(prevRoot: string, leaves: UsageLeaf[]): string {
+  let root = normalizeBytes32(prevRoot);
+  for (const leaf of leaves) {
+    root = extendUsageRoot(root, leaf);
+  }
+  return root;
+}
+
+export function buildUsageLeafBatch(prevRoot: string, leaves: UsageLeaf[]): UsageLeafBatch {
+  const normalizedPrevRoot = normalizeBytes32(prevRoot);
+  return {
+    version: 1,
+    prevRoot: normalizedPrevRoot,
+    usageRoot: computeUsageRoot(normalizedPrevRoot, leaves),
+    leaves,
+  };
+}
+
+export function computeUsageLeafBatchPointer(batch: UsageLeafBatch): UsageLeafBatchPointer {
+  const bytes = encoder.encode(canonicalJson(batch));
+  const hash = createHash('sha256').update(bytes).digest();
+  return {
+    cid: rawSha256CidV1(hash),
+    usageRoot: normalizeBytes32(batch.usageRoot),
+    bytes,
+    batch,
+  };
+}
+
 export function computeUsageManifestPointer(manifest: UsageManifest): UsageManifestPointer {
   const bytes = encoder.encode(canonicalJson(manifest));
   const hash = createHash('sha256').update(bytes).digest();
@@ -160,6 +219,7 @@ export function computeUsageManifestPointer(manifest: UsageManifest): UsageManif
 
 export class UsageManifestStore {
   private readonly _records = new Map<string, UsageManifestRecord[]>();
+  private readonly _usageRoots = new Map<string, string>();
 
   constructor(private readonly _baseDir: string) {
     mkdirSync(_baseDir, { recursive: true });
@@ -167,6 +227,10 @@ export class UsageManifestStore {
 
   getRecords(channelId: string): UsageManifestRecord[] {
     return [...this._getRecords(channelId)];
+  }
+
+  getUsageRoot(channelId: string): string {
+    return this._getUsageRoot(channelId);
   }
 
   append(channelId: string, record: UsageManifestRecord): UsageManifestPointer {
@@ -186,6 +250,34 @@ export class UsageManifestStore {
 
   computePointer(channelId: string, records: UsageManifestRecord[] = this.getRecords(channelId)): UsageManifestPointer {
     return computeUsageManifestPointer(buildUsageManifest(channelId, records));
+  }
+
+  appendLeafBatch(channelId: string, batch: UsageLeafBatch): UsageLeafBatchPointer {
+    const currentRoot = this._getUsageRoot(channelId);
+    if (batch.prevRoot.toLowerCase() !== currentRoot.toLowerCase()) {
+      throw new Error(`usage leaf batch prevRoot ${batch.prevRoot} does not match current root ${currentRoot}`);
+    }
+    const computedRoot = computeUsageRoot(batch.prevRoot, batch.leaves);
+    if (computedRoot.toLowerCase() !== batch.usageRoot.toLowerCase()) {
+      throw new Error(`usage leaf batch root mismatch`);
+    }
+    const records = this._getRecords(channelId);
+    const dir = this._channelDir(channelId);
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(join(dir, 'batches.jsonl'), `${JSON.stringify(batch)}\n`);
+    appendFileSync(join(dir, 'records.jsonl'), batch.leaves.map((leaf) => JSON.stringify(leaf)).join('\n') + (batch.leaves.length > 0 ? '\n' : ''));
+    writeFileSync(join(dir, 'latest-root'), batch.usageRoot);
+    this._usageRoots.set(channelId, batch.usageRoot);
+    records.push(...batch.leaves);
+    return this.writeLeafBatch(batch);
+  }
+
+  writeLeafBatch(batch: UsageLeafBatch): UsageLeafBatchPointer {
+    const pointer = computeUsageLeafBatchPointer(batch);
+    const dir = this._channelDir(batch.usageRoot);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${pointer.cid}.json`), pointer.bytes);
+    return pointer;
   }
 
   private _write(channelId: string, records: UsageManifestRecord[]): UsageManifestPointer {
@@ -222,9 +314,39 @@ export class UsageManifestStore {
     return records;
   }
 
+  private _getUsageRoot(channelId: string): string {
+    const existing = this._usageRoots.get(channelId);
+    if (existing) return existing;
+
+    const dir = this._channelDir(channelId);
+    const path = join(dir, 'latest-root');
+    let root = ZERO_USAGE_ROOT;
+    try {
+      const raw = readFileSync(path, 'utf8').trim();
+      root = normalizeBytes32(raw);
+    } catch {
+      const records = this._getRecords(channelId);
+      root = computeUsageRoot(ZERO_USAGE_ROOT, records);
+    }
+    this._usageRoots.set(channelId, root);
+    return root;
+  }
+
   private _channelDir(channelId: string): string {
     return join(this._baseDir, channelId.replace(/^0x/, ''));
   }
+}
+
+export function publishUsageLeafBatchBestEffort(pointer: UsageLeafBatchPointer): void {
+  const endpoint = process.env['ANTSEED_IPFS_API_URL'];
+  if (!endpoint || typeof fetch !== 'function') return;
+
+  const form = new FormData();
+  form.append('file', new Blob([pointer.bytes], { type: 'application/json' }), `${pointer.cid}.json`);
+  void fetch(`${endpoint.replace(/\/$/, '')}/api/v0/add?cid-version=1&raw-leaves=true&pin=true`, {
+    method: 'POST',
+    body: form,
+  }).catch(() => undefined);
 }
 
 export function publishUsageManifestBestEffort(pointer: UsageManifestPointer): void {
@@ -242,6 +364,13 @@ export function publishUsageManifestBestEffort(pointer: UsageManifestPointer): v
 function rawSha256CidV1(hash: Buffer): string {
   const cidBytes = Buffer.concat([Buffer.from([0x01, 0x55, 0x12, 0x20]), hash]);
   return `b${base32(cidBytes)}`;
+}
+
+function normalizeBytes32(value: string): string {
+  if (!/^0x[0-9a-fA-F]{64}$/.test(value)) {
+    throw new Error(`expected bytes32 hex value`);
+  }
+  return value.toLowerCase();
 }
 
 function base32(bytes: Uint8Array): string {

--- a/packages/node/src/payments/usage-manifest.ts
+++ b/packages/node/src/payments/usage-manifest.ts
@@ -1,0 +1,263 @@
+import { createHash } from 'node:crypto';
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const encoder = new TextEncoder();
+const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+
+export interface UsageManifestRecordInput {
+  requestId: string;
+  service?: string;
+  costUsdc: bigint;
+  cumulativeCostUsdc: bigint;
+  inputTokens: number | bigint;
+  cachedInputTokens: number | bigint;
+  freshInputTokens: number | bigint;
+  outputTokens: number | bigint;
+  inputBody: Uint8Array;
+  outputBody: Uint8Array;
+}
+
+export interface UsageManifestRecord {
+  requestId: string;
+  service?: string;
+  costUsdc: string;
+  cumulativeCostUsdc: string;
+  inputTokens: string;
+  cachedInputTokens: string;
+  freshInputTokens: string;
+  outputTokens: string;
+  inputSha256: string;
+  outputSha256: string;
+}
+
+export interface UsageManifestServiceTotals {
+  costUsdc: string;
+  inputTokens: string;
+  cachedInputTokens: string;
+  freshInputTokens: string;
+  outputTokens: string;
+  requestCount: string;
+}
+
+export interface UsageManifest {
+  version: 1;
+  channelId: string;
+  records: UsageManifestRecord[];
+  totals: {
+    costUsdc: string;
+    inputTokens: string;
+    cachedInputTokens: string;
+    freshInputTokens: string;
+    outputTokens: string;
+    requestCount: string;
+  };
+  services: Record<string, UsageManifestServiceTotals>;
+}
+
+export interface UsageManifestPointer {
+  cid: string;
+  usageRoot: string;
+  bytes: Uint8Array;
+  manifest: UsageManifest;
+}
+
+export function sha256Hex(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+export function buildUsageManifestRecord(input: UsageManifestRecordInput): UsageManifestRecord {
+  const record: UsageManifestRecord = {
+    requestId: input.requestId,
+    costUsdc: input.costUsdc.toString(),
+    cumulativeCostUsdc: input.cumulativeCostUsdc.toString(),
+    inputTokens: BigInt(input.inputTokens).toString(),
+    cachedInputTokens: BigInt(input.cachedInputTokens).toString(),
+    freshInputTokens: BigInt(input.freshInputTokens).toString(),
+    outputTokens: BigInt(input.outputTokens).toString(),
+    inputSha256: sha256Hex(input.inputBody),
+    outputSha256: sha256Hex(input.outputBody),
+  };
+  if (input.service) record.service = input.service;
+  return record;
+}
+
+export function buildUsageManifest(channelId: string, records: UsageManifestRecord[]): UsageManifest {
+  const services: Record<string, UsageManifestServiceTotals> = {};
+  let costUsdc = 0n;
+  let inputTokens = 0n;
+  let cachedInputTokens = 0n;
+  let freshInputTokens = 0n;
+  let outputTokens = 0n;
+
+  for (const record of records) {
+    const service = record.service ?? 'unknown';
+    const serviceTotals = services[service] ?? {
+      costUsdc: '0',
+      inputTokens: '0',
+      cachedInputTokens: '0',
+      freshInputTokens: '0',
+      outputTokens: '0',
+      requestCount: '0',
+    };
+
+    costUsdc += BigInt(record.costUsdc);
+    inputTokens += BigInt(record.inputTokens);
+    cachedInputTokens += BigInt(record.cachedInputTokens);
+    freshInputTokens += BigInt(record.freshInputTokens);
+    outputTokens += BigInt(record.outputTokens);
+
+    services[service] = {
+      costUsdc: (BigInt(serviceTotals.costUsdc) + BigInt(record.costUsdc)).toString(),
+      inputTokens: (BigInt(serviceTotals.inputTokens) + BigInt(record.inputTokens)).toString(),
+      cachedInputTokens: (BigInt(serviceTotals.cachedInputTokens) + BigInt(record.cachedInputTokens)).toString(),
+      freshInputTokens: (BigInt(serviceTotals.freshInputTokens) + BigInt(record.freshInputTokens)).toString(),
+      outputTokens: (BigInt(serviceTotals.outputTokens) + BigInt(record.outputTokens)).toString(),
+      requestCount: (BigInt(serviceTotals.requestCount) + 1n).toString(),
+    };
+  }
+
+  return {
+    version: 1,
+    channelId,
+    records,
+    totals: {
+      costUsdc: costUsdc.toString(),
+      inputTokens: inputTokens.toString(),
+      cachedInputTokens: cachedInputTokens.toString(),
+      freshInputTokens: freshInputTokens.toString(),
+      outputTokens: outputTokens.toString(),
+      requestCount: records.length.toString(),
+    },
+    services,
+  };
+}
+
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJson(entry)).join(',')}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`).join(',')}}`;
+}
+
+export function computeUsageManifestPointer(manifest: UsageManifest): UsageManifestPointer {
+  const bytes = encoder.encode(canonicalJson(manifest));
+  const hash = createHash('sha256').update(bytes).digest();
+  const usageRoot = `0x${hash.toString('hex')}`;
+  return {
+    cid: rawSha256CidV1(hash),
+    usageRoot,
+    bytes,
+    manifest,
+  };
+}
+
+export class UsageManifestStore {
+  private readonly _records = new Map<string, UsageManifestRecord[]>();
+
+  constructor(private readonly _baseDir: string) {
+    mkdirSync(_baseDir, { recursive: true });
+  }
+
+  getRecords(channelId: string): UsageManifestRecord[] {
+    return [...this._getRecords(channelId)];
+  }
+
+  append(channelId: string, record: UsageManifestRecord): UsageManifestPointer {
+    const records = this._getRecords(channelId);
+    records.push(record);
+    const dir = this._channelDir(channelId);
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(join(dir, 'records.jsonl'), `${JSON.stringify(record)}\n`);
+    return this._writeLatest(channelId, records);
+  }
+
+  replace(channelId: string, records: UsageManifestRecord[]): UsageManifestPointer {
+    const copy = [...records];
+    this._records.set(channelId, copy);
+    return this._write(channelId, copy);
+  }
+
+  computePointer(channelId: string, records: UsageManifestRecord[] = this.getRecords(channelId)): UsageManifestPointer {
+    return computeUsageManifestPointer(buildUsageManifest(channelId, records));
+  }
+
+  private _write(channelId: string, records: UsageManifestRecord[]): UsageManifestPointer {
+    const dir = this._channelDir(channelId);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'records.jsonl'), records.map((record) => JSON.stringify(record)).join('\n') + (records.length > 0 ? '\n' : ''));
+    return this._writeLatest(channelId, records);
+  }
+
+  private _writeLatest(channelId: string, records: UsageManifestRecord[]): UsageManifestPointer {
+    const dir = this._channelDir(channelId);
+    mkdirSync(dir, { recursive: true });
+    const pointer = computeUsageManifestPointer(buildUsageManifest(channelId, records));
+    writeFileSync(join(dir, 'latest.json'), pointer.bytes);
+    return pointer;
+  }
+
+  private _getRecords(channelId: string): UsageManifestRecord[] {
+    const existing = this._records.get(channelId);
+    if (existing) return existing;
+
+    const dir = this._channelDir(channelId);
+    const path = join(dir, 'records.jsonl');
+    let records: UsageManifestRecord[] = [];
+    try {
+      const raw = readFileSync(path, 'utf8').trim();
+      records = raw.length === 0
+        ? []
+        : raw.split('\n').map((line) => JSON.parse(line) as UsageManifestRecord);
+    } catch {
+      records = [];
+    }
+    this._records.set(channelId, records);
+    return records;
+  }
+
+  private _channelDir(channelId: string): string {
+    return join(this._baseDir, channelId.replace(/^0x/, ''));
+  }
+}
+
+export function publishUsageManifestBestEffort(pointer: UsageManifestPointer): void {
+  const endpoint = process.env['ANTSEED_IPFS_API_URL'];
+  if (!endpoint || typeof fetch !== 'function') return;
+
+  const form = new FormData();
+  form.append('file', new Blob([pointer.bytes], { type: 'application/json' }), `${pointer.cid}.json`);
+  void fetch(`${endpoint.replace(/\/$/, '')}/api/v0/add?cid-version=1&raw-leaves=true&pin=true`, {
+    method: 'POST',
+    body: form,
+  }).catch(() => undefined);
+}
+
+function rawSha256CidV1(hash: Buffer): string {
+  const cidBytes = Buffer.concat([Buffer.from([0x01, 0x55, 0x12, 0x20]), hash]);
+  return `b${base32(cidBytes)}`;
+}
+
+function base32(bytes: Uint8Array): string {
+  let bits = 0;
+  let value = 0;
+  let out = '';
+  for (const byte of bytes) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      out += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    out += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  }
+  return out;
+}

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -406,7 +406,7 @@ export class SellerRequestHandler {
             const accepted = spm.getAcceptedCumulative(session.sessionId);
             const requiredAmount = cumulativeSpend;
             const service = this._extractRequestedService(request) ?? undefined;
-            const usagePointer = this._writeUsageManifestBestEffort(buyerPeerId, {
+            this._recordUsageObservationBestEffort(buyerPeerId, {
               channelId: session.sessionId,
               request,
               responseBody,
@@ -428,7 +428,6 @@ export class SellerRequestHandler {
               cachedInputTokens: String(usage.cachedInputTokens),
               freshInputTokens: String(usage.freshInputTokens),
               service,
-              ...(usagePointer ? { usageCid: usagePointer.cid, usageRoot: usagePointer.usageRoot } : {}),
             }, buyerPeerId, 'post-response');
           }
         }
@@ -669,20 +668,19 @@ export class SellerRequestHandler {
     }
   }
 
-  private _writeUsageManifestBestEffort(
+  private _recordUsageObservationBestEffort(
     buyerPeerId: string,
-    input: Parameters<SellerUsageWriter['write']>[0],
-  ): ReturnType<SellerUsageWriter['write']> {
+    input: Parameters<SellerUsageWriter['recordObservation']>[0],
+  ): void {
     const writer = this._deps.usageWriter;
-    if (!writer) return null;
+    if (!writer) return;
     try {
-      return writer.write(input);
+      writer.recordObservation(input);
     } catch (err) {
       debugWarn(
-        `[SellerHandler] Usage manifest skipped for ${buyerPeerId.slice(0, 12)}...: ` +
+        `[SellerHandler] Usage observation skipped for ${buyerPeerId.slice(0, 12)}...: ` +
         `${err instanceof Error ? err.message : err}`,
       );
-      return null;
     }
   }
 

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -17,11 +17,7 @@ import { parseResponseUsage } from './utils/response-usage.js';
 import { computeCostUsdc, estimateTokensFromBytes, type ServicePricing } from './payments/pricing.js';
 import { debugLog, debugWarn } from './utils/debug.js';
 import { PAYMENT_CODE_CHANNEL_EXHAUSTED } from './types/protocol.js';
-import {
-  buildUsageManifestRecord,
-  publishUsageManifestBestEffort,
-  type UsageManifestStore,
-} from './payments/usage-manifest.js';
+import type { SellerUsageWriter } from './payments/seller-usage-writer.js';
 
 export interface SellerRequestHandlerDeps {
   providers: Provider[];
@@ -29,7 +25,7 @@ export interface SellerRequestHandlerDeps {
   sessionTracker: SellerSessionTracker | null;
   channelsClient: ChannelsClient | null;
   announcer: PeerAnnouncer | null;
-  usageManifestStore?: UsageManifestStore | null;
+  usageWriter?: SellerUsageWriter | null;
   maxUploadBodyBytes?: number;
   emit: (event: string, ...args: unknown[]) => boolean;
 }
@@ -410,9 +406,8 @@ export class SellerRequestHandler {
             const accepted = spm.getAcceptedCumulative(session.sessionId);
             const requiredAmount = cumulativeSpend;
             const service = this._extractRequestedService(request) ?? undefined;
-            const usagePointer = this._writeUsageManifestBestEffort({
+            const usagePointer = this._writeUsageManifestBestEffort(buyerPeerId, {
               channelId: session.sessionId,
-              buyerPeerId,
               request,
               responseBody,
               service,
@@ -674,37 +669,17 @@ export class SellerRequestHandler {
     }
   }
 
-  private _writeUsageManifestBestEffort(input: {
-    channelId: string;
-    buyerPeerId: string;
-    request: SerializedHttpRequest;
-    responseBody: Uint8Array;
-    service?: string;
-    costUsdc: bigint;
-    cumulativeSpend: bigint;
-    usage: ReturnType<typeof parseResponseUsage>;
-  }): { cid: string; usageRoot: string } | null {
-    const store = this._deps.usageManifestStore;
-    if (!store) return null;
+  private _writeUsageManifestBestEffort(
+    buyerPeerId: string,
+    input: Parameters<SellerUsageWriter['write']>[0],
+  ): ReturnType<SellerUsageWriter['write']> {
+    const writer = this._deps.usageWriter;
+    if (!writer) return null;
     try {
-      const record = buildUsageManifestRecord({
-        requestId: input.request.requestId,
-        service: input.service,
-        costUsdc: input.costUsdc,
-        cumulativeCostUsdc: input.cumulativeSpend,
-        inputTokens: input.usage.inputTokens,
-        cachedInputTokens: input.usage.cachedInputTokens,
-        freshInputTokens: input.usage.freshInputTokens,
-        outputTokens: input.usage.outputTokens,
-        inputBody: input.request.body,
-        outputBody: input.responseBody,
-      });
-      const pointer = store.append(input.channelId, record);
-      publishUsageManifestBestEffort(pointer);
-      return { cid: pointer.cid, usageRoot: pointer.usageRoot };
+      return writer.write(input);
     } catch (err) {
       debugWarn(
-        `[SellerHandler] Usage manifest skipped for ${input.buyerPeerId.slice(0, 12)}...: ` +
+        `[SellerHandler] Usage manifest skipped for ${buyerPeerId.slice(0, 12)}...: ` +
         `${err instanceof Error ? err.message : err}`,
       );
       return null;

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -17,6 +17,11 @@ import { parseResponseUsage } from './utils/response-usage.js';
 import { computeCostUsdc, estimateTokensFromBytes, type ServicePricing } from './payments/pricing.js';
 import { debugLog, debugWarn } from './utils/debug.js';
 import { PAYMENT_CODE_CHANNEL_EXHAUSTED } from './types/protocol.js';
+import {
+  buildUsageManifestRecord,
+  publishUsageManifestBestEffort,
+  type UsageManifestStore,
+} from './payments/usage-manifest.js';
 
 export interface SellerRequestHandlerDeps {
   providers: Provider[];
@@ -24,6 +29,7 @@ export interface SellerRequestHandlerDeps {
   sessionTracker: SellerSessionTracker | null;
   channelsClient: ChannelsClient | null;
   announcer: PeerAnnouncer | null;
+  usageManifestStore?: UsageManifestStore | null;
   maxUploadBodyBytes?: number;
   emit: (event: string, ...args: unknown[]) => boolean;
 }
@@ -403,6 +409,17 @@ export class SellerRequestHandler {
 
             const accepted = spm.getAcceptedCumulative(session.sessionId);
             const requiredAmount = cumulativeSpend;
+            const service = this._extractRequestedService(request) ?? undefined;
+            const usagePointer = this._writeUsageManifestBestEffort({
+              channelId: session.sessionId,
+              buyerPeerId,
+              request,
+              responseBody,
+              service,
+              costUsdc,
+              cumulativeSpend,
+              usage,
+            });
             debugLog(`[SellerHandler] Sending NeedAuth: cost=${costUsdc} cumulative=${cumulativeSpend} required=${requiredAmount}`);
             this._sendNeedAuthBestEffort(paymentMux, {
               channelId: session.sessionId,
@@ -415,7 +432,8 @@ export class SellerRequestHandler {
               outputTokens: String(usage.outputTokens),
               cachedInputTokens: String(usage.cachedInputTokens),
               freshInputTokens: String(usage.freshInputTokens),
-              service: this._extractRequestedService(request) ?? undefined,
+              service,
+              ...(usagePointer ? { usageCid: usagePointer.cid, usageRoot: usagePointer.usageRoot } : {}),
             }, buyerPeerId, 'post-response');
           }
         }
@@ -653,6 +671,43 @@ export class SellerRequestHandler {
       debugWarn(
         `[SellerHandler] NeedAuth send skipped (${phase}) for ${buyerPeerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`,
       );
+    }
+  }
+
+  private _writeUsageManifestBestEffort(input: {
+    channelId: string;
+    buyerPeerId: string;
+    request: SerializedHttpRequest;
+    responseBody: Uint8Array;
+    service?: string;
+    costUsdc: bigint;
+    cumulativeSpend: bigint;
+    usage: ReturnType<typeof parseResponseUsage>;
+  }): { cid: string; usageRoot: string } | null {
+    const store = this._deps.usageManifestStore;
+    if (!store) return null;
+    try {
+      const record = buildUsageManifestRecord({
+        requestId: input.request.requestId,
+        service: input.service,
+        costUsdc: input.costUsdc,
+        cumulativeCostUsdc: input.cumulativeSpend,
+        inputTokens: input.usage.inputTokens,
+        cachedInputTokens: input.usage.cachedInputTokens,
+        freshInputTokens: input.usage.freshInputTokens,
+        outputTokens: input.usage.outputTokens,
+        inputBody: input.request.body,
+        outputBody: input.responseBody,
+      });
+      const pointer = store.append(input.channelId, record);
+      publishUsageManifestBestEffort(pointer);
+      return { cid: pointer.cid, usageRoot: pointer.usageRoot };
+    } catch (err) {
+      debugWarn(
+        `[SellerHandler] Usage manifest skipped for ${input.buyerPeerId.slice(0, 12)}...: ` +
+        `${err instanceof Error ? err.message : err}`,
+      );
+      return null;
     }
   }
 

--- a/packages/node/src/types/protocol.ts
+++ b/packages/node/src/types/protocol.ts
@@ -136,4 +136,8 @@ export interface NeedAuthPayload {
   freshInputTokens?: string;
   /** Service/model name for service-specific pricing validation. */
   service?: string;
+  /** CID for a buyer-verifiable off-chain usage manifest. */
+  usageCid?: string;
+  /** 0x-prefixed sha256 root of the cumulative usage manifest. */
+  usageRoot?: string;
 }

--- a/packages/node/src/types/protocol.ts
+++ b/packages/node/src/types/protocol.ts
@@ -52,10 +52,29 @@ export interface SpendingAuthPayload {
   metadataHash: string;         // bytes32 hex
   metadata: string;             // hex-encoded abi.encode(version, inputTokens, outputTokens, requestCount)
   spendingAuthSig: string;      // EIP-712 SpendingAuth signature (covers amount + metadata)
+  /** Buyer-authored completed usage leaves covered by usageRoot. */
+  usageLeaves?: UsageAuthLeaf[];
+  /** CID of the published leaf batch covered by metadata version 2. */
+  usageCid?: string;
+  /** Chained usage root after applying usageLeaves. */
+  usageRoot?: string;
   // Only for initial reserve
   reserveSalt?: string;
   reserveMaxAmount?: string;
   reserveDeadline?: number;
+}
+
+export interface UsageAuthLeaf {
+  requestId: string;
+  service?: string;
+  costUsdc: string;
+  cumulativeCostUsdc: string;
+  inputTokens: string;
+  cachedInputTokens: string;
+  freshInputTokens: string;
+  outputTokens: string;
+  inputSha256: string;
+  outputSha256: string;
 }
 
 /**

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
-import { AbiCoder, Wallet } from 'ethers';
+import { AbiCoder, getBytes, keccak256, Wallet } from 'ethers';
 import { BuyerPaymentManager, type BuyerPaymentConfig } from '../src/payments/buyer-payment-manager.js';
 import { ChannelStore } from '../src/payments/channel-store.js';
 import type { PaymentMux } from '../src/p2p/payment-mux.js';
@@ -492,6 +492,50 @@ describe('BuyerPaymentManager', () => {
     expect(mux.sentSpendingAuths.length).toBe(1);
     const sent = mux.sentSpendingAuths[0] as Record<string, unknown>;
     expect(sent.cumulativeAmount).toBe('50000');
+  });
+
+  it('handleNeedAuth signs verified usage pointer metadata', async () => {
+    const sellerPeerId = fakePeerId('seller-needauth-pointer');
+    const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);
+    mux.sentSpendingAuths.length = 0;
+
+    const result = await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requiredCumulativeAmount: '50000',
+      currentAcceptedCumulative: '0',
+      deposit: '1000000',
+      usageCid: 'bafkreihash',
+      usageRoot: '0x' + '11'.repeat(32),
+    }, mux, { usagePointerVerified: true });
+
+    expect(result).toEqual({ signed: true, signedUsagePointer: true });
+    const sent = mux.sentSpendingAuths[0] as Record<string, string>;
+    const coder = AbiCoder.defaultAbiCoder();
+    const [version, cidBytes, usageRoot] = coder.decode(['uint256', 'bytes', 'bytes32'], sent.metadata);
+    expect(version).toBe(2n);
+    expect(new TextDecoder().decode(getBytes(cidBytes as string))).toBe('bafkreihash');
+    expect(usageRoot).toBe('0x' + '11'.repeat(32));
+    expect(sent.metadataHash).toBe(keccak256(sent.metadata));
+  });
+
+  it('handleNeedAuth keeps legacy metadata for unverified usage pointers', async () => {
+    const sellerPeerId = fakePeerId('seller-needauth-unverified-pointer');
+    const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);
+    mux.sentSpendingAuths.length = 0;
+
+    const result = await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requiredCumulativeAmount: '50000',
+      currentAcceptedCumulative: '0',
+      deposit: '1000000',
+      usageCid: 'bafkreihash',
+      usageRoot: '0x' + '11'.repeat(32),
+    }, mux, { usagePointerVerified: false });
+
+    expect(result).toEqual({ signed: true, signedUsagePointer: false });
+    const sent = mux.sentSpendingAuths[0] as Record<string, string>;
+    const [version] = AbiCoder.defaultAbiCoder().decode(['uint256', 'uint256', 'uint256', 'uint256'], sent.metadata);
+    expect(version).toBe(1n);
   });
 
   it('handleNeedAuth caps at reserve ceiling', async () => {

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -509,10 +509,13 @@ describe('BuyerPaymentManager', () => {
       usageCid: 'bafkreihash',
       usageRoot: '0x' + '11'.repeat(32),
     }, mux, {
-      verifiedMetadata: {
+      usageMetadata: {
         encodedMetadata,
         metadataHash: keccak256(encodedMetadata),
         requiredCumulativeAmount: 50000n,
+        usageCid: 'bafkreihash',
+        usageRoot: '0x' + '11'.repeat(32),
+        usageLeaves: [],
       },
     });
 
@@ -540,10 +543,13 @@ describe('BuyerPaymentManager', () => {
       usageCid: 'bafkreihash',
       usageRoot: '0x' + '11'.repeat(32),
     }, mux, {
-      verifiedMetadata: {
+      usageMetadata: {
         encodedMetadata,
         metadataHash: keccak256(encodedMetadata),
         requiredCumulativeAmount: 50001n,
+        usageCid: 'bafkreihash',
+        usageRoot: '0x' + '11'.repeat(32),
+        usageLeaves: [],
       },
     });
 

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -11,6 +11,7 @@ import type { Identity } from '../src/p2p/identity.js';
 import { bytesToHex } from '../src/utils/hex.js';
 import { toPeerId } from '../src/types/peer.js';
 import { estimateCostFromBytes } from '../src/payments/pricing.js';
+import { encodePointerMetadata } from '../src/payments/evm/signatures.js';
 
 const enc = new TextEncoder();
 
@@ -499,6 +500,7 @@ describe('BuyerPaymentManager', () => {
     const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);
     mux.sentSpendingAuths.length = 0;
 
+    const encodedMetadata = encodePointerMetadata('bafkreihash', '0x' + '11'.repeat(32));
     const result = await manager.handleNeedAuth(sellerPeerId, {
       channelId,
       requiredCumulativeAmount: '50000',
@@ -506,9 +508,15 @@ describe('BuyerPaymentManager', () => {
       deposit: '1000000',
       usageCid: 'bafkreihash',
       usageRoot: '0x' + '11'.repeat(32),
-    }, mux, { usagePointerVerified: true });
+    }, mux, {
+      verifiedMetadata: {
+        encodedMetadata,
+        metadataHash: keccak256(encodedMetadata),
+        requiredCumulativeAmount: 50000n,
+      },
+    });
 
-    expect(result).toEqual({ signed: true, signedUsagePointer: true });
+    expect(result).toEqual({ signed: true, signedVerifiedMetadata: true });
     const sent = mux.sentSpendingAuths[0] as Record<string, string>;
     const coder = AbiCoder.defaultAbiCoder();
     const [version, cidBytes, usageRoot] = coder.decode(['uint256', 'bytes', 'bytes32'], sent.metadata);
@@ -523,6 +531,7 @@ describe('BuyerPaymentManager', () => {
     const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);
     mux.sentSpendingAuths.length = 0;
 
+    const encodedMetadata = encodePointerMetadata('bafkreihash', '0x' + '11'.repeat(32));
     const result = await manager.handleNeedAuth(sellerPeerId, {
       channelId,
       requiredCumulativeAmount: '50000',
@@ -530,9 +539,15 @@ describe('BuyerPaymentManager', () => {
       deposit: '1000000',
       usageCid: 'bafkreihash',
       usageRoot: '0x' + '11'.repeat(32),
-    }, mux, { usagePointerVerified: false });
+    }, mux, {
+      verifiedMetadata: {
+        encodedMetadata,
+        metadataHash: keccak256(encodedMetadata),
+        requiredCumulativeAmount: 50001n,
+      },
+    });
 
-    expect(result).toEqual({ signed: true, signedUsagePointer: false });
+    expect(result).toEqual({ signed: true, signedVerifiedMetadata: false });
     const sent = mux.sentSpendingAuths[0] as Record<string, string>;
     const [version] = AbiCoder.defaultAbiCoder().decode(['uint256', 'uint256', 'uint256', 'uint256'], sent.metadata);
     expect(version).toBe(1n);

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { BuyerPaymentNegotiator, type BuyerNegotiatorConfig, type NegotiationEmitter } from '../src/payments/buyer-payment-negotiator.js';
 import type { PeerInfo, PeerId } from '../src/types/peer.js';
 import type { SerializedHttpResponse, SerializedHttpRequest } from '../src/types/http.js';
@@ -10,6 +13,12 @@ import type { StoredChannel } from '../src/payments/channel-store.js';
 import type { Identity } from '../src/p2p/identity.js';
 import type { PeerConnection } from '../src/p2p/connection-manager.js';
 import type { PaymentRequiredPayload } from '../src/types/protocol.js';
+import {
+  buildUsageManifest,
+  buildUsageManifestRecord,
+  computeUsageManifestPointer,
+  UsageManifestStore,
+} from '../src/payments/usage-manifest.js';
 
 const enc = new TextEncoder();
 
@@ -37,7 +46,7 @@ function createMockBpm(): BuyerPaymentManager & Record<string, unknown> {
       topUpNeeded: false,
     }),
     handleAuthAck: vi.fn(),
-    handleNeedAuth: vi.fn(),
+    handleNeedAuth: vi.fn().mockResolvedValue({ signed: true, signedUsagePointer: false }),
     authorizeSpending: vi.fn().mockResolvedValue(undefined),
     topUpReserve: vi.fn().mockResolvedValue(undefined),
     cleanupSession: vi.fn(),
@@ -645,6 +654,230 @@ describe('BuyerPaymentNegotiator', () => {
   });
 
   describe('cost tracking', () => {
+    it('verifies usage pointers before allowing v2 NeedAuth signing', async () => {
+      const request: SerializedHttpRequest = {
+        requestId: 'req-pointer-ok',
+        method: 'POST',
+        path: '/v1/chat/completions',
+        headers: { 'content-type': 'application/json' },
+        body: enc.encode(JSON.stringify({ model: 'gpt-5.5', messages: [{ role: 'user', content: 'hello' }] })),
+      };
+      const response: SerializedHttpResponse = {
+        requestId: request.requestId,
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' },
+        body: enc.encode(JSON.stringify({ usage: { prompt_tokens: 100, completion_tokens: 50 } })),
+      };
+      const costUsdc = 1050n;
+      const record = buildUsageManifestRecord({
+        requestId: request.requestId,
+        service: 'gpt-5.5',
+        costUsdc,
+        cumulativeCostUsdc: costUsdc,
+        inputTokens: 100,
+        cachedInputTokens: 0,
+        freshInputTokens: 100,
+        outputTokens: 50,
+        inputBody: request.body,
+        outputBody: response.body,
+      });
+      const pointer = computeUsageManifestPointer(buildUsageManifest('0x' + 'cc'.repeat(32), [record]));
+      (bpm.handleNeedAuth as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ signed: true, signedUsagePointer: true });
+
+      negotiator.estimateCostFromResponse(peer, response, 'gpt-5.5', request);
+      await negotiator.handleNeedAuth(peer.peerId, {
+        channelId: '0x' + 'cc'.repeat(32),
+        requiredCumulativeAmount: costUsdc.toString(),
+        currentAcceptedCumulative: '0',
+        deposit: '1000000',
+        requestId: request.requestId,
+        lastRequestCost: costUsdc.toString(),
+        inputTokens: '100',
+        cachedInputTokens: '0',
+        freshInputTokens: '100',
+        outputTokens: '50',
+        service: 'gpt-5.5',
+        usageCid: pointer.cid,
+        usageRoot: pointer.usageRoot,
+      }, {} as any);
+
+      expect(bpm.handleNeedAuth).toHaveBeenCalledWith(
+        peer.peerId,
+        expect.objectContaining({ usageCid: pointer.cid, usageRoot: pointer.usageRoot }),
+        expect.anything(),
+        { usagePointerVerified: true },
+      );
+      expect((negotiator as unknown as { _usageObservations: Map<string, unknown> })._usageObservations.size).toBe(0);
+    });
+
+    it('falls back to legacy NeedAuth signing when usage pointer verification fails', async () => {
+      const request: SerializedHttpRequest = {
+        requestId: 'req-pointer-bad',
+        method: 'POST',
+        path: '/v1/chat/completions',
+        headers: { 'content-type': 'application/json' },
+        body: enc.encode(JSON.stringify({ model: 'gpt-5.5', messages: [{ role: 'user', content: 'hello' }] })),
+      };
+      const response: SerializedHttpResponse = {
+        requestId: request.requestId,
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' },
+        body: enc.encode(JSON.stringify({ usage: { prompt_tokens: 100, completion_tokens: 50 } })),
+      };
+
+      negotiator.estimateCostFromResponse(peer, response, 'gpt-5.5', request);
+      await negotiator.handleNeedAuth(peer.peerId, {
+        channelId: '0x' + 'cc'.repeat(32),
+        requiredCumulativeAmount: '1050',
+        currentAcceptedCumulative: '0',
+        deposit: '1000000',
+        requestId: request.requestId,
+        lastRequestCost: '1050',
+        inputTokens: '100',
+        cachedInputTokens: '0',
+        freshInputTokens: '100',
+        outputTokens: '50',
+        service: 'gpt-5.5',
+        usageCid: 'bafkreiinvalid',
+        usageRoot: '0x' + '11'.repeat(32),
+      }, {} as any);
+
+      expect(bpm.handleNeedAuth).toHaveBeenCalledWith(
+        peer.peerId,
+        expect.objectContaining({ usageCid: 'bafkreiinvalid' }),
+        expect.anything(),
+        { usagePointerVerified: false },
+      );
+      expect((negotiator as unknown as { _usageObservations: Map<string, unknown> })._usageObservations.size).toBe(0);
+    });
+
+    it('persists verified usage records so a restarted buyer can verify the next cumulative pointer', async () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'buyer-usage-manifest-test-'));
+      try {
+        const manifestStore = new UsageManifestStore(tempDir);
+        negotiator = new BuyerPaymentNegotiator(
+          identity,
+          bpm as unknown as BuyerPaymentManager,
+          depositsClient,
+          channelsClient,
+          channelStore,
+          { usageManifestStore: manifestStore },
+          emitter,
+        );
+        const channelId = '0x' + 'cc'.repeat(32);
+        const request1: SerializedHttpRequest = {
+          requestId: 'req-restart-1',
+          method: 'POST',
+          path: '/v1/chat/completions',
+          headers: { 'content-type': 'application/json' },
+          body: enc.encode(JSON.stringify({ model: 'gpt-5.5', messages: [{ role: 'user', content: 'one' }] })),
+        };
+        const response1: SerializedHttpResponse = {
+          requestId: request1.requestId,
+          statusCode: 200,
+          headers: { 'content-type': 'application/json' },
+          body: enc.encode(JSON.stringify({ usage: { prompt_tokens: 100, completion_tokens: 50 } })),
+        };
+        const record1 = buildUsageManifestRecord({
+          requestId: request1.requestId,
+          service: 'gpt-5.5',
+          costUsdc: 1050n,
+          cumulativeCostUsdc: 1050n,
+          inputTokens: 100,
+          cachedInputTokens: 0,
+          freshInputTokens: 100,
+          outputTokens: 50,
+          inputBody: request1.body,
+          outputBody: response1.body,
+        });
+        const pointer1 = computeUsageManifestPointer(buildUsageManifest(channelId, [record1]));
+        (bpm.handleNeedAuth as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ signed: true, signedUsagePointer: true });
+
+        negotiator.estimateCostFromResponse(peer, response1, 'gpt-5.5', request1);
+        await negotiator.handleNeedAuth(peer.peerId, {
+          channelId,
+          requiredCumulativeAmount: '1050',
+          currentAcceptedCumulative: '0',
+          deposit: '1000000',
+          requestId: request1.requestId,
+          lastRequestCost: '1050',
+          inputTokens: '100',
+          cachedInputTokens: '0',
+          freshInputTokens: '100',
+          outputTokens: '50',
+          service: 'gpt-5.5',
+          usageCid: pointer1.cid,
+          usageRoot: pointer1.usageRoot,
+        }, {} as any);
+
+        const restartedBpm = createMockBpm();
+        restartedBpm.handleNeedAuth = vi.fn().mockResolvedValue({ signed: true, signedUsagePointer: true }) as any;
+        const restarted = new BuyerPaymentNegotiator(
+          identity,
+          restartedBpm as unknown as BuyerPaymentManager,
+          depositsClient,
+          channelsClient,
+          channelStore,
+          { usageManifestStore: new UsageManifestStore(tempDir) },
+          emitter,
+        );
+
+        const request2: SerializedHttpRequest = {
+          requestId: 'req-restart-2',
+          method: 'POST',
+          path: '/v1/chat/completions',
+          headers: { 'content-type': 'application/json' },
+          body: enc.encode(JSON.stringify({ model: 'gpt-5.5', messages: [{ role: 'user', content: 'two' }] })),
+        };
+        const response2: SerializedHttpResponse = {
+          requestId: request2.requestId,
+          statusCode: 200,
+          headers: { 'content-type': 'application/json' },
+          body: enc.encode(JSON.stringify({ usage: { prompt_tokens: 200, completion_tokens: 70 } })),
+        };
+        const record2 = buildUsageManifestRecord({
+          requestId: request2.requestId,
+          service: 'gpt-5.5',
+          costUsdc: 1650n,
+          cumulativeCostUsdc: 2700n,
+          inputTokens: 200,
+          cachedInputTokens: 0,
+          freshInputTokens: 200,
+          outputTokens: 70,
+          inputBody: request2.body,
+          outputBody: response2.body,
+        });
+        const pointer2 = computeUsageManifestPointer(buildUsageManifest(channelId, [record1, record2]));
+
+        restarted.estimateCostFromResponse(peer, response2, 'gpt-5.5', request2);
+        await restarted.handleNeedAuth(peer.peerId, {
+          channelId,
+          requiredCumulativeAmount: '2700',
+          currentAcceptedCumulative: '1050',
+          deposit: '1000000',
+          requestId: request2.requestId,
+          lastRequestCost: '1650',
+          inputTokens: '200',
+          cachedInputTokens: '0',
+          freshInputTokens: '200',
+          outputTokens: '70',
+          service: 'gpt-5.5',
+          usageCid: pointer2.cid,
+          usageRoot: pointer2.usageRoot,
+        }, {} as any);
+
+        expect(restartedBpm.handleNeedAuth).toHaveBeenCalledWith(
+          peer.peerId,
+          expect.objectContaining({ usageCid: pointer2.cid, usageRoot: pointer2.usageRoot }),
+          expect.anything(),
+          { usagePointerVerified: true },
+        );
+        expect(new UsageManifestStore(tempDir).getRecords(channelId)).toHaveLength(2);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     it('estimateCostFromResponse stores estimated cost', () => {
       const response: SerializedHttpResponse = {
         requestId: 'req-1',

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -14,9 +14,6 @@ import type { Identity } from '../src/p2p/identity.js';
 import type { PeerConnection } from '../src/p2p/connection-manager.js';
 import type { PaymentRequiredPayload } from '../src/types/protocol.js';
 import {
-  buildUsageManifest,
-  buildUsageManifestRecord,
-  computeUsageManifestPointer,
   UsageManifestStore,
 } from '../src/payments/usage-manifest.js';
 
@@ -666,6 +663,10 @@ describe('BuyerPaymentNegotiator', () => {
           { usageManifestStore: new UsageManifestStore(tempDir) },
           emitter,
         );
+        (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue({
+          ...makeActiveSession(peer.peerId),
+          sessionId: '0x' + 'cc'.repeat(32),
+        });
         const request: SerializedHttpRequest = {
           requestId: 'req-pointer-ok',
           method: 'POST',
@@ -680,19 +681,6 @@ describe('BuyerPaymentNegotiator', () => {
           body: enc.encode(JSON.stringify({ usage: { prompt_tokens: 100, completion_tokens: 50 } })),
         };
         const costUsdc = 1050n;
-        const record = buildUsageManifestRecord({
-          requestId: request.requestId,
-          service: 'gpt-5.5',
-          costUsdc,
-          cumulativeCostUsdc: costUsdc,
-          inputTokens: 100,
-          cachedInputTokens: 0,
-          freshInputTokens: 100,
-          outputTokens: 50,
-          inputBody: request.body,
-          outputBody: response.body,
-        });
-        const pointer = computeUsageManifestPointer(buildUsageManifest('0x' + 'cc'.repeat(32), [record]));
         (bpm.handleNeedAuth as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ signed: true, signedVerifiedMetadata: true });
 
         negotiator.estimateCostFromResponse(peer, response, 'gpt-5.5', request);
@@ -708,15 +696,22 @@ describe('BuyerPaymentNegotiator', () => {
           freshInputTokens: '100',
           outputTokens: '50',
           service: 'gpt-5.5',
-          usageCid: pointer.cid,
-          usageRoot: pointer.usageRoot,
         }, {} as any);
 
         expect(bpm.handleNeedAuth).toHaveBeenCalledWith(
           peer.peerId,
-          expect.objectContaining({ usageCid: pointer.cid, usageRoot: pointer.usageRoot }),
+          expect.objectContaining({ requestId: request.requestId }),
           expect.anything(),
-          { verifiedMetadata: expect.objectContaining({ requiredCumulativeAmount: costUsdc }) },
+          {
+            usageMetadata: expect.objectContaining({
+              requiredCumulativeAmount: costUsdc,
+              usageCid: expect.any(String),
+              usageRoot: expect.stringMatching(/^0x[0-9a-f]{64}$/),
+              usageLeaves: [
+                expect.objectContaining({ requestId: request.requestId, costUsdc: costUsdc.toString() }),
+              ],
+            }),
+          },
         );
         expect((negotiator as unknown as { _usageVerifier: { pendingObservationCount: number } })._usageVerifier.pendingObservationCount).toBe(0);
       } finally {
@@ -724,7 +719,7 @@ describe('BuyerPaymentNegotiator', () => {
       }
     });
 
-    it('falls back to legacy NeedAuth signing when usage pointer verification fails', async () => {
+    it('ignores stale seller pointer fields and signs buyer-authored usage metadata', async () => {
       const tempDir = mkdtempSync(join(tmpdir(), 'buyer-usage-manifest-test-'));
       try {
         negotiator = new BuyerPaymentNegotiator(
@@ -736,6 +731,11 @@ describe('BuyerPaymentNegotiator', () => {
           { usageManifestStore: new UsageManifestStore(tempDir) },
           emitter,
         );
+        (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue({
+          ...makeActiveSession(peer.peerId),
+          sessionId: '0x' + 'cc'.repeat(32),
+        });
+        (bpm.handleNeedAuth as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ signed: true, signedVerifiedMetadata: true });
         const request: SerializedHttpRequest = {
           requestId: 'req-pointer-bad',
           method: 'POST',
@@ -771,7 +771,16 @@ describe('BuyerPaymentNegotiator', () => {
           peer.peerId,
           expect.objectContaining({ usageCid: 'bafkreiinvalid' }),
           expect.anything(),
-          {},
+          {
+            usageMetadata: expect.objectContaining({
+              requiredCumulativeAmount: 1050n,
+              usageCid: expect.any(String),
+              usageRoot: expect.stringMatching(/^0x[0-9a-f]{64}$/),
+              usageLeaves: [
+                expect.objectContaining({ requestId: request.requestId, costUsdc: '1050' }),
+              ],
+            }),
+          },
         );
         expect((negotiator as unknown as { _usageVerifier: { pendingObservationCount: number } })._usageVerifier.pendingObservationCount).toBe(0);
       } finally {
@@ -793,6 +802,10 @@ describe('BuyerPaymentNegotiator', () => {
           emitter,
         );
         const channelId = '0x' + 'cc'.repeat(32);
+        (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue({
+          ...makeActiveSession(peer.peerId),
+          sessionId: channelId,
+        });
         const request1: SerializedHttpRequest = {
           requestId: 'req-restart-1',
           method: 'POST',
@@ -806,19 +819,6 @@ describe('BuyerPaymentNegotiator', () => {
           headers: { 'content-type': 'application/json' },
           body: enc.encode(JSON.stringify({ usage: { prompt_tokens: 100, completion_tokens: 50 } })),
         };
-        const record1 = buildUsageManifestRecord({
-          requestId: request1.requestId,
-          service: 'gpt-5.5',
-          costUsdc: 1050n,
-          cumulativeCostUsdc: 1050n,
-          inputTokens: 100,
-          cachedInputTokens: 0,
-          freshInputTokens: 100,
-          outputTokens: 50,
-          inputBody: request1.body,
-          outputBody: response1.body,
-        });
-        const pointer1 = computeUsageManifestPointer(buildUsageManifest(channelId, [record1]));
         (bpm.handleNeedAuth as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ signed: true, signedVerifiedMetadata: true });
 
         negotiator.estimateCostFromResponse(peer, response1, 'gpt-5.5', request1);
@@ -834,12 +834,14 @@ describe('BuyerPaymentNegotiator', () => {
           freshInputTokens: '100',
           outputTokens: '50',
           service: 'gpt-5.5',
-          usageCid: pointer1.cid,
-          usageRoot: pointer1.usageRoot,
         }, {} as any);
 
         const restartedBpm = createMockBpm();
         restartedBpm.handleNeedAuth = vi.fn().mockResolvedValue({ signed: true, signedVerifiedMetadata: true }) as any;
+        (restartedBpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue({
+          ...makeActiveSession(peer.peerId),
+          sessionId: channelId,
+        });
         const restarted = new BuyerPaymentNegotiator(
           identity,
           restartedBpm as unknown as BuyerPaymentManager,
@@ -863,20 +865,6 @@ describe('BuyerPaymentNegotiator', () => {
           headers: { 'content-type': 'application/json' },
           body: enc.encode(JSON.stringify({ usage: { prompt_tokens: 200, completion_tokens: 70 } })),
         };
-        const record2 = buildUsageManifestRecord({
-          requestId: request2.requestId,
-          service: 'gpt-5.5',
-          costUsdc: 1650n,
-          cumulativeCostUsdc: 2700n,
-          inputTokens: 200,
-          cachedInputTokens: 0,
-          freshInputTokens: 200,
-          outputTokens: 70,
-          inputBody: request2.body,
-          outputBody: response2.body,
-        });
-        const pointer2 = computeUsageManifestPointer(buildUsageManifest(channelId, [record1, record2]));
-
         restarted.estimateCostFromResponse(peer, response2, 'gpt-5.5', request2);
         await restarted.handleNeedAuth(peer.peerId, {
           channelId,
@@ -890,15 +878,22 @@ describe('BuyerPaymentNegotiator', () => {
           freshInputTokens: '200',
           outputTokens: '70',
           service: 'gpt-5.5',
-          usageCid: pointer2.cid,
-          usageRoot: pointer2.usageRoot,
         }, {} as any);
 
         expect(restartedBpm.handleNeedAuth).toHaveBeenCalledWith(
           peer.peerId,
-          expect.objectContaining({ usageCid: pointer2.cid, usageRoot: pointer2.usageRoot }),
+          expect.objectContaining({ requestId: request2.requestId }),
           expect.anything(),
-          { verifiedMetadata: expect.objectContaining({ requiredCumulativeAmount: 2700n }) },
+          {
+            usageMetadata: expect.objectContaining({
+              requiredCumulativeAmount: 2700n,
+              usageCid: expect.any(String),
+              usageRoot: expect.stringMatching(/^0x[0-9a-f]{64}$/),
+              usageLeaves: [
+                expect.objectContaining({ requestId: request2.requestId, costUsdc: '1650' }),
+              ],
+            }),
+          },
         );
         expect(new UsageManifestStore(tempDir).getRecords(channelId)).toHaveLength(2);
       } finally {

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -46,7 +46,7 @@ function createMockBpm(): BuyerPaymentManager & Record<string, unknown> {
       topUpNeeded: false,
     }),
     handleAuthAck: vi.fn(),
-    handleNeedAuth: vi.fn().mockResolvedValue({ signed: true, signedUsagePointer: false }),
+    handleNeedAuth: vi.fn().mockResolvedValue({ signed: true, signedVerifiedMetadata: false }),
     authorizeSpending: vi.fn().mockResolvedValue(undefined),
     topUpReserve: vi.fn().mockResolvedValue(undefined),
     cleanupSession: vi.fn(),
@@ -655,100 +655,128 @@ describe('BuyerPaymentNegotiator', () => {
 
   describe('cost tracking', () => {
     it('verifies usage pointers before allowing v2 NeedAuth signing', async () => {
-      const request: SerializedHttpRequest = {
-        requestId: 'req-pointer-ok',
-        method: 'POST',
-        path: '/v1/chat/completions',
-        headers: { 'content-type': 'application/json' },
-        body: enc.encode(JSON.stringify({ model: 'gpt-5.5', messages: [{ role: 'user', content: 'hello' }] })),
-      };
-      const response: SerializedHttpResponse = {
-        requestId: request.requestId,
-        statusCode: 200,
-        headers: { 'content-type': 'application/json' },
-        body: enc.encode(JSON.stringify({ usage: { prompt_tokens: 100, completion_tokens: 50 } })),
-      };
-      const costUsdc = 1050n;
-      const record = buildUsageManifestRecord({
-        requestId: request.requestId,
-        service: 'gpt-5.5',
-        costUsdc,
-        cumulativeCostUsdc: costUsdc,
-        inputTokens: 100,
-        cachedInputTokens: 0,
-        freshInputTokens: 100,
-        outputTokens: 50,
-        inputBody: request.body,
-        outputBody: response.body,
-      });
-      const pointer = computeUsageManifestPointer(buildUsageManifest('0x' + 'cc'.repeat(32), [record]));
-      (bpm.handleNeedAuth as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ signed: true, signedUsagePointer: true });
+      const tempDir = mkdtempSync(join(tmpdir(), 'buyer-usage-manifest-test-'));
+      try {
+        negotiator = new BuyerPaymentNegotiator(
+          identity,
+          bpm as unknown as BuyerPaymentManager,
+          depositsClient,
+          channelsClient,
+          channelStore,
+          { usageManifestStore: new UsageManifestStore(tempDir) },
+          emitter,
+        );
+        const request: SerializedHttpRequest = {
+          requestId: 'req-pointer-ok',
+          method: 'POST',
+          path: '/v1/chat/completions',
+          headers: { 'content-type': 'application/json' },
+          body: enc.encode(JSON.stringify({ model: 'gpt-5.5', messages: [{ role: 'user', content: 'hello' }] })),
+        };
+        const response: SerializedHttpResponse = {
+          requestId: request.requestId,
+          statusCode: 200,
+          headers: { 'content-type': 'application/json' },
+          body: enc.encode(JSON.stringify({ usage: { prompt_tokens: 100, completion_tokens: 50 } })),
+        };
+        const costUsdc = 1050n;
+        const record = buildUsageManifestRecord({
+          requestId: request.requestId,
+          service: 'gpt-5.5',
+          costUsdc,
+          cumulativeCostUsdc: costUsdc,
+          inputTokens: 100,
+          cachedInputTokens: 0,
+          freshInputTokens: 100,
+          outputTokens: 50,
+          inputBody: request.body,
+          outputBody: response.body,
+        });
+        const pointer = computeUsageManifestPointer(buildUsageManifest('0x' + 'cc'.repeat(32), [record]));
+        (bpm.handleNeedAuth as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ signed: true, signedVerifiedMetadata: true });
 
-      negotiator.estimateCostFromResponse(peer, response, 'gpt-5.5', request);
-      await negotiator.handleNeedAuth(peer.peerId, {
-        channelId: '0x' + 'cc'.repeat(32),
-        requiredCumulativeAmount: costUsdc.toString(),
-        currentAcceptedCumulative: '0',
-        deposit: '1000000',
-        requestId: request.requestId,
-        lastRequestCost: costUsdc.toString(),
-        inputTokens: '100',
-        cachedInputTokens: '0',
-        freshInputTokens: '100',
-        outputTokens: '50',
-        service: 'gpt-5.5',
-        usageCid: pointer.cid,
-        usageRoot: pointer.usageRoot,
-      }, {} as any);
+        negotiator.estimateCostFromResponse(peer, response, 'gpt-5.5', request);
+        await negotiator.handleNeedAuth(peer.peerId, {
+          channelId: '0x' + 'cc'.repeat(32),
+          requiredCumulativeAmount: costUsdc.toString(),
+          currentAcceptedCumulative: '0',
+          deposit: '1000000',
+          requestId: request.requestId,
+          lastRequestCost: costUsdc.toString(),
+          inputTokens: '100',
+          cachedInputTokens: '0',
+          freshInputTokens: '100',
+          outputTokens: '50',
+          service: 'gpt-5.5',
+          usageCid: pointer.cid,
+          usageRoot: pointer.usageRoot,
+        }, {} as any);
 
-      expect(bpm.handleNeedAuth).toHaveBeenCalledWith(
-        peer.peerId,
-        expect.objectContaining({ usageCid: pointer.cid, usageRoot: pointer.usageRoot }),
-        expect.anything(),
-        { usagePointerVerified: true },
-      );
-      expect((negotiator as unknown as { _usageObservations: Map<string, unknown> })._usageObservations.size).toBe(0);
+        expect(bpm.handleNeedAuth).toHaveBeenCalledWith(
+          peer.peerId,
+          expect.objectContaining({ usageCid: pointer.cid, usageRoot: pointer.usageRoot }),
+          expect.anything(),
+          { verifiedMetadata: expect.objectContaining({ requiredCumulativeAmount: costUsdc }) },
+        );
+        expect((negotiator as unknown as { _usageVerifier: { pendingObservationCount: number } })._usageVerifier.pendingObservationCount).toBe(0);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
     });
 
     it('falls back to legacy NeedAuth signing when usage pointer verification fails', async () => {
-      const request: SerializedHttpRequest = {
-        requestId: 'req-pointer-bad',
-        method: 'POST',
-        path: '/v1/chat/completions',
-        headers: { 'content-type': 'application/json' },
-        body: enc.encode(JSON.stringify({ model: 'gpt-5.5', messages: [{ role: 'user', content: 'hello' }] })),
-      };
-      const response: SerializedHttpResponse = {
-        requestId: request.requestId,
-        statusCode: 200,
-        headers: { 'content-type': 'application/json' },
-        body: enc.encode(JSON.stringify({ usage: { prompt_tokens: 100, completion_tokens: 50 } })),
-      };
+      const tempDir = mkdtempSync(join(tmpdir(), 'buyer-usage-manifest-test-'));
+      try {
+        negotiator = new BuyerPaymentNegotiator(
+          identity,
+          bpm as unknown as BuyerPaymentManager,
+          depositsClient,
+          channelsClient,
+          channelStore,
+          { usageManifestStore: new UsageManifestStore(tempDir) },
+          emitter,
+        );
+        const request: SerializedHttpRequest = {
+          requestId: 'req-pointer-bad',
+          method: 'POST',
+          path: '/v1/chat/completions',
+          headers: { 'content-type': 'application/json' },
+          body: enc.encode(JSON.stringify({ model: 'gpt-5.5', messages: [{ role: 'user', content: 'hello' }] })),
+        };
+        const response: SerializedHttpResponse = {
+          requestId: request.requestId,
+          statusCode: 200,
+          headers: { 'content-type': 'application/json' },
+          body: enc.encode(JSON.stringify({ usage: { prompt_tokens: 100, completion_tokens: 50 } })),
+        };
 
-      negotiator.estimateCostFromResponse(peer, response, 'gpt-5.5', request);
-      await negotiator.handleNeedAuth(peer.peerId, {
-        channelId: '0x' + 'cc'.repeat(32),
-        requiredCumulativeAmount: '1050',
-        currentAcceptedCumulative: '0',
-        deposit: '1000000',
-        requestId: request.requestId,
-        lastRequestCost: '1050',
-        inputTokens: '100',
-        cachedInputTokens: '0',
-        freshInputTokens: '100',
-        outputTokens: '50',
-        service: 'gpt-5.5',
-        usageCid: 'bafkreiinvalid',
-        usageRoot: '0x' + '11'.repeat(32),
-      }, {} as any);
+        negotiator.estimateCostFromResponse(peer, response, 'gpt-5.5', request);
+        await negotiator.handleNeedAuth(peer.peerId, {
+          channelId: '0x' + 'cc'.repeat(32),
+          requiredCumulativeAmount: '1050',
+          currentAcceptedCumulative: '0',
+          deposit: '1000000',
+          requestId: request.requestId,
+          lastRequestCost: '1050',
+          inputTokens: '100',
+          cachedInputTokens: '0',
+          freshInputTokens: '100',
+          outputTokens: '50',
+          service: 'gpt-5.5',
+          usageCid: 'bafkreiinvalid',
+          usageRoot: '0x' + '11'.repeat(32),
+        }, {} as any);
 
-      expect(bpm.handleNeedAuth).toHaveBeenCalledWith(
-        peer.peerId,
-        expect.objectContaining({ usageCid: 'bafkreiinvalid' }),
-        expect.anything(),
-        { usagePointerVerified: false },
-      );
-      expect((negotiator as unknown as { _usageObservations: Map<string, unknown> })._usageObservations.size).toBe(0);
+        expect(bpm.handleNeedAuth).toHaveBeenCalledWith(
+          peer.peerId,
+          expect.objectContaining({ usageCid: 'bafkreiinvalid' }),
+          expect.anything(),
+          {},
+        );
+        expect((negotiator as unknown as { _usageVerifier: { pendingObservationCount: number } })._usageVerifier.pendingObservationCount).toBe(0);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+      }
     });
 
     it('persists verified usage records so a restarted buyer can verify the next cumulative pointer', async () => {
@@ -791,7 +819,7 @@ describe('BuyerPaymentNegotiator', () => {
           outputBody: response1.body,
         });
         const pointer1 = computeUsageManifestPointer(buildUsageManifest(channelId, [record1]));
-        (bpm.handleNeedAuth as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ signed: true, signedUsagePointer: true });
+        (bpm.handleNeedAuth as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ signed: true, signedVerifiedMetadata: true });
 
         negotiator.estimateCostFromResponse(peer, response1, 'gpt-5.5', request1);
         await negotiator.handleNeedAuth(peer.peerId, {
@@ -811,7 +839,7 @@ describe('BuyerPaymentNegotiator', () => {
         }, {} as any);
 
         const restartedBpm = createMockBpm();
-        restartedBpm.handleNeedAuth = vi.fn().mockResolvedValue({ signed: true, signedUsagePointer: true }) as any;
+        restartedBpm.handleNeedAuth = vi.fn().mockResolvedValue({ signed: true, signedVerifiedMetadata: true }) as any;
         const restarted = new BuyerPaymentNegotiator(
           identity,
           restartedBpm as unknown as BuyerPaymentManager,
@@ -870,7 +898,7 @@ describe('BuyerPaymentNegotiator', () => {
           peer.peerId,
           expect.objectContaining({ usageCid: pointer2.cid, usageRoot: pointer2.usageRoot }),
           expect.anything(),
-          { usagePointerVerified: true },
+          { verifiedMetadata: expect.objectContaining({ requiredCumulativeAmount: 2700n }) },
         );
         expect(new UsageManifestStore(tempDir).getRecords(channelId)).toHaveLength(2);
       } finally {

--- a/packages/node/tests/node-payment-mux-wiring.test.ts
+++ b/packages/node/tests/node-payment-mux-wiring.test.ts
@@ -63,6 +63,7 @@ describe('BuyerRequestHandler payment mux wiring', () => {
       peer,
       expect.objectContaining({ statusCode: 200 }),
       undefined,
+      request,
     );
     expect(
       getOrCreatePaymentMux.mock.invocationCallOrder[0],
@@ -138,6 +139,7 @@ describe('BuyerRequestHandler payment mux wiring', () => {
       peer,
       expect.objectContaining({ statusCode: 200 }),
       undefined,
+      request,
     );
   });
 });


### PR DESCRIPTION
## Description

Adds buyer-verified off-chain usage manifests for payment stats. Sellers publish cumulative usage pointers in `NeedAuth`, buyers independently reconstruct and verify them before signing v2 metadata, and network-stats materializes verified manifests into service-level totals.

The buyer now persists verified usage records locally so cumulative pointer verification survives restarts. If pointer verification fails, payment falls back to legacy metadata signing instead of stalling.

## Release Notes

- Added buyer-verified usage manifest pointers for payment stats
- Added durable buyer and seller usage manifest files per channel
- Added network-stats materialization of verified per-service usage totals
- Preserved legacy metadata signing as a fallback when pointer verification fails

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
