### PR TITLE
fix(desktop): Show peer reputation scores

### DIFF
--- a/apps/desktop/src/main/peer-cache.ts
+++ b/apps/desktop/src/main/peer-cache.ts
@@ -12,6 +12,7 @@ export type DashboardNetworkPeer = {
   outputUsdPerMillion: number;
   capacityMsgPerHour: number;
   reputation: number;
+  onChainReputationScore: number | null;
   lastSeen: number;
   /**
    * Last successful transport-level contact with the peer. This can be fresher
@@ -65,7 +66,7 @@ function computePeerSignature(): string {
   // Fast hash: sorted peer IDs + their service lists.
   const parts: string[] = [];
   for (const [id, peer] of peerCache) {
-    parts.push(`${id}:${peer.services.join(',')}`);
+    parts.push(`${id}:${peer.services.join(',')}:${peer.onChainReputationScore ?? ''}`);
   }
   parts.sort();
   return parts.join('|');
@@ -130,6 +131,9 @@ export function parsePeerFromRaw(pr: Record<string, unknown>): DashboardNetworkP
     outputUsdPerMillion: Number(pr.defaultOutputUsdPerMillion) || 0,
     capacityMsgPerHour: (Number(pr.maxConcurrency) || 0) * 60,
     reputation: 100,
+    onChainReputationScore: typeof pr.onChainReputationScore === 'number' && Number.isFinite(pr.onChainReputationScore)
+      ? pr.onChainReputationScore
+      : null,
     lastSeen: Number(pr.lastSeen) || Date.now(),
     lastReachedAt: Number(pr.lastReachedAt) || null,
     source: 'dht',
@@ -171,6 +175,7 @@ export async function refreshPeerCache(): Promise<void> {
         peer.inputUsdPerMillion = peer.inputUsdPerMillion || existing.inputUsdPerMillion;
         peer.outputUsdPerMillion = peer.outputUsdPerMillion || existing.outputUsdPerMillion;
         peer.capacityMsgPerHour = peer.capacityMsgPerHour || existing.capacityMsgPerHour;
+        peer.onChainReputationScore = peer.onChainReputationScore ?? existing.onChainReputationScore;
         peer.lastSeen = Math.max(peer.lastSeen, existing.lastSeen);
         peer.lastReachedAt = Math.max(peer.lastReachedAt ?? 0, existing.lastReachedAt ?? 0) || null;
       }

--- a/apps/desktop/src/renderer/core/peer-utils.ts
+++ b/apps/desktop/src/renderer/core/peer-utils.ts
@@ -75,3 +75,38 @@ export function formatPerMillionPrice(usdPerMillion: number): string {
   if (usdPerMillion < 0.01) return `$${usdPerMillion.toFixed(3)}/M`;
   return `$${usdPerMillion.toFixed(2)}/M`;
 }
+
+export type PeerReputationSource = {
+  peerId: string;
+  onChainReputationScore?: number | null;
+};
+
+export function normalizeReputationScore(score: unknown): number | null {
+  return typeof score === 'number' && Number.isFinite(score) ? score : null;
+}
+
+export function formatReputationScore(score: unknown): string {
+  const normalized = normalizeReputationScore(score);
+  if (normalized === null) return '—';
+  return (normalized / 10).toFixed(1);
+}
+
+export function buildPeerReputationScoreMap(rows: PeerReputationSource[]): Map<string, number> {
+  const scores = new Map<string, number>();
+  for (const row of rows) {
+    const score = normalizeReputationScore(row.onChainReputationScore);
+    if (score === null) continue;
+    const existing = scores.get(row.peerId);
+    if (existing === undefined || score > existing) {
+      scores.set(row.peerId, score);
+    }
+  }
+  return scores;
+}
+
+export function getPeerReputationScore(
+  peer: PeerReputationSource,
+  scoresByPeerId: ReadonlyMap<string, number>,
+): number | null {
+  return scoresByPeerId.get(peer.peerId) ?? normalizeReputationScore(peer.onChainReputationScore);
+}

--- a/apps/desktop/src/renderer/core/state.ts
+++ b/apps/desktop/src/renderer/core/state.ts
@@ -36,6 +36,7 @@ export type PeerEntry = {
   outputUsdPerMillion: number;
   capacityMsgPerHour: number;
   reputation: number;
+  onChainReputationScore: number | null;
   lastSeen: number;
   lastReachedAt: number | null;
   source: string;

--- a/apps/desktop/src/renderer/modules/dashboard-render.ts
+++ b/apps/desktop/src/renderer/modules/dashboard-render.ts
@@ -8,6 +8,7 @@ import {
   formatLatency,
   formatEndpoint,
 } from '../core/format';
+import { normalizeReputationScore } from '../core/peer-utils';
 
 type DashboardRenderModuleOptions = {
   uiState: RendererUiState;
@@ -73,6 +74,7 @@ function normalizeNetworkData(
       outputUsdPerMillion: safeNumber(peer.outputUsdPerMillion, 0),
       capacityMsgPerHour: safeNumber(peer.capacityMsgPerHour, 0),
       reputation: safeNumber(peer.reputation, 0),
+      onChainReputationScore: normalizeReputationScore(peer.onChainReputationScore),
       lastSeen: safeNumber(peer.lastSeen, 0),
       lastReachedAt: safeNumber(peer.lastReachedAt, 0) || null,
       source: safeString(peer.source, 'dht'),
@@ -95,6 +97,7 @@ function normalizeNetworkData(
       outputUsdPerMillion: 0,
       capacityMsgPerHour: 0,
       reputation: 0,
+      onChainReputationScore: null,
       lastSeen: 0,
       lastReachedAt: null,
       source: 'daemon',
@@ -112,6 +115,7 @@ function normalizeNetworkData(
     if (safeNumber(peer.outputUsdPerMillion, 0) > 0) existing.outputUsdPerMillion = safeNumber(peer.outputUsdPerMillion, 0);
     if (safeNumber(peer.capacityMsgPerHour, 0) > 0) existing.capacityMsgPerHour = safeNumber(peer.capacityMsgPerHour, 0);
     if (safeNumber(peer.reputation, 0) > 0) existing.reputation = safeNumber(peer.reputation, 0);
+    existing.onChainReputationScore = normalizeReputationScore(peer.onChainReputationScore) ?? existing.onChainReputationScore;
     const daemonDn = typeof peer.displayName === 'string' && (peer.displayName as string).trim().length > 0 ? (peer.displayName as string).trim() : null;
     if (daemonDn) existing.displayName = daemonDn;
     if (!existing.source || existing.source === 'dht') existing.source = safeString(peer.source, 'daemon');
@@ -122,7 +126,9 @@ function normalizeNetworkData(
   const peers = Array.from(merged.values())
     .filter((peer) => peer.services.length > 0 || peer.providers.length > 0)
     .sort((a, b) => {
-      if (b.reputation !== a.reputation) return b.reputation - a.reputation;
+      const ar = a.onChainReputationScore ?? -1;
+      const br = b.onChainReputationScore ?? -1;
+      if (br !== ar) return br - ar;
       return b.lastSeen - a.lastSeen;
     });
 

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -15,7 +15,13 @@ import {
   formatCategoryLabel,
 } from './discover-filter-util';
 import { DiscoverFilters } from './DiscoverFilters';
-import { getPeerGradient, getPeerDisplayName, formatPerMillionPrice, getTagTint } from '../../../core/peer-utils';
+import {
+  getPeerGradient,
+  getPeerDisplayName,
+  formatPerMillionPrice,
+  getTagTint,
+  formatReputationScore,
+} from '../../../core/peer-utils';
 import { getKnownProxy, type KnownProxy } from '../../../core/known-proxies';
 import { InfoTooltip } from '../InfoTooltip';
 import styles from './DiscoverWelcome.module.scss';
@@ -242,11 +248,6 @@ function formatVolumeUsdc(n: number): string {
 
 function isLowReputation(score: number | null): boolean {
   return typeof score === 'number' && Number.isFinite(score) && score < LOW_REPUTATION_SCORE_THRESHOLD;
-}
-
-function formatReputationScore(score: number | null): string {
-  if (score == null || !Number.isFinite(score)) return '—';
-  return (score / 10).toFixed(1);
 }
 
 function formatReputationTooltip(item: CardItem): { avgChannelUsdc: string } {

--- a/apps/desktop/src/renderer/ui/components/views/OverviewView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/OverviewView.tsx
@@ -1,5 +1,11 @@
+import { useMemo } from 'react';
 import { useUiSnapshot } from '../../hooks/useUiSnapshot';
 import { formatShortId, formatInt } from '../../../core/format';
+import {
+  buildPeerReputationScoreMap,
+  formatReputationScore,
+  getPeerReputationScore,
+} from '../../../core/peer-utils';
 
 type OverviewViewProps = {
   active: boolean;
@@ -16,7 +22,23 @@ export function OverviewView({ active }: OverviewViewProps) {
     ovLastScan,
     ovPeersCount,
     overviewPeers,
+    discoverRows,
   } = useUiSnapshot();
+
+  const reputationScoresByPeerId = useMemo(
+    () => buildPeerReputationScoreMap(discoverRows),
+    [discoverRows],
+  );
+
+  const topPeersByReputation = useMemo(
+    () => [...overviewPeers].sort((a, b) => {
+      const ar = getPeerReputationScore(a, reputationScoresByPeerId) ?? -1;
+      const br = getPeerReputationScore(b, reputationScoresByPeerId) ?? -1;
+      if (br !== ar) return br - ar;
+      return b.lastSeen - a.lastSeen;
+    }),
+    [overviewPeers, reputationScoresByPeerId],
+  );
 
   return (
     <section className={`view${active ? ' active' : ''}`} role="tabpanel">
@@ -69,19 +91,19 @@ export function OverviewView({ active }: OverviewViewProps) {
                 </tr>
               </thead>
               <tbody>
-                {overviewPeers.length === 0 ? (
+                {topPeersByReputation.length === 0 ? (
                   <tr>
                     <td colSpan={4} className="empty">
                       No peers yet.
                     </td>
                   </tr>
                 ) : (
-                  overviewPeers.map((peer) => (
+                  topPeersByReputation.map((peer) => (
                     <tr key={peer.peerId}>
                       <td>{peer.displayName || '-'}</td>
                       <td title={peer.peerId}>{formatShortId(peer.peerId)}</td>
-                      <td>{peer.services.join(', ')}</td>
-                      <td>{formatInt(peer.reputation)}</td>
+                      <td>{formatInt(peer.services.length)}</td>
+                      <td>{formatReputationScore(getPeerReputationScore(peer, reputationScoresByPeerId))}</td>
                     </tr>
                   ))
                 )}

--- a/apps/desktop/src/renderer/ui/components/views/PeersView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/PeersView.tsx
@@ -2,6 +2,11 @@ import { useState, useMemo, useCallback } from 'react';
 import { useUiSnapshot } from '../../hooks/useUiSnapshot';
 import { useActions } from '../../hooks/useActions';
 import { formatShortId, formatInt, formatEndpoint } from '../../../core/format';
+import {
+  buildPeerReputationScoreMap,
+  formatReputationScore,
+  getPeerReputationScore,
+} from '../../../core/peer-utils';
 import { safeString } from '../../../core/safe';
 import type { PeerEntry, SortDirection } from '../../../core/state';
 
@@ -11,10 +16,22 @@ type PeersViewProps = {
 
 type SortKey = string;
 
-function sortPeers(items: PeerEntry[], key: SortKey, dir: SortDirection): PeerEntry[] {
+function sortPeers(
+  items: PeerEntry[],
+  key: SortKey,
+  dir: SortDirection,
+  reputationScoresByPeerId: ReadonlyMap<string, number>,
+): PeerEntry[] {
   return [...items].sort((a, b) => {
     let va: unknown = (a as Record<string, unknown>)[key];
     let vb: unknown = (b as Record<string, unknown>)[key];
+    if (key === 'services') {
+      va = a.services.length;
+      vb = b.services.length;
+    } else if (key === 'reputation') {
+      va = getPeerReputationScore(a, reputationScoresByPeerId) ?? -1;
+      vb = getPeerReputationScore(b, reputationScoresByPeerId) ?? -1;
+    }
     if (Array.isArray(va)) va = (va as string[]).join(', ');
     if (Array.isArray(vb)) vb = (vb as string[]).join(', ');
     if (typeof va === 'string') va = va.toLowerCase();
@@ -27,7 +44,11 @@ function sortPeers(items: PeerEntry[], key: SortKey, dir: SortDirection): PeerEn
   });
 }
 
-function filterPeers(peers: PeerEntry[], filterText: string): PeerEntry[] {
+function filterPeers(
+  peers: PeerEntry[],
+  filterText: string,
+  reputationScoresByPeerId: ReadonlyMap<string, number>,
+): PeerEntry[] {
   if (!filterText) return peers;
   const lower = filterText.toLowerCase();
   return peers.filter((peer) => {
@@ -38,7 +59,7 @@ function filterPeers(peers: PeerEntry[], filterText: string): PeerEntry[] {
       String(peer.inputUsdPerMillion),
       String(peer.outputUsdPerMillion),
       String(peer.capacityMsgPerHour),
-      String(peer.reputation),
+      formatReputationScore(getPeerReputationScore(peer, reputationScoresByPeerId)),
       formatEndpoint(peer),
     ]
       .join(' ')
@@ -61,7 +82,7 @@ const COLUMNS: { key: string; label: string; sortable: boolean }[] = [
 ];
 
 export function PeersView({ active }: PeersViewProps) {
-  const { lastPeers, peersMeta, peersMessage } = useUiSnapshot();
+  const { lastPeers, peersMeta, peersMessage, discoverRows } = useUiSnapshot();
   const actions = useActions();
 
   const [sortKey, setSortKey] = useState('reputation');
@@ -80,10 +101,15 @@ export function PeersView({ active }: PeersViewProps) {
     [sortKey],
   );
 
+  const reputationScoresByPeerId = useMemo(
+    () => buildPeerReputationScoreMap(discoverRows),
+    [discoverRows],
+  );
+
   const displayPeers = useMemo(() => {
-    const filtered = filterPeers(lastPeers, filter);
-    return sortPeers(filtered, sortKey, sortDir);
-  }, [lastPeers, filter, sortKey, sortDir]);
+    const filtered = filterPeers(lastPeers, filter, reputationScoresByPeerId);
+    return sortPeers(filtered, sortKey, sortDir, reputationScoresByPeerId);
+  }, [lastPeers, filter, sortKey, sortDir, reputationScoresByPeerId]);
 
   return (
     <section className={`view${active ? ' active' : ''}`} role="tabpanel">
@@ -143,7 +169,7 @@ export function PeersView({ active }: PeersViewProps) {
                       <td>{peer.displayName || '-'}</td>
                       <td title={peer.peerId}>{formatShortId(peer.peerId)}</td>
                       <td>{safeString(peer.source, 'n/a').toUpperCase()}</td>
-                      <td>{peer.services.join(', ')}</td>
+                      <td>{formatInt(peer.services.length)}</td>
                       <td>{String(peer.inputUsdPerMillion)}</td>
                       <td>{String(peer.outputUsdPerMillion)}</td>
                       <td>
@@ -151,7 +177,7 @@ export function PeersView({ active }: PeersViewProps) {
                           ? `${formatInt(peer.capacityMsgPerHour)}/h`
                           : 'n/a'}
                       </td>
-                      <td>{formatInt(peer.reputation)}</td>
+                      <td>{formatReputationScore(getPeerReputationScore(peer, reputationScoresByPeerId))}</td>
                       <td>{formatEndpoint(peer)}</td>
                     </tr>
                   ))


### PR DESCRIPTION
## Description

Updates the desktop Network and Peers views to show peer service counts instead of long service-name lists. It also uses the same on-chain reputation score source and display format as Discover, including sorting top peers by reputation.

## Release Notes

- Desktop Network and Peers tables now show service counts in the Services column.
- Desktop peer reputation values now match the Discover view and sort top peers by that reputation score.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Verification:
- `pnpm -C apps/desktop run typecheck:renderer`
- `pnpm -C apps/desktop run build:main`