### PR TITLE
fix(payments): Serve over-reserve estimates

### DIFF
--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -125,6 +125,8 @@ export interface PaymentsCLIConfig {
    * amount. Default: "2000" (~$0.002).
    */
   minSettleDelta?: string;
+  /** Optional seller-side slack for estimate-only reserve preflight checks. Unset disables estimate-only rejection. */
+  reserveEstimateOverdraftUsdc?: string;
   /**
    * Maximum USDC the buyer authorizes per single request in base units — the
    * per-request overdraft window beyond the buyer's independently-verified

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -134,6 +134,8 @@ export interface NodePaymentsConfig {
   minBudgetPerRequest?: string;
   /** Minimum unsettled delta (base units) required before idle settle submits a tx. Default: "2000" (~$0.002). */
   minSettleDelta?: string;
+  /** Optional seller-side slack for estimate-only reserve preflight checks. Unset disables estimate-only rejection. */
+  reserveEstimateOverdraftUsdc?: string;
   /** Maximum USDC the buyer authorizes per single request (base units). Default: "500000" ($0.50). */
   maxPerRequestUsdc?: string;
   /** Maximum total USDC the buyer will reserve in a single SpendingAuth (base units). Default: "10000000" ($10.00). */
@@ -1194,6 +1196,9 @@ export class AntseedNode extends EventEmitter {
       channelsClient: this._channelsClient,
       announcer: this._announcer,
       maxUploadBodyBytes: this._config.maxUploadBodyBytes,
+      ...(this._config.payments?.reserveEstimateOverdraftUsdc != null
+        ? { reserveEstimateOverdraftUsdc: BigInt(this._config.payments.reserveEstimateOverdraftUsdc) }
+        : {}),
       emit: (event, ...args) => this.emit(event, ...args),
     });
 

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -25,6 +25,7 @@ export interface SellerRequestHandlerDeps {
   channelsClient: ChannelsClient | null;
   announcer: PeerAnnouncer | null;
   maxUploadBodyBytes?: number;
+  reserveEstimateOverdraftUsdc?: bigint;
   emit: (event: string, ...args: unknown[]) => boolean;
 }
 
@@ -206,9 +207,14 @@ export class SellerRequestHandler {
           const requestCostEstimate = this._estimateMaxRequestCostUsdc(request, requestPricing);
           const estimatedRequestCost = requestCostEstimate?.cost ?? 0n;
           const remainingLockedReserve = reserveMax > spent ? reserveMax - spent : 0n;
-          const estimatedCostExceedsLockedReserve = reserveMax > 0n
+          const reserveEstimateOverdraft = this._deps.reserveEstimateOverdraftUsdc;
+          const effectiveEstimateLimit = reserveEstimateOverdraft != null
+            ? remainingLockedReserve + reserveEstimateOverdraft
+            : null;
+          const estimatedCostExceedsLockedReserve = effectiveEstimateLimit != null
+            && reserveMax > 0n
             && estimatedRequestCost > 0n
-            && estimatedRequestCost > remainingLockedReserve;
+            && estimatedRequestCost > effectiveEstimateLimit;
 
           if (isBlocked || (spent > 0n && (spent > accepted || isAtExactSpendLimit)) || estimatedCostExceedsLockedReserve) {
             const baseRequirements = spm.getPaymentRequirements(
@@ -239,7 +245,7 @@ export class SellerRequestHandler {
               } else if (estimatedCostExceedsLockedReserve) {
                 reason = 'insufficient locked reserve for estimated request';
               }
-              debugLog(`[SellerHandler] Session ${reason} for ${buyerPeerId.slice(0, 12)}... (spent=${spent} accepted=${accepted} target=${target} reserveMax=${reserveMax} remainingLockedReserve=${remainingLockedReserve} estimatedRequestCost=${estimatedRequestCost} estimatedInputTokens=${requestCostEstimate?.inputTokens ?? 0} estimatedMaxOutputTokens=${requestCostEstimate?.maxOutputTokens ?? 0}) — returning 402`);
+              debugLog(`[SellerHandler] Session ${reason} for ${buyerPeerId.slice(0, 12)}... (spent=${spent} accepted=${accepted} target=${target} reserveMax=${reserveMax} remainingLockedReserve=${remainingLockedReserve} reserveEstimateOverdraft=${reserveEstimateOverdraft ?? 'disabled'} effectiveEstimateLimit=${effectiveEstimateLimit ?? 'disabled'} estimatedRequestCost=${estimatedRequestCost} estimatedInputTokens=${requestCostEstimate?.inputTokens ?? 0} estimatedMaxOutputTokens=${requestCostEstimate?.maxOutputTokens ?? 0}) — returning 402`);
               if (isBlocked || isAlreadyExhausted || estimatedCostExceedsLockedReserve) {
                 // Default settleSession() performs final close(); do not use
                 // settleOnly here because exhausted channels must release the

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -436,6 +436,41 @@ describe('SellerRequestHandler payment pricing selection', () => {
     expect(response.statusCode).toBe(200);
   });
 
+  it('continues serving when the next estimate exceeds locked reserve by default', async () => {
+    const provider = makeProvider(0, 1_000_000, { name: 'paid-tier', services: ['local-test'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
+
+    const sendPaymentRequired = vi.fn();
+    const sendNeedAuth = vi.fn();
+    const settleSession = vi.fn(async () => {});
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: makeSpmMock({
+        getCumulativeSpend: () => 100_000n,
+        getAcceptedCumulative: () => 100_000n,
+        getReserveMax: () => 1_000_000n,
+        settleSession,
+      }),
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-estimate-within-overdraft', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test', max_tokens: 1 })) }) });
+
+    expect(provider.handleRequest).toHaveBeenCalledOnce();
+    expect(sendPaymentRequired).not.toHaveBeenCalled();
+    expect(settleSession).not.toHaveBeenCalled();
+    const response = decodeHttpResponse(decodeFrame(sentFrames[0]!)!.message.payload);
+    expect(response.statusCode).toBe(200);
+  });
+
   it('closes below-threshold channels when the next estimate exceeds locked reserve', async () => {
     const provider = makeProvider(0, 1_000_000, { name: 'paid-tier', services: ['local-test'] });
     provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
@@ -454,6 +489,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
       sessionTracker: null,
       channelsClient: {} as any,
       announcer: null,
+      reserveEstimateOverdraftUsdc: 0n,
       emit: () => false,
     });
 


### PR DESCRIPTION
## Description

Stops sellers from rejecting requests solely because the worst-case cost estimate is above the currently locked reserve. The estimate-only guard is now opt-in via `payments.reserveEstimateOverdraftUsdc`, so sellers can still enforce a strict preflight cap when needed while the default path lets the normal post-response authorization flow handle actual spend.

## Release Notes

- Sellers no longer reject large-context paid requests solely because the estimate exceeds the current locked reserve.
- Added optional `payments.reserveEstimateOverdraftUsdc` for sellers that want strict estimate-based preflight rejection.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes