### PR TITLE
fix(payments): Show deposit button text

### DIFF
--- a/apps/payments/web/src/components/DepositView.scss
+++ b/apps/payments/web/src/components/DepositView.scss
@@ -274,7 +274,7 @@
   .dv-step--done & {
     background: var(--accent);
     border-color: var(--accent);
-    color: var(--accent-text);
+    color: var(--on-accent, #07140d);
   }
 
   .dv-step--active & {
@@ -297,7 +297,7 @@
   width: 100%;
   padding: var(--sp-3) var(--sp-4);
   background: var(--accent);
-  color: var(--accent-text);
+  color: var(--on-accent, #07140d);
   border: none;
   border-radius: var(--radius-md);
   font: inherit;


### PR DESCRIPTION
## Description

The deposit wizard connect/submit button used the accent text token on top of the accent background. In dark mode those tokens resolve to the same green, making the button label appear blank.

This changes filled deposit controls to use the on-accent foreground token so the label remains readable in dark mode.

## Release Notes

- Fixed the deposit wizard button label disappearing in dark mode.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Validation: pnpm --filter=@antseed/payments run build:web