### PR TITLE
fix(desktop): harden bash auto-allow against interpreter command escapes

### DIFF
--- a/apps/desktop/src/main/chat-tool-policy.test.ts
+++ b/apps/desktop/src/main/chat-tool-policy.test.ts
@@ -36,6 +36,87 @@ test('read-looking shell commands with mutation operators are not auto-allowed',
   assert.equal(describeBash('sed -i s/foo/bar/g file.txt').permissionKey, 'bash:other');
 });
 
+test('awk system()/getline/shell-pipe must not auto-allow', () => {
+  // POSIX awk's system() and getline-via-pipe execute arbitrary shell. The
+  // first-word allowlist would otherwise classify these as `bash:read` and
+  // skip the approval prompt entirely.
+  const bypasses = [
+    "awk 'BEGIN{system(\"env\")}'",
+    "awk 'BEGIN{\"id\" | getline x; print x}' /dev/null",
+    "awk '{print | \"sh\"}' file",
+  ];
+  for (const command of bypasses) {
+    const approval = describeBash(command);
+    assert.equal(
+      isToolPermissionAutoAllowed(approval.permissionKey),
+      false,
+      `expected ${command} to require explicit approval, got ${approval.permissionKey}`,
+    );
+  }
+});
+
+test('sed e command/flag and -f script-from-file must not auto-allow', () => {
+  // sed's `e` flag on s/// substitutions and `e` command after an address
+  // both execute arbitrary shell. `-f` reads a script from a file whose
+  // contents we cannot verify.
+  const bypasses = [
+    "sed -n '1e cat /etc/passwd' file",
+    "sed 's/a/b/e' file",
+    "sed -n '1,$e id' file",
+    "sed 's/a/b/ge' file",
+    "sed -f script.sed file",
+  ];
+  for (const command of bypasses) {
+    const approval = describeBash(command);
+    assert.equal(
+      isToolPermissionAutoAllowed(approval.permissionKey),
+      false,
+      `expected ${command} to require explicit approval, got ${approval.permissionKey}`,
+    );
+  }
+});
+
+test('find -fprintf / -fprint / -fls must not auto-allow', () => {
+  // These find predicates write arbitrary content to an arbitrary path with
+  // no `>` operator, bypassing hasShellWriteOperator.
+  const bypasses = [
+    "find . -fprintf /tmp/pwn '%p\\n'",
+    "find . -fprint /tmp/list",
+    "find . -fprint0 /tmp/list0",
+    "find . -fls /tmp/listing",
+  ];
+  for (const command of bypasses) {
+    const approval = describeBash(command);
+    assert.equal(
+      isToolPermissionAutoAllowed(approval.permissionKey),
+      false,
+      `expected ${command} to require explicit approval, got ${approval.permissionKey}`,
+    );
+  }
+});
+
+test('benign awk/sed/find invocations stay auto-allowed', () => {
+  // Regression guard against the new interpreter blocks: ordinary read-only
+  // usages of these tools must still classify as bash:read.
+  const benign = [
+    "awk '{print $1}' file",
+    "awk '/pattern/ {print}' file",
+    "sed 's/foo/bar/' file",
+    "sed -n '1,10p' file",
+    "sed 's/red/blue/g' file",
+    "find . -name '*.ts'",
+    "find . -type f -print",
+  ];
+  for (const command of benign) {
+    const approval = describeBash(command);
+    assert.equal(
+      approval.permissionKey,
+      'bash:read',
+      `expected ${command} to classify as bash:read, got ${approval.permissionKey}`,
+    );
+  }
+});
+
 test('sensitive commands cannot be saved as reusable peer approvals', () => {
   for (const command of ['sudo make install', 'rm -rf dist', 'git reset --hard HEAD']) {
     const approval = describeBash(command);

--- a/apps/desktop/src/main/chat-tool-policy.test.ts
+++ b/apps/desktop/src/main/chat-tool-policy.test.ts
@@ -56,14 +56,18 @@ test('awk system()/getline/shell-pipe must not auto-allow', () => {
 });
 
 test('sed e command/flag and -f script-from-file must not auto-allow', () => {
-  // sed's `e` flag on s/// substitutions and `e` command after an address
-  // both execute arbitrary shell. `-f` reads a script from a file whose
-  // contents we cannot verify.
+  // sed's `e` flag on s/// substitutions and `e` command both execute
+  // arbitrary shell. `w` commands/flags write files without a shell redirect.
+  // `-f` reads a script from a file whose contents we cannot verify.
   const bypasses = [
+    "sed 'e id' file",
     "sed -n '1e cat /etc/passwd' file",
+    "sed -n '/foo/e id' file",
     "sed 's/a/b/e' file",
     "sed -n '1,$e id' file",
     "sed 's/a/b/ge' file",
+    "sed -n 'w /tmp/pwn' file",
+    "sed 's/a/b/w /tmp/pwn' file",
     "sed -f script.sed file",
   ];
   for (const command of bypasses) {
@@ -76,10 +80,14 @@ test('sed e command/flag and -f script-from-file must not auto-allow', () => {
   }
 });
 
-test('find -fprintf / -fprint / -fls must not auto-allow', () => {
-  // These find predicates write arbitrary content to an arbitrary path with
-  // no `>` operator, bypassing hasShellWriteOperator.
+test('find -exec / -fprintf / -fprint / -fls must not auto-allow', () => {
+  // These find predicates either execute commands or write arbitrary content
+  // to an arbitrary path with no `>` operator, bypassing the shell-level
+  // composition and write-operator checks.
   const bypasses = [
+    "find . -exec python3 -c 'print(1)' {} +",
+    "find . -execdir sh -c 'id' {} +",
+    "find . -ok python3 -c 'print(1)' {} +",
     "find . -fprintf /tmp/pwn '%p\\n'",
     "find . -fprint /tmp/list",
     "find . -fprint0 /tmp/list0",

--- a/apps/desktop/src/main/chat-tool-policy.ts
+++ b/apps/desktop/src/main/chat-tool-policy.ts
@@ -76,14 +76,15 @@ function hasUnsafeShellComposition(command: string): boolean {
 // Several allowlisted commands are general-purpose interpreters or have
 // file-writing flags, so the first-word match alone is not sufficient. These
 // guards reject intra-command escape forms that would otherwise smuggle a
-// silent `bash:read` auto-allow (awk `system()`/`getline`, sed `e` flag/`e`
-// command/`-f` script-from-file, find `-fprint*`/`-fls` arbitrary file write).
+// silent `bash:read` auto-allow (awk `system()`/`getline`, sed `e`/`w`
+// commands and flags, sed `-f` script-from-file, find `-exec*`/`-ok*`, and
+// find `-fprint*`/`-fls` arbitrary file write).
 function isReadOnlySegment(segment: string): boolean {
   const word = firstShellWord(segment);
   return READ_ONLY_SHELL_COMMANDS.has(word)
     && !hasShellWriteOperator(segment)
-    && !/\bfind\b[^\n]*(?:\s-delete|\s-exec\s+(?:rm|mv|cp|chmod|chown|sh|bash)\b|\s-fprint(?:f|0)?\b|\s-fls\b)/.test(segment)
-    && !/\bsed\b[^\n]*\s(?:-i(?:\s|$)|-f\s|['"][^'"]*(?:\/[gipm0-9]*e[gipm0-9]*['"\s]|[0-9$~!,]+\s*!?e[\s'"]))/.test(segment)
+    && !/\bfind\b[^\n]*(?:\s-delete|\s-(?:exec|execdir|ok|okdir)\b|\s-fprint(?:f|0)?\b|\s-fls\b)/.test(segment)
+    && !/\bsed\b[^\n]*\s(?:-i(?:\s|$)|-f(?:\s|=)|['"](?:\s*(?:[0-9$~!,]+|\/[^\/'"]*\/)?\s*!?[ew](?:[\s'";}]|$)|[^'"]*(?:\/[gipm0-9]*[ew][gipm0-9]*(?:['"\s]|$)|[;{\s](?:[0-9$~!,]+|\/[^\/'"]*\/)?\s*!?[ew](?:[\s'";}]|$))))/.test(segment)
     && !/\bawk\b[^\n]*(?:\bsystem\s*\(|\bgetline\b|\{[^}]*(?:\|\s*["']|["']\s*\|))/.test(segment);
 }
 

--- a/apps/desktop/src/main/chat-tool-policy.ts
+++ b/apps/desktop/src/main/chat-tool-policy.ts
@@ -73,12 +73,18 @@ function hasUnsafeShellComposition(command: string): boolean {
     || /[;&]/.test(command);
 }
 
+// Several allowlisted commands are general-purpose interpreters or have
+// file-writing flags, so the first-word match alone is not sufficient. These
+// guards reject intra-command escape forms that would otherwise smuggle a
+// silent `bash:read` auto-allow (awk `system()`/`getline`, sed `e` flag/`e`
+// command/`-f` script-from-file, find `-fprint*`/`-fls` arbitrary file write).
 function isReadOnlySegment(segment: string): boolean {
   const word = firstShellWord(segment);
   return READ_ONLY_SHELL_COMMANDS.has(word)
     && !hasShellWriteOperator(segment)
-    && !/\bfind\b[^\n]*(?:\s-delete|\s-exec\s+(?:rm|mv|cp|chmod|chown|sh|bash)\b)/.test(segment)
-    && !/\bsed\b[^\n]*\s-i(?:\s|$)/.test(segment);
+    && !/\bfind\b[^\n]*(?:\s-delete|\s-exec\s+(?:rm|mv|cp|chmod|chown|sh|bash)\b|\s-fprint(?:f|0)?\b|\s-fls\b)/.test(segment)
+    && !/\bsed\b[^\n]*\s(?:-i(?:\s|$)|-f\s|['"][^'"]*(?:\/[gipm0-9]*e[gipm0-9]*['"\s]|[0-9$~!,]+\s*!?e[\s'"]))/.test(segment)
+    && !/\bawk\b[^\n]*(?:\bsystem\s*\(|\bgetline\b|\{[^}]*(?:\|\s*["']|["']\s*\|))/.test(segment);
 }
 
 function isReadOnlyShellCommand(command: string): boolean {


### PR DESCRIPTION
Three intra-command escapes from the `bash:read` auto-allow surface that bypass `hasUnsafeShellComposition` / `hasShellWriteOperator` by living inside an allowlisted command's own argument grammar — same threat class as the composition-level holes closed in #573 / `128dab9a`, one layer deeper.

## What

`isReadOnlySegment` in [`apps/desktop/src/main/chat-tool-policy.ts`](https://github.com/AntSeed/antseed/blob/main/apps/desktop/src/main/chat-tool-policy.ts) allowed three commands whose argument grammars contain shell-exec or arbitrary-file-write primitives:

- **awk** — `system("…")`, `"cmd"|getline`, `{print | "sh"}`
- **sed** — `s///e` flag, `1e cmd` / `1,$e cmd` commands, `-f script.sed` (script from unverifiable file)
- **find** — `-fprintf path content`, `-fprint path`, `-fprint0 path`, `-fls path` (writes arbitrary content to arbitrary path with no `>` operator)

All three classified as `bash:read` → `isToolPermissionAutoAllowed` → silent execution, no approval prompt, no renderer event.

## Repro (against unpatched main, classifier harness)

```
awk 'BEGIN{system("env")}'      → bash:read → AUTO
sed -n '1e id' f                → bash:read → AUTO
find . -fprintf /tmp/x '%p\n'   → bash:read → AUTO
```

## Fix

Extend the existing guard alternations in `isReadOnlySegment` (mirrors the maintainer's blocklist-extension pattern from `128dab9a`):

- `find`: add `-fprintf|-fprint|-fprint0|-fls`
- `sed`: add the `e` command/flag and `-f` script-from-file
- `awk`: add `system(`, `getline`, and `| "…"` / `"…" |` pipe-to-shell forms

Total: 4 lines changed in `chat-tool-policy.ts` (one comment block + the three regex extensions).

## Tests

Four new `node:test` suites in `chat-tool-policy.test.ts`:

- `awk system()/getline/shell-pipe must not auto-allow` — 3 PoCs
- `sed e command/flag and -f script-from-file must not auto-allow` — 5 PoCs
- `find -fprintf / -fprint / -fls must not auto-allow` — 4 PoCs
- `benign awk/sed/find invocations stay auto-allowed` — 7-case regression guard so ordinary `awk '{print $1}'`, `sed 's/foo/bar/' f`, `find . -name '*.ts'`, etc. still classify as `bash:read`

`npm test` in `apps/desktop`: **12/12 pass** locally.

## Lineage

Continuation of the chat-safety auto-allow arc: #592 (initial guard), #631 (zero-width-bypass fix), #642 (inline-blur hotfix), #643 (lowercase base58), #573 / `128dab9a` (composition-level intra-command fix). This PR closes the equivalent escapes at the *builtin-command* level rather than the composition level.

Internal triage IDs in this fork's audit: BUG-200 (awk, High), BUG-201 (sed, High), BUG-202 (find, Medium).
