### PR TITLE
feat(node): Add response auth samples

### DIFF
--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -14,6 +14,7 @@ import type { BuyerPaymentNegotiator } from "./payments/buyer-payment-negotiator
 import { debugLog, debugWarn } from "./utils/debug.js";
 import type { VerificationMux } from "./verification/verification-mux.js";
 import type { VerificationStorage } from "./verification/storage.js";
+import type { VerificationSampler } from "./verification/samples.js";
 import { verifyResponseAuth } from "./verification/response-auth.js";
 
 export interface RequestStreamResponseMetadata {
@@ -46,6 +47,7 @@ export interface BuyerRequestHandlerDeps {
   localPeerId: PeerId;
   negotiator: BuyerPaymentNegotiator | null;
   verificationStorage: VerificationStorage | null;
+  verificationSampler: VerificationSampler | null;
   getConnection: (peer: PeerInfo) => Promise<PeerConnection>;
   getMux: (peerId: PeerId, conn: PeerConnection) => ProxyMux;
   getVerificationMux: (peerId: PeerId, conn: PeerConnection) => VerificationMux;
@@ -338,6 +340,16 @@ export class BuyerRequestHandler {
           receivedAt: Date.now(),
           verified: verification.valid,
           verificationError: verification.reason ?? null,
+        });
+
+        void this._deps.verificationSampler?.maybeStoreResponseAuthSample({
+          request,
+          response,
+          responseAuth: payload,
+          verified: verification.valid,
+          verificationError: verification.reason ?? null,
+        }).catch((err) => {
+          debugWarn(`[BuyerRequest] Failed to store ResponseAuth sample for ${request.requestId.slice(0, 8)}: ${err instanceof Error ? err.message : err}`);
         });
       })
       .catch((err) => {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -79,12 +79,16 @@ export { formatUsdc, parseUsdc } from './payments/usdc-utils.js';
 export { ProxyMux } from './proxy/proxy-mux.js';
 export {
   VerificationMux,
+  VerificationSampler,
   VerificationStorage,
   createResponseAuthPayload,
   verifyResponseAuth,
   hashRequest,
   hashResponse,
+  type ResponseAuthSampleInput,
   type StoredResponseAuth,
+  type StoredVerificationSample,
+  type VerificationSampleConfig,
 } from './verification/index.js';
 export { resolveProvider } from './proxy/provider-detection.js';
 export {

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -466,6 +466,7 @@ export class AntseedNode extends EventEmitter {
       }
       this._verificationStorage = null;
     }
+    this._verificationSampler = null;
 
     if (this._timeoutCheckerInterval) {
       clearInterval(this._timeoutCheckerInterval);

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -46,6 +46,7 @@ import { ProxyMux } from "./proxy/proxy-mux.js";
 import { PaymentMux } from "./p2p/payment-mux.js";
 import { VerificationMux } from "./verification/verification-mux.js";
 import { VerificationStorage } from "./verification/storage.js";
+import { VerificationSampler } from "./verification/samples.js";
 import { FrameDecoder, encodeFrame } from "./p2p/message-protocol.js";
 import { KeepaliveManager, buildPongPayload } from "./p2p/keepalive.js";
 import { MessageType } from "./types/protocol.js";
@@ -144,6 +145,15 @@ export interface NodePaymentsConfig {
   maxReserveAmountUsdc?: string;
 }
 
+export interface NodeVerificationConfig {
+  /** Random sample rate for storing full buyer request/response evidence. Default: 0.01. */
+  sampleRate?: number;
+  /** Maximum combined encoded request + response bytes per sample. Default: 16 MiB. */
+  maxSampleBytes?: number;
+  /** Optional directory for verification samples. Default: <dataDir>/verification_samples. */
+  samplesDir?: string;
+}
+
 export interface NodeConfig {
   role: 'seller' | 'buyer';
   displayName?: string;
@@ -171,6 +181,8 @@ export interface NodeConfig {
   dhtOperationTimeoutMs?: number;
   /** Optional seller-side payment runtime wiring. */
   payments?: NodePaymentsConfig;
+  /** Optional buyer-side verification storage and sampling settings. */
+  verification?: NodeVerificationConfig;
   /** Pluggable identity storage backend. When set, takes precedence over dataDir for identity loading. */
   identityStore?: IdentityStore;
   /** Optional explicit config.json path for runtime config reloads. */
@@ -249,6 +261,8 @@ export class AntseedNode extends EventEmitter {
   private _channelStore: ChannelStore | null = null;
   /** Buyer-side response authentication storage. */
   private _verificationStorage: VerificationStorage | null = null;
+  /** Buyer-side plaintext evidence sampler for verified response auths. */
+  private _verificationSampler: VerificationSampler | null = null;
   /** Periodic timeout checker interval. */
   private _timeoutCheckerInterval: ReturnType<typeof setInterval> | null = null;
   /** Block cursor for CloseRequested event polling. */
@@ -1330,6 +1344,7 @@ export class AntseedNode extends EventEmitter {
         localPeerId: identity.peerId,
         negotiator: this._buyerNegotiator,
         verificationStorage: this._verificationStorage,
+        verificationSampler: this._verificationSampler,
         getConnection: (peer) => this._getOrCreateConnection(peer),
         getMux: (peerId, conn) => this._getOrCreateMux(peerId, conn),
         getVerificationMux: (peerId, conn) => this._getOrCreateVerificationMux(peerId, conn),
@@ -1522,6 +1537,13 @@ export class AntseedNode extends EventEmitter {
     if (this._verificationStorage) return;
     try {
       this._verificationStorage = new VerificationStorage(join(dataDir, "verification.db"));
+      this._verificationSampler = new VerificationSampler(
+        this._config.verification?.samplesDir ?? join(dataDir, "verification_samples"),
+        {
+          sampleRate: this._config.verification?.sampleRate,
+          maxSampleBytes: this._config.verification?.maxSampleBytes,
+        },
+      );
       debugLog("[Node] Verification storage initialized");
     } catch (err) {
       debugWarn(`[Node] Verification storage unavailable: ${err instanceof Error ? err.message : err}`);

--- a/packages/node/src/verification/index.ts
+++ b/packages/node/src/verification/index.ts
@@ -9,4 +9,10 @@ export {
   type ResponseAuthVerificationExpected,
   type ResponseAuthVerificationResult,
 } from './response-auth.js';
+export {
+  VerificationSampler,
+  type ResponseAuthSampleInput,
+  type StoredVerificationSample,
+  type VerificationSampleConfig,
+} from './samples.js';
 export { VerificationStorage, type StoredResponseAuth } from './storage.js';

--- a/packages/node/src/verification/samples.ts
+++ b/packages/node/src/verification/samples.ts
@@ -1,0 +1,148 @@
+import { randomInt } from 'node:crypto';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { SerializedHttpRequest, SerializedHttpResponse } from '../types/http.js';
+import type { ResponseAuthPayload } from '../types/protocol.js';
+import { encodeHttpRequest, encodeHttpResponse } from '../proxy/request-codec.js';
+
+const SAMPLE_RANDOM_SCALE = 1_000_000;
+const DEFAULT_SAMPLE_RATE = 0.01;
+const DEFAULT_MAX_SAMPLE_BYTES = 16 * 1024 * 1024;
+
+export interface VerificationSampleConfig {
+  sampleRate?: number;
+  maxSampleBytes?: number;
+  random?: () => number;
+}
+
+export interface ResponseAuthSampleInput {
+  request: SerializedHttpRequest;
+  response: SerializedHttpResponse;
+  responseAuth: ResponseAuthPayload;
+  verified: boolean;
+  verificationError: string | null;
+}
+
+export interface StoredVerificationSample {
+  sampleId: string;
+  directory: string;
+  savedAt: number;
+}
+
+export class VerificationSampler {
+  private readonly _samplesDir: string;
+  private readonly _sampleRate: number;
+  private readonly _maxSampleBytes: number;
+  private readonly _random: () => number;
+
+  constructor(samplesDir: string, config: VerificationSampleConfig = {}) {
+    this._samplesDir = samplesDir;
+    this._sampleRate = normalizeSampleRate(config.sampleRate ?? DEFAULT_SAMPLE_RATE);
+    this._maxSampleBytes = Math.max(1, config.maxSampleBytes ?? DEFAULT_MAX_SAMPLE_BYTES);
+    this._random = config.random ?? cryptoRandomFloat;
+  }
+
+  shouldSample(): boolean {
+    if (this._sampleRate <= 0) return false;
+    if (this._sampleRate >= 1) return true;
+    return this._random() < this._sampleRate;
+  }
+
+  async maybeStoreResponseAuthSample(input: ResponseAuthSampleInput): Promise<StoredVerificationSample | null> {
+    if (!input.verified) return null;
+    if (!this.shouldSample()) return null;
+
+    const requestBytes = encodeHttpRequest(input.request);
+    const responseBytes = encodeHttpResponse(input.response);
+    const combinedBytes = requestBytes.byteLength + responseBytes.byteLength;
+    if (combinedBytes > this._maxSampleBytes) {
+      return null;
+    }
+
+    const savedAt = Date.now();
+    const sampleId = sampleIdFor(input.responseAuth);
+    const directory = join(this._samplesDir, input.responseAuth.sellerPeerId, sampleId);
+    await mkdir(directory, { recursive: true });
+
+    const manifest: VerificationSampleManifest = {
+      version: 1,
+      savedAt,
+      requestId: input.responseAuth.requestId,
+      buyerPeerId: input.responseAuth.buyerPeerId,
+      sellerPeerId: input.responseAuth.sellerPeerId,
+      advertisedService: input.responseAuth.advertisedService,
+      provider: input.responseAuth.provider,
+      statusCode: input.responseAuth.statusCode,
+      requestHash: input.responseAuth.requestHash,
+      responseHash: input.responseAuth.responseHash,
+      responseStartedAt: input.responseAuth.responseStartedAt,
+      responseCompletedAt: input.responseAuth.responseCompletedAt,
+      verified: input.verified,
+      verificationError: input.verificationError,
+      responseAuth: input.responseAuth,
+      files: {
+        request: 'request.bin',
+        response: 'response.bin',
+        encoding: 'antseed-http-codec-v1',
+      },
+    };
+
+    await writeFileAtomic(join(directory, 'request.bin'), requestBytes);
+    await writeFileAtomic(join(directory, 'response.bin'), responseBytes);
+    await writeFileAtomic(
+      join(directory, 'manifest.json'),
+      new TextEncoder().encode(JSON.stringify(manifest, null, 2)),
+    );
+
+    return { sampleId, directory, savedAt };
+  }
+}
+
+interface VerificationSampleManifest {
+  version: 1;
+  savedAt: number;
+  requestId: string;
+  buyerPeerId: string;
+  sellerPeerId: string;
+  advertisedService: string;
+  provider: string;
+  statusCode: number;
+  requestHash: string;
+  responseHash: string;
+  responseStartedAt: number;
+  responseCompletedAt: number;
+  verified: boolean;
+  verificationError: string | null;
+  responseAuth: ResponseAuthPayload;
+  files: {
+    request: string;
+    response: string;
+    encoding: 'antseed-http-codec-v1';
+  };
+}
+
+function sampleIdFor(payload: ResponseAuthPayload): string {
+  return `${sanitizePathSegment(payload.requestId)}-${payload.requestHash.slice(2, 18)}`;
+}
+
+function sanitizePathSegment(value: string): string {
+  const sanitized = value.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 96);
+  return sanitized.length > 0 ? sanitized : 'sample';
+}
+
+function normalizeSampleRate(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_SAMPLE_RATE;
+  if (value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}
+
+function cryptoRandomFloat(): number {
+  return randomInt(0, SAMPLE_RANDOM_SCALE) / SAMPLE_RANDOM_SCALE;
+}
+
+async function writeFileAtomic(path: string, data: Uint8Array): Promise<void> {
+  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmp, data);
+  await rename(tmp, path);
+}

--- a/packages/node/src/verification/samples.ts
+++ b/packages/node/src/verification/samples.ts
@@ -1,4 +1,4 @@
-import { randomInt } from 'node:crypto';
+import { randomBytes, randomInt } from 'node:crypto';
 import { mkdir, rename, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { SerializedHttpRequest, SerializedHttpResponse } from '../types/http.js';
@@ -89,6 +89,9 @@ export class VerificationSampler {
 
     await writeFileAtomic(join(directory, 'request.bin'), requestBytes);
     await writeFileAtomic(join(directory, 'response.bin'), responseBytes);
+    // The manifest is the completion marker. Readers should ignore sample
+    // directories without manifest.json because the process may have stopped
+    // between evidence writes.
     await writeFileAtomic(
       join(directory, 'manifest.json'),
       new TextEncoder().encode(JSON.stringify(manifest, null, 2)),
@@ -142,7 +145,7 @@ function cryptoRandomFloat(): number {
 }
 
 async function writeFileAtomic(path: string, data: Uint8Array): Promise<void> {
-  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  const tmp = `${path}.${process.pid}.${randomBytes(4).toString('hex')}.tmp`;
   await writeFile(tmp, data);
   await rename(tmp, path);
 }

--- a/packages/node/tests/buyer-response-auth-sampling.test.ts
+++ b/packages/node/tests/buyer-response-auth-sampling.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BuyerRequestHandler } from '../src/buyer-request-handler.js';
+import { identityFromPrivateKeyHex } from '../src/p2p/identity.js';
+import { createResponseAuthPayload } from '../src/verification/index.js';
+import type { PeerInfo, PeerId } from '../src/types/peer.js';
+import type { SerializedHttpRequest, SerializedHttpResponse } from '../src/types/http.js';
+
+describe('BuyerRequestHandler response auth sampling', () => {
+  it('passes verified response auth evidence to the sampler', async () => {
+    const seller = identityFromPrivateKeyHex('11'.repeat(32));
+    const buyer = identityFromPrivateKeyHex('22'.repeat(32));
+    const peer = { peerId: seller.peerId } as PeerInfo;
+    const request: SerializedHttpRequest = {
+      requestId: 'req-sampled',
+      method: 'POST',
+      path: '/v1/messages',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ model: 'sample-model' })),
+    };
+    const response: SerializedHttpResponse = {
+      requestId: request.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ content: [{ type: 'text', text: 'ok' }] })),
+    };
+    const responseAuth = createResponseAuthPayload({
+      request,
+      response,
+      buyerPeerId: buyer.peerId,
+      sellerPeerId: seller.peerId,
+      advertisedService: 'sample-model',
+      provider: 'test-provider',
+      responseStartedAt: 100,
+      responseCompletedAt: 200,
+    }, seller.wallet);
+
+    const maybeStoreResponseAuthSample = vi.fn(async () => null);
+    const handler = new BuyerRequestHandler(
+      {},
+      {
+        localPeerId: buyer.peerId as PeerId,
+        negotiator: null,
+        verificationStorage: null,
+        verificationSampler: { maybeStoreResponseAuthSample } as any,
+        getConnection: vi.fn(async () => ({ state: 'open' })) as any,
+        getMux: vi.fn(() => ({
+          sendProxyRequest: vi.fn((
+            _request: SerializedHttpRequest,
+            onResponse: (res: SerializedHttpResponse, metadata: { streamingStart: boolean }) => void,
+          ) => {
+            onResponse(response, { streamingStart: false });
+          }),
+          cancelProxyRequest: vi.fn(),
+        })) as any,
+        getVerificationMux: vi.fn(() => ({
+          waitForResponseAuth: vi.fn(async () => responseAuth),
+        })) as any,
+        registerPaymentMux: vi.fn(),
+      },
+    );
+
+    await handler.sendRequest(peer, request);
+
+    await vi.waitFor(() => {
+      expect(maybeStoreResponseAuthSample).toHaveBeenCalledOnce();
+    });
+    expect(maybeStoreResponseAuthSample).toHaveBeenCalledWith(expect.objectContaining({
+      request,
+      response,
+      responseAuth,
+      verified: true,
+      verificationError: null,
+    }));
+  });
+});

--- a/packages/node/tests/node-payment-mux-wiring.test.ts
+++ b/packages/node/tests/node-payment-mux-wiring.test.ts
@@ -54,6 +54,7 @@ describe('BuyerRequestHandler payment mux wiring', () => {
           recordResponseContent: vi.fn(),
         } as any,
         verificationStorage: null,
+        verificationSampler: null,
         getConnection: vi.fn(async () => conn) as any,
         getMux: vi.fn(() => ({
           sendProxyRequest,
@@ -132,6 +133,7 @@ describe('BuyerRequestHandler payment mux wiring', () => {
           recordResponseContent: vi.fn(),
         } as any,
         verificationStorage: null,
+        verificationSampler: null,
         getConnection: vi.fn(async () => conn) as any,
         getMux: vi.fn(() => ({
           sendProxyRequest,

--- a/packages/node/tests/node-stream-security.test.ts
+++ b/packages/node/tests/node-stream-security.test.ts
@@ -48,6 +48,7 @@ function createHandler(config: BuyerRequestHandlerConfig): { handler: BuyerReque
     localPeerId: 'a'.repeat(40),
     negotiator: null,
     verificationStorage: null,
+    verificationSampler: null,
     getConnection: vi.fn(async () => ({ state: 'open' })) as any,
     getMux: vi.fn(() => mux) as any,
     getVerificationMux: vi.fn(() => createNoopVerificationMux()) as any,

--- a/packages/node/tests/verification-samples.test.ts
+++ b/packages/node/tests/verification-samples.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { identityFromPrivateKeyHex } from '../src/p2p/identity.js';
+import { decodeHttpRequest, decodeHttpResponse } from '../src/proxy/request-codec.js';
+import type { SerializedHttpRequest, SerializedHttpResponse } from '../src/types/http.js';
+import { createResponseAuthPayload, VerificationSampler } from '../src/verification/index.js';
+
+function makeRequest(body = JSON.stringify({ model: 'sample-model', messages: [] })): SerializedHttpRequest {
+  return {
+    requestId: 'req/sample-1',
+    method: 'POST',
+    path: '/v1/messages',
+    headers: { 'content-type': 'application/json' },
+    body: new TextEncoder().encode(body),
+  };
+}
+
+function makeResponse(body = JSON.stringify({ content: [{ type: 'text', text: 'sampled' }] })): SerializedHttpResponse {
+  return {
+    requestId: 'req/sample-1',
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: new TextEncoder().encode(body),
+  };
+}
+
+describe('VerificationSampler', () => {
+  it('stores sampled request and response evidence with the response auth manifest', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'verification-samples-test-'));
+    try {
+      const seller = identityFromPrivateKeyHex('11'.repeat(32));
+      const buyer = identityFromPrivateKeyHex('22'.repeat(32));
+      const request = makeRequest();
+      const response = makeResponse();
+      const responseAuth = createResponseAuthPayload({
+        request,
+        response,
+        buyerPeerId: buyer.peerId,
+        sellerPeerId: seller.peerId,
+        advertisedService: 'sample-model',
+        provider: 'test-provider',
+        responseStartedAt: 100,
+        responseCompletedAt: 200,
+      }, seller.wallet);
+
+      const sampler = new VerificationSampler(tempDir, { sampleRate: 1 });
+      const sample = await sampler.maybeStoreResponseAuthSample({
+        request,
+        response,
+        responseAuth,
+        verified: true,
+        verificationError: null,
+      });
+
+      expect(sample).not.toBeNull();
+      const manifest = JSON.parse(readFileSync(join(sample!.directory, 'manifest.json'), 'utf8')) as Record<string, unknown>;
+      expect(manifest.requestId).toBe(request.requestId);
+      expect(manifest.requestHash).toBe(responseAuth.requestHash);
+      expect(manifest.responseHash).toBe(responseAuth.responseHash);
+      expect((manifest.files as Record<string, unknown>).encoding).toBe('antseed-http-codec-v1');
+
+      const storedRequest = decodeHttpRequest(readFileSync(join(sample!.directory, 'request.bin')));
+      const storedResponse = decodeHttpResponse(readFileSync(join(sample!.directory, 'response.bin')));
+      expect(storedRequest.path).toBe(request.path);
+      expect(new TextDecoder().decode(storedRequest.body)).toBe(new TextDecoder().decode(request.body));
+      expect(storedResponse.statusCode).toBe(response.statusCode);
+      expect(new TextDecoder().decode(storedResponse.body)).toBe(new TextDecoder().decode(response.body));
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips samples over the configured byte limit', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'verification-samples-limit-test-'));
+    try {
+      const seller = identityFromPrivateKeyHex('11'.repeat(32));
+      const buyer = identityFromPrivateKeyHex('22'.repeat(32));
+      const request = makeRequest('x'.repeat(128));
+      const response = makeResponse('y'.repeat(128));
+      const responseAuth = createResponseAuthPayload({
+        request,
+        response,
+        buyerPeerId: buyer.peerId,
+        sellerPeerId: seller.peerId,
+        advertisedService: 'sample-model',
+        provider: 'test-provider',
+        responseStartedAt: 100,
+        responseCompletedAt: 200,
+      }, seller.wallet);
+
+      const sampler = new VerificationSampler(tempDir, { sampleRate: 1, maxSampleBytes: 32 });
+      const sample = await sampler.maybeStoreResponseAuthSample({
+        request,
+        response,
+        responseAuth,
+        verified: true,
+        verificationError: null,
+      });
+
+      expect(sample).toBeNull();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Description

Adds buyer-side sampling for verified response-auth evidence. When a response auth verifies and the sampling policy selects it, the buyer stores the encoded request, encoded response, and a manifest under a verification samples directory.

## Release Notes

- Added optional buyer-side storage for sampled response-auth verification evidence
- Added verification sampling settings for sample rate, maximum sample size, and sample directory

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
