### PR TITLE
feat(payments): Track service metadata totals

### DIFF
--- a/packages/contracts/AntseedChannels.sol
+++ b/packages/contracts/AntseedChannels.sol
@@ -20,7 +20,9 @@ import {IAntseedStats} from "./interfaces/IAntseedStats.sol";
  *
  *         The buyer signs a single EIP-712 SpendingAuth on every request:
  *         - cumulativeAmount: total USDC authorized so far
- *         - metadataHash: hash of (inputTokens, outputTokens, latencyMs, requestCount)
+ *         - metadataHash: hash of buyer metadata bytes. Current metadata starts
+ *           with (version, cumulativeInputTokens, cumulativeOutputTokens,
+ *           cumulativeRequestCount) and may append off-chain indexer fields.
  *
  *         Money flow:
  *           reserve:  Deposits locks buyer funds

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -88,6 +88,11 @@ ReserveAuth(bytes32 channelId, uint128 maxAmount, uint256 deadline)
 SpendingAuth(bytes32 channelId, uint256 cumulativeAmount, bytes32 metadataHash)
 ```
 
+`metadataHash` is the hash of buyer metadata bytes. Current metadata keeps the
+first four ABI fields stable for legacy decoders:
+`version, cumulativeInputTokens, cumulativeOutputTokens, cumulativeRequestCount`,
+then appends service attribution data for off-chain indexers.
+
 channelId = keccak256(abi.encode(buyer, seller, salt))
 
 **Owner functions:**

--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -277,12 +277,12 @@ export class BuyerRequestHandler {
       if (result.action === 'return') return result.response;
       startTime = Date.now();
       const retriedResponse = await executeRequest();
-      negotiator.estimateCostFromResponse(peer, retriedResponse, requestedService);
+      negotiator.estimateCostFromResponse(peer, retriedResponse, requestedService, req.requestId);
       return retriedResponse;
     }
 
     if (negotiator) {
-      negotiator.estimateCostFromResponse(peer, response, requestedService);
+      negotiator.estimateCostFromResponse(peer, response, requestedService, req.requestId);
     }
 
     return response;

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -60,11 +60,12 @@ export {
   SET_OPERATOR_TYPES,
   computeMetadataHash,
   encodeMetadata,
+  getServiceMetadataId,
   computeChannelId,
   ZERO_METADATA,
   ZERO_METADATA_HASH,
 } from './payments/evm/signatures.js';
-export type { SpendingAuthMessage, ReserveAuthMessage, SetOperatorMessage, SpendingAuthMetadata } from './payments/evm/signatures.js';
+export type { SpendingAuthMessage, ReserveAuthMessage, SetOperatorMessage, SpendingAuthMetadata, SpendingAuthServiceMetadata } from './payments/evm/signatures.js';
 export { NatTraversal, type NatMapping, type NatTraversalResult } from './p2p/nat-traversal.js';
 export { BuyerPaymentManager } from './payments/buyer-payment-manager.js';
 export type { BuyerPaymentConfig } from './payments/buyer-payment-manager.js';

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -14,11 +14,12 @@ import {
   makeChannelsDomain,
   computeMetadataHash,
   encodeMetadata,
+  getServiceMetadataId,
   ZERO_METADATA,
   ZERO_METADATA_HASH,
   computeChannelId,
 } from './evm/signatures.js';
-import type { SpendingAuthMessage, ReserveAuthMessage, SpendingAuthMetadata } from './evm/signatures.js';
+import type { SpendingAuthMessage, ReserveAuthMessage, SpendingAuthMetadata, SpendingAuthServiceMetadata } from './evm/signatures.js';
 import { debugLog, debugWarn } from '../utils/debug.js';
 import { peerIdToAddress, type PeerId } from '../types/peer.js';
 import type { SellerAddressResolver } from '../discovery/seller-address-resolver.js';
@@ -133,11 +134,20 @@ export class BuyerPaymentManager {
     for (const channel of activeChannels) {
       const peerId = channel.peerId;
       const persistedCumulative = BigInt(channel.authMax);
+      const persistedServiceTotals = this._channelStore.getServiceTotals(channel.sessionId);
       this._cumulativeAmount.set(peerId, persistedCumulative);
       this._metadata.set(peerId, {
         cumulativeInputTokens: BigInt(channel.tokensDelivered),
         cumulativeOutputTokens: BigInt(channel.previousConsumption),
         cumulativeRequestCount: BigInt(channel.requestCount),
+        services: persistedServiceTotals.map((total) => ({
+          serviceId: total.serviceId,
+          cumulativeAmount: BigInt(total.cumulativeAmount),
+          cumulativeInputTokens: BigInt(total.cumulativeInputTokens),
+          cumulativeCachedInputTokens: BigInt(total.cumulativeCachedInputTokens),
+          cumulativeOutputTokens: BigInt(total.cumulativeOutputTokens),
+          cumulativeRequestCount: BigInt(total.cumulativeRequestCount),
+        })),
       });
       // Hydrate verifiedCost to authMax so _maxSignable can grow beyond maxPerRequestUsdc.
       // Without this, maxSignable = 0 + maxPerRequestUsdc after restart, permanently capping
@@ -370,6 +380,64 @@ export class BuyerPaymentManager {
     return requestedAmount > maxSignable && maxSignable >= ceiling;
   }
 
+  private _withServiceMetadata(
+    metadata: SpendingAuthMetadata,
+    service: string | undefined,
+    delta: {
+      amount: bigint;
+      inputTokens: bigint;
+      cachedInputTokens: bigint;
+      outputTokens: bigint;
+    },
+  ): SpendingAuthMetadata {
+    if (!service || service.trim().length === 0) return metadata;
+
+    const serviceId = getServiceMetadataId(service);
+    const byServiceId = new Map<string, SpendingAuthServiceMetadata>();
+    for (const entry of metadata.services ?? []) {
+      byServiceId.set(entry.serviceId.toLowerCase(), { ...entry });
+    }
+
+    const existing = byServiceId.get(serviceId.toLowerCase()) ?? {
+      serviceId,
+      cumulativeAmount: 0n,
+      cumulativeInputTokens: 0n,
+      cumulativeCachedInputTokens: 0n,
+      cumulativeOutputTokens: 0n,
+      cumulativeRequestCount: 0n,
+    };
+
+    byServiceId.set(serviceId.toLowerCase(), {
+      serviceId,
+      cumulativeAmount: existing.cumulativeAmount + delta.amount,
+      cumulativeInputTokens: existing.cumulativeInputTokens + delta.inputTokens,
+      cumulativeCachedInputTokens: existing.cumulativeCachedInputTokens + delta.cachedInputTokens,
+      cumulativeOutputTokens: existing.cumulativeOutputTokens + delta.outputTokens,
+      cumulativeRequestCount: existing.cumulativeRequestCount + 1n,
+    });
+
+    return {
+      ...metadata,
+      services: [...byServiceId.values()].sort((a, b) =>
+        a.serviceId.toLowerCase().localeCompare(b.serviceId.toLowerCase()),
+      ),
+    };
+  }
+
+  private _persistServiceMetadata(sessionId: string, metadata: SpendingAuthMetadata): void {
+    this._channelStore.replaceServiceTotals(
+      sessionId,
+      (metadata.services ?? []).map((service) => ({
+        serviceId: service.serviceId,
+        cumulativeAmount: service.cumulativeAmount.toString(),
+        cumulativeInputTokens: service.cumulativeInputTokens.toString(),
+        cumulativeCachedInputTokens: service.cumulativeCachedInputTokens.toString(),
+        cumulativeOutputTokens: service.cumulativeOutputTokens.toString(),
+        cumulativeRequestCount: service.cumulativeRequestCount.toString(),
+      })),
+    );
+  }
+
   private async _sendUpdatedSpendingAuth(
     session: StoredChannel,
     sellerPeerId: string,
@@ -387,6 +455,7 @@ export class BuyerPaymentManager {
     const spendingAuthSig = await signSpendingAuth(this._signer, this._channelsDomain, metadataMsg);
 
     this._cumulativeAmount.set(sellerPeerId, cumulativeAmount);
+    this._persistServiceMetadata(session.sessionId, metadata);
     this._channelStore.upsertChannel({
       ...session,
       authMax: cumulativeAmount.toString(),
@@ -681,12 +750,14 @@ export class BuyerPaymentManager {
 
     let estimatedInputTokens: bigint;
     let estimatedOutputTokens: bigint;
+    let estimatedCachedInputTokens = 0n;
     let buyerEstimatedRequestCost: bigint;
 
     if (hasReportedTokens) {
       estimatedInputTokens = responseStats.reportedInputTokens ?? 0n;
       estimatedOutputTokens = responseStats.reportedOutputTokens ?? 0n;
       const cachedInputTokens = responseStats.reportedCachedInputTokens ?? 0n;
+      estimatedCachedInputTokens = cachedInputTokens;
       // For cost estimation, reportedInputTokens is normalized to total logical
       // input tokens (fresh + cached), so split fresh by subtracting cached.
       const freshInputTokens = cachedInputTokens > 0n
@@ -751,15 +822,6 @@ export class BuyerPaymentManager {
     // If cost is 0, the cumulative amount stays the same — no spending auth needed
     // but we still sign one to keep the seller's session alive.
 
-    // Update cumulative metadata
-    const prev = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
-    const newMeta: SpendingAuthMetadata = {
-      cumulativeInputTokens: prev.cumulativeInputTokens + estimatedInputTokens,
-      cumulativeOutputTokens: prev.cumulativeOutputTokens + estimatedOutputTokens,
-      cumulativeRequestCount: prev.cumulativeRequestCount + 1n,
-    };
-    this._metadata.set(sellerPeerId, newMeta);
-
     // Advance cumulative amount by the accepted cost, then add overdraft headroom
     // for the next request (so the seller has budget to serve it).
     // maxSignable already caps at reserve ceiling, so one cap is sufficient
@@ -768,6 +830,24 @@ export class BuyerPaymentManager {
     let newAmount = prevAmount + acceptedCost;
     if (newAmount > maxSignable) newAmount = maxSignable;
     this._cumulativeAmount.set(sellerPeerId, newAmount);
+    const signedDelta = newAmount - prevAmount;
+
+    // Update cumulative metadata
+    const prev = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
+    const totalsMeta: SpendingAuthMetadata = {
+      cumulativeInputTokens: prev.cumulativeInputTokens + estimatedInputTokens,
+      cumulativeOutputTokens: prev.cumulativeOutputTokens + estimatedOutputTokens,
+      cumulativeRequestCount: prev.cumulativeRequestCount + 1n,
+      services: prev.services ?? [],
+    };
+    const newMeta = this._withServiceMetadata(totalsMeta, responseStats.service, {
+      amount: signedDelta,
+      inputTokens: estimatedInputTokens,
+      cachedInputTokens: estimatedCachedInputTokens,
+      outputTokens: estimatedOutputTokens,
+    });
+    this._metadata.set(sellerPeerId, newMeta);
+    this._persistServiceMetadata(session.sessionId, newMeta);
 
     debugLog(
       `[BuyerPayment] signPerRequestAuth #${newMeta.cumulativeRequestCount}: ` +
@@ -843,12 +923,21 @@ export class BuyerPaymentManager {
     }
     if (payload.requestId) this._requestService.delete(payload.requestId);
 
+    let acceptedServiceCost = 0n;
+    let reportedInputTokens = BigInt(payload.inputTokens ?? '0');
+    let reportedCachedInputTokens = BigInt(payload.cachedInputTokens ?? '0');
+    let reportedOutputTokens = BigInt(payload.outputTokens ?? '0');
+
     // Validate the seller's claimed cost if reported
     if (payload.lastRequestCost) {
       const sellerCost = BigInt(payload.lastRequestCost);
       const sellerIn = BigInt(payload.inputTokens ?? '0');
       const sellerOut = BigInt(payload.outputTokens ?? '0');
       const sellerCached = BigInt(payload.cachedInputTokens ?? '0');
+      acceptedServiceCost = sellerCost;
+      reportedInputTokens = sellerIn;
+      reportedCachedInputTokens = sellerCached;
+      reportedOutputTokens = sellerOut;
       // Prefer seller-supplied freshInputTokens to avoid OpenAI-vs-Anthropic
       // cached-semantics ambiguity (OpenAI: prompt_tokens includes cached;
       // Anthropic: input_tokens excludes cached). Fall back to OpenAI-style
@@ -929,12 +1018,23 @@ export class BuyerPaymentManager {
     // Advance cumulative metadata. requestCount always increments so the
     // on-chain metadata stays consistent even when older sellers omit token
     // fields; absent token fields contribute 0 to the running totals.
+    const signedDelta = effectiveAmount - currentCumulative;
+    const serviceAmountDelta = acceptedServiceCost > 0n
+      ? (acceptedServiceCost < signedDelta ? acceptedServiceCost : signedDelta)
+      : 0n;
     const prevMeta = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
-    const newMeta: SpendingAuthMetadata = {
-      cumulativeInputTokens: prevMeta.cumulativeInputTokens + BigInt(payload.inputTokens ?? '0'),
-      cumulativeOutputTokens: prevMeta.cumulativeOutputTokens + BigInt(payload.outputTokens ?? '0'),
+    const totalsMeta: SpendingAuthMetadata = {
+      cumulativeInputTokens: prevMeta.cumulativeInputTokens + reportedInputTokens,
+      cumulativeOutputTokens: prevMeta.cumulativeOutputTokens + reportedOutputTokens,
       cumulativeRequestCount: prevMeta.cumulativeRequestCount + 1n,
+      services: prevMeta.services ?? [],
     };
+    const newMeta = this._withServiceMetadata(totalsMeta, buyerService, {
+      amount: serviceAmountDelta,
+      inputTokens: reportedInputTokens,
+      cachedInputTokens: reportedCachedInputTokens,
+      outputTokens: reportedOutputTokens,
+    });
     this._metadata.set(sellerPeerId, newMeta);
 
     // Send via PaymentMux

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -388,6 +388,7 @@ export class BuyerPaymentManager {
       inputTokens: bigint;
       cachedInputTokens: bigint;
       outputTokens: bigint;
+      requests: bigint;
     },
   ): SpendingAuthMetadata {
     if (!service || service.trim().length === 0) return metadata;
@@ -395,10 +396,10 @@ export class BuyerPaymentManager {
     const serviceId = getServiceMetadataId(service);
     const byServiceId = new Map<string, SpendingAuthServiceMetadata>();
     for (const entry of metadata.services ?? []) {
-      byServiceId.set(entry.serviceId.toLowerCase(), { ...entry });
+      byServiceId.set(entry.serviceId, { ...entry });
     }
 
-    const existing = byServiceId.get(serviceId.toLowerCase()) ?? {
+    const existing = byServiceId.get(serviceId) ?? {
       serviceId,
       cumulativeAmount: 0n,
       cumulativeInputTokens: 0n,
@@ -407,21 +408,37 @@ export class BuyerPaymentManager {
       cumulativeRequestCount: 0n,
     };
 
-    byServiceId.set(serviceId.toLowerCase(), {
+    byServiceId.set(serviceId, {
       serviceId,
       cumulativeAmount: existing.cumulativeAmount + delta.amount,
       cumulativeInputTokens: existing.cumulativeInputTokens + delta.inputTokens,
       cumulativeCachedInputTokens: existing.cumulativeCachedInputTokens + delta.cachedInputTokens,
       cumulativeOutputTokens: existing.cumulativeOutputTokens + delta.outputTokens,
-      cumulativeRequestCount: existing.cumulativeRequestCount + 1n,
+      cumulativeRequestCount: existing.cumulativeRequestCount + delta.requests,
     });
 
     return {
       ...metadata,
       services: [...byServiceId.values()].sort((a, b) =>
-        a.serviceId.toLowerCase().localeCompare(b.serviceId.toLowerCase()),
+        a.serviceId < b.serviceId ? -1 : a.serviceId > b.serviceId ? 1 : 0,
       ),
     };
+  }
+
+  /**
+   * Both signPerRequestAuth (buyer-initiated) and handleNeedAuth (seller-initiated)
+   * can fire for the same request when the proactive auth doesn't fully cover the
+   * seller's required cumulative. Whichever path counts a request's tokens first
+   * records its requestId here so the other path attributes only the amount delta.
+   */
+  private readonly _serviceTokensCounted = new Set<string>();
+
+  private _markServiceTokensCounted(requestId: string): void {
+    if (this._serviceTokensCounted.size >= 512) {
+      const oldest = this._serviceTokensCounted.values().next().value;
+      if (oldest !== undefined) this._serviceTokensCounted.delete(oldest);
+    }
+    this._serviceTokensCounted.add(requestId);
   }
 
   private _persistServiceMetadata(sessionId: string, metadata: SpendingAuthMetadata): void {
@@ -734,6 +751,7 @@ export class BuyerPaymentManager {
       reportedOutputTokens?: bigint;
       reportedCachedInputTokens?: bigint;
       service?: string;
+      requestId?: string;
     },
   ): Promise<PerRequestAuthResult> {
     const session = this.getActiveSession(sellerPeerId);
@@ -840,12 +858,23 @@ export class BuyerPaymentManager {
       cumulativeRequestCount: prev.cumulativeRequestCount + 1n,
       services: prev.services ?? [],
     };
-    const newMeta = this._withServiceMetadata(totalsMeta, responseStats.service, {
-      amount: signedDelta,
-      inputTokens: estimatedInputTokens,
-      cachedInputTokens: estimatedCachedInputTokens,
-      outputTokens: estimatedOutputTokens,
-    });
+    // If handleNeedAuth already counted this request (seller-initiated NeedAuth
+    // raced ahead), skip service attribution entirely: service totals are
+    // documented as lower bounds, so undercounting beats double-counting.
+    const alreadyCounted =
+      responseStats.requestId != null && this._serviceTokensCounted.has(responseStats.requestId);
+    const newMeta = alreadyCounted
+      ? totalsMeta
+      : this._withServiceMetadata(totalsMeta, responseStats.service, {
+          amount: signedDelta,
+          inputTokens: estimatedInputTokens,
+          cachedInputTokens: estimatedCachedInputTokens,
+          outputTokens: estimatedOutputTokens,
+          requests: 1n,
+        });
+    if (responseStats.requestId != null && !alreadyCounted) {
+      this._markServiceTokensCounted(responseStats.requestId);
+    }
     this._metadata.set(sellerPeerId, newMeta);
     this._persistServiceMetadata(session.sessionId, newMeta);
 
@@ -924,20 +953,17 @@ export class BuyerPaymentManager {
     if (payload.requestId) this._requestService.delete(payload.requestId);
 
     let acceptedServiceCost = 0n;
-    let reportedInputTokens = BigInt(payload.inputTokens ?? '0');
-    let reportedCachedInputTokens = BigInt(payload.cachedInputTokens ?? '0');
-    let reportedOutputTokens = BigInt(payload.outputTokens ?? '0');
+    const reportedInputTokens = BigInt(payload.inputTokens ?? '0');
+    const reportedCachedInputTokens = BigInt(payload.cachedInputTokens ?? '0');
+    const reportedOutputTokens = BigInt(payload.outputTokens ?? '0');
 
     // Validate the seller's claimed cost if reported
     if (payload.lastRequestCost) {
       const sellerCost = BigInt(payload.lastRequestCost);
-      const sellerIn = BigInt(payload.inputTokens ?? '0');
-      const sellerOut = BigInt(payload.outputTokens ?? '0');
-      const sellerCached = BigInt(payload.cachedInputTokens ?? '0');
+      const sellerIn = reportedInputTokens;
+      const sellerOut = reportedOutputTokens;
+      const sellerCached = reportedCachedInputTokens;
       acceptedServiceCost = sellerCost;
-      reportedInputTokens = sellerIn;
-      reportedCachedInputTokens = sellerCached;
-      reportedOutputTokens = sellerOut;
       // Prefer seller-supplied freshInputTokens to avoid OpenAI-vs-Anthropic
       // cached-semantics ambiguity (OpenAI: prompt_tokens includes cached;
       // Anthropic: input_tokens excludes cached). Fall back to OpenAI-style
@@ -1029,12 +1055,24 @@ export class BuyerPaymentManager {
       cumulativeRequestCount: prevMeta.cumulativeRequestCount + 1n,
       services: prevMeta.services ?? [],
     };
-    const newMeta = this._withServiceMetadata(totalsMeta, buyerService, {
-      amount: serviceAmountDelta,
-      inputTokens: reportedInputTokens,
-      cachedInputTokens: reportedCachedInputTokens,
-      outputTokens: reportedOutputTokens,
-    });
+    // If signPerRequestAuth already counted this request (buyer-initiated auth
+    // raced ahead but didn't fully cover the seller's required cumulative), skip
+    // service attribution entirely: service totals are documented as lower
+    // bounds, so undercounting beats double-counting.
+    const alreadyCounted =
+      payload.requestId != null && this._serviceTokensCounted.has(payload.requestId);
+    const newMeta = alreadyCounted
+      ? totalsMeta
+      : this._withServiceMetadata(totalsMeta, buyerService, {
+          amount: serviceAmountDelta,
+          inputTokens: reportedInputTokens,
+          cachedInputTokens: reportedCachedInputTokens,
+          outputTokens: reportedOutputTokens,
+          requests: 1n,
+        });
+    if (payload.requestId != null && !alreadyCounted) {
+      this._markServiceTokensCounted(payload.requestId);
+    }
     this._metadata.set(sellerPeerId, newMeta);
 
     // Send via PaymentMux

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -40,6 +40,7 @@ interface LastResponseCost {
   outputContent: Uint8Array;
   latencyMs: number;
   service?: string;
+  requestId?: string;
 }
 
 function parsePaymentRequiredBody(body: Uint8Array): Record<string, unknown> | null {
@@ -210,10 +211,11 @@ export class BuyerPaymentNegotiator {
     const reportedOutputTokens = lastCost?.outputTokens;
     const reportedCachedInputTokens = lastCost?.cachedInputTokens;
     const service = lastCost?.service;
+    const requestId = lastCost?.requestId;
     try {
       const { payload, topUpNeeded } = await this._bpm.signPerRequestAuth(
         peer.peerId,
-        { inputBytes, outputBytes, sellerClaimedCost, reportedInputTokens, reportedOutputTokens, reportedCachedInputTokens, service },
+        { inputBytes, outputBytes, sellerClaimedCost, reportedInputTokens, reportedOutputTokens, reportedCachedInputTokens, service, requestId },
       );
       pmux.sendSpendingAuth(payload);
       // Release held content to free memory — no longer needed after signing
@@ -442,7 +444,7 @@ export class BuyerPaymentNegotiator {
     }
   }
 
-  estimateCostFromResponse(peer: PeerInfo, response: SerializedHttpResponse, service?: string): void {
+  estimateCostFromResponse(peer: PeerInfo, response: SerializedHttpResponse, service?: string, requestId?: string): void {
     // Prefer session pricing (from PaymentRequired negotiation, includes service-specific rates)
     // over peer-level defaults which may be different from the actual service pricing.
     const sessionPricing = this._bpm.getSessionPricing(peer.peerId, service);
@@ -471,6 +473,7 @@ export class BuyerPaymentNegotiator {
       outputContent: response.body,
       latencyMs: 0,
       service,
+      requestId,
     });
 
     debugLog(

--- a/packages/node/src/payments/channel-store.ts
+++ b/packages/node/src/payments/channel-store.ts
@@ -46,6 +46,17 @@ export interface StoredReceipt {
   createdAt: number;
 }
 
+export interface StoredChannelServiceTotal {
+  sessionId: string;
+  serviceId: string;
+  cumulativeAmount: string; // bigint as string
+  cumulativeInputTokens: string; // bigint as string
+  cumulativeCachedInputTokens: string; // bigint as string
+  cumulativeOutputTokens: string; // bigint as string
+  cumulativeRequestCount: string; // bigint as string
+  updatedAt: number;
+}
+
 export class ChannelStore {
   private _db: Database.Database;
 
@@ -57,6 +68,7 @@ export class ChannelStore {
     requestCount: number,
     receipt: Omit<StoredReceipt, 'id'>,
   ) => void;
+  private readonly _replaceServiceTotalsTxn: (sessionId: string, totals: StoredChannelServiceTotal[]) => void;
 
   private readonly _stmts: {
     upsert: Database.Statement;
@@ -77,6 +89,9 @@ export class ChannelStore {
     getActiveChannels: Database.Statement;
     getActiveChannelsByBuyer: Database.Statement;
     getTotalsByPeerAndBuyer: Database.Statement;
+    deleteServiceTotals: Database.Statement;
+    insertServiceTotal: Database.Statement;
+    getServiceTotals: Database.Statement;
   };
 
   constructor(dataDir: string) {
@@ -91,6 +106,21 @@ export class ChannelStore {
         this.insertReceipt(receipt);
       },
     );
+    this._replaceServiceTotalsTxn = this._db.transaction((sessionId: string, totals: StoredChannelServiceTotal[]) => {
+      this._stmts.deleteServiceTotals.run(sessionId);
+      for (const total of totals) {
+        this._stmts.insertServiceTotal.run({
+          sessionId: total.sessionId,
+          serviceId: total.serviceId,
+          cumulativeAmount: total.cumulativeAmount,
+          cumulativeInputTokens: total.cumulativeInputTokens,
+          cumulativeCachedInputTokens: total.cumulativeCachedInputTokens,
+          cumulativeOutputTokens: total.cumulativeOutputTokens,
+          cumulativeRequestCount: total.cumulativeRequestCount,
+          updatedAt: total.updatedAt,
+        });
+      }
+    });
   }
 
   private _prepareStatements() {
@@ -188,6 +218,23 @@ export class ChannelStore {
         FROM payment_channels
         WHERE peer_id = ? AND role = ? AND buyer_evm_addr = ?
       `),
+      deleteServiceTotals: this._db.prepare(
+        'DELETE FROM payment_channel_service_totals WHERE session_id = ?',
+      ),
+      insertServiceTotal: this._db.prepare(`
+        INSERT INTO payment_channel_service_totals (
+          session_id, service_id, cumulative_amount, cumulative_input_tokens,
+          cumulative_cached_input_tokens, cumulative_output_tokens,
+          cumulative_request_count, updated_at
+        ) VALUES (
+          @sessionId, @serviceId, @cumulativeAmount, @cumulativeInputTokens,
+          @cumulativeCachedInputTokens, @cumulativeOutputTokens,
+          @cumulativeRequestCount, @updatedAt
+        )
+      `),
+      getServiceTotals: this._db.prepare(
+        'SELECT * FROM payment_channel_service_totals WHERE session_id = ? ORDER BY service_id',
+      ),
     };
   }
 
@@ -406,6 +453,25 @@ export class ChannelStore {
     this._stmts.updateReceiptAck.run(buyerAckSig, sessionId, runningTotal, requestCount);
   }
 
+  // ── Service total CRUD ────────────────────────────────────────
+
+  replaceServiceTotals(sessionId: string, totals: Omit<StoredChannelServiceTotal, 'sessionId' | 'updatedAt'>[]): void {
+    const updatedAt = Date.now();
+    this._replaceServiceTotalsTxn(
+      sessionId,
+      totals.map((total) => ({
+        sessionId,
+        ...total,
+        updatedAt,
+      })),
+    );
+  }
+
+  getServiceTotals(sessionId: string): StoredChannelServiceTotal[] {
+    const rows = this._stmts.getServiceTotals.all(sessionId) as ServiceTotalRow[];
+    return rows.map(rowToServiceTotal);
+  }
+
   // ── Lifecycle ─────────────────────────────────────────────────
 
   close(): void {
@@ -450,6 +516,17 @@ interface ReceiptRow {
   created_at: number;
 }
 
+interface ServiceTotalRow {
+  session_id: string;
+  service_id: string;
+  cumulative_amount: string;
+  cumulative_input_tokens: string;
+  cumulative_cached_input_tokens: string;
+  cumulative_output_tokens: string;
+  cumulative_request_count: string;
+  updated_at: number;
+}
+
 function rowToChannel(row: ChannelRow): StoredChannel {
   return {
     sessionId: row.session_id,
@@ -486,5 +563,18 @@ function rowToReceipt(row: ReceiptRow): StoredReceipt {
     sellerSig: row.seller_sig,
     buyerAckSig: row.buyer_ack_sig,
     createdAt: row.created_at,
+  };
+}
+
+function rowToServiceTotal(row: ServiceTotalRow): StoredChannelServiceTotal {
+  return {
+    sessionId: row.session_id,
+    serviceId: row.service_id,
+    cumulativeAmount: row.cumulative_amount,
+    cumulativeInputTokens: row.cumulative_input_tokens,
+    cumulativeCachedInputTokens: row.cumulative_cached_input_tokens,
+    cumulativeOutputTokens: row.cumulative_output_tokens,
+    cumulativeRequestCount: row.cumulative_request_count,
+    updatedAt: row.updated_at,
   };
 }

--- a/packages/node/src/payments/evm/signatures.ts
+++ b/packages/node/src/payments/evm/signatures.ts
@@ -1,4 +1,4 @@
-import { type AbstractSigner, type TypedDataDomain, AbiCoder, keccak256 } from 'ethers';
+import { type AbstractSigner, type TypedDataDomain, AbiCoder, id, keccak256 } from 'ethers';
 
 // =========================================================================
 // EIP-712 Types — AntSeed SpendingAuth (cumulative payment authorization)
@@ -52,20 +52,69 @@ export interface SetOperatorMessage {
 // Metadata encoding
 // =========================================================================
 
+/**
+ * SpendingAuth metadata v2.
+ *
+ * ABI layout:
+ *   abi.encode(
+ *     uint256 version,
+ *     uint256 cumulativeInputTokens,
+ *     uint256 cumulativeOutputTokens,
+ *     uint256 cumulativeRequestCount,
+ *     ServiceTotal[] services
+ *   )
+ *
+ * The first four fields intentionally match v1 so legacy decoders can read
+ * aggregate token/request counters by decoding only those fields. Service
+ * entries are buyer-side attribution metadata for indexers: input tokens
+ * include cached input, with cached input broken out separately.
+ *
+ * Service cumulativeAmount values may be lower than the top-level
+ * cumulativeAmount because the buyer can sign reserve headroom, cap a
+ * per-request amount, or extend auth without attributing that delta to a
+ * specific service.
+ */
+
 export interface SpendingAuthMetadata {
   cumulativeInputTokens: bigint;
   cumulativeOutputTokens: bigint;
   cumulativeRequestCount: bigint;
+  services?: SpendingAuthServiceMetadata[];
 }
 
-export const METADATA_VERSION = 1n;
+export interface SpendingAuthServiceMetadata {
+  serviceId: string;
+  cumulativeAmount: bigint;
+  cumulativeInputTokens: bigint;
+  cumulativeCachedInputTokens: bigint;
+  cumulativeOutputTokens: bigint;
+  cumulativeRequestCount: bigint;
+}
+
+export const METADATA_VERSION = 2n;
+
+const SERVICE_METADATA_ABI_TYPE =
+  'tuple(bytes32 serviceId,uint256 cumulativeAmount,uint256 cumulativeInputTokens,uint256 cumulativeCachedInputTokens,uint256 cumulativeOutputTokens,uint256 cumulativeRequestCount)[]';
 
 export function encodeMetadata(metadata: SpendingAuthMetadata): string {
   const coder = AbiCoder.defaultAbiCoder();
-  return coder.encode(
-    ['uint256', 'uint256', 'uint256', 'uint256'],
-    [METADATA_VERSION, metadata.cumulativeInputTokens, metadata.cumulativeOutputTokens, metadata.cumulativeRequestCount],
+  const services = [...(metadata.services ?? [])].sort((a, b) =>
+    a.serviceId.toLowerCase().localeCompare(b.serviceId.toLowerCase()),
   );
+  return coder.encode(
+    ['uint256', 'uint256', 'uint256', 'uint256', SERVICE_METADATA_ABI_TYPE],
+    [
+      METADATA_VERSION,
+      metadata.cumulativeInputTokens,
+      metadata.cumulativeOutputTokens,
+      metadata.cumulativeRequestCount,
+      services,
+    ],
+  );
+}
+
+export function getServiceMetadataId(service: string): string {
+  return id(service.trim());
 }
 
 export function computeMetadataHash(metadata: SpendingAuthMetadata): string {
@@ -76,6 +125,7 @@ export const ZERO_METADATA: SpendingAuthMetadata = {
   cumulativeInputTokens: 0n,
   cumulativeOutputTokens: 0n,
   cumulativeRequestCount: 0n,
+  services: [],
 };
 
 export const ZERO_METADATA_HASH: string = computeMetadataHash(ZERO_METADATA);

--- a/packages/node/src/payments/evm/signatures.ts
+++ b/packages/node/src/payments/evm/signatures.ts
@@ -99,7 +99,7 @@ const SERVICE_METADATA_ABI_TYPE =
 export function encodeMetadata(metadata: SpendingAuthMetadata): string {
   const coder = AbiCoder.defaultAbiCoder();
   const services = [...(metadata.services ?? [])].sort((a, b) =>
-    a.serviceId.toLowerCase().localeCompare(b.serviceId.toLowerCase()),
+    a.serviceId < b.serviceId ? -1 : a.serviceId > b.serviceId ? 1 : 0,
   );
   return coder.encode(
     ['uint256', 'uint256', 'uint256', 'uint256', SERVICE_METADATA_ABI_TYPE],

--- a/packages/node/src/payments/index.ts
+++ b/packages/node/src/payments/index.ts
@@ -43,12 +43,13 @@ export {
   SET_OPERATOR_TYPES,
   computeMetadataHash,
   encodeMetadata,
+  getServiceMetadataId,
   METADATA_VERSION,
   computeChannelId,
   ZERO_METADATA,
   ZERO_METADATA_HASH,
 } from './evm/signatures.js';
-export type { SpendingAuthMessage, ReserveAuthMessage, SetOperatorMessage, SpendingAuthMetadata } from './evm/signatures.js';
+export type { SpendingAuthMessage, ReserveAuthMessage, SetOperatorMessage, SpendingAuthMetadata, SpendingAuthServiceMetadata } from './evm/signatures.js';
 
 // ANTS token
 export { ANTSTokenClient } from './evm/ants-token-client.js';

--- a/packages/node/src/storage/migrations/channels/003_create_service_totals.ts
+++ b/packages/node/src/storage/migrations/channels/003_create_service_totals.ts
@@ -17,9 +17,6 @@ export const migration: Migration = {
         PRIMARY KEY (session_id, service_id),
         FOREIGN KEY (session_id) REFERENCES payment_channels(session_id)
       );
-
-      CREATE INDEX IF NOT EXISTS idx_channel_service_totals_session
-        ON payment_channel_service_totals(session_id);
     `);
   },
 };

--- a/packages/node/src/storage/migrations/channels/003_create_service_totals.ts
+++ b/packages/node/src/storage/migrations/channels/003_create_service_totals.ts
@@ -1,0 +1,25 @@
+import type { Migration } from '../../migrate.js';
+
+export const migration: Migration = {
+  version: 3,
+  name: 'create_service_totals',
+  up: (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS payment_channel_service_totals (
+        session_id TEXT NOT NULL,
+        service_id TEXT NOT NULL,
+        cumulative_amount TEXT NOT NULL,
+        cumulative_input_tokens TEXT NOT NULL,
+        cumulative_cached_input_tokens TEXT NOT NULL,
+        cumulative_output_tokens TEXT NOT NULL,
+        cumulative_request_count TEXT NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (session_id, service_id),
+        FOREIGN KEY (session_id) REFERENCES payment_channels(session_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_channel_service_totals_session
+        ON payment_channel_service_totals(session_id);
+    `);
+  },
+};

--- a/packages/node/src/storage/migrations/channels/index.ts
+++ b/packages/node/src/storage/migrations/channels/index.ts
@@ -1,5 +1,6 @@
 import type { Migration } from '../../migrate.js';
 import { migration as m001 } from './001_create_tables.js';
 import { migration as m002 } from './002_add_auth_sig_columns.js';
+import { migration as m003 } from './003_create_service_totals.js';
 
-export const channelMigrations: Migration[] = [m001, m002];
+export const channelMigrations: Migration[] = [m001, m002, m003];

--- a/packages/node/src/types/protocol.ts
+++ b/packages/node/src/types/protocol.ts
@@ -50,7 +50,7 @@ export interface SpendingAuthPayload {
   channelId: string;
   cumulativeAmount: string;
   metadataHash: string;         // bytes32 hex
-  metadata: string;             // hex-encoded abi.encode(version, inputTokens, outputTokens, requestCount)
+  metadata: string;             // hex-encoded abi.encode(version, inputTokens, outputTokens, requestCount, services[])
   spendingAuthSig: string;      // EIP-712 SpendingAuth signature (covers amount + metadata)
   // Only for initial reserve
   reserveSalt?: string;

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -679,6 +679,52 @@ describe('BuyerPaymentManager', () => {
     }]);
   });
 
+  it('handleNeedAuth does not double-count service totals for a request already counted by signPerRequestAuth', async () => {
+    const sellerPeerId = fakePeerId('seller-service-dedup');
+    const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);
+    manager.trackRequestService('req-dedup', 'gpt-5');
+
+    await manager.signPerRequestAuth(
+      sellerPeerId,
+      {
+        inputBytes: SAMPLE_INPUT,
+        outputBytes: SAMPLE_OUTPUT,
+        sellerClaimedCost: 100n,
+        reportedInputTokens: 1000n,
+        reportedCachedInputTokens: 200n,
+        reportedOutputTokens: 50n,
+        service: 'gpt-5',
+        requestId: 'req-dedup',
+      },
+    );
+
+    // Seller demands more headroom for the same request — must not re-count it.
+    mux.sentSpendingAuths.length = 0;
+    await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requestId: 'req-dedup',
+      requiredCumulativeAmount: '50000',
+      currentAcceptedCumulative: '0',
+      deposit: '1000000',
+      lastRequestCost: '100',
+      inputTokens: '1000',
+      cachedInputTokens: '200',
+      outputTokens: '50',
+    }, mux);
+
+    expect(mux.sentSpendingAuths.length).toBe(1);
+    const sent = mux.sentSpendingAuths[0] as Record<string, string>;
+    const services = decodeMetadataServices(sent.metadata);
+    expect(services).toEqual([{
+      serviceId: id('gpt-5'),
+      cumulativeAmount: 100n,
+      cumulativeInputTokens: 1000n,
+      cumulativeCachedInputTokens: 200n,
+      cumulativeOutputTokens: 50n,
+      cumulativeRequestCount: 1n,
+    }]);
+  });
+
   it('handleNeedAuth caps at reserve ceiling', async () => {
     const sellerPeerId = fakePeerId('seller-needauth-cap');
     // Reserve ceiling = 10_000 (initial suggested amount)

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
-import { AbiCoder, Wallet } from 'ethers';
+import { AbiCoder, id, Wallet } from 'ethers';
 import { BuyerPaymentManager, type BuyerPaymentConfig } from '../src/payments/buyer-payment-manager.js';
 import { ChannelStore } from '../src/payments/channel-store.js';
 import type { PaymentMux } from '../src/p2p/payment-mux.js';
@@ -31,6 +31,32 @@ function decodeMetadataTokens(metadata: string): { inputTokens: bigint; outputTo
   const coder = AbiCoder.defaultAbiCoder();
   const [, inputTokens, outputTokens] = coder.decode(['uint256', 'uint256', 'uint256', 'uint256'], metadata);
   return { inputTokens, outputTokens };
+}
+
+function decodeMetadataServices(metadata: string): Array<{
+  serviceId: string;
+  cumulativeAmount: bigint;
+  cumulativeInputTokens: bigint;
+  cumulativeCachedInputTokens: bigint;
+  cumulativeOutputTokens: bigint;
+  cumulativeRequestCount: bigint;
+}> {
+  const coder = AbiCoder.defaultAbiCoder();
+  const [, , , , services] = coder.decode([
+    'uint256',
+    'uint256',
+    'uint256',
+    'uint256',
+    'tuple(bytes32 serviceId,uint256 cumulativeAmount,uint256 cumulativeInputTokens,uint256 cumulativeCachedInputTokens,uint256 cumulativeOutputTokens,uint256 cumulativeRequestCount)[]',
+  ], metadata);
+  return [...services].map((service) => ({
+    serviceId: service.serviceId as string,
+    cumulativeAmount: service.cumulativeAmount as bigint,
+    cumulativeInputTokens: service.cumulativeInputTokens as bigint,
+    cumulativeCachedInputTokens: service.cumulativeCachedInputTokens as bigint,
+    cumulativeOutputTokens: service.cumulativeOutputTokens as bigint,
+    cumulativeRequestCount: service.cumulativeRequestCount as bigint,
+  }));
 }
 
 function createMockPaymentMux(): PaymentMux & {
@@ -133,8 +159,8 @@ describe('BuyerPaymentManager', () => {
     expect(sent.metadata).toBeTypeOf('string');
     expect(sent.metadata).not.toBe('');
     expect((sent.metadata as string).startsWith('0x')).toBe(true);
-    // Should be ABI-encoded (version,inputTokens,outputTokens,requestCount) = 4 * 32 bytes + 0x prefix
-    expect((sent.metadata as string).length).toBe(2 + 4 * 64);
+    // Should preserve the first four ABI fields and append an empty dynamic services array.
+    expect((sent.metadata as string).length).toBe(2 + 6 * 64);
   });
 
   it('authorizeSpending rejects if minBudgetPerRequest exceeds maxPerRequestUsdc', async () => {
@@ -468,6 +494,133 @@ describe('BuyerPaymentManager', () => {
     expect(BigInt(payload.cumulativeAmount)).toBe(2340n);
   });
 
+  it('signPerRequestAuth appends cumulative per-service metadata', async () => {
+    const sellerPeerId = fakePeerId('seller-service-meta');
+    await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);
+
+    await manager.signPerRequestAuth(
+      sellerPeerId,
+      {
+        inputBytes: SAMPLE_INPUT,
+        outputBytes: SAMPLE_OUTPUT,
+        sellerClaimedCost: 100n,
+        reportedInputTokens: 1000n,
+        reportedCachedInputTokens: 200n,
+        reportedOutputTokens: 50n,
+        service: 'gpt-5',
+      },
+    );
+
+    await manager.signPerRequestAuth(
+      sellerPeerId,
+      {
+        inputBytes: SAMPLE_INPUT,
+        outputBytes: SAMPLE_OUTPUT,
+        sellerClaimedCost: 150n,
+        reportedInputTokens: 500n,
+        reportedCachedInputTokens: 100n,
+        reportedOutputTokens: 25n,
+        service: 'gpt-5',
+      },
+    );
+
+    const { payload } = await manager.signPerRequestAuth(
+      sellerPeerId,
+      {
+        inputBytes: SAMPLE_INPUT,
+        outputBytes: SAMPLE_OUTPUT,
+        sellerClaimedCost: 250n,
+        reportedInputTokens: 2000n,
+        reportedCachedInputTokens: 300n,
+        reportedOutputTokens: 75n,
+        service: 'claude-opus',
+      },
+    );
+
+    // The legacy first-four-field decode still works with the appended services array.
+    const meta = decodeMetadataTokens(payload.metadata);
+    expect(meta.inputTokens).toBe(3500n);
+    expect(meta.outputTokens).toBe(150n);
+
+    const services = decodeMetadataServices(payload.metadata);
+    expect(services).toHaveLength(2);
+    expect(services).toContainEqual({
+      serviceId: id('gpt-5'),
+      cumulativeAmount: 250n,
+      cumulativeInputTokens: 1500n,
+      cumulativeCachedInputTokens: 300n,
+      cumulativeOutputTokens: 75n,
+      cumulativeRequestCount: 2n,
+    });
+    expect(services).toContainEqual({
+      serviceId: id('claude-opus'),
+      cumulativeAmount: 250n,
+      cumulativeInputTokens: 2000n,
+      cumulativeCachedInputTokens: 300n,
+      cumulativeOutputTokens: 75n,
+      cumulativeRequestCount: 1n,
+    });
+
+    const channel = store.getActiveChannelByPeer(sellerPeerId, 'buyer');
+    expect(channel).not.toBeNull();
+    const storedServices = store.getServiceTotals(channel!.sessionId);
+    expect(storedServices).toHaveLength(2);
+    expect(storedServices).toContainEqual(expect.objectContaining({
+      serviceId: id('gpt-5'),
+      cumulativeAmount: '250',
+      cumulativeInputTokens: '1500',
+      cumulativeCachedInputTokens: '300',
+      cumulativeOutputTokens: '75',
+      cumulativeRequestCount: '2',
+    }));
+  });
+
+  it('signPerRequestAuth hydrates cumulative service metadata after restart', async () => {
+    const sellerPeerId = fakePeerId('seller-service-restart');
+    await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);
+
+    await manager.signPerRequestAuth(
+      sellerPeerId,
+      {
+        inputBytes: SAMPLE_INPUT,
+        outputBytes: SAMPLE_OUTPUT,
+        sellerClaimedCost: 100n,
+        reportedInputTokens: 1000n,
+        reportedCachedInputTokens: 200n,
+        reportedOutputTokens: 50n,
+        service: 'gpt-5',
+      },
+    );
+
+    store.close();
+    store = new ChannelStore(tempDir);
+    manager = new BuyerPaymentManager(identity, makeConfig(tempDir), store);
+    manager.setSigner(identity.wallet);
+
+    const { payload } = await manager.signPerRequestAuth(
+      sellerPeerId,
+      {
+        inputBytes: SAMPLE_INPUT,
+        outputBytes: SAMPLE_OUTPUT,
+        sellerClaimedCost: 150n,
+        reportedInputTokens: 500n,
+        reportedCachedInputTokens: 100n,
+        reportedOutputTokens: 25n,
+        service: 'gpt-5',
+      },
+    );
+
+    const [service] = decodeMetadataServices(payload.metadata);
+    expect(service).toEqual({
+      serviceId: id('gpt-5'),
+      cumulativeAmount: 250n,
+      cumulativeInputTokens: 1500n,
+      cumulativeCachedInputTokens: 300n,
+      cumulativeOutputTokens: 75n,
+      cumulativeRequestCount: 2n,
+    });
+  });
+
   it('signPerRequestAuth throws if no active session', async () => {
     await expect(
       manager.signPerRequestAuth('nonexistent-peer', { inputBytes: new Uint8Array(0), outputBytes: new Uint8Array(0) }),
@@ -492,6 +645,38 @@ describe('BuyerPaymentManager', () => {
     expect(mux.sentSpendingAuths.length).toBe(1);
     const sent = mux.sentSpendingAuths[0] as Record<string, unknown>;
     expect(sent.cumulativeAmount).toBe('50000');
+  });
+
+  it('handleNeedAuth does not attribute unsigned headroom to service amount without reported cost', async () => {
+    const sellerPeerId = fakePeerId('seller-needauth-headroom');
+    const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);
+    manager.trackRequestService('req-headroom', 'gpt-5');
+    mux.sentSpendingAuths.length = 0;
+
+    await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requestId: 'req-headroom',
+      requiredCumulativeAmount: '50000',
+      currentAcceptedCumulative: '0',
+      deposit: '1000000',
+      inputTokens: '1000',
+      cachedInputTokens: '200',
+      outputTokens: '100',
+    }, mux);
+
+    expect(mux.sentSpendingAuths.length).toBe(1);
+    const sent = mux.sentSpendingAuths[0] as Record<string, string>;
+    expect(sent.cumulativeAmount).toBe('50000');
+
+    const services = decodeMetadataServices(sent.metadata);
+    expect(services).toEqual([{
+      serviceId: id('gpt-5'),
+      cumulativeAmount: 0n,
+      cumulativeInputTokens: 1000n,
+      cumulativeCachedInputTokens: 200n,
+      cumulativeOutputTokens: 100n,
+      cumulativeRequestCount: 1n,
+    }]);
   });
 
   it('handleNeedAuth caps at reserve ceiling', async () => {

--- a/packages/node/tests/node-payment-mux-wiring.test.ts
+++ b/packages/node/tests/node-payment-mux-wiring.test.ts
@@ -63,6 +63,7 @@ describe('BuyerRequestHandler payment mux wiring', () => {
       peer,
       expect.objectContaining({ statusCode: 200 }),
       undefined,
+      'req-payment-mux',
     );
     expect(
       getOrCreatePaymentMux.mock.invocationCallOrder[0],
@@ -138,6 +139,7 @@ describe('BuyerRequestHandler payment mux wiring', () => {
       peer,
       expect.objectContaining({ statusCode: 200 }),
       undefined,
+      'req-relock',
     );
   });
 });


### PR DESCRIPTION
## Description

Adds versioned SpendingAuth metadata with cumulative per-service attribution while preserving the first four ABI fields for existing decoders. Persists buyer-side service totals in the channel store so restarted buyers can continue signing cumulative service metadata.

## Release Notes

- Added buyer-signed per-service payment metadata for off-chain indexers
- Persisted per-service channel totals across buyer restarts
- Documented SpendingAuth metadata v2 compatibility and attribution semantics

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
