### PR TITLE
refactor(node): Share JSON codec helpers

### DIFF
--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -16,6 +16,7 @@ import type { VerificationMux } from "./verification/verification-mux.js";
 import type { VerificationStorage } from "./verification/storage.js";
 import type { VerificationSampler } from "./verification/samples.js";
 import { verifyResponseAuth } from "./verification/response-auth.js";
+import { tryParseJsonObject } from "./utils/json-codec.js";
 
 export interface RequestStreamResponseMetadata {
   streaming: boolean;
@@ -360,11 +361,9 @@ export class BuyerRequestHandler {
 
 /** Extract the service/model name from a JSON request body, or undefined if not found. */
 function extractServiceFromBody(body: Uint8Array): string | undefined {
-  try {
-    const parsed = JSON.parse(new TextDecoder().decode(body)) as Record<string, unknown>;
-    const service = parsed.service ?? parsed.model;
-    if (typeof service === 'string' && service.length > 0) return service;
-  } catch { /* not JSON or no model field */ }
+  const parsed = tryParseJsonObject(body);
+  const service = parsed?.service ?? parsed?.model;
+  if (typeof service === 'string' && service.length > 0) return service;
   return undefined;
 }
 

--- a/packages/node/src/p2p/payment-codec.ts
+++ b/packages/node/src/p2p/payment-codec.ts
@@ -5,31 +5,19 @@ import {
   type PaymentRequiredPayload,
   type NeedAuthPayload,
 } from '../types/protocol.js';
+import { parseJsonObject, requireStringField } from '../utils/json-codec.js';
 
 const encoder = new TextEncoder();
-const decoder = new TextDecoder();
 
 // --- Validation helpers ---
 
 const MAX_PAYLOAD_SIZE = 65536; // 64KB
 
-function parseJson(data: Uint8Array): Record<string, unknown> {
-  if (data.byteLength > MAX_PAYLOAD_SIZE) {
-    throw new Error(`Payment payload too large: ${data.byteLength} bytes (max ${MAX_PAYLOAD_SIZE})`);
-  }
-  const raw: unknown = JSON.parse(decoder.decode(data));
-  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
-    throw new Error('Expected JSON object');
-  }
-  return raw as Record<string, unknown>;
-}
-
-function requireString(obj: Record<string, unknown>, field: string): string {
-  const val = obj[field];
-  if (typeof val !== 'string' || val.length === 0) {
-    throw new Error(`Missing or invalid string field: ${field}`);
-  }
-  return val;
+function parsePaymentJson(data: Uint8Array): Record<string, unknown> {
+  return parseJsonObject(data, {
+    maxBytes: MAX_PAYLOAD_SIZE,
+    payloadName: 'Payment payload',
+  });
 }
 
 // --- Encoders ---
@@ -53,13 +41,13 @@ export function encodeNeedAuth(payload: NeedAuthPayload): Uint8Array {
 // --- Decoders (with runtime validation) ---
 
 export function decodeSpendingAuth(data: Uint8Array): SpendingAuthPayload {
-  const obj = parseJson(data);
+  const obj = parsePaymentJson(data);
   const result: SpendingAuthPayload = {
-    channelId: requireString(obj, 'channelId'),
-    cumulativeAmount: requireString(obj, 'cumulativeAmount'),
-    metadataHash: requireString(obj, 'metadataHash'),
+    channelId: requireStringField(obj, 'channelId'),
+    cumulativeAmount: requireStringField(obj, 'cumulativeAmount'),
+    metadataHash: requireStringField(obj, 'metadataHash'),
     metadata: typeof obj.metadata === 'string' ? obj.metadata : '',
-    spendingAuthSig: requireString(obj, 'spendingAuthSig'),
+    spendingAuthSig: requireStringField(obj, 'spendingAuthSig'),
   };
   // Optional reserve params (only on initial auth)
   if (typeof obj.reserveSalt === 'string') result.reserveSalt = obj.reserveSalt;
@@ -69,18 +57,18 @@ export function decodeSpendingAuth(data: Uint8Array): SpendingAuthPayload {
 }
 
 export function decodeAuthAck(data: Uint8Array): AuthAckPayload {
-  const obj = parseJson(data);
+  const obj = parsePaymentJson(data);
   return {
-    channelId: requireString(obj, 'channelId'),
+    channelId: requireStringField(obj, 'channelId'),
   };
 }
 
 export function decodePaymentRequired(data: Uint8Array): PaymentRequiredPayload {
-  const obj = parseJson(data);
+  const obj = parsePaymentJson(data);
   const result: PaymentRequiredPayload = {
-    minBudgetPerRequest: requireString(obj, 'minBudgetPerRequest'),
-    suggestedAmount: requireString(obj, 'suggestedAmount'),
-    requestId: requireString(obj, 'requestId'),
+    minBudgetPerRequest: requireStringField(obj, 'minBudgetPerRequest'),
+    suggestedAmount: requireStringField(obj, 'suggestedAmount'),
+    requestId: requireStringField(obj, 'requestId'),
   };
   if (typeof obj.inputUsdPerMillion === 'number') result.inputUsdPerMillion = obj.inputUsdPerMillion;
   if (typeof obj.outputUsdPerMillion === 'number') result.outputUsdPerMillion = obj.outputUsdPerMillion;
@@ -95,12 +83,12 @@ export function decodePaymentRequired(data: Uint8Array): PaymentRequiredPayload 
 }
 
 export function decodeNeedAuth(data: Uint8Array): NeedAuthPayload {
-  const obj = parseJson(data);
+  const obj = parsePaymentJson(data);
   const result: NeedAuthPayload = {
-    channelId: requireString(obj, 'channelId'),
-    requiredCumulativeAmount: requireString(obj, 'requiredCumulativeAmount'),
-    currentAcceptedCumulative: requireString(obj, 'currentAcceptedCumulative'),
-    deposit: requireString(obj, 'deposit'),
+    channelId: requireStringField(obj, 'channelId'),
+    requiredCumulativeAmount: requireStringField(obj, 'requiredCumulativeAmount'),
+    currentAcceptedCumulative: requireStringField(obj, 'currentAcceptedCumulative'),
+    deposit: requireStringField(obj, 'deposit'),
   };
   if (typeof obj.requestId === 'string') result.requestId = obj.requestId;
   if (typeof obj.lastRequestCost === 'string') result.lastRequestCost = obj.lastRequestCost;

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -16,6 +16,7 @@ import { SellerAuthorizationError } from '../discovery/seller-address-resolver.j
 import { parseResponseUsage } from '../utils/response-usage.js';
 import { computeCostUsdc, type ServicePricing } from './pricing.js';
 import { formatUsdc } from './usdc-utils.js';
+import { parseJsonObject, tryParseJsonObject } from '../utils/json-codec.js';
 
 export interface BuyerNegotiatorConfig {}
 
@@ -44,12 +45,7 @@ interface LastResponseCost {
 }
 
 function parsePaymentRequiredBody(body: Uint8Array): Record<string, unknown> | null {
-  try {
-    const parsed = JSON.parse(new TextDecoder().decode(body)) as Record<string, unknown>;
-    return parsed && typeof parsed === 'object' ? parsed : null;
-  } catch {
-    return null;
-  }
+  return tryParseJsonObject(body);
 }
 
 function safeBigInt(value: string): bigint | null {
@@ -520,7 +516,7 @@ export class BuyerPaymentNegotiator {
     };
     try {
       const decoded = Buffer.from(headerValue, 'base64').toString('utf-8');
-      payload = JSON.parse(decoded);
+      payload = parseJsonObject(decoded) as typeof payload;
     } catch {
       throw new Error('Invalid x-antseed-spending-auth header: failed to decode');
     }

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -20,6 +20,7 @@ import { debugLog, debugWarn } from './utils/debug.js';
 import { CONNECTION_CAPABILITY_RESPONSE_AUTH_V1, PAYMENT_CODE_CHANNEL_EXHAUSTED } from './types/protocol.js';
 import { VerificationMux } from './verification/verification-mux.js';
 import { createResponseAuthPayload } from './verification/response-auth.js';
+import { hasJsonContentType, tryParseJsonObject } from './utils/json-codec.js';
 
 export interface SellerRequestHandlerDeps {
   identity: Identity;
@@ -594,28 +595,15 @@ export class SellerRequestHandler {
       && cachedPrice === 0;
   }
 
-  private _parseJsonObject(body: Uint8Array): Record<string, unknown> | null {
-    try {
-      const parsed = JSON.parse(new TextDecoder().decode(body)) as unknown;
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        return null;
-      }
-      return parsed as Record<string, unknown>;
-    } catch {
-      return null;
-    }
-  }
-
   private _isJsonRequest(request: SerializedHttpRequest): boolean {
-    const contentType = request.headers["content-type"] ?? request.headers["Content-Type"] ?? "";
-    return contentType.toLowerCase().includes("application/json");
+    return hasJsonContentType(request.headers);
   }
 
   private _extractRequestedService(request: SerializedHttpRequest): string | null {
     if (!this._isJsonRequest(request)) {
       return null;
     }
-    const body = this._parseJsonObject(request.body);
+    const body = tryParseJsonObject(request.body);
     const service = body?.["service"] ?? body?.["model"];
     if (typeof service !== "string" || service.trim().length === 0) {
       return null;
@@ -639,7 +627,7 @@ export class SellerRequestHandler {
     if (!this._isJsonRequest(request)) {
       return null;
     }
-    const body = this._parseJsonObject(request.body);
+    const body = tryParseJsonObject(request.body);
     if (!body) {
       return null;
     }

--- a/packages/node/src/utils/json-codec.ts
+++ b/packages/node/src/utils/json-codec.ts
@@ -1,0 +1,67 @@
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+export interface JsonObjectParseOptions {
+  maxBytes?: number;
+  payloadName?: string;
+}
+
+export function parseJsonObject(
+  input: Uint8Array | string,
+  options: JsonObjectParseOptions = {},
+): Record<string, unknown> {
+  const text = decodeJsonInput(input, options);
+  const raw: unknown = JSON.parse(text);
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    throw new Error('Expected JSON object');
+  }
+  return raw as Record<string, unknown>;
+}
+
+export function tryParseJsonObject(
+  input: Uint8Array | string,
+  options: JsonObjectParseOptions = {},
+): Record<string, unknown> | null {
+  try {
+    return parseJsonObject(input, options);
+  } catch {
+    return null;
+  }
+}
+
+export function hasJsonContentType(headers: Record<string, string>): boolean {
+  const contentType = headers['content-type'] ?? headers['Content-Type'] ?? '';
+  return contentType.toLowerCase().includes('application/json');
+}
+
+export function requireStringField(obj: Record<string, unknown>, field: string): string {
+  const value = obj[field];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Missing or invalid string field: ${field}`);
+  }
+  return value;
+}
+
+export function requireFiniteNumberField(obj: Record<string, unknown>, field: string): number {
+  const value = obj[field];
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw new Error(`Missing or invalid number field: ${field}`);
+  }
+  return value;
+}
+
+function decodeJsonInput(input: Uint8Array | string, options: JsonObjectParseOptions): string {
+  const maxBytes = options.maxBytes;
+  const payloadName = options.payloadName ?? 'JSON payload';
+  if (typeof input === 'string') {
+    const byteLength = maxBytes === undefined ? 0 : encoder.encode(input).byteLength;
+    if (maxBytes !== undefined && byteLength > maxBytes) {
+      throw new Error(`${payloadName} too large: ${byteLength} bytes (max ${maxBytes})`);
+    }
+    return input;
+  }
+  if (maxBytes !== undefined && input.byteLength > maxBytes) {
+    throw new Error(`${payloadName} too large: ${input.byteLength} bytes (max ${maxBytes})`);
+  }
+  return decoder.decode(input);
+}

--- a/packages/node/src/verification/codec.ts
+++ b/packages/node/src/verification/codec.ts
@@ -1,35 +1,19 @@
 import type { ResponseAuthPayload } from '../types/protocol.js';
+import {
+  parseJsonObject,
+  requireFiniteNumberField,
+  requireStringField,
+} from '../utils/json-codec.js';
 
 const encoder = new TextEncoder();
-const decoder = new TextDecoder();
 
 const MAX_PAYLOAD_SIZE = 64 * 1024;
 
-function parseJson(data: Uint8Array): Record<string, unknown> {
-  if (data.byteLength > MAX_PAYLOAD_SIZE) {
-    throw new Error(`Verification payload too large: ${data.byteLength} bytes (max ${MAX_PAYLOAD_SIZE})`);
-  }
-  const raw: unknown = JSON.parse(decoder.decode(data));
-  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
-    throw new Error('Expected JSON object');
-  }
-  return raw as Record<string, unknown>;
-}
-
-function requireString(obj: Record<string, unknown>, field: string): string {
-  const value = obj[field];
-  if (typeof value !== 'string' || value.length === 0) {
-    throw new Error(`Missing or invalid string field: ${field}`);
-  }
-  return value;
-}
-
-function requireNumber(obj: Record<string, unknown>, field: string): number {
-  const value = obj[field];
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    throw new Error(`Missing or invalid number field: ${field}`);
-  }
-  return value;
+function parseVerificationJson(data: Uint8Array): Record<string, unknown> {
+  return parseJsonObject(data, {
+    maxBytes: MAX_PAYLOAD_SIZE,
+    payloadName: 'Verification payload',
+  });
 }
 
 export function encodeResponseAuth(payload: ResponseAuthPayload): Uint8Array {
@@ -37,7 +21,7 @@ export function encodeResponseAuth(payload: ResponseAuthPayload): Uint8Array {
 }
 
 export function decodeResponseAuth(data: Uint8Array): ResponseAuthPayload {
-  const obj = parseJson(data);
+  const obj = parseVerificationJson(data);
   const version = obj.version;
   if (version !== 1) {
     throw new Error(`Unsupported response auth version: ${String(version)}`);
@@ -45,17 +29,17 @@ export function decodeResponseAuth(data: Uint8Array): ResponseAuthPayload {
 
   const result: ResponseAuthPayload = {
     version,
-    requestId: requireString(obj, 'requestId'),
-    buyerPeerId: requireString(obj, 'buyerPeerId'),
-    sellerPeerId: requireString(obj, 'sellerPeerId'),
-    advertisedService: requireString(obj, 'advertisedService'),
-    provider: requireString(obj, 'provider'),
-    statusCode: requireNumber(obj, 'statusCode'),
-    requestHash: requireString(obj, 'requestHash'),
-    responseHash: requireString(obj, 'responseHash'),
-    responseStartedAt: requireNumber(obj, 'responseStartedAt'),
-    responseCompletedAt: requireNumber(obj, 'responseCompletedAt'),
-    signature: requireString(obj, 'signature'),
+    requestId: requireStringField(obj, 'requestId'),
+    buyerPeerId: requireStringField(obj, 'buyerPeerId'),
+    sellerPeerId: requireStringField(obj, 'sellerPeerId'),
+    advertisedService: requireStringField(obj, 'advertisedService'),
+    provider: requireStringField(obj, 'provider'),
+    statusCode: requireFiniteNumberField(obj, 'statusCode'),
+    requestHash: requireStringField(obj, 'requestHash'),
+    responseHash: requireStringField(obj, 'responseHash'),
+    responseStartedAt: requireFiniteNumberField(obj, 'responseStartedAt'),
+    responseCompletedAt: requireFiniteNumberField(obj, 'responseCompletedAt'),
+    signature: requireStringField(obj, 'signature'),
   };
   if (typeof obj.channelId === 'string' && obj.channelId.length > 0) {
     result.channelId = obj.channelId;

--- a/packages/node/tests/json-codec.test.ts
+++ b/packages/node/tests/json-codec.test.ts
@@ -20,6 +20,10 @@ describe('json-codec utilities', () => {
       maxBytes: 4,
       payloadName: 'Test payload',
     })).toThrow('Test payload too large');
+    expect(() => parseJsonObject(new TextEncoder().encode('{"too":"large"}'), {
+      maxBytes: 4,
+      payloadName: 'Test payload',
+    })).toThrow('Test payload too large');
   });
 
   it('returns null from tryParseJsonObject for invalid inputs', () => {
@@ -40,5 +44,7 @@ describe('json-codec utilities', () => {
     expect(requireFiniteNumberField(obj, 'count')).toBe(3);
     expect(() => requireStringField(obj, 'missing')).toThrow('Missing or invalid string field');
     expect(() => requireFiniteNumberField({ count: Number.NaN }, 'count')).toThrow('Missing or invalid number field');
+    expect(() => requireFiniteNumberField({ count: Infinity }, 'count')).toThrow('Missing or invalid number field');
+    expect(() => requireFiniteNumberField({ count: -Infinity }, 'count')).toThrow('Missing or invalid number field');
   });
 });

--- a/packages/node/tests/json-codec.test.ts
+++ b/packages/node/tests/json-codec.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasJsonContentType,
+  parseJsonObject,
+  requireFiniteNumberField,
+  requireStringField,
+  tryParseJsonObject,
+} from '../src/utils/json-codec.js';
+
+describe('json-codec utilities', () => {
+  it('parses JSON objects from bytes and strings', () => {
+    expect(parseJsonObject(new TextEncoder().encode('{"ok":true}'))).toEqual({ ok: true });
+    expect(parseJsonObject('{"name":"antseed"}')).toEqual({ name: 'antseed' });
+  });
+
+  it('rejects non-object JSON and oversized payloads', () => {
+    expect(() => parseJsonObject('[]')).toThrow('Expected JSON object');
+    expect(() => parseJsonObject('"x"')).toThrow('Expected JSON object');
+    expect(() => parseJsonObject('{"too":"large"}', {
+      maxBytes: 4,
+      payloadName: 'Test payload',
+    })).toThrow('Test payload too large');
+  });
+
+  it('returns null from tryParseJsonObject for invalid inputs', () => {
+    expect(tryParseJsonObject('{')).toBeNull();
+    expect(tryParseJsonObject('[]')).toBeNull();
+    expect(tryParseJsonObject('{"ok":true}')).toEqual({ ok: true });
+  });
+
+  it('detects JSON content type case-insensitively', () => {
+    expect(hasJsonContentType({ 'content-type': 'application/json; charset=utf-8' })).toBe(true);
+    expect(hasJsonContentType({ 'Content-Type': 'Application/JSON' })).toBe(true);
+    expect(hasJsonContentType({ 'content-type': 'text/plain' })).toBe(false);
+  });
+
+  it('validates required object fields', () => {
+    const obj = { text: 'value', count: 3 };
+    expect(requireStringField(obj, 'text')).toBe('value');
+    expect(requireFiniteNumberField(obj, 'count')).toBe(3);
+    expect(() => requireStringField(obj, 'missing')).toThrow('Missing or invalid string field');
+    expect(() => requireFiniteNumberField({ count: Number.NaN }, 'count')).toThrow('Missing or invalid number field');
+  });
+});


### PR DESCRIPTION
## Description

Adds shared node JSON codec utilities for strict object parsing, try-parse behavior, JSON content-type detection, and common required field validation. Migrates payment, verification, seller request, buyer request, and buyer payment parsing code to use the shared helper instead of local duplicate parsers.

This branch is stacked on top of #666 and targets main as requested. Until #666 merges, GitHub may show the sampling commit in the comparison; the new commit here is `refactor(node): Share JSON codec helpers`.

## Release Notes

- Refactored internal JSON codec parsing helpers used by node payment and verification paths

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes