### PR TITLE
docs: add peer curation spec (curators and lists)

### DIFF
--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -12,6 +12,7 @@ AntSeed is a peer-to-peer AI services network that enables direct connections be
   - [04-payments.md](spec/04-payments.md) — Settlement, deposits, sessions, and disputes
   - [05-reputation.md](spec/05-reputation.md) — Trust scoring and attestations
   - [06-security-overview.md](spec/06-security-overview.md) — End-to-end security model and hardening guidance
+  - [08-curators.md](spec/08-curators.md) — Curators, curated lists, and the peer curation badge
 - [templates/provider-plugin/](templates/provider-plugin/) — Starter template for building a provider plugin (offer AI services)
 - [templates/router-plugin/](templates/router-plugin/) — Starter template for building a router plugin (consume AI services)
 

--- a/docs/protocol/spec/08-curators.md
+++ b/docs/protocol/spec/08-curators.md
@@ -1,0 +1,227 @@
+# 08 - Peer Curation: Curators and Lists
+
+AntSeed's network is open: anyone can announce a service and become a peer, so the
+peer list a buyer sees can grow large and noisy. Peer curation tames that, letting
+a buyer narrow the open set down to a subset that third parties it trusts have
+vouched for.
+
+A *curator* publishes one or more *lists* of peers it vouches for. The buyer adds
+curators it trusts, the client downloads their lists, and any peer on a list gets
+a checkmark.
+
+Curation is display-only: it's a badge a human reads, and never feeds peer
+selection, scoring, routing, metering, or payments. A vouch is just as plain: a
+peer is in a list or not, with no per-peer claim, level, or reason. Any meaning
+lives in the list: its name, and the curator behind it.
+
+That minimalism is the point. A bare vouch and a publish-anywhere manifest let
+many kinds of list grow on top, with no new protocol surface.
+
+Who keeps a list is open:
+
+- An individual's personal list of peers they trust.
+- A company's list of partners it has vetted.
+- A community list maintained together, say a JSON file in a public Git repo,
+  where the pull requests and edit history are the trust signal.
+- A bot-generated list, say one ranking peers by on-chain signals like
+  settlement volume or stake age, republished as the chain changes.
+
+What a list *means* is open too, carried by its name and contents rather than any
+field in the file:
+
+- A general "peers we trust" list.
+- Only companies the curator has KYB-verified.
+- Only providers whose TEE attestation someone checked.
+
+The protocol defines none of these. A curator just publishes a separate, clearly
+named list, and the buyer reads its meaning from the curator and the list's name.
+
+## 1. Scope
+
+This specification defines:
+
+- The curator manifest: the document a curator publishes describing itself and its
+  lists, and where it is served.
+- How a buyer client adds, stores, fetches, and refreshes curators.
+- How a client matches a peer against subscribed curators and shows the curated
+  badge and the "curated only" filter.
+- The trust and security properties of the feature.
+
+## 2. Participants
+
+| Participant | Responsibility |
+|---|---|
+| Curator | A third party that publishes a manifest (Section 6) as a JSON file at a URL it shares, describing one or more lists of the peers it vouches for. Trusted only by the URL the buyer adds, and only by buyers that explicitly add it. |
+| Buyer client | The AntSeed Desktop app or CLI. Stores the buyer's curators, fetches each curator's manifest, matches peers locally, and renders the curated badge and filter. |
+| Peer | Any node that appears in the buyer's peer list, identified by its PeerId. A peer takes no part in curation: it does not opt in, publish, or learn that it was listed. |
+
+## 3. Data Conventions
+
+Unless otherwise stated, this document uses the conventions in
+[00-conventions.md](./00-conventions.md). A peer is named by its **PeerId**, the
+canonical EVM address defined there, which the buyer already holds for every peer
+(`PeerInfo.peerId`).
+
+## 4. Trust Model
+
+| Rule | Why it holds |
+|---|---|
+| Display-only. | A vouch never affects selection, scoring, routing, metering, or payments. |
+| Buyer controls the list. | A curator affects nothing unless the buyer adds it, and the buyer can remove it anytime. |
+| Trust is the URL. | The buyer trusts the file at the URL it added; `name`, `icon`, and list names are display text, never trust inputs. |
+| Vouches are bare and positive. | A listing only ever says "this list vouches for this peer," so a curator may list any address without consent. |
+| The PeerId is a key. | It is the peer's EVM address, so a vouch can only name the real key holder; no impersonation to defend. |
+
+The only real defense is the buyer's choice of curator: one that vouches for bad
+peers spends its own reputation and gets removed. A positive vouch over a key
+needs no consent or signatures.
+
+## 5. The Curation Flow
+
+```text
+USER                BUYER CLIENT                   CURATOR SITE
+ | add manifest URL    |                                |
+ |-------------------->| store URL                      |
+ |                     | GET manifest ----------------->|
+ |                     |<----------------------------- manifest (lists)
+ |                     | cache manifest                 |
+ |                     |                                |
+ | browse peers        |                                |
+ |-------------------->| match each peerId vs. lists in  |
+ |                     | cached manifests, locally      |
+ |<--------------------| render checkmark + attribution |
+ |                     |                                |
+ |  (launch / hourly)  | refetch manifests ------------>|
+```
+
+The user adds a curator by pasting its manifest URL; everything after happens
+locally. The client caches each manifest (Section 8) and, when the user browses,
+matches PeerIds against the cached lists to render checkmarks (Section 9).
+
+## 6. The Curator Manifest
+
+A curator publishes its manifest as a JSON file at any HTTPS URL it shares, on its
+own site or any host that can serve a file (a gist, object storage). The buyer
+pastes that URL directly:
+
+```text
+GET https://curator.example/lists/trusted.json
+```
+
+```json
+{
+  "version": 1,
+  "kind": "antseed.curator.manifest",
+  "name": "Acme Curated",
+  "homepage": "https://curator.example",
+  "icon": "https://curator.example/icon.png",
+  "lists": [
+    {
+      "id": "trusted-providers",
+      "name": "Trusted Providers",
+      "peers": [
+        "abcabcabcabcabcabcabcabcabcabcabcabcabca",
+        "def0def0def0def0def0def0def0def0def0def0"
+      ]
+    },
+    {
+      "id": "audited-tee",
+      "name": "Audited TEE",
+      "peers": [
+        "1234123412341234123412341234123412341234"
+      ]
+    }
+  ]
+}
+```
+
+| Field | Requirement |
+|---|---|
+| `version` | Manifest version. MUST be `1`. |
+| `kind` | MUST be `antseed.curator.manifest`. |
+| `name` | Display name of the curator, shown to the user. Display-only and untrusted. |
+| `homepage` | Optional. Curator homepage, HTTPS in production. Display-only. |
+| `icon` | Optional. Curator icon URL, HTTPS in production. Display-only. |
+| `lists` | Array of lists (below). MAY be empty. |
+
+Each entry of `lists` is an object:
+
+| Field | Requirement |
+|---|---|
+| `id` | Stable identifier for the list, unique within the manifest. Clients MAY use it to track a list across refetches. |
+| `name` | Display name of the list, shown to the user. Display-only and untrusted. |
+| `peers` | Array of canonical PeerIds the list vouches for. MAY be empty. |
+
+The manifest carries no security input: there is no registry of curators and no
+signature. The buyer trusts the file only because it chose its URL (Section 4).
+
+## 7. Adding and Storing Curators
+
+To add a curator, the user pastes the manifest URL. The client fetches it,
+validates the manifest (Section 6), and stores the URL as the curator's identity.
+The buyer can remove a curator at any time.
+
+URL rules:
+
+- A production URL MUST use `https://`; local development MAY use
+  `http://localhost` (or `127.0.0.1` / `[::1]`).
+- The client stores and shows the exact URL so the buyer can confirm what it
+  trusts. A look-alike or attacker-controlled URL is the user's risk; showing the
+  exact URL is the only mitigation.
+- The client MUST de-duplicate by URL, so adding the same URL twice does nothing
+  extra.
+
+## 8. Fetching and Caching
+
+The client fetches each curator's manifest on launch and periodically thereafter
+(about hourly), plus on an explicit refresh if it offers one. It caches the last
+manifest it fetched successfully; on a failed fetch it keeps the cached one and
+SHOULD mark that curator stale. A curator with no successful fetch yet contributes
+no vouches.
+
+A vouch is reflected only on the next successful refetch, so **revocation latency
+is one refresh cycle**: a curator drops a PeerId from a list, and the checkmark
+disappears after the next fetch.
+
+## 9. Matching, the Badge, and the Filter
+
+The client matches locally. A peer is **curated** when its PeerId appears in the
+`peers` of at least one list of at least one subscribed curator, including a
+manifest currently marked stale.
+
+- The client marks every curated peer in the peer list with a checkmark. The mark
+  need not literally be a checkmark; any clear visual indicator works, and this
+  spec calls it the checkmark for short.
+- The client SHOULD show, in the peer's detail view, which curators and lists
+  vouch for it, naming each curator by its manifest URL and `name` and each list
+  by its `name`.
+- The client SHOULD offer a **"curated only" filter**: a UI toggle that hides
+  uncurated peers from the displayed list. The filter is a view over the list the
+  user is already looking at; it MUST NOT change which peers the router discovers,
+  scores, or selects.
+
+Matching never contacts the peer or the curator: it is a set membership test
+against already-fetched manifests, so a curator never learns which peers the buyer
+cares about. Curation adds no field to `PeerInfo`, the discovery metadata, or the
+DHT.
+
+## 10. Relationship to Reputation
+
+Curation and reputation are complementary. Reputation
+([05-reputation.md](./05-reputation.md)) ranks every peer mechanically from earned
+signals (on-chain settlement volume, stake age, ghost rate, runtime metrics) and
+feeds router selection. Curation hand-picks a subset a human opts into, and feeds
+nothing automatic.
+
+The two compose: a curator can build a list *from* reputation signals, say a bot
+that lists peers above some settlement volume or stake age, so reputation is one
+of the primitives a list can be generated from. The resulting list is still a
+display badge, off-chain and unsigned. A curator that wants its endorsements to
+carry machine-usable, on-chain weight should use reputation and attestation
+directly instead.
+
+## 11. Versioning
+
+This specification defines version `1` manifests. Clients MUST reject a manifest
+with an unknown `version` and MAY ignore unknown fields. Any future change to what
+a vouch means goes under a new `version`.

--- a/docs/protocol/spec/README.md
+++ b/docs/protocol/spec/README.md
@@ -91,10 +91,12 @@ See: [06-security-overview.md](./06-security-overview.md)
 | [04-payments.md](./04-payments.md) | Payments | Payment settlement and pricing |
 | [05-reputation.md](./05-reputation.md) | Reputation | Trust and reputation system |
 | [06-security-overview.md](./06-security-overview.md) | Security | Cross-layer security model, controls, and hardening priorities |
+| [08-curators.md](./08-curators.md) | Reputation | Curators, curated lists, and the peer curation badge |
 
 ## Version History
 
 | Version | Date | Notes |
 |---|---|---|
+| 1.3 | 2026-06-08 | Added peer curation via curators and lists |
 | 1.1 | 2026-03-01 | Added cross-layer security overview for buyer-seller flow |
 | 1.0 | 2026-02-18 | Initial protocol specification |


### PR DESCRIPTION
## Summary

Adds the peer curation spec (`docs/protocol/spec/08-curators.md`) and links it from the protocol READMEs.

AntSeed's network is open, so the peer list a buyer sees can grow large and noisy. Peer curation lets a buyer narrow it down to a subset that third parties it trusts have vouched for. A *curator* publishes a JSON *manifest* at any HTTPS URL, holding one or more named *lists* of PeerIds it vouches for. The buyer adds a curator by pasting its URL; the client downloads the manifest and marks any peer on a list with a checkmark. A "curated only" filter hides the rest.

## Design

- **Display-only.** Curation is a badge a human reads. It never feeds peer selection, scoring, routing, metering, or payments. The "curated only" filter is a view, not a routing gate.
- **Bare vouch.** A peer is in a list or not — no per-peer claim, level, or reason. Any meaning lives in the list's name and the curator behind it.
- **URL is the trust anchor.** The buyer trusts the file at the URL it added; the client stores and shows the exact URL. The manifest is unsigned and there is no registry; `name`/`icon`/list names are display-only and untrusted.
- **Buyer-controlled.** The buyer can add and remove curators at any time. Whether the client ships defaults is the client's choice.
- **Local matching.** A peer is named by its PeerId (EVM address), which the buyer already holds, so matching is a local set-membership test against fetched manifests. A curator never learns which peers the buyer cares about. Manifests refetch on launch and ~hourly; revocation latency is one cycle.

## Open to many uses

The spec calls out that a bare vouch + publish-anywhere manifest is a minimal base many kinds of list can grow on:

- **Who maintains a list:** an individual, a company (vetted partners), a community (a JSON file in a public Git repo, where PRs and edit history are the trust signal), or a bot (e.g. ranking peers by on-chain volume or stake age).
- **What a list means:** carried by its name and contents, not a typed field — a general "peers we trust" list, only KYB-verified companies, only checked-TEE providers, etc.

## Relationship to reputation

Curation and reputation are complementary. Reputation (`05-reputation.md`) ranks peers mechanically and feeds router selection; curation hand-picks a subset and feeds nothing automatic. The two compose: a curator can build a list *from* reputation signals, but the resulting list stays an off-chain, unsigned display badge.

## Files

- `docs/protocol/spec/08-curators.md`: the spec
- `docs/protocol/spec/README.md`: index row and version-history entry
- `docs/protocol/README.md`: index entry