### PR TITLE
feat(node): Add response auth mux

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -33,6 +33,10 @@
       "import": "./dist/payments/index.js",
       "types": "./dist/payments/index.d.ts"
     },
+    "./verification": {
+      "import": "./dist/verification/index.js",
+      "types": "./dist/verification/index.d.ts"
+    },
     "./types": {
       "import": "./dist/types/index.js",
       "types": "./dist/types/index.d.ts"

--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -12,6 +12,9 @@ import type { PaymentMux } from "./p2p/payment-mux.js";
 import { ConnectionState } from "./types/connection.js";
 import type { BuyerPaymentNegotiator } from "./payments/buyer-payment-negotiator.js";
 import { debugLog, debugWarn } from "./utils/debug.js";
+import type { VerificationMux } from "./verification/verification-mux.js";
+import type { VerificationStorage } from "./verification/storage.js";
+import { verifyResponseAuth } from "./verification/response-auth.js";
 
 export interface RequestStreamResponseMetadata {
   streaming: boolean;
@@ -33,14 +36,19 @@ export interface BuyerRequestHandlerConfig {
   requestTimeoutMs?: number;
   maxStreamBufferBytes?: number;
   maxStreamDurationMs?: number;
+  responseAuthTimeoutMs?: number;
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 5 * 60_000;
+const DEFAULT_RESPONSE_AUTH_GRACE_MS = 30_000;
 
 export interface BuyerRequestHandlerDeps {
+  localPeerId: PeerId;
   negotiator: BuyerPaymentNegotiator | null;
+  verificationStorage: VerificationStorage | null;
   getConnection: (peer: PeerInfo) => Promise<PeerConnection>;
   getMux: (peerId: PeerId, conn: PeerConnection) => ProxyMux;
+  getVerificationMux: (peerId: PeerId, conn: PeerConnection) => VerificationMux;
   registerPaymentMux: (peerId: PeerId, mux: PaymentMux) => void;
 }
 
@@ -76,6 +84,7 @@ export class BuyerRequestHandler {
     const conn = await this._deps.getConnection(peer);
     debugLog(`[BuyerRequest] Connection to ${peer.peerId.slice(0, 12)}... state=${conn.state}`);
     const mux = this._deps.getMux(peer.peerId, conn);
+    const verificationMux = this._deps.getVerificationMux(peer.peerId, conn);
     const negotiator = this._deps.negotiator;
     if (negotiator) {
       this._deps.registerPaymentMux(peer.peerId, negotiator.getOrCreatePaymentMux(peer.peerId, conn));
@@ -280,6 +289,7 @@ export class BuyerRequestHandler {
       startTime = Date.now();
       const retriedResponse = await executeRequest();
       negotiator.estimateCostFromResponse(peer, retriedResponse, requestedService, req.requestId);
+      this._recordResponseAuth(peer, req, retriedResponse, requestedService, verificationMux);
       return retriedResponse;
     }
 
@@ -287,7 +297,52 @@ export class BuyerRequestHandler {
       negotiator.estimateCostFromResponse(peer, response, requestedService, req.requestId);
     }
 
+    this._recordResponseAuth(peer, req, response, requestedService, verificationMux);
     return response;
+  }
+
+  private _recordResponseAuth(
+    peer: PeerInfo,
+    request: SerializedHttpRequest,
+    response: SerializedHttpResponse,
+    requestedService: string | undefined,
+    verificationMux: VerificationMux,
+  ): void {
+    const storage = this._deps.verificationStorage;
+    const advertisedService = requestedService ?? 'unknown';
+    const expectedChannelId = this._deps.negotiator?.bpm?.getActiveSession(peer.peerId)?.sessionId ?? null;
+    const responseAuthPromise = verificationMux.waitForResponseAuth(
+      request.requestId,
+      this._config.responseAuthTimeoutMs ?? DEFAULT_RESPONSE_AUTH_GRACE_MS,
+    );
+
+    void responseAuthPromise
+      .then((payload) => {
+        const verification = verifyResponseAuth(payload, {
+          request,
+          response,
+          buyerPeerId: this._deps.localPeerId,
+          sellerPeerId: peer.peerId,
+          advertisedService,
+          channelId: expectedChannelId,
+        });
+
+        if (!verification.valid) {
+          debugWarn(
+            `[BuyerRequest] Invalid ResponseAuth for ${request.requestId.slice(0, 8)} from ${peer.peerId.slice(0, 12)}...: ${verification.reason ?? 'unknown'}`,
+          );
+        }
+
+        storage?.insertResponseAuth({
+          ...payload,
+          receivedAt: Date.now(),
+          verified: verification.valid,
+          verificationError: verification.reason ?? null,
+        });
+      })
+      .catch((err) => {
+        debugWarn(`[BuyerRequest] Missing ResponseAuth for ${request.requestId.slice(0, 8)} from ${peer.peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
+      });
   }
 }
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -77,6 +77,15 @@ export { getChainConfig, resolveChainConfig, DEFAULT_CHAIN_ID, CHAIN_CONFIGS } f
 export type { ChainConfig } from './payments/chain-config.js';
 export { formatUsdc, parseUsdc } from './payments/usdc-utils.js';
 export { ProxyMux } from './proxy/proxy-mux.js';
+export {
+  VerificationMux,
+  VerificationStorage,
+  createResponseAuthPayload,
+  verifyResponseAuth,
+  hashRequest,
+  hashResponse,
+  type StoredResponseAuth,
+} from './verification/index.js';
 export { resolveProvider } from './proxy/provider-detection.js';
 export {
   detectRequestServiceApiProtocol,

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -44,6 +44,8 @@ import {
 import { HttpMetadataResolver } from "./discovery/http-metadata-resolver.js";
 import { ProxyMux } from "./proxy/proxy-mux.js";
 import { PaymentMux } from "./p2p/payment-mux.js";
+import { VerificationMux } from "./verification/verification-mux.js";
+import { VerificationStorage } from "./verification/storage.js";
 import { FrameDecoder, encodeFrame } from "./p2p/message-protocol.js";
 import { KeepaliveManager, buildPongPayload } from "./p2p/keepalive.js";
 import { MessageType } from "./types/protocol.js";
@@ -232,6 +234,7 @@ export class AntseedNode extends EventEmitter {
   private _sellerAddressResolver: SellerAddressResolver | null = null;
   private _identityClient: IdentityClient | null = null;
   private _paymentMuxes = new Map<PeerId, PaymentMux>();
+  private _verificationMuxes = new Map<PeerId, VerificationMux>();
   /** Seller-side request handler (provider matching, execution, load tracking). */
   private _sellerHandler: SellerRequestHandler | null = null;
   /** Buyer-side payment manager (initialized when buyer has payment config). */
@@ -244,6 +247,8 @@ export class AntseedNode extends EventEmitter {
   private _sellerPaymentManager: SellerPaymentManager | null = null;
   /** Shared channel store for payment persistence. */
   private _channelStore: ChannelStore | null = null;
+  /** Buyer-side response authentication storage. */
+  private _verificationStorage: VerificationStorage | null = null;
   /** Periodic timeout checker interval. */
   private _timeoutCheckerInterval: ReturnType<typeof setInterval> | null = null;
   /** Block cursor for CloseRequested event polling. */
@@ -403,6 +408,7 @@ export class AntseedNode extends EventEmitter {
     // Close all proxy muxes
     this._muxes.clear();
     this._paymentMuxes.clear();
+    this._verificationMuxes.clear();
     this._decoders.clear();
 
     // Close all connections
@@ -433,6 +439,15 @@ export class AntseedNode extends EventEmitter {
         // ignore close errors
       }
       this._metering = null;
+    }
+
+    if (this._verificationStorage) {
+      try {
+        this._verificationStorage.close();
+      } catch {
+        // ignore close errors
+      }
+      this._verificationStorage = null;
     }
 
     if (this._timeoutCheckerInterval) {
@@ -971,6 +986,7 @@ export class AntseedNode extends EventEmitter {
       }
       const proxyMux = this._muxes.get(peerId);
       const paymentMux = this._paymentMuxes.get(peerId);
+      const verificationMux = this._verificationMuxes.get(peerId);
       for (const frame of frames) {
         // Keepalive: respond to Ping, dispatch Pong to manager
         if (frame.type === MessageType.Ping) {
@@ -991,6 +1007,11 @@ export class AntseedNode extends EventEmitter {
           paymentMux.handleFrame(frame).catch((err) => {
             const message = err instanceof Error ? err.message : String(err);
             debugWarn(`[Node] Failed to handle payment frame from ${peerId.slice(0, 12)}...: ${message}`);
+          });
+        } else if (verificationMux && VerificationMux.isVerificationMessage(frame.type)) {
+          verificationMux.handleFrame(frame).catch((err) => {
+            const message = err instanceof Error ? err.message : String(err);
+            debugWarn(`[Node] Failed to handle verification frame from ${peerId.slice(0, 12)}...: ${message}`);
           });
         } else if (proxyMux) {
           proxyMux.handleFrame(frame).catch((err) => {
@@ -1190,6 +1211,7 @@ export class AntseedNode extends EventEmitter {
 
     // Create seller request handler
     this._sellerHandler = new SellerRequestHandler({
+      identity,
       providers: this._providers,
       sellerPaymentManager: this._sellerPaymentManager,
       sessionTracker: this._sessionTracker,
@@ -1216,6 +1238,7 @@ export class AntseedNode extends EventEmitter {
     debugLog(`[Node] Starting buyer — DHT port=${dhtPort}`);
 
     const dataDir = this._config.dataDir ?? join(homedir(), ".antseed");
+    this._initializeVerificationStorage(dataDir);
     await this._initializePayments(dataDir);
 
     // Start DHT with ephemeral port
@@ -1299,9 +1322,12 @@ export class AntseedNode extends EventEmitter {
         maxStreamDurationMs: this._config.maxStreamDurationMs,
       },
       {
+        localPeerId: identity.peerId,
         negotiator: this._buyerNegotiator,
+        verificationStorage: this._verificationStorage,
         getConnection: (peer) => this._getOrCreateConnection(peer),
         getMux: (peerId, conn) => this._getOrCreateMux(peerId, conn),
+        getVerificationMux: (peerId, conn) => this._getOrCreateVerificationMux(peerId, conn),
         registerPaymentMux: (peerId, pmux) => this._paymentMuxes.set(peerId, pmux),
       },
     );
@@ -1315,6 +1341,7 @@ export class AntseedNode extends EventEmitter {
 
     // Create PaymentMux alongside ProxyMux (seller-side)
     const paymentMux = new PaymentMux(conn);
+    const verificationMux = new VerificationMux(conn);
     if (this._sellerPaymentManager) {
       const spm = this._sellerPaymentManager;
       paymentMux.onSpendingAuth((payload) => {
@@ -1335,8 +1362,9 @@ export class AntseedNode extends EventEmitter {
       });
     }
     this._paymentMuxes.set(buyerPeerId, paymentMux);
+    this._verificationMuxes.set(buyerPeerId, verificationMux);
 
-    const { mux } = this._sellerHandler!.handleConnection(conn, buyerPeerId, paymentMux);
+    const { mux } = this._sellerHandler!.handleConnection(conn, buyerPeerId, paymentMux, verificationMux);
 
     this._muxes.set(buyerPeerId, mux);
     this._wireConnection(conn, buyerPeerId);
@@ -1485,6 +1513,16 @@ export class AntseedNode extends EventEmitter {
     });
   }
 
+  private _initializeVerificationStorage(dataDir: string): void {
+    if (this._verificationStorage) return;
+    try {
+      this._verificationStorage = new VerificationStorage(join(dataDir, "verification.db"));
+      debugLog("[Node] Verification storage initialized");
+    } catch (err) {
+      debugWarn(`[Node] Verification storage unavailable: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
   private async _getOrCreateConnection(peer: PeerInfo): Promise<PeerConnection> {
     if (!this._connectionManager || !this._identity) {
       throw new Error("Node not started");
@@ -1578,6 +1616,17 @@ export class AntseedNode extends EventEmitter {
       maxUploadBodyBytes: this._config.maxUploadBodyBytes,
     });
     this._muxes.set(peerId, mux);
+    return mux;
+  }
+
+  private _getOrCreateVerificationMux(peerId: PeerId, conn: PeerConnection): VerificationMux {
+    const existing = this._verificationMuxes.get(peerId);
+    if (existing) {
+      return existing;
+    }
+
+    const mux = new VerificationMux(conn);
+    this._verificationMuxes.set(peerId, mux);
     return mux;
   }
 

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -408,6 +408,9 @@ export class AntseedNode extends EventEmitter {
     // Close all proxy muxes
     this._muxes.clear();
     this._paymentMuxes.clear();
+    for (const verificationMux of this._verificationMuxes.values()) {
+      verificationMux.close();
+    }
     this._verificationMuxes.clear();
     this._decoders.clear();
 
@@ -1038,6 +1041,8 @@ export class AntseedNode extends EventEmitter {
         this._muxes.get(peerId)?.abortPendingUploads();
         this._muxes.delete(peerId);
         this._paymentMuxes.delete(peerId);
+        this._verificationMuxes.get(peerId)?.close();
+        this._verificationMuxes.delete(peerId);
         this._decoders.delete(peerId);
         // Clean up buyer-side payment state on disconnect
         this._buyerNegotiator?.onPeerDisconnect(peerId);

--- a/packages/node/src/p2p/connection-manager.ts
+++ b/packages/node/src/p2p/connection-manager.ts
@@ -7,6 +7,7 @@ import type {
 } from "node-datachannel";
 import { type PeerId } from "../types/peer.js";
 import { ConnectionState, type ConnectionConfig } from "../types/connection.js";
+import { CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 } from "../types/protocol.js";
 import { type IceConfig, getDefaultIceConfig } from "./ice-config.js";
 import type { Wallet } from "ethers";
 import {
@@ -39,10 +40,12 @@ type InitialWireMessage =
   | {
       type: "intro";
       auth: ConnectionAuthEnvelope;
+      capabilities?: string[];
     }
   | {
       type: "hello";
       auth: ConnectionAuthEnvelope;
+      capabilities?: string[];
     };
 
 type SignalingMessage =
@@ -62,6 +65,7 @@ const LINE_SEPARATOR = "\n";
 const INITIAL_LINE_TIMEOUT_MS = 10_000;
 const MAX_INITIAL_LINE_BYTES = 8 * 1024;
 const TCP_KEEPALIVE_INITIAL_DELAY_MS = 10_000;
+const LOCAL_CONNECTION_CAPABILITIES = [CONNECTION_CAPABILITY_RESPONSE_AUTH_V1] as const;
 
 /** Represents a single P2P connection. */
 export class PeerConnection extends EventEmitter {
@@ -74,6 +78,7 @@ export class PeerConnection extends EventEmitter {
   private _dataChannel: NativeDataChannel | null = null;
   private _rawSocket: Socket | null = null;
   private _signalingSocket: Socket | null = null;
+  private _remoteCapabilities = new Set<string>();
 
   constructor(config: ConnectionConfig) {
     super();
@@ -84,6 +89,14 @@ export class PeerConnection extends EventEmitter {
 
   get state(): ConnectionState {
     return this._state;
+  }
+
+  setRemoteCapabilities(capabilities: Iterable<string>): void {
+    this._remoteCapabilities = new Set(capabilities);
+  }
+
+  hasRemoteCapability(capability: string): boolean {
+    return this._remoteCapabilities.has(capability);
   }
 
   attachRtcPeer(rtc: NativeRtcPeerConnection): void {
@@ -261,6 +274,18 @@ export class PeerConnection extends EventEmitter {
       this.emit("error", err);
     }
   }
+}
+
+function normalizeCapabilities(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const capabilities: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string" || item.length === 0 || item.length > 128) {
+      continue;
+    }
+    capabilities.push(item);
+  }
+  return capabilities;
 }
 
 /** Manages all peer connections and optional inbound listening. */
@@ -498,6 +523,7 @@ export class ConnectionManager extends EventEmitter {
           this._localPeerId!,
           this._localWallet!,
         ),
+        capabilities: [...LOCAL_CONNECTION_CAPABILITIES],
       });
 
       rtc = this._createRtcPeer(config.remotePeerId);
@@ -538,6 +564,7 @@ export class ConnectionManager extends EventEmitter {
           this._localPeerId!,
           this._localWallet!,
         ),
+        capabilities: [...LOCAL_CONNECTION_CAPABILITIES],
       });
       conn.attachRawSocket(socket);
     });
@@ -608,13 +635,15 @@ export class ConnectionManager extends EventEmitter {
         return;
       }
 
+      const remoteCapabilities = normalizeCapabilities(intro.capabilities);
+
       if (intro.type === "intro") {
-        this._acceptTcpInbound(socket, verified.peerId, remaining);
+        this._acceptTcpInbound(socket, verified.peerId, remaining, remoteCapabilities);
         return;
       }
 
       if (intro.type === "hello") {
-        this._acceptWebRtcInbound(socket, verified.peerId, remaining.toString("utf8"));
+        this._acceptWebRtcInbound(socket, verified.peerId, remaining.toString("utf8"), remoteCapabilities);
         return;
       }
 
@@ -691,7 +720,12 @@ export class ConnectionManager extends EventEmitter {
     );
   }
 
-  private _acceptTcpInbound(socket: Socket, remotePeerId: PeerId, remainingData: Buffer): void {
+  private _acceptTcpInbound(
+    socket: Socket,
+    remotePeerId: PeerId,
+    remainingData: Buffer,
+    remoteCapabilities: string[],
+  ): void {
     const existing = this._connections.get(remotePeerId);
     if (existing && existing.state !== ConnectionState.Closed && existing.state !== ConnectionState.Failed) {
       // Replace stale/ghost connections from the same peer instead of rejecting
@@ -703,6 +737,7 @@ export class ConnectionManager extends EventEmitter {
       remotePeerId,
       isInitiator: false,
     });
+    conn.setRemoteCapabilities(remoteCapabilities);
     this._registerConnection(remotePeerId, conn);
     conn.attachRawSocket(
       socket,
@@ -711,7 +746,12 @@ export class ConnectionManager extends EventEmitter {
     this.emit("connection", conn);
   }
 
-  private _acceptWebRtcInbound(socket: Socket, remotePeerId: PeerId, initialSignalingBuffer: string): void {
+  private _acceptWebRtcInbound(
+    socket: Socket,
+    remotePeerId: PeerId,
+    initialSignalingBuffer: string,
+    remoteCapabilities: string[],
+  ): void {
     const existing = this._connections.get(remotePeerId);
     if (existing && existing.state !== ConnectionState.Closed && existing.state !== ConnectionState.Failed) {
       // Replace stale/ghost connections from the same peer instead of rejecting
@@ -723,6 +763,7 @@ export class ConnectionManager extends EventEmitter {
       remotePeerId,
       isInitiator: false,
     });
+    conn.setRemoteCapabilities(remoteCapabilities);
     conn.attachSignalingSocket(socket);
     this._registerConnection(remotePeerId, conn);
 

--- a/packages/node/src/p2p/message-protocol.ts
+++ b/packages/node/src/p2p/message-protocol.ts
@@ -32,14 +32,6 @@ export function encodeFrame(msg: FramedMessage): Uint8Array {
   return frame;
 }
 
-const VALID_MESSAGE_TYPES = new Set<number>(
-  Object.values(MessageType).filter((v): v is number => typeof v === "number"),
-);
-
-function isValidMessageType(value: number): boolean {
-  return VALID_MESSAGE_TYPES.has(value);
-}
-
 /**
  * Decode a single FramedMessage from a binary buffer.
  * Returns the message and the number of bytes consumed.
@@ -53,11 +45,7 @@ export function decodeFrame(
   }
 
   const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  const rawType = view.getUint8(0);
-  if (!isValidMessageType(rawType)) {
-    throw new Error(`Invalid message type: 0x${rawType.toString(16).padStart(2, "0")}`);
-  }
-  const type = rawType as MessageType;
+  const type = view.getUint8(0);
   const messageId = view.getUint32(1);
   const payloadLength = view.getUint32(5);
 

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -455,9 +455,7 @@ export class SellerRequestHandler {
           }
         }
 
-        const buyerSupportsResponseAuth =
-          typeof (conn as { hasRemoteCapability?: unknown }).hasRemoteCapability === 'function'
-          && conn.hasRemoteCapability(CONNECTION_CAPABILITY_RESPONSE_AUTH_V1);
+        const buyerSupportsResponseAuth = conn.hasRemoteCapability(CONNECTION_CAPABILITY_RESPONSE_AUTH_V1);
 
         if (responseForAuth && buyerSupportsResponseAuth) {
           const channelId = spm?.getChannelByPeer(buyerPeerId)?.sessionId ?? null;

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -5,6 +5,7 @@ import type {
 } from './interfaces/seller-provider.js';
 import type { SellerSessionTracker } from './metering/seller-session-tracker.js';
 import type { PaymentMux } from './p2p/payment-mux.js';
+import type { Identity } from './p2p/identity.js';
 import type { ChannelsClient } from './payments/evm/channels-client.js';
 import type { SellerPaymentManager } from './payments/seller-payment-manager.js';
 import { ProxyMux } from './proxy/proxy-mux.js';
@@ -16,9 +17,12 @@ import type {
 import { parseResponseUsage } from './utils/response-usage.js';
 import { computeCostUsdc, estimateTokensFromBytes, type ServicePricing } from './payments/pricing.js';
 import { debugLog, debugWarn } from './utils/debug.js';
-import { PAYMENT_CODE_CHANNEL_EXHAUSTED } from './types/protocol.js';
+import { CONNECTION_CAPABILITY_RESPONSE_AUTH_V1, PAYMENT_CODE_CHANNEL_EXHAUSTED } from './types/protocol.js';
+import { VerificationMux } from './verification/verification-mux.js';
+import { createResponseAuthPayload } from './verification/response-auth.js';
 
 export interface SellerRequestHandlerDeps {
+  identity: Identity;
   providers: Provider[];
   sellerPaymentManager: SellerPaymentManager | null;
   sessionTracker: SellerSessionTracker | null;
@@ -57,6 +61,7 @@ export class SellerRequestHandler {
     conn: PeerConnection,
     buyerPeerId: string,
     paymentMux: PaymentMux,
+    verificationMux: VerificationMux,
   ): { mux: ProxyMux } {
     const mux = new ProxyMux(conn, {
       maxUploadBodyBytes: this._deps.maxUploadBodyBytes,
@@ -300,6 +305,11 @@ export class SellerRequestHandler {
         }
       }
 
+      const responseAuthRequest: SerializedHttpRequest = {
+        ...request,
+        headers: { ...request.headers },
+      };
+
       // Track active seller session at request start
       this._deps.sessionTracker?.getOrCreateSession(buyerPeerId, provider.name);
 
@@ -312,6 +322,10 @@ export class SellerRequestHandler {
       let responseBody: Uint8Array = new Uint8Array(0);
       let streamedResponseStarted = false;
       let heldDoneChunkData: Uint8Array | null = null;
+      let responseStartedAt = startTime;
+      let responseForAuth: SerializedHttpResponse | null = null;
+      let streamAuthStatusCode = 0;
+      let streamAuthHeaders: Record<string, string> | null = null;
       let responseUsage: import('./utils/response-usage.js').ResponseUsage = { inputTokens: 0, outputTokens: 0, freshInputTokens: 0, cachedInputTokens: 0 };
       this.adjustProviderLoad(provider.name, 1);
       try {
@@ -319,7 +333,10 @@ export class SellerRequestHandler {
           const response = await this._executeRequest(provider, request, {
             onResponseStart: (streamResponseStart) => {
               streamedResponseStarted = true;
+              responseStartedAt = Date.now();
               statusCode = streamResponseStart.statusCode;
+              streamAuthStatusCode = streamResponseStart.statusCode;
+              streamAuthHeaders = { ...streamResponseStart.headers };
               mux.sendProxyResponse(streamResponseStart);
             },
             onResponseChunk: (chunk) => {
@@ -334,6 +351,7 @@ export class SellerRequestHandler {
           });
           statusCode = response.statusCode;
           responseBody = response.body ?? new Uint8Array(0);
+          responseForAuth = response;
           if (statusCode >= 400) {
             const errBody = new TextDecoder().decode(responseBody).slice(0, 200);
             debugWarn(`[SellerHandler] Provider error response: status=${statusCode} provider="${provider.name}" model="${requestedModel}" buyer=${buyerPeerId.slice(0, 12)}... (${Date.now() - startTime}ms) body=${errBody}`);
@@ -358,9 +376,11 @@ export class SellerRequestHandler {
           debugWarn(`[SellerHandler] Provider exception: provider="${provider.name}" model="${requestedModel}" buyer=${buyerPeerId.slice(0, 12)}... (${Date.now() - startTime}ms) ${message}`);
           responseBody = new TextEncoder().encode(message);
           if (streamedResponseStarted) {
+            const errorFrame = new TextEncoder().encode(`event: error\ndata: ${message}\n\n`);
+            responseBody = errorFrame;
             mux.sendProxyChunk({
               requestId: request.requestId,
-              data: new TextEncoder().encode(`event: error\ndata: ${message}\n\n`),
+              data: errorFrame,
               done: false,
             });
             mux.sendProxyChunk({
@@ -368,14 +388,23 @@ export class SellerRequestHandler {
               data: new Uint8Array(0),
               done: true,
             });
+            if (streamAuthHeaders !== null) {
+              responseForAuth = {
+                requestId: request.requestId,
+                statusCode: streamAuthStatusCode,
+                headers: streamAuthHeaders,
+                body: errorFrame,
+              };
+            }
           } else {
             statusCode = 500;
-            mux.sendProxyResponse({
+            responseForAuth = {
               requestId: request.requestId,
               statusCode: 500,
               headers: { "content-type": "text/plain" },
               body: responseBody,
-            });
+            };
+            mux.sendProxyResponse(responseForAuth);
           }
         }
 
@@ -424,6 +453,27 @@ export class SellerRequestHandler {
               service: this._extractRequestedService(request) ?? undefined,
             }, buyerPeerId, 'post-response');
           }
+        }
+
+        const buyerSupportsResponseAuth =
+          typeof (conn as { hasRemoteCapability?: unknown }).hasRemoteCapability === 'function'
+          && conn.hasRemoteCapability(CONNECTION_CAPABILITY_RESPONSE_AUTH_V1);
+
+        if (responseForAuth && buyerSupportsResponseAuth) {
+          const channelId = spm?.getChannelByPeer(buyerPeerId)?.sessionId ?? null;
+          this._sendResponseAuthBestEffort(
+            verificationMux,
+            responseAuthRequest,
+            responseForAuth,
+            {
+              buyerPeerId,
+              providerName: provider.name,
+              advertisedService: requestedModel,
+              responseStartedAt,
+              responseCompletedAt: Date.now(),
+              channelId,
+            },
+          );
         }
       } finally {
         this.adjustProviderLoad(provider.name, -1);
@@ -678,6 +728,37 @@ export class SellerRequestHandler {
     this._metadataRefreshTimer = timer;
     if (typeof (timer as { unref?: () => void }).unref === "function") {
       (timer as { unref: () => void }).unref();
+    }
+  }
+
+  private _sendResponseAuthBestEffort(
+    verificationMux: VerificationMux,
+    request: SerializedHttpRequest,
+    response: SerializedHttpResponse,
+    context: {
+      buyerPeerId: string;
+      providerName: string;
+      advertisedService: string;
+      responseStartedAt: number;
+      responseCompletedAt: number;
+      channelId: string | null;
+    },
+  ): void {
+    try {
+      const payload = createResponseAuthPayload({
+        request,
+        response,
+        buyerPeerId: context.buyerPeerId,
+        sellerPeerId: this._deps.identity.peerId,
+        advertisedService: context.advertisedService,
+        provider: context.providerName,
+        responseStartedAt: context.responseStartedAt,
+        responseCompletedAt: context.responseCompletedAt,
+        channelId: context.channelId,
+      }, this._deps.identity.wallet);
+      verificationMux.sendResponseAuth(payload);
+    } catch (err) {
+      debugWarn(`[SellerHandler] Failed to send ResponseAuth for ${request.requestId.slice(0, 8)}: ${err instanceof Error ? err.message : err}`);
     }
   }
 }

--- a/packages/node/src/storage/migrations/verification/001_create_tables.ts
+++ b/packages/node/src/storage/migrations/verification/001_create_tables.ts
@@ -1,0 +1,32 @@
+import type { Migration } from '../../migrate.js';
+
+export const migration: Migration = {
+  version: 1,
+  name: 'create_verification_tables',
+  up: (db) => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS response_auths (
+        request_id TEXT PRIMARY KEY,
+        version INTEGER NOT NULL,
+        channel_id TEXT,
+        buyer_peer_id TEXT NOT NULL,
+        seller_peer_id TEXT NOT NULL,
+        advertised_service TEXT NOT NULL,
+        provider TEXT NOT NULL,
+        status_code INTEGER NOT NULL,
+        request_hash TEXT NOT NULL,
+        response_hash TEXT NOT NULL,
+        response_started_at INTEGER NOT NULL,
+        response_completed_at INTEGER NOT NULL,
+        signature TEXT NOT NULL,
+        received_at INTEGER NOT NULL,
+        verified INTEGER NOT NULL,
+        verification_error TEXT
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_response_auths_seller ON response_auths(seller_peer_id);
+      CREATE INDEX IF NOT EXISTS idx_response_auths_service ON response_auths(advertised_service);
+      CREATE INDEX IF NOT EXISTS idx_response_auths_received ON response_auths(received_at);
+    `);
+  },
+};

--- a/packages/node/src/storage/migrations/verification/index.ts
+++ b/packages/node/src/storage/migrations/verification/index.ts
@@ -1,0 +1,4 @@
+import type { Migration } from '../../migrate.js';
+import { migration as m001 } from './001_create_tables.js';
+
+export const verificationMigrations: Migration[] = [m001];

--- a/packages/node/src/types/protocol.ts
+++ b/packages/node/src/types/protocol.ts
@@ -27,9 +27,14 @@ export enum MessageType {
   RatingQuery = 0x71,
   RatingResponse = 0x72,
 
+  // Verification / attestation protocol (0x80-0x8F)
+  VerificationResponseAuth = 0x80,
+
   Disconnect = 0xF0,
   Error = 0xFF,
 }
+
+export const CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 = 'verification.response-auth.v1' as const;
 
 export interface FramedMessage {
   type: MessageType;
@@ -136,4 +141,26 @@ export interface NeedAuthPayload {
   freshInputTokens?: string;
   /** Service/model name for service-specific pricing validation. */
   service?: string;
+}
+
+// ─── Bilateral Verification Messages ───────────────────────────
+
+/**
+ * Seller-signed commitment for one completed inference response.
+ * Carries hashes and context only; plaintext request/response bytes stay local.
+ */
+export interface ResponseAuthPayload {
+  version: 1;
+  requestId: string;
+  channelId?: string;
+  buyerPeerId: string;
+  sellerPeerId: string;
+  advertisedService: string;
+  provider: string;
+  statusCode: number;
+  requestHash: string;
+  responseHash: string;
+  responseStartedAt: number;
+  responseCompletedAt: number;
+  signature: string;
 }

--- a/packages/node/src/verification/codec.ts
+++ b/packages/node/src/verification/codec.ts
@@ -1,0 +1,64 @@
+import type { ResponseAuthPayload } from '../types/protocol.js';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const MAX_PAYLOAD_SIZE = 64 * 1024;
+
+function parseJson(data: Uint8Array): Record<string, unknown> {
+  if (data.byteLength > MAX_PAYLOAD_SIZE) {
+    throw new Error(`Verification payload too large: ${data.byteLength} bytes (max ${MAX_PAYLOAD_SIZE})`);
+  }
+  const raw: unknown = JSON.parse(decoder.decode(data));
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error('Expected JSON object');
+  }
+  return raw as Record<string, unknown>;
+}
+
+function requireString(obj: Record<string, unknown>, field: string): string {
+  const value = obj[field];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Missing or invalid string field: ${field}`);
+  }
+  return value;
+}
+
+function requireNumber(obj: Record<string, unknown>, field: string): number {
+  const value = obj[field];
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`Missing or invalid number field: ${field}`);
+  }
+  return value;
+}
+
+export function encodeResponseAuth(payload: ResponseAuthPayload): Uint8Array {
+  return encoder.encode(JSON.stringify(payload));
+}
+
+export function decodeResponseAuth(data: Uint8Array): ResponseAuthPayload {
+  const obj = parseJson(data);
+  const version = obj.version;
+  if (version !== 1) {
+    throw new Error(`Unsupported response auth version: ${String(version)}`);
+  }
+
+  const result: ResponseAuthPayload = {
+    version,
+    requestId: requireString(obj, 'requestId'),
+    buyerPeerId: requireString(obj, 'buyerPeerId'),
+    sellerPeerId: requireString(obj, 'sellerPeerId'),
+    advertisedService: requireString(obj, 'advertisedService'),
+    provider: requireString(obj, 'provider'),
+    statusCode: requireNumber(obj, 'statusCode'),
+    requestHash: requireString(obj, 'requestHash'),
+    responseHash: requireString(obj, 'responseHash'),
+    responseStartedAt: requireNumber(obj, 'responseStartedAt'),
+    responseCompletedAt: requireNumber(obj, 'responseCompletedAt'),
+    signature: requireString(obj, 'signature'),
+  };
+  if (typeof obj.channelId === 'string' && obj.channelId.length > 0) {
+    result.channelId = obj.channelId;
+  }
+  return result;
+}

--- a/packages/node/src/verification/index.ts
+++ b/packages/node/src/verification/index.ts
@@ -1,0 +1,12 @@
+export { decodeResponseAuth, encodeResponseAuth } from './codec.js';
+export { VerificationMux } from './verification-mux.js';
+export {
+  createResponseAuthPayload,
+  hashRequest,
+  hashResponse,
+  verifyResponseAuth,
+  type ResponseAuthInput,
+  type ResponseAuthVerificationExpected,
+  type ResponseAuthVerificationResult,
+} from './response-auth.js';
+export { VerificationStorage, type StoredResponseAuth } from './storage.js';

--- a/packages/node/src/verification/response-auth.ts
+++ b/packages/node/src/verification/response-auth.ts
@@ -1,0 +1,146 @@
+import { keccak256 } from 'ethers';
+import type { Wallet } from 'ethers';
+import type { ResponseAuthPayload } from '../types/protocol.js';
+import type { SerializedHttpRequest, SerializedHttpResponse } from '../types/http.js';
+import { ANTSEED_STREAMING_RESPONSE_HEADER } from '../types/http.js';
+import { bytesToHex, hexToBytes, signData, verifySignature } from '../p2p/identity.js';
+import { encodeHttpRequest, encodeHttpResponse } from '../proxy/request-codec.js';
+
+const RESPONSE_AUTH_DOMAIN = 'antseed-response-auth-v1';
+
+export interface ResponseAuthInput {
+  request: SerializedHttpRequest;
+  response: SerializedHttpResponse;
+  buyerPeerId: string;
+  sellerPeerId: string;
+  advertisedService: string;
+  provider: string;
+  responseStartedAt: number;
+  responseCompletedAt: number;
+  channelId?: string | null;
+}
+
+export interface ResponseAuthVerificationExpected {
+  request: SerializedHttpRequest;
+  response: SerializedHttpResponse;
+  buyerPeerId: string;
+  sellerPeerId: string;
+  advertisedService: string;
+  channelId?: string | null;
+}
+
+export interface ResponseAuthVerificationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+export function createResponseAuthPayload(input: ResponseAuthInput, signer: Wallet): ResponseAuthPayload {
+  const payload: Omit<ResponseAuthPayload, 'signature'> = {
+    version: 1,
+    requestId: input.request.requestId,
+    ...(input.channelId ? { channelId: input.channelId } : {}),
+    buyerPeerId: normalizePeerId(input.buyerPeerId),
+    sellerPeerId: normalizePeerId(input.sellerPeerId),
+    advertisedService: input.advertisedService,
+    provider: input.provider,
+    statusCode: input.response.statusCode,
+    requestHash: hashRequest(input.request),
+    responseHash: hashResponse(input.response),
+    responseStartedAt: input.responseStartedAt,
+    responseCompletedAt: input.responseCompletedAt,
+  };
+  const signature = bytesToHex(signData(signer, buildResponseAuthSigningBytes(payload)));
+  return { ...payload, signature };
+}
+
+export function verifyResponseAuth(
+  payload: ResponseAuthPayload,
+  expected: ResponseAuthVerificationExpected,
+): ResponseAuthVerificationResult {
+  const expectedRequestHash = hashRequest(expected.request);
+  if (payload.requestHash !== expectedRequestHash) {
+    return { valid: false, reason: 'request_hash_mismatch' };
+  }
+
+  const expectedResponseHash = hashResponse(expected.response);
+  if (payload.responseHash !== expectedResponseHash) {
+    return { valid: false, reason: 'response_hash_mismatch' };
+  }
+
+  if (payload.requestId !== expected.request.requestId) {
+    return { valid: false, reason: 'request_id_mismatch' };
+  }
+  if (payload.statusCode !== expected.response.statusCode) {
+    return { valid: false, reason: 'status_code_mismatch' };
+  }
+  if (normalizePeerId(payload.buyerPeerId) !== normalizePeerId(expected.buyerPeerId)) {
+    return { valid: false, reason: 'buyer_peer_mismatch' };
+  }
+  if (normalizePeerId(payload.sellerPeerId) !== normalizePeerId(expected.sellerPeerId)) {
+    return { valid: false, reason: 'seller_peer_mismatch' };
+  }
+  if (payload.advertisedService !== expected.advertisedService) {
+    return { valid: false, reason: 'advertised_service_mismatch' };
+  }
+  if (expected.channelId && payload.channelId !== expected.channelId) {
+    return { valid: false, reason: 'channel_id_mismatch' };
+  }
+
+  const { signature: _signature, ...unsigned } = payload;
+  let validSignature = false;
+  try {
+    const signature = hexToBytes(payload.signature);
+    validSignature = verifySignature(
+      normalizePeerId(expected.sellerPeerId),
+      signature,
+      buildResponseAuthSigningBytes(unsigned),
+    );
+  } catch {
+    validSignature = false;
+  }
+  if (!validSignature) {
+    return { valid: false, reason: 'invalid_signature' };
+  }
+
+  return { valid: true };
+}
+
+export function hashRequest(request: SerializedHttpRequest): string {
+  return keccak256(encodeHttpRequest(request));
+}
+
+export function hashResponse(response: SerializedHttpResponse): string {
+  return keccak256(encodeHttpResponse(stripStreamingHeader(response)));
+}
+
+function buildResponseAuthSigningBytes(payload: Omit<ResponseAuthPayload, 'signature'>): Uint8Array {
+  const fields = [
+    RESPONSE_AUTH_DOMAIN,
+    String(payload.version),
+    payload.requestId,
+    payload.channelId ?? '',
+    normalizePeerId(payload.buyerPeerId),
+    normalizePeerId(payload.sellerPeerId),
+    payload.advertisedService,
+    payload.provider,
+    String(payload.statusCode),
+    payload.requestHash,
+    payload.responseHash,
+    String(payload.responseStartedAt),
+    String(payload.responseCompletedAt),
+  ];
+  return new TextEncoder().encode(fields.join('|'));
+}
+
+function stripStreamingHeader(response: SerializedHttpResponse): SerializedHttpResponse {
+  if (response.headers[ANTSEED_STREAMING_RESPONSE_HEADER] !== '1') {
+    return response;
+  }
+  const headers = { ...response.headers };
+  delete headers[ANTSEED_STREAMING_RESPONSE_HEADER];
+  return { ...response, headers };
+}
+
+function normalizePeerId(peerId: string): string {
+  return peerId.startsWith('0x') ? peerId.slice(2).toLowerCase() : peerId.toLowerCase();
+}

--- a/packages/node/src/verification/response-auth.ts
+++ b/packages/node/src/verification/response-auth.ts
@@ -114,6 +114,7 @@ export function hashResponse(response: SerializedHttpResponse): string {
 }
 
 function buildResponseAuthSigningBytes(payload: Omit<ResponseAuthPayload, 'signature'>): Uint8Array {
+  const encoder = new TextEncoder();
   const fields = [
     RESPONSE_AUTH_DOMAIN,
     String(payload.version),
@@ -128,8 +129,19 @@ function buildResponseAuthSigningBytes(payload: Omit<ResponseAuthPayload, 'signa
     payload.responseHash,
     String(payload.responseStartedAt),
     String(payload.responseCompletedAt),
-  ];
-  return new TextEncoder().encode(fields.join('|'));
+  ].map((field) => encoder.encode(field));
+
+  const totalLength = fields.reduce((sum, field) => sum + 4 + field.length, 0);
+  const out = new Uint8Array(totalLength);
+  const view = new DataView(out.buffer);
+  let offset = 0;
+  for (const field of fields) {
+    view.setUint32(offset, field.length);
+    offset += 4;
+    out.set(field, offset);
+    offset += field.length;
+  }
+  return out;
 }
 
 function stripStreamingHeader(response: SerializedHttpResponse): SerializedHttpResponse {

--- a/packages/node/src/verification/storage.ts
+++ b/packages/node/src/verification/storage.ts
@@ -131,7 +131,7 @@ interface ResponseAuthRow {
 
 function rowToResponseAuth(row: ResponseAuthRow): StoredResponseAuth {
   return {
-    version: 1,
+    version: row.version as 1,
     requestId: row.request_id,
     ...(row.channel_id ? { channelId: row.channel_id } : {}),
     buyerPeerId: row.buyer_peer_id,

--- a/packages/node/src/verification/storage.ts
+++ b/packages/node/src/verification/storage.ts
@@ -1,0 +1,151 @@
+import Database from 'better-sqlite3';
+import type { ResponseAuthPayload } from '../types/protocol.js';
+import { runMigrations } from '../storage/migrate.js';
+import { verificationMigrations } from '../storage/migrations/verification/index.js';
+
+export interface StoredResponseAuth extends ResponseAuthPayload {
+  receivedAt: number;
+  verified: boolean;
+  verificationError: string | null;
+}
+
+export class VerificationStorage {
+  private readonly _db: Database.Database;
+  private readonly _insertResponseAuth: Database.Statement;
+  private readonly _getResponseAuth: Database.Statement;
+  private readonly _listResponseAuthsBySeller: Database.Statement;
+
+  constructor(dbPath: string) {
+    this._db = new Database(dbPath);
+    this._db.pragma('journal_mode = WAL');
+    runMigrations(this._db, verificationMigrations);
+
+    const statements = this._prepareStatements();
+    this._insertResponseAuth = statements.insertResponseAuth;
+    this._getResponseAuth = statements.getResponseAuth;
+    this._listResponseAuthsBySeller = statements.listResponseAuthsBySeller;
+  }
+
+  private _prepareStatements(): VerificationStorageStatements {
+    return {
+      insertResponseAuth: this._prepareInsertResponseAuthStatement(),
+      getResponseAuth: this._db.prepare('SELECT * FROM response_auths WHERE request_id = ?'),
+      listResponseAuthsBySeller: this._db.prepare(
+        'SELECT * FROM response_auths WHERE seller_peer_id = ? ORDER BY received_at DESC LIMIT ?',
+      ),
+    };
+  }
+
+  private _prepareInsertResponseAuthStatement(): Database.Statement {
+    return this._db.prepare(`
+      INSERT INTO response_auths (
+        request_id, version, channel_id, buyer_peer_id, seller_peer_id,
+        advertised_service, provider, status_code, request_hash, response_hash,
+        response_started_at, response_completed_at, signature,
+        received_at, verified, verification_error
+      ) VALUES (
+        @requestId, @version, @channelId, @buyerPeerId, @sellerPeerId,
+        @advertisedService, @provider, @statusCode, @requestHash, @responseHash,
+        @responseStartedAt, @responseCompletedAt, @signature,
+        @receivedAt, @verified, @verificationError
+      )
+      ON CONFLICT(request_id) DO UPDATE SET
+        version = excluded.version,
+        channel_id = excluded.channel_id,
+        buyer_peer_id = excluded.buyer_peer_id,
+        seller_peer_id = excluded.seller_peer_id,
+        advertised_service = excluded.advertised_service,
+        provider = excluded.provider,
+        status_code = excluded.status_code,
+        request_hash = excluded.request_hash,
+        response_hash = excluded.response_hash,
+        response_started_at = excluded.response_started_at,
+        response_completed_at = excluded.response_completed_at,
+        signature = excluded.signature,
+        received_at = excluded.received_at,
+        verified = excluded.verified,
+        verification_error = excluded.verification_error
+    `);
+  }
+
+  insertResponseAuth(record: StoredResponseAuth): void {
+    this._insertResponseAuth.run({
+      requestId: record.requestId,
+      version: record.version,
+      channelId: record.channelId ?? null,
+      buyerPeerId: record.buyerPeerId,
+      sellerPeerId: record.sellerPeerId,
+      advertisedService: record.advertisedService,
+      provider: record.provider,
+      statusCode: record.statusCode,
+      requestHash: record.requestHash,
+      responseHash: record.responseHash,
+      responseStartedAt: record.responseStartedAt,
+      responseCompletedAt: record.responseCompletedAt,
+      signature: record.signature,
+      receivedAt: record.receivedAt,
+      verified: record.verified ? 1 : 0,
+      verificationError: record.verificationError,
+    });
+  }
+
+  getResponseAuth(requestId: string): StoredResponseAuth | null {
+    const row = this._getResponseAuth.get(requestId) as ResponseAuthRow | undefined;
+    return row ? rowToResponseAuth(row) : null;
+  }
+
+  listResponseAuthsBySeller(sellerPeerId: string, limit = 100): StoredResponseAuth[] {
+    const rows = this._listResponseAuthsBySeller.all(sellerPeerId, Math.max(1, limit)) as ResponseAuthRow[];
+    return rows.map(rowToResponseAuth);
+  }
+
+  close(): void {
+    this._db.close();
+  }
+}
+
+interface VerificationStorageStatements {
+  insertResponseAuth: Database.Statement;
+  getResponseAuth: Database.Statement;
+  listResponseAuthsBySeller: Database.Statement;
+}
+
+interface ResponseAuthRow {
+  request_id: string;
+  version: number;
+  channel_id: string | null;
+  buyer_peer_id: string;
+  seller_peer_id: string;
+  advertised_service: string;
+  provider: string;
+  status_code: number;
+  request_hash: string;
+  response_hash: string;
+  response_started_at: number;
+  response_completed_at: number;
+  signature: string;
+  received_at: number;
+  verified: number;
+  verification_error: string | null;
+}
+
+function rowToResponseAuth(row: ResponseAuthRow): StoredResponseAuth {
+  return {
+    version: 1,
+    requestId: row.request_id,
+    ...(row.channel_id ? { channelId: row.channel_id } : {}),
+    buyerPeerId: row.buyer_peer_id,
+    sellerPeerId: row.seller_peer_id,
+    advertisedService: row.advertised_service,
+    provider: row.provider,
+    statusCode: row.status_code,
+    requestHash: row.request_hash,
+    responseHash: row.response_hash,
+    responseStartedAt: row.response_started_at,
+    responseCompletedAt: row.response_completed_at,
+    signature: row.signature,
+    receivedAt: row.received_at,
+    verified: row.verified === 1,
+    verificationError: row.verification_error,
+  };
+}

--- a/packages/node/src/verification/verification-mux.ts
+++ b/packages/node/src/verification/verification-mux.ts
@@ -60,6 +60,15 @@ export class VerificationMux {
     return promise;
   }
 
+  close(): void {
+    for (const pending of this._pendingResponseAuths.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error('VerificationMux closed'));
+    }
+    this._pendingResponseAuths.clear();
+    this._bufferedResponseAuths.clear();
+  }
+
   async handleFrame(frame: FramedMessage): Promise<boolean> {
     const name = MESSAGE_TYPE_NAME[frame.type];
     if (!name) return false;

--- a/packages/node/src/verification/verification-mux.ts
+++ b/packages/node/src/verification/verification-mux.ts
@@ -1,0 +1,115 @@
+import { MessageType, type FramedMessage, type ResponseAuthPayload } from '../types/protocol.js';
+import type { PeerConnection } from '../p2p/connection-manager.js';
+import { encodeFrame } from '../p2p/message-protocol.js';
+import { debugLog } from '../utils/debug.js';
+import { decodeResponseAuth, encodeResponseAuth } from './codec.js';
+
+const MESSAGE_TYPE_NAME: Record<number, string> = {
+  [MessageType.VerificationResponseAuth]: 'VerificationResponseAuth',
+};
+
+const MAX_BUFFERED_AUTHS = 256;
+const DEFAULT_RESPONSE_AUTH_TIMEOUT_MS = 30_000;
+
+export type VerificationMessageHandler<T> = (payload: T) => void | Promise<void>;
+
+export class VerificationMux {
+  private readonly _connection: PeerConnection;
+  private _messageIdCounter = 0;
+  private _onResponseAuth?: VerificationMessageHandler<ResponseAuthPayload>;
+  private readonly _pendingResponseAuths = new Map<string, PendingResponseAuth>();
+  private readonly _bufferedResponseAuths = new Map<string, ResponseAuthPayload>();
+
+  constructor(connection: PeerConnection) {
+    this._connection = connection;
+  }
+
+  onResponseAuth(handler: VerificationMessageHandler<ResponseAuthPayload>): void {
+    this._onResponseAuth = handler;
+  }
+
+  sendResponseAuth(payload: ResponseAuthPayload): void {
+    this._send(MessageType.VerificationResponseAuth, encodeResponseAuth(payload));
+  }
+
+  waitForResponseAuth(
+    requestId: string,
+    timeoutMs = DEFAULT_RESPONSE_AUTH_TIMEOUT_MS,
+  ): Promise<ResponseAuthPayload> {
+    const buffered = this._bufferedResponseAuths.get(requestId);
+    if (buffered) {
+      this._bufferedResponseAuths.delete(requestId);
+      return Promise.resolve(buffered);
+    }
+
+    const existing = this._pendingResponseAuths.get(requestId);
+    if (existing) return existing.promise;
+
+    let resolve!: (payload: ResponseAuthPayload) => void;
+    let reject!: (error: Error) => void;
+    const timer = setTimeout(() => {
+      this._pendingResponseAuths.delete(requestId);
+      reject(new Error(`ResponseAuth timed out for request ${requestId}`));
+    }, Math.max(1, timeoutMs));
+
+    const promise = new Promise<ResponseAuthPayload>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    this._pendingResponseAuths.set(requestId, { promise, resolve, reject, timer });
+    return promise;
+  }
+
+  async handleFrame(frame: FramedMessage): Promise<boolean> {
+    const name = MESSAGE_TYPE_NAME[frame.type];
+    if (!name) return false;
+    debugLog(`[VerificationMux] ← recv ${name} (${frame.payload.length}b)`);
+
+    switch (frame.type) {
+      case MessageType.VerificationResponseAuth: {
+        const payload = decodeResponseAuth(frame.payload);
+        const pending = this._pendingResponseAuths.get(payload.requestId);
+        if (pending) {
+          clearTimeout(pending.timer);
+          this._pendingResponseAuths.delete(payload.requestId);
+          pending.resolve(payload);
+        } else {
+          this._bufferResponseAuth(payload);
+        }
+        await this._onResponseAuth?.(payload);
+        return true;
+      }
+      default:
+        return false;
+    }
+  }
+
+  static isVerificationMessage(type: number): boolean {
+    return type >= 0x80 && type <= 0x8f;
+  }
+
+  private _bufferResponseAuth(payload: ResponseAuthPayload): void {
+    if (this._bufferedResponseAuths.size >= MAX_BUFFERED_AUTHS) {
+      const oldest = this._bufferedResponseAuths.keys().next().value as string | undefined;
+      if (oldest) this._bufferedResponseAuths.delete(oldest);
+    }
+    this._bufferedResponseAuths.set(payload.requestId, payload);
+  }
+
+  private _send(type: MessageType, payload: Uint8Array): void {
+    debugLog(`[VerificationMux] → send ${MESSAGE_TYPE_NAME[type] ?? `0x${type.toString(16)}`} (${payload.length}b)`);
+    const frame = encodeFrame({
+      type,
+      messageId: this._messageIdCounter++ & 0xffffffff,
+      payload,
+    });
+    this._connection.send(frame);
+  }
+}
+
+interface PendingResponseAuth {
+  promise: Promise<ResponseAuthPayload>;
+  resolve: (payload: ResponseAuthPayload) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}

--- a/packages/node/tests/connection-capabilities.test.ts
+++ b/packages/node/tests/connection-capabilities.test.ts
@@ -1,0 +1,78 @@
+import net, { type Socket } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildConnectionAuthEnvelope } from '../src/p2p/connection-auth.js';
+import { ConnectionManager, type PeerConnection } from '../src/p2p/connection-manager.js';
+import { identityFromPrivateKeyHex } from '../src/p2p/identity.js';
+import { CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 } from '../src/types/protocol.js';
+
+const sellerIdentity = identityFromPrivateKeyHex('11'.repeat(32));
+const buyerIdentity = identityFromPrivateKeyHex('22'.repeat(32));
+
+const managers: ConnectionManager[] = [];
+const sockets: Socket[] = [];
+
+function trackManager(manager: ConnectionManager): ConnectionManager {
+  managers.push(manager);
+  return manager;
+}
+
+function waitForConnection(manager: ConnectionManager): Promise<PeerConnection> {
+  return new Promise((resolve) => manager.once('connection', resolve));
+}
+
+function connectSocket(port: number): Promise<Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect({ host: '127.0.0.1', port });
+    sockets.push(socket);
+    socket.once('connect', () => resolve(socket));
+    socket.once('error', reject);
+  });
+}
+
+describe('connection capabilities', () => {
+  afterEach(async () => {
+    for (const socket of sockets.splice(0)) {
+      socket.destroy();
+    }
+    for (const manager of managers.splice(0)) {
+      manager.closeAll();
+      await manager.stopListening();
+    }
+  });
+
+  it('treats peers without capabilities as old clients', async () => {
+    const seller = trackManager(new ConnectionManager());
+    seller.setLocalIdentity(sellerIdentity);
+    await seller.startListening({ peerId: sellerIdentity.peerId, host: '127.0.0.1', port: 0 });
+
+    const inbound = waitForConnection(seller);
+    const socket = await connectSocket(seller.getListeningPort()!);
+    socket.write(JSON.stringify({
+      type: 'intro',
+      auth: buildConnectionAuthEnvelope('intro', buyerIdentity.peerId, buyerIdentity.wallet),
+    }) + '\n');
+
+    const conn = await inbound;
+    expect(conn.remotePeerId).toBe(buyerIdentity.peerId);
+    expect(conn.hasRemoteCapability(CONNECTION_CAPABILITY_RESPONSE_AUTH_V1)).toBe(false);
+  });
+
+  it('records response-auth support from new clients', async () => {
+    const seller = trackManager(new ConnectionManager());
+    const buyer = trackManager(new ConnectionManager());
+    seller.setLocalIdentity(sellerIdentity);
+    buyer.setLocalIdentity(buyerIdentity);
+    await seller.startListening({ peerId: sellerIdentity.peerId, host: '127.0.0.1', port: 0 });
+
+    const inbound = waitForConnection(seller);
+    buyer.createConnection({
+      remotePeerId: sellerIdentity.peerId,
+      isInitiator: true,
+      endpoint: { host: '127.0.0.1', port: seller.getListeningPort()! },
+    });
+
+    const conn = await inbound;
+    expect(conn.remotePeerId).toBe(buyerIdentity.peerId);
+    expect(conn.hasRemoteCapability(CONNECTION_CAPABILITY_RESPONSE_AUTH_V1)).toBe(true);
+  });
+});

--- a/packages/node/tests/message-protocol.test.ts
+++ b/packages/node/tests/message-protocol.test.ts
@@ -82,13 +82,17 @@ describe('encodeFrame / decodeFrame', () => {
     expect(() => decodeFrame(buf)).toThrow('exceeds maximum');
   });
 
-  it('should throw for invalid message type', () => {
+  it('should decode unknown message types for forward compatibility', () => {
     const buf = new Uint8Array(FRAME_HEADER_SIZE);
     const view = new DataView(buf.buffer);
     view.setUint8(0, 0x99);
     view.setUint32(1, 1);
     view.setUint32(5, 0);
-    expect(() => decodeFrame(buf)).toThrow('Invalid message type');
+
+    const decoded = decodeFrame(buf);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.message.type).toBe(0x99);
+    expect(decoded!.bytesConsumed).toBe(FRAME_HEADER_SIZE);
   });
 
   it('should handle all message types', () => {
@@ -162,7 +166,7 @@ describe('FrameDecoder', () => {
     expect(decoder.bufferedBytes).toBe(0);
   });
 
-  it('should clear buffered data and throw on invalid frame type', () => {
+  it('should decode unknown frame types and clear buffered data', () => {
     const decoder = new FrameDecoder();
     const buf = new Uint8Array(FRAME_HEADER_SIZE);
     const view = new DataView(buf.buffer);
@@ -170,7 +174,9 @@ describe('FrameDecoder', () => {
     view.setUint32(1, 1);
     view.setUint32(5, 0);
 
-    expect(() => decoder.feed(buf)).toThrow('Invalid message type');
+    const frames = decoder.feed(buf);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]!.type).toBe(0x99);
     expect(decoder.bufferedBytes).toBe(0);
   });
 });

--- a/packages/node/tests/node-payment-mux-wiring.test.ts
+++ b/packages/node/tests/node-payment-mux-wiring.test.ts
@@ -4,6 +4,12 @@ import type { SerializedHttpRequest } from '../src/types/http.js';
 import type { SerializedHttpResponse } from '../src/types/http.js';
 import type { PeerInfo, PeerId } from '../src/types/peer.js';
 
+function createNoopVerificationMux(): { waitForResponseAuth: ReturnType<typeof vi.fn> } {
+  return {
+    waitForResponseAuth: vi.fn(() => Promise.reject(new Error('response auth unavailable in test'))),
+  };
+}
+
 describe('BuyerRequestHandler payment mux wiring', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -38,6 +44,7 @@ describe('BuyerRequestHandler payment mux wiring', () => {
     const handler = new BuyerRequestHandler(
       {},
       {
+        localPeerId: 'a'.repeat(40) as PeerId,
         negotiator: {
           getOrCreatePaymentMux,
           preparePreRequestAuth: vi.fn(),
@@ -46,11 +53,13 @@ describe('BuyerRequestHandler payment mux wiring', () => {
           parseCostHeaders: vi.fn(),
           recordResponseContent: vi.fn(),
         } as any,
+        verificationStorage: null,
         getConnection: vi.fn(async () => conn) as any,
         getMux: vi.fn(() => ({
           sendProxyRequest,
           cancelProxyRequest: vi.fn(),
         })) as any,
+        getVerificationMux: vi.fn(() => createNoopVerificationMux()) as any,
         registerPaymentMux,
       },
     );
@@ -113,6 +122,7 @@ describe('BuyerRequestHandler payment mux wiring', () => {
     const handler = new BuyerRequestHandler(
       {},
       {
+        localPeerId: 'a'.repeat(40) as PeerId,
         negotiator: {
           getOrCreatePaymentMux: vi.fn().mockReturnValue({}),
           preparePreRequestAuth: vi.fn(),
@@ -121,11 +131,13 @@ describe('BuyerRequestHandler payment mux wiring', () => {
           parseCostHeaders: vi.fn(),
           recordResponseContent: vi.fn(),
         } as any,
+        verificationStorage: null,
         getConnection: vi.fn(async () => conn) as any,
         getMux: vi.fn(() => ({
           sendProxyRequest,
           cancelProxyRequest: vi.fn(),
         })) as any,
+        getVerificationMux: vi.fn(() => createNoopVerificationMux()) as any,
         registerPaymentMux: vi.fn(),
       },
     );

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -53,6 +53,15 @@ function makeSpmMock(overrides: Record<string, unknown> = {}): any {
   };
 }
 
+function makeConn(sentFrames: Uint8Array[]): any {
+  return {
+    send(frame: Uint8Array) {
+      sentFrames.push(frame);
+    },
+    hasRemoteCapability: () => false,
+  };
+}
+
 describe('SellerRequestHandler payment pricing selection', () => {
   it('routes GET /v1/models to the local handler even when a query string is appended', async () => {
     const provider = makeProvider(1, 1, {
@@ -69,7 +78,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired: vi.fn() } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -109,7 +118,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired: vi.fn() } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -202,7 +211,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth, sendPaymentRequired: vi.fn() } as any;
 
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
@@ -243,7 +252,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth, sendPaymentRequired: vi.fn() } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -294,7 +303,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth, sendPaymentRequired: vi.fn() } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -321,7 +330,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -355,7 +364,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -389,7 +398,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -421,7 +430,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -458,7 +467,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -494,7 +503,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -534,7 +543,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -564,7 +573,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -601,7 +610,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -644,7 +653,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 
@@ -677,7 +686,7 @@ describe('SellerRequestHandler payment pricing selection', () => {
     });
 
     const sentFrames: Uint8Array[] = [];
-    const conn = { send(frame: Uint8Array) { sentFrames.push(frame); } } as any;
+    const conn = makeConn(sentFrames);
     const paymentMux = { sendNeedAuth, sendPaymentRequired } as any;
     const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
 

--- a/packages/node/tests/node-stream-security.test.ts
+++ b/packages/node/tests/node-stream-security.test.ts
@@ -15,6 +15,12 @@ interface StreamingHarness {
   emitChunk: (chunk: SerializedHttpResponseChunk) => void;
 }
 
+function createNoopVerificationMux(): { waitForResponseAuth: ReturnType<typeof vi.fn> } {
+  return {
+    waitForResponseAuth: vi.fn(() => Promise.reject(new Error('response auth unavailable in test'))),
+  };
+}
+
 function createHandler(config: BuyerRequestHandlerConfig): { handler: BuyerRequestHandler; harness: StreamingHarness } {
   let onResponse: ((response: SerializedHttpResponse, metadata: { streamingStart: boolean }) => void) | null = null;
   let onChunk: ((chunk: SerializedHttpResponseChunk) => void) | null = null;
@@ -39,9 +45,12 @@ function createHandler(config: BuyerRequestHandlerConfig): { handler: BuyerReque
   };
 
   const handler = new BuyerRequestHandler(config, {
+    localPeerId: 'a'.repeat(40),
     negotiator: null,
+    verificationStorage: null,
     getConnection: vi.fn(async () => ({ state: 'open' })) as any,
     getMux: vi.fn(() => mux) as any,
+    getVerificationMux: vi.fn(() => createNoopVerificationMux()) as any,
     registerPaymentMux: vi.fn(),
   });
 

--- a/packages/node/tests/response-auth.test.ts
+++ b/packages/node/tests/response-auth.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { identityFromPrivateKeyHex } from '../src/p2p/identity.js';
+import type { SerializedHttpRequest, SerializedHttpResponse } from '../src/types/http.js';
+import {
+  createResponseAuthPayload,
+  verifyResponseAuth,
+  VerificationStorage,
+} from '../src/verification/index.js';
+
+function makeRequest(): SerializedHttpRequest {
+  return {
+    requestId: 'req-1',
+    method: 'POST',
+    path: '/v1/messages',
+    headers: { 'content-type': 'application/json' },
+    body: new TextEncoder().encode(JSON.stringify({ model: 'claude-sonnet-test', messages: [] })),
+  };
+}
+
+function makeResponse(): SerializedHttpResponse {
+  return {
+    requestId: 'req-1',
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: new TextEncoder().encode(JSON.stringify({ content: [{ type: 'text', text: 'ok' }] })),
+  };
+}
+
+describe('ResponseAuth', () => {
+  it('signs and verifies one response auth payload', () => {
+    const seller = identityFromPrivateKeyHex('11'.repeat(32));
+    const buyer = identityFromPrivateKeyHex('22'.repeat(32));
+    const request = makeRequest();
+    const response = makeResponse();
+
+    const payload = createResponseAuthPayload({
+      request,
+      response,
+      buyerPeerId: buyer.peerId,
+      sellerPeerId: seller.peerId,
+      advertisedService: 'claude-sonnet-test',
+      provider: 'anthropic',
+      responseStartedAt: 100,
+      responseCompletedAt: 200,
+      channelId: '0x' + 'aa'.repeat(32),
+    }, seller.wallet);
+
+    expect(payload.signature).toHaveLength(130);
+    expect(verifyResponseAuth(payload, {
+      request,
+      response,
+      buyerPeerId: buyer.peerId,
+      sellerPeerId: seller.peerId,
+      advertisedService: 'claude-sonnet-test',
+      channelId: '0x' + 'aa'.repeat(32),
+    })).toEqual({ valid: true });
+  });
+
+  it('rejects a payload when the response bytes differ', () => {
+    const seller = identityFromPrivateKeyHex('11'.repeat(32));
+    const buyer = identityFromPrivateKeyHex('22'.repeat(32));
+    const request = makeRequest();
+    const response = makeResponse();
+
+    const payload = createResponseAuthPayload({
+      request,
+      response,
+      buyerPeerId: buyer.peerId,
+      sellerPeerId: seller.peerId,
+      advertisedService: 'claude-sonnet-test',
+      provider: 'anthropic',
+      responseStartedAt: 100,
+      responseCompletedAt: 200,
+    }, seller.wallet);
+
+    const tamperedResponse = {
+      ...response,
+      body: new TextEncoder().encode(JSON.stringify({ content: [{ type: 'text', text: 'tampered' }] })),
+    };
+    const result = verifyResponseAuth(payload, {
+      request,
+      response: tamperedResponse,
+      buyerPeerId: buyer.peerId,
+      sellerPeerId: seller.peerId,
+      advertisedService: 'claude-sonnet-test',
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('response_hash_mismatch');
+  });
+
+  it('stores lightweight response auth records locally', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'verification-store-test-'));
+    const storage = new VerificationStorage(join(tempDir, 'verification.db'));
+    try {
+      const seller = identityFromPrivateKeyHex('11'.repeat(32));
+      const buyer = identityFromPrivateKeyHex('22'.repeat(32));
+      const payload = createResponseAuthPayload({
+        request: makeRequest(),
+        response: makeResponse(),
+        buyerPeerId: buyer.peerId,
+        sellerPeerId: seller.peerId,
+        advertisedService: 'claude-sonnet-test',
+        provider: 'anthropic',
+        responseStartedAt: 100,
+        responseCompletedAt: 200,
+      }, seller.wallet);
+
+      storage.insertResponseAuth({
+        ...payload,
+        receivedAt: 300,
+        verified: true,
+        verificationError: null,
+      });
+
+      const loaded = storage.getResponseAuth(payload.requestId);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.requestHash).toBe(payload.requestHash);
+      expect(loaded!.verified).toBe(true);
+      expect(loaded!.verificationError).toBeNull();
+    } finally {
+      storage.close();
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/node/tests/response-auth.test.ts
+++ b/packages/node/tests/response-auth.test.ts
@@ -92,6 +92,41 @@ describe('ResponseAuth', () => {
     expect(result.reason).toBe('response_hash_mismatch');
   });
 
+  it('signs and verifies fields containing delimiter characters', () => {
+    const seller = identityFromPrivateKeyHex('11'.repeat(32));
+    const buyer = identityFromPrivateKeyHex('22'.repeat(32));
+    const request = {
+      ...makeRequest(),
+      requestId: 'req|with|pipes',
+    };
+    const response = {
+      ...makeResponse(),
+      requestId: request.requestId,
+    };
+    const channelId = 'channel|with|pipes';
+
+    const payload = createResponseAuthPayload({
+      request,
+      response,
+      buyerPeerId: buyer.peerId,
+      sellerPeerId: seller.peerId,
+      advertisedService: 'claude|sonnet|test',
+      provider: 'anthropic|test',
+      responseStartedAt: 100,
+      responseCompletedAt: 200,
+      channelId,
+    }, seller.wallet);
+
+    expect(verifyResponseAuth(payload, {
+      request,
+      response,
+      buyerPeerId: buyer.peerId,
+      sellerPeerId: seller.peerId,
+      advertisedService: 'claude|sonnet|test',
+      channelId,
+    })).toEqual({ valid: true });
+  });
+
   it('stores lightweight response auth records locally', () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'verification-store-test-'));
     const storage = new VerificationStorage(join(tempDir, 'verification.db'));
@@ -121,6 +156,11 @@ describe('ResponseAuth', () => {
       expect(loaded!.requestHash).toBe(payload.requestHash);
       expect(loaded!.verified).toBe(true);
       expect(loaded!.verificationError).toBeNull();
+
+      (storage as unknown as { _db: { prepare: (sql: string) => { run: (...args: unknown[]) => void } } })
+        ._db.prepare('UPDATE response_auths SET version = ? WHERE request_id = ?')
+        .run(7, payload.requestId);
+      expect(storage.getResponseAuth(payload.requestId)!.version).toBe(7);
     } finally {
       storage.close();
       rmSync(tempDir, { recursive: true, force: true });

--- a/packages/node/tests/seller-response-auth-compat.test.ts
+++ b/packages/node/tests/seller-response-auth-compat.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { identityFromPrivateKeyHex } from '../src/p2p/identity.js';
+import { decodeFrame } from '../src/p2p/message-protocol.js';
+import { encodeHttpRequest } from '../src/proxy/request-codec.js';
+import { SellerRequestHandler } from '../src/seller-request-handler.js';
+import {
+  CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+  MessageType,
+} from '../src/types/protocol.js';
+import type { Provider } from '../src/interfaces/seller-provider.js';
+import { VerificationMux } from '../src/verification/index.js';
+
+function makeProvider(): Provider {
+  return {
+    name: 'test-provider',
+    services: ['test-model'],
+    pricing: {
+      defaults: { inputUsdPerMillion: 0, outputUsdPerMillion: 0 },
+    },
+    maxConcurrency: 1,
+    async handleRequest(req) {
+      return {
+        requestId: req.requestId,
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' },
+        body: new TextEncoder().encode(JSON.stringify({ ok: true })),
+      };
+    },
+    getCapacity() {
+      return { current: 0, max: 1 };
+    },
+  };
+}
+
+function makeHandler(): SellerRequestHandler {
+  return new SellerRequestHandler({
+    identity: identityFromPrivateKeyHex('11'.repeat(32)),
+    providers: [makeProvider()],
+    sellerPaymentManager: null,
+    sessionTracker: null,
+    channelsClient: null,
+    announcer: null,
+    emit: () => false,
+  });
+}
+
+async function serveRequest(conn: {
+  send: ReturnType<typeof vi.fn>;
+  hasRemoteCapability: (capability: string) => boolean;
+}): Promise<number[]> {
+  const handler = makeHandler();
+  const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired: vi.fn() } as any;
+  const verificationMux = new VerificationMux(conn as any);
+  const { mux } = handler.handleConnection(conn as any, '22'.repeat(20), paymentMux, verificationMux);
+
+  await mux.handleFrame({
+    type: MessageType.HttpRequest,
+    messageId: 1,
+    payload: encodeHttpRequest({
+      requestId: 'req-response-auth-compat',
+      method: 'POST',
+      path: '/v1/messages',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ model: 'test-model' })),
+    }),
+  });
+
+  return conn.send.mock.calls.map(([frame]) => decodeFrame(frame)!.message.type);
+}
+
+describe('Seller response auth compatibility', () => {
+  it('does not send response auth to peers without the response-auth capability', async () => {
+    const conn = {
+      send: vi.fn(),
+      hasRemoteCapability: vi.fn(() => false),
+    };
+
+    const frameTypes = await serveRequest(conn);
+
+    expect(frameTypes).toContain(MessageType.HttpResponse);
+    expect(frameTypes).not.toContain(MessageType.VerificationResponseAuth);
+  });
+
+  it('sends response auth to peers that advertise the response-auth capability', async () => {
+    const conn = {
+      send: vi.fn(),
+      hasRemoteCapability: vi.fn((capability: string) => capability === CONNECTION_CAPABILITY_RESPONSE_AUTH_V1),
+    };
+
+    const frameTypes = await serveRequest(conn);
+
+    expect(frameTypes).toContain(MessageType.HttpResponse);
+    expect(frameTypes).toContain(MessageType.VerificationResponseAuth);
+  });
+});

--- a/packages/node/tests/verification-mux.test.ts
+++ b/packages/node/tests/verification-mux.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { FrameDecoder } from '../src/p2p/message-protocol.js';
+import type { PeerConnection } from '../src/p2p/connection-manager.js';
+import { VerificationMux } from '../src/verification/index.js';
+import type { ResponseAuthPayload } from '../src/types/protocol.js';
+
+function makePayload(): ResponseAuthPayload {
+  return {
+    version: 1,
+    requestId: 'req-1',
+    buyerPeerId: '22'.repeat(20),
+    sellerPeerId: '11'.repeat(20),
+    advertisedService: 'claude-sonnet-test',
+    provider: 'anthropic',
+    statusCode: 200,
+    requestHash: '0x' + 'aa'.repeat(32),
+    responseHash: '0x' + 'bb'.repeat(32),
+    responseStartedAt: 100,
+    responseCompletedAt: 200,
+    signature: 'cc'.repeat(65),
+  };
+}
+
+describe('VerificationMux', () => {
+  it('delivers response auth frames to request waiters', async () => {
+    const sent: Uint8Array[] = [];
+    const sender = new VerificationMux({
+      send: (frame: Uint8Array) => sent.push(frame),
+    } as unknown as PeerConnection);
+    const receiver = new VerificationMux({
+      send: () => {},
+    } as unknown as PeerConnection);
+
+    const waiter = receiver.waitForResponseAuth('req-1');
+    sender.sendResponseAuth(makePayload());
+
+    const decoder = new FrameDecoder();
+    const frames = decoder.feed(sent[0]!);
+    expect(frames).toHaveLength(1);
+    await receiver.handleFrame(frames[0]!);
+
+    await expect(waiter).resolves.toMatchObject({
+      requestId: 'req-1',
+      advertisedService: 'claude-sonnet-test',
+    });
+  });
+});

--- a/packages/node/tests/verification-mux.test.ts
+++ b/packages/node/tests/verification-mux.test.ts
@@ -44,4 +44,15 @@ describe('VerificationMux', () => {
       advertisedService: 'claude-sonnet-test',
     });
   });
+
+  it('rejects pending response auth waits when closed', async () => {
+    const mux = new VerificationMux({
+      send: () => {},
+    } as unknown as PeerConnection);
+
+    const waiter = mux.waitForResponseAuth('req-1', 10_000);
+    mux.close();
+
+    await expect(waiter).rejects.toThrow('VerificationMux closed');
+  });
 });


### PR DESCRIPTION
## Description

Adds a verification mux and response-auth payload for seller-signed per-response commitments. Buyers verify and persist lightweight response-auth metadata, while sellers only send response-auth frames to peers that advertise support.

## Release Notes

- Added response-auth verification plumbing for seller-signed response commitments
- Added connection capability advertising so old buyers and sellers remain compatible

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
