### PR TITLE
feat(node): Add seller verification claims

### DIFF
--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -556,6 +556,10 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
       if (verificationDomains.length > 0) {
         console.log(chalk.dim(`  domain verification: ${verificationDomains.join(', ')}`))
       }
+      const verificationGithub = (effectiveSellerConfig.verifications?.github ?? []).map((claim) => claim.username)
+      if (verificationGithub.length > 0) {
+        console.log(chalk.dim(`  github verification: ${verificationGithub.join(', ')}`))
+      }
       console.log('')
 
       const nodeSpinner = ora('Starting seeding daemon...').start()

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -552,6 +552,10 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
       if (maxUploadBodyBytes !== undefined) {
         console.log(chalk.dim(`  max upload body bytes: ${maxUploadBodyBytes}`))
       }
+      const verificationDomains = (effectiveSellerConfig.verifications?.domains ?? []).map((claim) => claim.domain)
+      if (verificationDomains.length > 0) {
+        console.log(chalk.dim(`  domain verification: ${verificationDomains.join(', ')}`))
+      }
       console.log('')
 
       const nodeSpinner = ora('Starting seeding daemon...').start()
@@ -568,6 +572,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
         role: 'seller',
         displayName: config.identity.displayName,
         ...(config.seller.publicAddress ? { publicAddress: config.seller.publicAddress } : {}),
+        ...(effectiveSellerConfig.verifications ? { verifications: effectiveSellerConfig.verifications } : {}),
         bootstrapNodes,
         dataDir: globalOpts.dataDir,
         ...(dhtPort ? { dhtPort } : {}),

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -276,6 +276,28 @@ test('loadConfig preserves seller publicAddress override', async () => {
   );
 });
 
+test('loadConfig preserves seller verifications.domains claims', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      seller: {
+        verifications: {
+          domains: [
+            { domain: 'Example.COM', methods: ['https-well-known', 'dns-txt'] },
+          ],
+        },
+      },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.deepEqual(config.seller.verifications, {
+        domains: [
+          { domain: 'example.com', methods: ['https-well-known', 'dns-txt'] },
+        ],
+      });
+    }
+  );
+});
+
 test('loadConfig preserves seller maxUploadBodyBytes setting', async () => {
   await withTempConfig(
     JSON.stringify({

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -318,6 +318,50 @@ test('loadConfig rejects unknown domain verification methods instead of dropping
   );
 });
 
+test('loadConfig preserves seller verifications.github claims', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      seller: {
+        verifications: {
+          github: [
+            { username: 'OctoCat' },
+            { username: 'hubber', repository: 'Antseed-Proofs' },
+          ],
+        },
+      },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.deepEqual(config.seller.verifications, {
+        github: [
+          { username: 'octocat' },
+          { username: 'hubber', repository: 'antseed-proofs' },
+        ],
+      });
+    }
+  );
+});
+
+test('loadConfig rejects invalid github verification usernames', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      seller: {
+        verifications: {
+          github: [
+            { username: '-invalid-' },
+          ],
+        },
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        loadConfig(configPath),
+        /verifications\.github\[0\]\.username/,
+      );
+    }
+  );
+});
+
 test('loadConfig rejects empty seller verifications', async () => {
   await withTempConfig(
     JSON.stringify({

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -298,6 +298,42 @@ test('loadConfig preserves seller verifications.domains claims', async () => {
   );
 });
 
+test('loadConfig rejects unknown domain verification methods instead of dropping them', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      seller: {
+        verifications: {
+          domains: [
+            { domain: 'example.com', methods: ['dns-text'] },
+          ],
+        },
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        loadConfig(configPath),
+        /verifications\.domains\[0\]\.methods\[0\]/,
+      );
+    }
+  );
+});
+
+test('loadConfig rejects empty seller verifications', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      seller: {
+        verifications: { domains: [] },
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        loadConfig(configPath),
+        /verifications\.domains/,
+      );
+    }
+  );
+});
+
 test('loadConfig preserves seller maxUploadBodyBytes setting', async () => {
   await withTempConfig(
     JSON.stringify({

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -4,6 +4,8 @@ import { homedir } from 'node:os';
 import type {
   HierarchicalPricingConfig,
   AntseedConfig,
+  DomainVerificationConfig,
+  DomainVerificationMethod,
   SellerProviderConfig,
   SellerServiceConfig,
   TokenPricingUsdPerMillion,
@@ -180,6 +182,51 @@ function normalizeAgentDir(
   return fallback ? { agentDir: fallback } : {};
 }
 
+function normalizeDomainVerification(
+  value: unknown,
+): DomainVerificationConfig[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: DomainVerificationConfig[] = [];
+  for (const rawClaim of value) {
+    if (!isRecord(rawClaim)) continue;
+    if (typeof rawClaim['domain'] !== 'string' || rawClaim['domain'].trim().length === 0) continue;
+    const domain = rawClaim['domain'].trim().toLowerCase();
+    const claim: DomainVerificationConfig = { domain };
+    if (Array.isArray(rawClaim['methods'])) {
+      const methods = rawClaim['methods']
+        .filter((method): method is DomainVerificationMethod => method === 'dns-txt' || method === 'https-well-known');
+      if (methods.length > 0) claim.methods = Array.from(new Set(methods));
+    }
+    out.push(claim);
+  }
+  return out.length > 0 ? out : undefined;
+}
+
+function cloneVerifications(
+  value: AntseedConfig['seller']['verifications'],
+): AntseedConfig['seller']['verifications'] {
+  if (!value) return undefined;
+  const domains = value.domains
+    ? value.domains.map((claim) => ({
+      domain: claim.domain,
+      ...(claim.methods ? { methods: [...claim.methods] } : {}),
+    }))
+    : undefined;
+  return domains && domains.length > 0 ? { domains } : undefined;
+}
+
+function normalizeVerifications(
+  value: unknown,
+  fallback?: AntseedConfig['seller']['verifications'],
+): { verifications: NonNullable<AntseedConfig['seller']['verifications']> } | Record<string, never> {
+  if (!isRecord(value)) {
+    const cloned = cloneVerifications(fallback);
+    return cloned ? { verifications: cloned } : {};
+  }
+  const domains = normalizeDomainVerification(value['domains']);
+  return domains ? { verifications: { domains } } : {};
+}
+
 function mergeSellerConfig(
   defaults: AntseedConfig['seller'],
   value: unknown
@@ -192,6 +239,7 @@ function mergeSellerConfig(
       publicAddress: defaults.publicAddress,
       ...(typeof defaults.maxUploadBodyBytes === 'number' ? { maxUploadBodyBytes: defaults.maxUploadBodyBytes } : {}),
       ...(defaults.agentDir ? { agentDir: defaults.agentDir } : {}),
+      ...(normalizeVerifications(undefined, defaults.verifications)),
     };
   }
 
@@ -206,6 +254,7 @@ function mergeSellerConfig(
     publicAddress: typeof value['publicAddress'] === 'string'
       ? value['publicAddress']
       : defaults.publicAddress,
+    ...(normalizeVerifications(value['verifications'], defaults.verifications)),
     ...(typeof value['maxUploadBodyBytes'] === 'number'
       ? { maxUploadBodyBytes: value['maxUploadBodyBytes'] }
       : typeof defaults.maxUploadBodyBytes === 'number'

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -182,6 +182,10 @@ function normalizeAgentDir(
   return fallback ? { agentDir: fallback } : {};
 }
 
+// Normalizes shape only (trim + lowercase domains). Invalid domains, unknown
+// methods, duplicates, and empty arrays are preserved so validateConfig can
+// reject them loudly instead of the loader silently dropping them — dropping
+// a typo'd methods entry would widen the claim to "all methods".
 function normalizeDomainVerification(
   value: unknown,
 ): DomainVerificationConfig[] | undefined {
@@ -189,17 +193,15 @@ function normalizeDomainVerification(
   const out: DomainVerificationConfig[] = [];
   for (const rawClaim of value) {
     if (!isRecord(rawClaim)) continue;
-    if (typeof rawClaim['domain'] !== 'string' || rawClaim['domain'].trim().length === 0) continue;
-    const domain = rawClaim['domain'].trim().toLowerCase();
+    const rawDomain = rawClaim['domain'];
+    const domain = typeof rawDomain === 'string' ? rawDomain.trim().toLowerCase() : '';
     const claim: DomainVerificationConfig = { domain };
     if (Array.isArray(rawClaim['methods'])) {
-      const methods = rawClaim['methods']
-        .filter((method): method is DomainVerificationMethod => method === 'dns-txt' || method === 'https-well-known');
-      if (methods.length > 0) claim.methods = Array.from(new Set(methods));
+      claim.methods = [...rawClaim['methods']] as DomainVerificationMethod[];
     }
     out.push(claim);
   }
-  return out.length > 0 ? out : undefined;
+  return out;
 }
 
 function cloneVerifications(
@@ -223,8 +225,10 @@ function normalizeVerifications(
     const cloned = cloneVerifications(fallback);
     return cloned ? { verifications: cloned } : {};
   }
+  // Keep the user-supplied object (even when empty or malformed) so
+  // validateConfig reports the problem instead of silently ignoring it.
   const domains = normalizeDomainVerification(value['domains']);
-  return domains ? { verifications: { domains } } : {};
+  return { verifications: { ...(domains !== undefined ? { domains } : {}) } };
 }
 
 function mergeSellerConfig(

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -6,6 +6,7 @@ import type {
   AntseedConfig,
   DomainVerificationConfig,
   DomainVerificationMethod,
+  GithubVerificationConfig,
   SellerProviderConfig,
   SellerServiceConfig,
   TokenPricingUsdPerMillion,
@@ -204,6 +205,27 @@ function normalizeDomainVerification(
   return out;
 }
 
+// Same shape-only normalization contract as normalizeDomainVerification.
+function normalizeGithubVerification(
+  value: unknown,
+): GithubVerificationConfig[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const out: GithubVerificationConfig[] = [];
+  for (const rawClaim of value) {
+    if (!isRecord(rawClaim)) continue;
+    const rawUsername = rawClaim['username'];
+    const username = typeof rawUsername === 'string' ? rawUsername.trim().toLowerCase() : '';
+    const claim: GithubVerificationConfig = { username };
+    if (rawClaim['repository'] !== undefined) {
+      claim.repository = typeof rawClaim['repository'] === 'string'
+        ? rawClaim['repository'].trim().toLowerCase()
+        : '';
+    }
+    out.push(claim);
+  }
+  return out;
+}
+
 function cloneVerifications(
   value: AntseedConfig['seller']['verifications'],
 ): AntseedConfig['seller']['verifications'] {
@@ -214,7 +236,17 @@ function cloneVerifications(
       ...(claim.methods ? { methods: [...claim.methods] } : {}),
     }))
     : undefined;
-  return domains && domains.length > 0 ? { domains } : undefined;
+  const github = value.github
+    ? value.github.map((claim) => ({
+      username: claim.username,
+      ...(claim.repository !== undefined ? { repository: claim.repository } : {}),
+    }))
+    : undefined;
+  const cloned = {
+    ...(domains && domains.length > 0 ? { domains } : {}),
+    ...(github && github.length > 0 ? { github } : {}),
+  };
+  return Object.keys(cloned).length > 0 ? cloned : undefined;
 }
 
 function normalizeVerifications(
@@ -228,7 +260,13 @@ function normalizeVerifications(
   // Keep the user-supplied object (even when empty or malformed) so
   // validateConfig reports the problem instead of silently ignoring it.
   const domains = normalizeDomainVerification(value['domains']);
-  return { verifications: { ...(domains !== undefined ? { domains } : {}) } };
+  const github = normalizeGithubVerification(value['github']);
+  return {
+    verifications: {
+      ...(domains !== undefined ? { domains } : {}),
+      ...(github !== undefined ? { github } : {}),
+    },
+  };
 }
 
 function mergeSellerConfig(

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -62,6 +62,20 @@ export interface SellerProviderConfig {
   services: Record<string, SellerServiceConfig>;
 }
 
+export type DomainVerificationMethod = 'dns-txt' | 'https-well-known';
+
+export interface DomainVerificationConfig {
+  /** Domain name to prove, without scheme, path, or port. */
+  domain: string;
+  /** Accepted proof transports. Omit to let clients try every supported method. */
+  methods?: DomainVerificationMethod[];
+}
+
+export interface VerificationConfig {
+  /** Domain ownership claims. */
+  domains?: DomainVerificationConfig[];
+}
+
 /**
  * Seller-specific configuration within the Antseed config.
  */
@@ -88,6 +102,8 @@ export interface SellerCLIConfig {
   agentDir?: string | Record<string, string>;
   /** Publicly reachable seller address override announced in metadata, e.g. "peer.example.com:6882". */
   publicAddress?: string;
+  /** Optional external ownership claims announced in signed peer metadata. */
+  verifications?: VerificationConfig;
   /** Maximum upload body size (bytes) accepted from buyers per request. Default: 64 MiB. */
   maxUploadBodyBytes?: number;
 }

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -71,9 +71,21 @@ export interface DomainVerificationConfig {
   methods?: DomainVerificationMethod[];
 }
 
+export interface GithubVerificationConfig {
+  /** GitHub username to prove. */
+  username: string;
+  /**
+   * Public repository holding `antseed.json` at its root. Defaults to the
+   * profile repository `<username>/<username>` when omitted.
+   */
+  repository?: string;
+}
+
 export interface VerificationConfig {
   /** Domain ownership claims. */
   domains?: DomainVerificationConfig[];
+  /** GitHub account ownership claims. */
+  github?: GithubVerificationConfig[];
 }
 
 /**

--- a/apps/cli/src/config/validation.ts
+++ b/apps/cli/src/config/validation.ts
@@ -1,4 +1,6 @@
 import type {
+  DomainVerificationConfig,
+  DomainVerificationMethod,
   HierarchicalPricingConfig,
   AntseedConfig,
   SellerProviderConfig,
@@ -7,6 +9,10 @@ import type {
 
 const SERVICE_CATEGORY_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const MAX_PUBLIC_ADDRESS_LENGTH = 255;
+const MAX_DOMAIN_VERIFICATION_CLAIMS = 5;
+const MAX_DOMAIN_LENGTH = 253;
+const DOMAIN_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const DOMAIN_VERIFICATION_METHODS = new Set<DomainVerificationMethod>(['dns-txt', 'https-well-known']);
 const MIN_SELLER_UPLOAD_BODY_BYTES = 1024 * 1024;
 const MIN_BUYER_PEER_REFRESH_INTERVAL_MS = 1_000;
 export const MIN_BUYER_METADATA_FETCH_TIMEOUT_MS = 100;
@@ -126,6 +132,84 @@ function parsePublicAddress(value: string): { host: string; port: number } | nul
   return { host, port };
 }
 
+function isValidDomainName(value: string): boolean {
+  if (value.length === 0 || value.length > MAX_DOMAIN_LENGTH) return false;
+  if (value.includes('..') || value.endsWith('.')) return false;
+  const labels = value.split('.');
+  if (labels.length < 2) return false;
+  return labels.every((label) => DOMAIN_LABEL_PATTERN.test(label));
+}
+
+function validateDomainVerification(
+  path: string,
+  claims: DomainVerificationConfig[] | undefined,
+  errors: string[],
+): void {
+  if (claims === undefined) return;
+  if (!Array.isArray(claims)) {
+    errors.push(`${path} must be an array when provided`);
+    return;
+  }
+  if (claims.length === 0) {
+    errors.push(`${path} must be a non-empty array when provided`);
+    return;
+  }
+  if (claims.length > MAX_DOMAIN_VERIFICATION_CLAIMS) {
+    errors.push(`${path} must contain at most ${MAX_DOMAIN_VERIFICATION_CLAIMS} claims`);
+  }
+  const domains = new Set<string>();
+  for (let i = 0; i < claims.length; i += 1) {
+    const claim = claims[i];
+    const claimPath = `${path}[${i}]`;
+    const domain = typeof claim?.domain === 'string' ? claim.domain.trim().toLowerCase() : '';
+    if (!isValidDomainName(domain)) {
+      errors.push(`${claimPath}.domain must be a lower-case hostname with at least two labels`);
+    } else if (domains.has(domain)) {
+      errors.push(`${claimPath}.domain is duplicated`);
+    }
+    domains.add(domain);
+
+    if (claim?.methods !== undefined) {
+      if (!Array.isArray(claim.methods) || claim.methods.length === 0) {
+        errors.push(`${claimPath}.methods must be a non-empty array when provided`);
+      } else {
+        const methods = new Set<string>();
+        for (let j = 0; j < claim.methods.length; j += 1) {
+          const method = claim.methods[j];
+          if (typeof method !== 'string' || !DOMAIN_VERIFICATION_METHODS.has(method as DomainVerificationMethod)) {
+            errors.push(`${claimPath}.methods[${j}] must be "dns-txt" or "https-well-known"`);
+            continue;
+          }
+          if (methods.has(method)) {
+            errors.push(`${claimPath}.methods[${j}] is duplicated`);
+          }
+          methods.add(method);
+        }
+      }
+    }
+  }
+}
+
+function validateVerifications(
+  path: string,
+  verifications: AntseedConfig['seller']['verifications'],
+  errors: string[],
+): void {
+  if (verifications === undefined) return;
+  if (!verifications || typeof verifications !== 'object' || Array.isArray(verifications)) {
+    errors.push(`${path} must be an object when provided`);
+    return;
+  }
+  validateDomainVerification(`${path}.domains`, verifications.domains, errors);
+  const unknownKeys = Object.keys(verifications).filter((key) => key !== 'domains');
+  for (const key of unknownKeys) {
+    errors.push(`${path}.${key} is not a supported verification namespace`);
+  }
+  if (verifications.domains === undefined && unknownKeys.length === 0) {
+    errors.push(`${path} must include at least one verification namespace when provided`);
+  }
+}
+
 /**
  * Validate the full config and return all issues.
  */
@@ -190,6 +274,8 @@ export function validateConfig(config: AntseedConfig): string[] {
       errors.push('seller.publicAddress must be in the form "host:port" with a valid port');
     }
   }
+
+  validateVerifications('seller.verifications', config.seller.verifications, errors);
 
   return errors;
 }

--- a/apps/cli/src/config/validation.ts
+++ b/apps/cli/src/config/validation.ts
@@ -1,6 +1,7 @@
 import type {
   DomainVerificationConfig,
   DomainVerificationMethod,
+  GithubVerificationConfig,
   HierarchicalPricingConfig,
   AntseedConfig,
   SellerProviderConfig,
@@ -13,6 +14,12 @@ const MAX_DOMAIN_VERIFICATION_CLAIMS = 5;
 const MAX_DOMAIN_LENGTH = 253;
 const DOMAIN_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const DOMAIN_VERIFICATION_METHODS = new Set<DomainVerificationMethod>(['dns-txt', 'https-well-known']);
+const MAX_GITHUB_VERIFICATION_CLAIMS = 5;
+const MAX_GITHUB_USERNAME_LENGTH = 39;
+const MAX_GITHUB_REPOSITORY_LENGTH = 100;
+const GITHUB_USERNAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const GITHUB_REPOSITORY_PATTERN = /^[a-z0-9._-]+$/;
+const VERIFICATION_NAMESPACES = new Set(['domains', 'github']);
 const MIN_SELLER_UPLOAD_BODY_BYTES = 1024 * 1024;
 const MIN_BUYER_PEER_REFRESH_INTERVAL_MS = 1_000;
 export const MIN_BUYER_METADATA_FETCH_TIMEOUT_MS = 100;
@@ -190,6 +197,58 @@ function validateDomainVerification(
   }
 }
 
+function validateGithubVerification(
+  path: string,
+  claims: GithubVerificationConfig[] | undefined,
+  errors: string[],
+): void {
+  if (claims === undefined) return;
+  if (!Array.isArray(claims)) {
+    errors.push(`${path} must be an array when provided`);
+    return;
+  }
+  if (claims.length === 0) {
+    errors.push(`${path} must be a non-empty array when provided`);
+    return;
+  }
+  if (claims.length > MAX_GITHUB_VERIFICATION_CLAIMS) {
+    errors.push(`${path} must contain at most ${MAX_GITHUB_VERIFICATION_CLAIMS} claims`);
+  }
+  const seen = new Set<string>();
+  for (let i = 0; i < claims.length; i += 1) {
+    const claim = claims[i];
+    const claimPath = `${path}[${i}]`;
+    const username = typeof claim?.username === 'string' ? claim.username.trim().toLowerCase() : '';
+    if (
+      username.length === 0
+      || username.length > MAX_GITHUB_USERNAME_LENGTH
+      || username.includes('--')
+      || !GITHUB_USERNAME_PATTERN.test(username)
+    ) {
+      errors.push(`${claimPath}.username must be a valid GitHub username`);
+    }
+    const rawRepository = claim?.repository;
+    let repository = '';
+    if (rawRepository !== undefined) {
+      repository = typeof rawRepository === 'string' ? rawRepository.trim().toLowerCase() : '';
+      if (
+        repository.length === 0
+        || repository.length > MAX_GITHUB_REPOSITORY_LENGTH
+        || repository === '.'
+        || repository === '..'
+        || !GITHUB_REPOSITORY_PATTERN.test(repository)
+      ) {
+        errors.push(`${claimPath}.repository must be a valid GitHub repository name`);
+      }
+    }
+    const key = `${username}/${repository}`;
+    if (seen.has(key)) {
+      errors.push(`${claimPath} is duplicated`);
+    }
+    seen.add(key);
+  }
+}
+
 function validateVerifications(
   path: string,
   verifications: AntseedConfig['seller']['verifications'],
@@ -201,11 +260,12 @@ function validateVerifications(
     return;
   }
   validateDomainVerification(`${path}.domains`, verifications.domains, errors);
-  const unknownKeys = Object.keys(verifications).filter((key) => key !== 'domains');
+  validateGithubVerification(`${path}.github`, verifications.github, errors);
+  const unknownKeys = Object.keys(verifications).filter((key) => !VERIFICATION_NAMESPACES.has(key));
   for (const key of unknownKeys) {
     errors.push(`${path}.${key} is not a supported verification namespace`);
   }
-  if (verifications.domains === undefined && unknownKeys.length === 0) {
+  if (verifications.domains === undefined && verifications.github === undefined && unknownKeys.length === 0) {
     errors.push(`${path} must include at least one verification namespace when provided`);
   }
 }

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -12,6 +12,7 @@ import {
 import type { PeerOffering } from "../types/capability.js";
 import type { DomainVerificationClaim, DomainVerificationMethod, PeerMetadata, PeerVerifications, ProviderAnnouncement } from "./peer-metadata.js";
 import { METADATA_VERSION } from "./peer-metadata.js";
+import { MAX_DOMAIN_LENGTH, MAX_DOMAIN_VERIFICATION_CLAIMS } from "./metadata-validator.js";
 
 import type { ServiceApiProtocol } from "../types/service-api.js";
 import { isKnownServiceApiProtocol } from "../types/service-api.js";
@@ -196,7 +197,7 @@ export class PeerAnnouncer {
     const methodOrder: DomainVerificationMethod[] = ["dns-txt", "https-well-known"];
     for (const claim of claims) {
       const normalizedDomain = claim.domain.trim().toLowerCase();
-      if (!normalizedDomain || seen.has(normalizedDomain)) continue;
+      if (!normalizedDomain || normalizedDomain.length > MAX_DOMAIN_LENGTH || seen.has(normalizedDomain)) continue;
       seen.add(normalizedDomain);
       const methods = claim.methods
         ? methodOrder.filter((method) => claim.methods!.includes(method))
@@ -206,7 +207,10 @@ export class PeerAnnouncer {
         ...(methods && methods.length > 0 ? { methods } : {}),
       });
     }
-    return domains.length > 0 ? { domains: domains.sort((a, b) => a.domain.localeCompare(b.domain)) } : undefined;
+    if (domains.length === 0) return undefined;
+    // Code-unit sort (matches the codec) so signed claim order is locale-independent.
+    domains.sort((a, b) => (a.domain < b.domain ? -1 : a.domain > b.domain ? 1 : 0));
+    return { domains: domains.slice(0, MAX_DOMAIN_VERIFICATION_CLAIMS) };
   }
 
   private async _buildSignedMetadata(includeOnChainReputation = true): Promise<PeerMetadata> {

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -10,9 +10,15 @@ import {
   topicToInfoHash,
 } from "./dht-node.js";
 import type { PeerOffering } from "../types/capability.js";
-import type { DomainVerificationClaim, DomainVerificationMethod, PeerMetadata, PeerVerifications, ProviderAnnouncement } from "./peer-metadata.js";
+import type { DomainVerificationClaim, DomainVerificationMethod, GithubVerificationClaim, PeerMetadata, PeerVerifications, ProviderAnnouncement } from "./peer-metadata.js";
 import { METADATA_VERSION } from "./peer-metadata.js";
-import { MAX_DOMAIN_LENGTH, MAX_DOMAIN_VERIFICATION_CLAIMS } from "./metadata-validator.js";
+import {
+  MAX_DOMAIN_LENGTH,
+  MAX_DOMAIN_VERIFICATION_CLAIMS,
+  MAX_GITHUB_REPOSITORY_LENGTH,
+  MAX_GITHUB_USERNAME_LENGTH,
+  MAX_GITHUB_VERIFICATION_CLAIMS,
+} from "./metadata-validator.js";
 
 import type { ServiceApiProtocol } from "../types/service-api.js";
 import { isKnownServiceApiProtocol } from "../types/service-api.js";
@@ -207,10 +213,32 @@ export class PeerAnnouncer {
         ...(methods && methods.length > 0 ? { methods } : {}),
       });
     }
-    if (domains.length === 0) return undefined;
-    // Code-unit sort (matches the codec) so signed claim order is locale-independent.
+    // Code-unit sorts (matching the codec) so signed claim order is locale-independent.
     domains.sort((a, b) => (a.domain < b.domain ? -1 : a.domain > b.domain ? 1 : 0));
-    return { domains: domains.slice(0, MAX_DOMAIN_VERIFICATION_CLAIMS) };
+
+    const githubClaims = this.config.verifications?.github ?? [];
+    const github: GithubVerificationClaim[] = [];
+    const seenGithub = new Set<string>();
+    for (const claim of githubClaims) {
+      const username = claim.username.trim().toLowerCase();
+      const repository = claim.repository ? claim.repository.trim().toLowerCase() : "";
+      const key = `${username}/${repository}`;
+      if (!username || username.length > MAX_GITHUB_USERNAME_LENGTH) continue;
+      if (repository.length > MAX_GITHUB_REPOSITORY_LENGTH || seenGithub.has(key)) continue;
+      seenGithub.add(key);
+      github.push({
+        username,
+        ...(repository ? { repository } : {}),
+      });
+    }
+    github.sort((a, b) => (a.username < b.username ? -1 : a.username > b.username ? 1
+      : (a.repository ?? "") < (b.repository ?? "") ? -1 : (a.repository ?? "") > (b.repository ?? "") ? 1 : 0));
+
+    if (domains.length === 0 && github.length === 0) return undefined;
+    return {
+      ...(domains.length > 0 ? { domains: domains.slice(0, MAX_DOMAIN_VERIFICATION_CLAIMS) } : {}),
+      ...(github.length > 0 ? { github: github.slice(0, MAX_GITHUB_VERIFICATION_CLAIMS) } : {}),
+    };
   }
 
   private async _buildSignedMetadata(includeOnChainReputation = true): Promise<PeerMetadata> {

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -10,7 +10,7 @@ import {
   topicToInfoHash,
 } from "./dht-node.js";
 import type { PeerOffering } from "../types/capability.js";
-import type { PeerMetadata, ProviderAnnouncement } from "./peer-metadata.js";
+import type { DomainVerificationClaim, DomainVerificationMethod, PeerMetadata, PeerVerifications, ProviderAnnouncement } from "./peer-metadata.js";
 import { METADATA_VERSION } from "./peer-metadata.js";
 
 import type { ServiceApiProtocol } from "../types/service-api.js";
@@ -50,6 +50,8 @@ export interface AnnouncerConfig {
   }>;
   displayName?: string;
   publicAddress?: string;
+  /** External ownership claims to include in signed metadata for client verification. */
+  verifications?: PeerVerifications;
   region: string;
   pricing: Map<
     string,
@@ -187,6 +189,26 @@ export class PeerAnnouncer {
     return cfg.sellerContract.toLowerCase().replace(/^0x/, "");
   }
 
+  private _normalizedVerifications(): PeerVerifications | undefined {
+    const claims = this.config.verifications?.domains ?? [];
+    const domains: DomainVerificationClaim[] = [];
+    const seen = new Set<string>();
+    const methodOrder: DomainVerificationMethod[] = ["dns-txt", "https-well-known"];
+    for (const claim of claims) {
+      const normalizedDomain = claim.domain.trim().toLowerCase();
+      if (!normalizedDomain || seen.has(normalizedDomain)) continue;
+      seen.add(normalizedDomain);
+      const methods = claim.methods
+        ? methodOrder.filter((method) => claim.methods!.includes(method))
+        : undefined;
+      domains.push({
+        domain: normalizedDomain,
+        ...(methods && methods.length > 0 ? { methods } : {}),
+      });
+    }
+    return domains.length > 0 ? { domains: domains.sort((a, b) => a.domain.localeCompare(b.domain)) } : undefined;
+  }
+
   private async _buildSignedMetadata(includeOnChainReputation = true): Promise<PeerMetadata> {
     const providers: ProviderAnnouncement[] = this.config.providers.map((p) => {
       const pricing = p.pricing ?? this.config.pricing.get(p.provider) ?? {
@@ -231,6 +253,10 @@ export class PeerAnnouncer {
     }
     if (this.config.stakeAmountUSDC != null) {
       metadata.stakeAmountUSDC = this.config.stakeAmountUSDC;
+    }
+    const verifications = this._normalizedVerifications();
+    if (verifications) {
+      metadata.verifications = verifications;
     }
 
     if (this.config.paymentsEnabled) {

--- a/packages/node/src/discovery/domain-verification.ts
+++ b/packages/node/src/discovery/domain-verification.ts
@@ -1,6 +1,15 @@
 import { resolveTxt } from "node:dns/promises";
 
 import type { DomainVerificationClaim, DomainVerificationMethod, PeerMetadata } from "./peer-metadata.js";
+import {
+  DEFAULT_VERIFICATION_TIMEOUT_MS,
+  MAX_VERIFICATION_PROOF_BYTES,
+  formatError,
+  normalizePeerId,
+  readBodyWithLimit,
+  withTimeout,
+  withTimeoutSignal,
+} from "./verification-utils.js";
 
 export const DOMAIN_VERIFICATION_TXT_PREFIX = "antseed-peer=";
 export const DOMAIN_VERIFICATION_TXT_NAME_PREFIX = "_antseed.";
@@ -36,14 +45,6 @@ interface WellKnownDomainProof {
 }
 
 const ALL_DOMAIN_VERIFICATION_METHODS: DomainVerificationMethod[] = ["dns-txt", "https-well-known"];
-const DEFAULT_VERIFICATION_TIMEOUT_MS = 3_000;
-// Proofs are tiny JSON documents; cap reads so a hostile domain can't stream
-// an unbounded body into the verifying client.
-const MAX_WELL_KNOWN_PROOF_BYTES = 4_096;
-
-function normalizePeerId(peerId: string): string {
-  return peerId.trim().toLowerCase().replace(/^0x/, "");
-}
 
 function normalizeDomain(domain: string): string {
   return domain.trim().toLowerCase();
@@ -56,37 +57,6 @@ function normalizeMethods(claim: DomainVerificationClaim): DomainVerificationMet
   return ALL_DOMAIN_VERIFICATION_METHODS.filter((method) => methods.includes(method));
 }
 
-function formatError(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
-}
-
-function withTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number): {
-  signal: AbortSignal;
-  cleanup: () => void;
-} {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(new Error("domain verification timed out")), timeoutMs);
-  if (!signal) {
-    return {
-      signal: controller.signal,
-      cleanup: () => clearTimeout(timer),
-    };
-  }
-  const onAbort = () => controller.abort(signal.reason);
-  if (signal.aborted) {
-    onAbort();
-  } else {
-    signal.addEventListener("abort", onAbort, { once: true });
-  }
-  return {
-    signal: controller.signal,
-    cleanup: () => {
-      clearTimeout(timer);
-      signal.removeEventListener("abort", onAbort);
-    },
-  };
-}
-
 function txtRecordMatchesPeerId(record: string, peerId: string): boolean {
   return record
     .split(/\s+/)
@@ -94,50 +64,6 @@ function txtRecordMatchesPeerId(record: string, peerId: string): boolean {
       const [key, value] = part.split("=", 2);
       return key === DOMAIN_VERIFICATION_TXT_PREFIX.slice(0, -1) && normalizePeerId(value ?? "") === peerId;
     });
-}
-
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(message)), timeoutMs);
-    promise.then(
-      (value) => { clearTimeout(timer); resolve(value); },
-      (err: unknown) => { clearTimeout(timer); reject(err); },
-    );
-  });
-}
-
-async function readBodyWithLimit(response: Response, maxBytes: number): Promise<string> {
-  const contentLength = Number(response.headers.get("content-length") ?? "");
-  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
-    throw new Error(`Proof body exceeds ${maxBytes} bytes`);
-  }
-  if (!response.body) {
-    const text = await response.text();
-    if (text.length > maxBytes) {
-      throw new Error(`Proof body exceeds ${maxBytes} bytes`);
-    }
-    return text;
-  }
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > maxBytes) {
-      await reader.cancel().catch(() => {});
-      throw new Error(`Proof body exceeds ${maxBytes} bytes`);
-    }
-    chunks.push(value);
-  }
-  const merged = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    merged.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return new TextDecoder().decode(merged);
 }
 
 async function verifyDnsTxt(
@@ -179,7 +105,7 @@ async function verifyWellKnown(
     if (!response.ok) {
       return { method: "https-well-known", verified: false, error: `HTTP ${response.status}` };
     }
-    const proof = JSON.parse(await readBodyWithLimit(response, MAX_WELL_KNOWN_PROOF_BYTES)) as WellKnownDomainProof;
+    const proof = JSON.parse(await readBodyWithLimit(response, MAX_VERIFICATION_PROOF_BYTES)) as WellKnownDomainProof;
     const proofPeerId = typeof proof.peerId === "string" ? normalizePeerId(proof.peerId) : "";
     const proofDomain = typeof proof.domain === "string" ? normalizeDomain(proof.domain) : domain;
     if (proof.type !== DOMAIN_VERIFICATION_WELL_KNOWN_TYPE) {

--- a/packages/node/src/discovery/domain-verification.ts
+++ b/packages/node/src/discovery/domain-verification.ts
@@ -36,6 +36,10 @@ interface WellKnownDomainProof {
 }
 
 const ALL_DOMAIN_VERIFICATION_METHODS: DomainVerificationMethod[] = ["dns-txt", "https-well-known"];
+const DEFAULT_VERIFICATION_TIMEOUT_MS = 3_000;
+// Proofs are tiny JSON documents; cap reads so a hostile domain can't stream
+// an unbounded body into the verifying client.
+const MAX_WELL_KNOWN_PROOF_BYTES = 4_096;
 
 function normalizePeerId(peerId: string): string {
   return peerId.trim().toLowerCase().replace(/^0x/, "");
@@ -69,7 +73,11 @@ function withTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number): 
     };
   }
   const onAbort = () => controller.abort(signal.reason);
-  signal.addEventListener("abort", onAbort, { once: true });
+  if (signal.aborted) {
+    onAbort();
+  } else {
+    signal.addEventListener("abort", onAbort, { once: true });
+  }
   return {
     signal: controller.signal,
     cleanup: () => {
@@ -88,14 +96,59 @@ function txtRecordMatchesPeerId(record: string, peerId: string): boolean {
     });
 }
 
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    promise.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (err: unknown) => { clearTimeout(timer); reject(err); },
+    );
+  });
+}
+
+async function readBodyWithLimit(response: Response, maxBytes: number): Promise<string> {
+  const contentLength = Number(response.headers.get("content-length") ?? "");
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new Error(`Proof body exceeds ${maxBytes} bytes`);
+  }
+  if (!response.body) {
+    const text = await response.text();
+    if (text.length > maxBytes) {
+      throw new Error(`Proof body exceeds ${maxBytes} bytes`);
+    }
+    return text;
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => {});
+      throw new Error(`Proof body exceeds ${maxBytes} bytes`);
+    }
+    chunks.push(value);
+  }
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
 async function verifyDnsTxt(
   domain: string,
   peerId: string,
   resolver: (hostname: string) => Promise<string[][]>,
+  timeoutMs: number,
 ): Promise<DomainVerificationAttemptResult> {
   const hostname = `${DOMAIN_VERIFICATION_TXT_NAME_PREFIX}${domain}`;
   try {
-    const records = await resolver(hostname);
+    const records = await withTimeout(resolver(hostname), timeoutMs, "DNS TXT lookup timed out");
     const verified = records
       .map((chunks) => chunks.join(""))
       .some((record) => txtRecordMatchesPeerId(record, peerId));
@@ -112,17 +165,21 @@ async function verifyWellKnown(
   peerId: string,
   options: Required<Pick<DomainVerificationOptions, "fetch">> & Pick<DomainVerificationOptions, "signal" | "timeoutMs">,
 ): Promise<DomainVerificationAttemptResult> {
-  const timeoutMs = options.timeoutMs ?? 3_000;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_VERIFICATION_TIMEOUT_MS;
   const { signal, cleanup } = withTimeoutSignal(options.signal, timeoutMs);
   try {
+    // Never follow redirects: ownership proof must be served by the claimed
+    // domain itself, otherwise an open redirect on the domain would let an
+    // attacker serve a valid proof from a host they control.
     const response = await options.fetch(`https://${domain}${DOMAIN_VERIFICATION_WELL_KNOWN_PATH}`, {
       headers: { accept: "application/json" },
+      redirect: "error",
       signal,
     });
     if (!response.ok) {
       return { method: "https-well-known", verified: false, error: `HTTP ${response.status}` };
     }
-    const proof = await response.json() as WellKnownDomainProof;
+    const proof = JSON.parse(await readBodyWithLimit(response, MAX_WELL_KNOWN_PROOF_BYTES)) as WellKnownDomainProof;
     const proofPeerId = typeof proof.peerId === "string" ? normalizePeerId(proof.peerId) : "";
     const proofDomain = typeof proof.domain === "string" ? normalizeDomain(proof.domain) : domain;
     if (proof.type !== DOMAIN_VERIFICATION_WELL_KNOWN_TYPE) {
@@ -168,7 +225,12 @@ export async function verifyDomainVerificationClaim(
   const methods = normalizeMethods(claim);
   const attempts = await Promise.all(methods.map((method) => {
     if (method === "dns-txt") {
-      return verifyDnsTxt(normalizedDomain, normalizedPeerId, options?.resolveTxt ?? resolveTxt);
+      return verifyDnsTxt(
+        normalizedDomain,
+        normalizedPeerId,
+        options?.resolveTxt ?? resolveTxt,
+        options?.timeoutMs ?? DEFAULT_VERIFICATION_TIMEOUT_MS,
+      );
     }
     return verifyWellKnown(normalizedDomain, normalizedPeerId, {
       fetch: options?.fetch ?? fetch,

--- a/packages/node/src/discovery/domain-verification.ts
+++ b/packages/node/src/discovery/domain-verification.ts
@@ -107,7 +107,7 @@ async function verifyWellKnown(
     }
     const proof = JSON.parse(await readBodyWithLimit(response, MAX_VERIFICATION_PROOF_BYTES)) as WellKnownDomainProof;
     const proofPeerId = typeof proof.peerId === "string" ? normalizePeerId(proof.peerId) : "";
-    const proofDomain = typeof proof.domain === "string" ? normalizeDomain(proof.domain) : domain;
+    const proofDomain = typeof proof.domain === "string" ? normalizeDomain(proof.domain) : "";
     if (proof.type !== DOMAIN_VERIFICATION_WELL_KNOWN_TYPE) {
       return { method: "https-well-known", verified: false, error: "Proof type mismatch" };
     }

--- a/packages/node/src/discovery/domain-verification.ts
+++ b/packages/node/src/discovery/domain-verification.ts
@@ -1,0 +1,198 @@
+import { resolveTxt } from "node:dns/promises";
+
+import type { DomainVerificationClaim, DomainVerificationMethod, PeerMetadata } from "./peer-metadata.js";
+
+export const DOMAIN_VERIFICATION_TXT_PREFIX = "antseed-peer=";
+export const DOMAIN_VERIFICATION_TXT_NAME_PREFIX = "_antseed.";
+export const DOMAIN_VERIFICATION_WELL_KNOWN_PATH = "/.well-known/antseed.json";
+export const DOMAIN_VERIFICATION_WELL_KNOWN_TYPE = "antseed-domain-verification";
+
+export interface DomainVerificationAttemptResult {
+  method: DomainVerificationMethod;
+  verified: boolean;
+  error?: string;
+}
+
+export interface DomainVerificationResult {
+  domain: string;
+  peerId: string;
+  verified: boolean;
+  method?: DomainVerificationMethod;
+  checkedAtMs: number;
+  attempts: DomainVerificationAttemptResult[];
+}
+
+export interface DomainVerificationOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  fetch?: typeof fetch;
+  resolveTxt?: (hostname: string) => Promise<string[][]>;
+}
+
+interface WellKnownDomainProof {
+  type?: unknown;
+  peerId?: unknown;
+  domain?: unknown;
+}
+
+const ALL_DOMAIN_VERIFICATION_METHODS: DomainVerificationMethod[] = ["dns-txt", "https-well-known"];
+
+function normalizePeerId(peerId: string): string {
+  return peerId.trim().toLowerCase().replace(/^0x/, "");
+}
+
+function normalizeDomain(domain: string): string {
+  return domain.trim().toLowerCase();
+}
+
+function normalizeMethods(claim: DomainVerificationClaim): DomainVerificationMethod[] {
+  const methods = claim.methods && claim.methods.length > 0
+    ? claim.methods
+    : ALL_DOMAIN_VERIFICATION_METHODS;
+  return ALL_DOMAIN_VERIFICATION_METHODS.filter((method) => methods.includes(method));
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function withTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error("domain verification timed out")), timeoutMs);
+  if (!signal) {
+    return {
+      signal: controller.signal,
+      cleanup: () => clearTimeout(timer),
+    };
+  }
+  const onAbort = () => controller.abort(signal.reason);
+  signal.addEventListener("abort", onAbort, { once: true });
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+    },
+  };
+}
+
+function txtRecordMatchesPeerId(record: string, peerId: string): boolean {
+  return record
+    .split(/\s+/)
+    .some((part) => {
+      const [key, value] = part.split("=", 2);
+      return key === DOMAIN_VERIFICATION_TXT_PREFIX.slice(0, -1) && normalizePeerId(value ?? "") === peerId;
+    });
+}
+
+async function verifyDnsTxt(
+  domain: string,
+  peerId: string,
+  resolver: (hostname: string) => Promise<string[][]>,
+): Promise<DomainVerificationAttemptResult> {
+  const hostname = `${DOMAIN_VERIFICATION_TXT_NAME_PREFIX}${domain}`;
+  try {
+    const records = await resolver(hostname);
+    const verified = records
+      .map((chunks) => chunks.join(""))
+      .some((record) => txtRecordMatchesPeerId(record, peerId));
+    return verified
+      ? { method: "dns-txt", verified: true }
+      : { method: "dns-txt", verified: false, error: `No TXT record matched ${DOMAIN_VERIFICATION_TXT_PREFIX}${peerId}` };
+  } catch (err) {
+    return { method: "dns-txt", verified: false, error: formatError(err) };
+  }
+}
+
+async function verifyWellKnown(
+  domain: string,
+  peerId: string,
+  options: Required<Pick<DomainVerificationOptions, "fetch">> & Pick<DomainVerificationOptions, "signal" | "timeoutMs">,
+): Promise<DomainVerificationAttemptResult> {
+  const timeoutMs = options.timeoutMs ?? 3_000;
+  const { signal, cleanup } = withTimeoutSignal(options.signal, timeoutMs);
+  try {
+    const response = await options.fetch(`https://${domain}${DOMAIN_VERIFICATION_WELL_KNOWN_PATH}`, {
+      headers: { accept: "application/json" },
+      signal,
+    });
+    if (!response.ok) {
+      return { method: "https-well-known", verified: false, error: `HTTP ${response.status}` };
+    }
+    const proof = await response.json() as WellKnownDomainProof;
+    const proofPeerId = typeof proof.peerId === "string" ? normalizePeerId(proof.peerId) : "";
+    const proofDomain = typeof proof.domain === "string" ? normalizeDomain(proof.domain) : domain;
+    if (proof.type !== DOMAIN_VERIFICATION_WELL_KNOWN_TYPE) {
+      return { method: "https-well-known", verified: false, error: "Proof type mismatch" };
+    }
+    if (proofPeerId !== peerId) {
+      return { method: "https-well-known", verified: false, error: "Proof peerId mismatch" };
+    }
+    if (proofDomain !== domain) {
+      return { method: "https-well-known", verified: false, error: "Proof domain mismatch" };
+    }
+    return { method: "https-well-known", verified: true };
+  } catch (err) {
+    return { method: "https-well-known", verified: false, error: formatError(err) };
+  } finally {
+    cleanup();
+  }
+}
+
+export function buildDomainVerificationTxtValue(peerId: string): string {
+  return `${DOMAIN_VERIFICATION_TXT_PREFIX}${normalizePeerId(peerId)}`;
+}
+
+export function buildDomainVerificationWellKnownProof(peerId: string, domain: string): {
+  type: typeof DOMAIN_VERIFICATION_WELL_KNOWN_TYPE;
+  peerId: string;
+  domain: string;
+} {
+  return {
+    type: DOMAIN_VERIFICATION_WELL_KNOWN_TYPE,
+    peerId: normalizePeerId(peerId),
+    domain: normalizeDomain(domain),
+  };
+}
+
+export async function verifyDomainVerificationClaim(
+  claim: DomainVerificationClaim,
+  peerId: string,
+  options?: DomainVerificationOptions,
+): Promise<DomainVerificationResult> {
+  const normalizedPeerId = normalizePeerId(peerId);
+  const normalizedDomain = normalizeDomain(claim.domain);
+  const methods = normalizeMethods(claim);
+  const attempts = await Promise.all(methods.map((method) => {
+    if (method === "dns-txt") {
+      return verifyDnsTxt(normalizedDomain, normalizedPeerId, options?.resolveTxt ?? resolveTxt);
+    }
+    return verifyWellKnown(normalizedDomain, normalizedPeerId, {
+      fetch: options?.fetch ?? fetch,
+      signal: options?.signal,
+      timeoutMs: options?.timeoutMs,
+    });
+  }));
+  const success = attempts.find((attempt) => attempt.verified);
+  return {
+    domain: normalizedDomain,
+    peerId: normalizedPeerId,
+    verified: success !== undefined,
+    ...(success ? { method: success.method } : {}),
+    checkedAtMs: Date.now(),
+    attempts,
+  };
+}
+
+export async function verifyPeerMetadataDomains(
+  metadata: PeerMetadata,
+  options?: DomainVerificationOptions,
+): Promise<DomainVerificationResult[]> {
+  const claims = metadata.verifications?.domains ?? [];
+  return Promise.all(
+    claims.map((claim) => verifyDomainVerificationClaim(claim, metadata.peerId, options)),
+  );
+}

--- a/packages/node/src/discovery/github-verification.ts
+++ b/packages/node/src/discovery/github-verification.ts
@@ -1,0 +1,121 @@
+import type { GithubVerificationClaim, PeerMetadata } from "./peer-metadata.js";
+import {
+  DEFAULT_VERIFICATION_TIMEOUT_MS,
+  MAX_VERIFICATION_PROOF_BYTES,
+  formatError,
+  normalizePeerId,
+  readBodyWithLimit,
+  withTimeoutSignal,
+} from "./verification-utils.js";
+
+export const GITHUB_VERIFICATION_PROOF_FILE = "antseed.json";
+export const GITHUB_VERIFICATION_PROOF_TYPE = "antseed-github-verification";
+
+export interface GithubVerificationResult {
+  username: string;
+  repository: string;
+  peerId: string;
+  verified: boolean;
+  checkedAtMs: number;
+  error?: string;
+}
+
+export interface GithubVerificationOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  fetch?: typeof fetch;
+}
+
+interface GithubProof {
+  type?: unknown;
+  peerId?: unknown;
+  username?: unknown;
+}
+
+function normalizeName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function resolveRepository(claim: GithubVerificationClaim): string {
+  const repository = claim.repository ? normalizeName(claim.repository) : "";
+  return repository || normalizeName(claim.username);
+}
+
+/**
+ * URL of the proof document for a claim. Ownership is bound by the username
+ * in the `raw.githubusercontent.com` path: only the account owner can place
+ * a file in a repository under that path.
+ */
+export function buildGithubVerificationProofUrl(claim: GithubVerificationClaim): string {
+  const username = normalizeName(claim.username);
+  return `https://raw.githubusercontent.com/${username}/${resolveRepository(claim)}/HEAD/${GITHUB_VERIFICATION_PROOF_FILE}`;
+}
+
+export function buildGithubVerificationProof(peerId: string, username: string): {
+  type: typeof GITHUB_VERIFICATION_PROOF_TYPE;
+  peerId: string;
+  username: string;
+} {
+  return {
+    type: GITHUB_VERIFICATION_PROOF_TYPE,
+    peerId: normalizePeerId(peerId),
+    username: normalizeName(username),
+  };
+}
+
+export async function verifyGithubVerificationClaim(
+  claim: GithubVerificationClaim,
+  peerId: string,
+  options?: GithubVerificationOptions,
+): Promise<GithubVerificationResult> {
+  const normalizedPeerId = normalizePeerId(peerId);
+  const username = normalizeName(claim.username);
+  const repository = resolveRepository(claim);
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_VERIFICATION_TIMEOUT_MS;
+  const { signal, cleanup } = withTimeoutSignal(options?.signal, timeoutMs);
+  const base = {
+    username,
+    repository,
+    peerId: normalizedPeerId,
+  };
+  try {
+    // redirect: "error" keeps the proof pinned to the claimed account: a
+    // renamed or transferred repository must re-publish the proof under the
+    // claimed username rather than verify through a redirect.
+    const response = await (options?.fetch ?? fetch)(buildGithubVerificationProofUrl(claim), {
+      headers: { accept: "application/json" },
+      redirect: "error",
+      signal,
+    });
+    if (!response.ok) {
+      return { ...base, verified: false, checkedAtMs: Date.now(), error: `HTTP ${response.status}` };
+    }
+    const proof = JSON.parse(await readBodyWithLimit(response, MAX_VERIFICATION_PROOF_BYTES)) as GithubProof;
+    if (proof.type !== GITHUB_VERIFICATION_PROOF_TYPE) {
+      return { ...base, verified: false, checkedAtMs: Date.now(), error: "Proof type mismatch" };
+    }
+    const proofPeerId = typeof proof.peerId === "string" ? normalizePeerId(proof.peerId) : "";
+    if (proofPeerId !== normalizedPeerId) {
+      return { ...base, verified: false, checkedAtMs: Date.now(), error: "Proof peerId mismatch" };
+    }
+    const proofUsername = typeof proof.username === "string" ? normalizeName(proof.username) : "";
+    if (proofUsername !== username) {
+      return { ...base, verified: false, checkedAtMs: Date.now(), error: "Proof username mismatch" };
+    }
+    return { ...base, verified: true, checkedAtMs: Date.now() };
+  } catch (err) {
+    return { ...base, verified: false, checkedAtMs: Date.now(), error: formatError(err) };
+  } finally {
+    cleanup();
+  }
+}
+
+export async function verifyPeerMetadataGithub(
+  metadata: PeerMetadata,
+  options?: GithubVerificationOptions,
+): Promise<GithubVerificationResult[]> {
+  const claims = metadata.verifications?.github ?? [];
+  return Promise.all(
+    claims.map((claim) => verifyGithubVerificationClaim(claim, metadata.peerId, options)),
+  );
+}

--- a/packages/node/src/discovery/index.ts
+++ b/packages/node/src/discovery/index.ts
@@ -22,6 +22,7 @@ export {
   WELL_KNOWN_SERVICE_CATEGORIES,
   type DomainVerificationClaim,
   type DomainVerificationMethod,
+  type GithubVerificationClaim,
   type PeerMetadata,
   type PeerVerifications,
   type ProviderAnnouncement,
@@ -39,6 +40,16 @@ export {
   type DomainVerificationOptions,
   type DomainVerificationResult,
 } from './domain-verification.js';
+export {
+  GITHUB_VERIFICATION_PROOF_FILE,
+  GITHUB_VERIFICATION_PROOF_TYPE,
+  buildGithubVerificationProof,
+  buildGithubVerificationProofUrl,
+  verifyGithubVerificationClaim,
+  verifyPeerMetadataGithub,
+  type GithubVerificationOptions,
+  type GithubVerificationResult,
+} from './github-verification.js';
 export { parsePublicAddress, MAX_PUBLIC_ADDRESS_LENGTH, type ParsedPublicAddress } from './public-address.js';
 export { type MetadataResolver, type PeerEndpoint } from './metadata-resolver.js';
 export { HttpMetadataResolver, type HttpMetadataResolverConfig } from './http-metadata-resolver.js';

--- a/packages/node/src/discovery/index.ts
+++ b/packages/node/src/discovery/index.ts
@@ -17,7 +17,28 @@ export { PeerLookup, DEFAULT_LOOKUP_CONFIG, type LookupConfig, type LookupResult
 export { OFFICIAL_BOOTSTRAP_NODES, parseBootstrapList, mergeBootstrapNodes, toBootstrapConfig, type BootstrapNode } from './bootstrap.js';
 export { encodeMetadata, encodeMetadataForSigning, decodeMetadata } from './metadata-codec.js';
 export { validateMetadata, MAX_METADATA_SIZE, MAX_PROVIDERS, type ValidationError } from './metadata-validator.js';
-export { METADATA_VERSION, WELL_KNOWN_SERVICE_CATEGORIES, type PeerMetadata, type ProviderAnnouncement } from './peer-metadata.js';
+export {
+  METADATA_VERSION,
+  WELL_KNOWN_SERVICE_CATEGORIES,
+  type DomainVerificationClaim,
+  type DomainVerificationMethod,
+  type PeerMetadata,
+  type PeerVerifications,
+  type ProviderAnnouncement,
+} from './peer-metadata.js';
+export {
+  DOMAIN_VERIFICATION_TXT_PREFIX,
+  DOMAIN_VERIFICATION_TXT_NAME_PREFIX,
+  DOMAIN_VERIFICATION_WELL_KNOWN_PATH,
+  DOMAIN_VERIFICATION_WELL_KNOWN_TYPE,
+  buildDomainVerificationTxtValue,
+  buildDomainVerificationWellKnownProof,
+  verifyDomainVerificationClaim,
+  verifyPeerMetadataDomains,
+  type DomainVerificationAttemptResult,
+  type DomainVerificationOptions,
+  type DomainVerificationResult,
+} from './domain-verification.js';
 export { parsePublicAddress, MAX_PUBLIC_ADDRESS_LENGTH, type ParsedPublicAddress } from './public-address.js';
 export { type MetadataResolver, type PeerEndpoint } from './metadata-resolver.js';
 export { HttpMetadataResolver, type HttpMetadataResolverConfig } from './http-metadata-resolver.js';

--- a/packages/node/src/discovery/metadata-codec.ts
+++ b/packages/node/src/discovery/metadata-codec.ts
@@ -249,10 +249,19 @@ function encodeBody(metadata: PeerMetadata): Uint8Array {
           : undefined,
       }))
       .filter((claim) => claim.domain.length > 0)
-      .sort((a, b) => a.domain.localeCompare(b.domain));
+      // Code-unit sort, not localeCompare: buyers verify signatures by
+      // re-encoding decoded metadata, so claim order must not depend on the
+      // verifier's locale.
+      .sort((a, b) => (a.domain < b.domain ? -1 : a.domain > b.domain ? 1 : 0));
+    if (claims.length > 255) {
+      throw new Error(`Too many domain verification claims (${claims.length})`);
+    }
     parts.push(new Uint8Array([claims.length]));
     for (const claim of claims) {
       const domainBytes = new TextEncoder().encode(claim.domain);
+      if (domainBytes.length > 255) {
+        throw new Error(`Domain verification claim too long (${domainBytes.length} bytes)`);
+      }
       parts.push(new Uint8Array([domainBytes.length]));
       parts.push(domainBytes);
       const methods = claim.methods

--- a/packages/node/src/discovery/metadata-codec.ts
+++ b/packages/node/src/discovery/metadata-codec.ts
@@ -1,4 +1,4 @@
-import type { PeerMetadata } from "./peer-metadata.js";
+import type { DomainVerificationClaim, DomainVerificationMethod, PeerMetadata } from "./peer-metadata.js";
 import type { PeerOffering } from "../types/capability.js";
 import { hexToBytes, bytesToHex } from "../utils/hex.js";
 import { toPeerId } from "../types/peer.js";
@@ -9,6 +9,12 @@ const SERVICE_CATEGORIES_METADATA_VERSION = 3;
 const SERVICE_API_PROTOCOLS_METADATA_VERSION = 4;
 const PUBLIC_ADDRESS_METADATA_VERSION = 5;
 const SELLER_CONTRACT_METADATA_VERSION = 8;
+const DOMAIN_VERIFICATION_METADATA_VERSION = 9;
+const DOMAIN_VERIFICATION_METHOD_IDS: Record<DomainVerificationMethod, number> = {
+  "dns-txt": 0,
+  "https-well-known": 1,
+};
+const DOMAIN_VERIFICATION_METHODS_BY_ID: DomainVerificationMethod[] = ["dns-txt", "https-well-known"];
 
 /**
  * Encode metadata into binary format:
@@ -27,6 +33,9 @@ const SELLER_CONTRACT_METADATA_VERSION = 8;
  * protocol(v4+): [protocolLen:1][protocol:N]
  * [displayNameFlag:1][displayNameLen:1][displayName:N] (v3+ only)
  * [publicAddressFlag:1][publicAddressLen:1][publicAddress:N] (v5+ only)
+ * [sellerContractFlag:1][sellerContract:20] (v8+ only)
+ * [domainVerificationCount:1][domainVerificationEntries...] (v9+ only)
+ * domainVerificationEntry(v9+): [domainLen:1][domain:N][methodCount:1][methodIds...]
  * [signature:65]
  */
 export function encodeMetadata(metadata: PeerMetadata): Uint8Array {
@@ -228,6 +237,37 @@ function encodeBody(metadata: PeerMetadata): Uint8Array {
       parts.push(hexToBytes(sc)); // 20 bytes
     } else {
       parts.push(new Uint8Array([0]));
+    }
+  }
+
+  if (metadata.version >= DOMAIN_VERIFICATION_METADATA_VERSION) {
+    const claims = (metadata.verifications?.domains ?? [])
+      .map((claim) => ({
+        domain: claim.domain.trim().toLowerCase(),
+        methods: claim.methods
+          ? Array.from(new Set(claim.methods.map((method) => method.trim() as DomainVerificationMethod)))
+          : undefined,
+      }))
+      .filter((claim) => claim.domain.length > 0)
+      .sort((a, b) => a.domain.localeCompare(b.domain));
+    parts.push(new Uint8Array([claims.length]));
+    for (const claim of claims) {
+      const domainBytes = new TextEncoder().encode(claim.domain);
+      parts.push(new Uint8Array([domainBytes.length]));
+      parts.push(domainBytes);
+      const methods = claim.methods
+        ? claim.methods
+          .slice()
+          .sort((a, b) => DOMAIN_VERIFICATION_METHOD_IDS[a] - DOMAIN_VERIFICATION_METHOD_IDS[b])
+        : [];
+      parts.push(new Uint8Array([methods.length]));
+      for (const method of methods) {
+        const methodId = DOMAIN_VERIFICATION_METHOD_IDS[method];
+        if (methodId === undefined) {
+          throw new Error(`Unsupported domain verification method "${method}"`);
+        }
+        parts.push(new Uint8Array([methodId]));
+      }
     }
   }
 
@@ -557,6 +597,42 @@ export function decodeMetadata(data: Uint8Array): PeerMetadata {
     }
   }
 
+  let domainVerifications: DomainVerificationClaim[] | undefined;
+  if (version >= DOMAIN_VERIFICATION_METADATA_VERSION) {
+    checkBounds(offset, 1, data.length - 65);
+    const domainVerificationCount = data[offset]!;
+    offset += 1;
+    if (domainVerificationCount > 0) {
+      domainVerifications = [];
+      for (let i = 0; i < domainVerificationCount; i += 1) {
+        checkBounds(offset, 1, data.length - 65);
+        const domainLen = data[offset]!;
+        offset += 1;
+        checkBounds(offset, domainLen, data.length - 65);
+        const domain = new TextDecoder().decode(data.slice(offset, offset + domainLen));
+        offset += domainLen;
+
+        checkBounds(offset, 1, data.length - 65);
+        const methodCount = data[offset]!;
+        offset += 1;
+        const methods: DomainVerificationMethod[] = [];
+        for (let j = 0; j < methodCount; j += 1) {
+          checkBounds(offset, 1, data.length - 65);
+          const method = DOMAIN_VERIFICATION_METHODS_BY_ID[data[offset]!];
+          offset += 1;
+          if (method === undefined) {
+            throw new Error("Unsupported domain verification method id");
+          }
+          methods.push(method);
+        }
+        domainVerifications.push({
+          domain,
+          ...(methods.length > 0 ? { methods } : {}),
+        });
+      }
+    }
+  }
+
   // offerings
   const PRICING_UNIT_REVERSE: Array<'token' | 'request' | 'minute' | 'task'> = ['token', 'request', 'minute', 'task'];
   let offerings: PeerOffering[] | undefined;
@@ -642,6 +718,7 @@ export function decodeMetadata(data: Uint8Array): PeerMetadata {
     ...(onChainChannelCount !== undefined ? { onChainChannelCount } : {}),
     ...(onChainGhostCount !== undefined ? { onChainGhostCount } : {}),
     ...(sellerContract ? { sellerContract } : {}),
+    ...(domainVerifications && domainVerifications.length > 0 ? { verifications: { domains: domainVerifications } } : {}),
     region,
     timestamp,
     signature,

--- a/packages/node/src/discovery/metadata-codec.ts
+++ b/packages/node/src/discovery/metadata-codec.ts
@@ -1,4 +1,4 @@
-import type { DomainVerificationClaim, DomainVerificationMethod, PeerMetadata } from "./peer-metadata.js";
+import type { DomainVerificationClaim, DomainVerificationMethod, GithubVerificationClaim, PeerMetadata } from "./peer-metadata.js";
 import type { PeerOffering } from "../types/capability.js";
 import { hexToBytes, bytesToHex } from "../utils/hex.js";
 import { toPeerId } from "../types/peer.js";
@@ -36,6 +36,8 @@ const DOMAIN_VERIFICATION_METHODS_BY_ID: DomainVerificationMethod[] = ["dns-txt"
  * [sellerContractFlag:1][sellerContract:20] (v8+ only)
  * [domainVerificationCount:1][domainVerificationEntries...] (v9+ only)
  * domainVerificationEntry(v9+): [domainLen:1][domain:N][methodCount:1][methodIds...]
+ * [githubVerificationCount:1][githubVerificationEntries...] (v9+ only)
+ * githubVerificationEntry(v9+): [usernameLen:1][username:N][repoLen:1][repo:N] (repoLen 0 = profile repo)
  * [signature:65]
  */
 export function encodeMetadata(metadata: PeerMetadata): Uint8Array {
@@ -277,6 +279,31 @@ function encodeBody(metadata: PeerMetadata): Uint8Array {
         }
         parts.push(new Uint8Array([methodId]));
       }
+    }
+
+    const githubClaims = (metadata.verifications?.github ?? [])
+      .map((claim) => ({
+        username: claim.username.trim().toLowerCase(),
+        repository: claim.repository ? claim.repository.trim().toLowerCase() : "",
+      }))
+      .filter((claim) => claim.username.length > 0)
+      // Code-unit sort for the same locale-independence reason as domains.
+      .sort((a, b) => (a.username < b.username ? -1 : a.username > b.username ? 1
+        : a.repository < b.repository ? -1 : a.repository > b.repository ? 1 : 0));
+    if (githubClaims.length > 255) {
+      throw new Error(`Too many GitHub verification claims (${githubClaims.length})`);
+    }
+    parts.push(new Uint8Array([githubClaims.length]));
+    for (const claim of githubClaims) {
+      const usernameBytes = new TextEncoder().encode(claim.username);
+      const repositoryBytes = new TextEncoder().encode(claim.repository);
+      if (usernameBytes.length > 255 || repositoryBytes.length > 255) {
+        throw new Error("GitHub verification claim too long");
+      }
+      parts.push(new Uint8Array([usernameBytes.length]));
+      parts.push(usernameBytes);
+      parts.push(new Uint8Array([repositoryBytes.length]));
+      parts.push(repositoryBytes);
     }
   }
 
@@ -642,6 +669,36 @@ export function decodeMetadata(data: Uint8Array): PeerMetadata {
     }
   }
 
+  let githubVerifications: GithubVerificationClaim[] | undefined;
+  if (version >= DOMAIN_VERIFICATION_METADATA_VERSION) {
+    checkBounds(offset, 1, data.length - 65);
+    const githubVerificationCount = data[offset]!;
+    offset += 1;
+    if (githubVerificationCount > 0) {
+      githubVerifications = [];
+      for (let i = 0; i < githubVerificationCount; i += 1) {
+        checkBounds(offset, 1, data.length - 65);
+        const usernameLen = data[offset]!;
+        offset += 1;
+        checkBounds(offset, usernameLen, data.length - 65);
+        const username = new TextDecoder().decode(data.slice(offset, offset + usernameLen));
+        offset += usernameLen;
+
+        checkBounds(offset, 1, data.length - 65);
+        const repositoryLen = data[offset]!;
+        offset += 1;
+        checkBounds(offset, repositoryLen, data.length - 65);
+        const repository = new TextDecoder().decode(data.slice(offset, offset + repositoryLen));
+        offset += repositoryLen;
+
+        githubVerifications.push({
+          username,
+          ...(repository.length > 0 ? { repository } : {}),
+        });
+      }
+    }
+  }
+
   // offerings
   const PRICING_UNIT_REVERSE: Array<'token' | 'request' | 'minute' | 'task'> = ['token', 'request', 'minute', 'task'];
   let offerings: PeerOffering[] | undefined;
@@ -717,6 +774,11 @@ export function decodeMetadata(data: Uint8Array): PeerMetadata {
   const signatureBytes = data.slice(offset, offset + 65);
   const signature = bytesToHex(signatureBytes);
 
+  const verifications = {
+    ...(domainVerifications && domainVerifications.length > 0 ? { domains: domainVerifications } : {}),
+    ...(githubVerifications && githubVerifications.length > 0 ? { github: githubVerifications } : {}),
+  };
+
   return {
     peerId: toPeerId(peerId),
     version,
@@ -727,7 +789,7 @@ export function decodeMetadata(data: Uint8Array): PeerMetadata {
     ...(onChainChannelCount !== undefined ? { onChainChannelCount } : {}),
     ...(onChainGhostCount !== undefined ? { onChainGhostCount } : {}),
     ...(sellerContract ? { sellerContract } : {}),
-    ...(domainVerifications && domainVerifications.length > 0 ? { verifications: { domains: domainVerifications } } : {}),
+    ...(Object.keys(verifications).length > 0 ? { verifications } : {}),
     region,
     timestamp,
     signature,

--- a/packages/node/src/discovery/metadata-validator.ts
+++ b/packages/node/src/discovery/metadata-validator.ts
@@ -1,22 +1,33 @@
-import type { PeerMetadata } from "./peer-metadata.js";
+import type { DomainVerificationMethod, PeerMetadata } from "./peer-metadata.js";
 import { METADATA_VERSION, WELL_KNOWN_SERVICE_API_PROTOCOLS } from "./peer-metadata.js";
 import { encodeMetadata } from "./metadata-codec.js";
 import { MAX_PUBLIC_ADDRESS_LENGTH, parsePublicAddress } from "./public-address.js";
 
-// v8 adds 21 bytes for the optional sellerContract field (1-byte flag + 20-byte
-// address). Bumped from 1000 so sellers already near the limit don't silently
-// fail validation when they enable a seller facade.
-export const MAX_METADATA_SIZE = 1024;
+// v9 adds signed domain verification claims. Keep enough room for several
+// normal hostnames while still bounding DHT-served metadata fetch payloads.
+export const MAX_METADATA_SIZE = 1400;
 export const MAX_PROVIDERS = 10;
 export const MAX_SERVICES_PER_PROVIDER = 20;
 export const MAX_SERVICE_NAME_LENGTH = 64;
 export const MAX_REGION_LENGTH = 32;
 export const MAX_DISPLAY_NAME_LENGTH = 64;
+export const MAX_DOMAIN_VERIFICATION_CLAIMS = 5;
+export const MAX_DOMAIN_LENGTH = 253;
 export const MAX_SERVICE_CATEGORIES_PER_SERVICE = 8;
 export const MAX_SERVICE_CATEGORY_LENGTH = 32;
 export const MAX_SERVICE_API_PROTOCOLS_PER_SERVICE = 4;
 const SERVICE_CATEGORY_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const DOMAIN_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+const DOMAIN_VERIFICATION_METHODS = new Set<DomainVerificationMethod>(["dns-txt", "https-well-known"]);
 const SERVICE_API_PROTOCOL_SET = new Set<string>(WELL_KNOWN_SERVICE_API_PROTOCOLS);
+
+function isValidDomainName(value: string): boolean {
+  if (value.length === 0 || value.length > MAX_DOMAIN_LENGTH) return false;
+  if (value.includes("..") || value.endsWith(".")) return false;
+  const labels = value.split(".");
+  if (labels.length < 2) return false;
+  return labels.every((label) => DOMAIN_LABEL_PATTERN.test(label));
+}
 
 export interface ValidationError {
   field: string;
@@ -92,6 +103,91 @@ export function validateMetadata(metadata: PeerMetadata): ValidationError[] {
   if (metadata.sellerContract !== undefined) {
     if (!/^[0-9a-f]{40}$/.test(metadata.sellerContract)) {
       errors.push({ field: "sellerContract", message: "Must be 40 lowercase hex chars" });
+    }
+  }
+
+  if (metadata.verifications !== undefined) {
+    if (!metadata.verifications || typeof metadata.verifications !== "object" || Array.isArray(metadata.verifications)) {
+      errors.push({ field: "verifications", message: "Must be an object when provided" });
+    } else {
+      const domainClaims = metadata.verifications.domains;
+      if (domainClaims !== undefined) {
+        if (!Array.isArray(domainClaims)) {
+          errors.push({ field: "verifications.domains", message: "Must be an array when provided" });
+        } else {
+          if (domainClaims.length === 0) {
+            errors.push({ field: "verifications.domains", message: "Must not be empty when provided" });
+          }
+          if (domainClaims.length > MAX_DOMAIN_VERIFICATION_CLAIMS) {
+            errors.push({
+              field: "verifications.domains",
+              message: `Domain verification claim count ${domainClaims.length} exceeds max ${MAX_DOMAIN_VERIFICATION_CLAIMS}`,
+            });
+          }
+          const domains = new Set<string>();
+          for (let i = 0; i < domainClaims.length; i += 1) {
+            const claim = domainClaims[i];
+            if (!claim || typeof claim !== "object" || Array.isArray(claim)) {
+              errors.push({ field: `verifications.domains[${i}]`, message: "Domain verification claim must be an object" });
+              continue;
+            }
+            const domain = typeof claim.domain === "string" ? claim.domain.trim().toLowerCase() : "";
+            if (!isValidDomainName(domain)) {
+              errors.push({
+                field: `verifications.domains[${i}].domain`,
+                message: "Domain must be a lower-case hostname with at least two labels",
+              });
+            } else if (domains.has(domain)) {
+              errors.push({
+                field: `verifications.domains[${i}].domain`,
+                message: "Domain verification claims must be unique",
+              });
+            }
+            domains.add(domain);
+
+            if (claim.methods !== undefined) {
+              if (!Array.isArray(claim.methods) || claim.methods.length === 0) {
+                errors.push({
+                  field: `verifications.domains[${i}].methods`,
+                  message: "Methods must be a non-empty string array when provided",
+                });
+              } else {
+                const methods = new Set<string>();
+                for (let j = 0; j < claim.methods.length; j += 1) {
+                  const method = claim.methods[j];
+                  if (typeof method !== "string" || !DOMAIN_VERIFICATION_METHODS.has(method as DomainVerificationMethod)) {
+                    errors.push({
+                      field: `verifications.domains[${i}].methods[${j}]`,
+                      message: "Unsupported domain verification method",
+                    });
+                    continue;
+                  }
+                  if (methods.has(method)) {
+                    errors.push({
+                      field: `verifications.domains[${i}].methods[${j}]`,
+                      message: "Domain verification methods must be unique per claim",
+                    });
+                  }
+                  methods.add(method);
+                }
+              }
+            }
+          }
+        }
+      }
+      const unknownKeys = Object.keys(metadata.verifications).filter((key) => key !== "domains");
+      for (const key of unknownKeys) {
+        errors.push({
+          field: `verifications.${key}`,
+          message: "Unsupported verification namespace",
+        });
+      }
+      if (metadata.verifications.domains === undefined && unknownKeys.length === 0) {
+        errors.push({
+          field: "verifications",
+          message: "Must include at least one verification namespace when provided",
+        });
+      }
     }
   }
 

--- a/packages/node/src/discovery/metadata-validator.ts
+++ b/packages/node/src/discovery/metadata-validator.ts
@@ -13,12 +13,18 @@ export const MAX_REGION_LENGTH = 32;
 export const MAX_DISPLAY_NAME_LENGTH = 64;
 export const MAX_DOMAIN_VERIFICATION_CLAIMS = 5;
 export const MAX_DOMAIN_LENGTH = 253;
+export const MAX_GITHUB_VERIFICATION_CLAIMS = 5;
+export const MAX_GITHUB_USERNAME_LENGTH = 39;
+export const MAX_GITHUB_REPOSITORY_LENGTH = 100;
 export const MAX_SERVICE_CATEGORIES_PER_SERVICE = 8;
 export const MAX_SERVICE_CATEGORY_LENGTH = 32;
 export const MAX_SERVICE_API_PROTOCOLS_PER_SERVICE = 4;
 const SERVICE_CATEGORY_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const DOMAIN_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const DOMAIN_VERIFICATION_METHODS = new Set<DomainVerificationMethod>(["dns-txt", "https-well-known"]);
+const GITHUB_USERNAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+const GITHUB_REPOSITORY_PATTERN = /^[a-z0-9._-]+$/;
+const VERIFICATION_NAMESPACES = new Set(["domains", "github"]);
 const SERVICE_API_PROTOCOL_SET = new Set<string>(WELL_KNOWN_SERVICE_API_PROTOCOLS);
 
 function isValidDomainName(value: string): boolean {
@@ -27,6 +33,21 @@ function isValidDomainName(value: string): boolean {
   const labels = value.split(".");
   if (labels.length < 2) return false;
   return labels.every((label) => DOMAIN_LABEL_PATTERN.test(label));
+}
+
+function isValidGithubUsername(value: string): boolean {
+  return value.length > 0
+    && value.length <= MAX_GITHUB_USERNAME_LENGTH
+    && !value.includes("--")
+    && GITHUB_USERNAME_PATTERN.test(value);
+}
+
+function isValidGithubRepository(value: string): boolean {
+  return value.length > 0
+    && value.length <= MAX_GITHUB_REPOSITORY_LENGTH
+    && value !== "."
+    && value !== ".."
+    && GITHUB_REPOSITORY_PATTERN.test(value);
 }
 
 export interface ValidationError {
@@ -175,14 +196,62 @@ export function validateMetadata(metadata: PeerMetadata): ValidationError[] {
           }
         }
       }
-      const unknownKeys = Object.keys(metadata.verifications).filter((key) => key !== "domains");
+      const githubClaims = metadata.verifications.github;
+      if (githubClaims !== undefined) {
+        if (!Array.isArray(githubClaims)) {
+          errors.push({ field: "verifications.github", message: "Must be an array when provided" });
+        } else {
+          if (githubClaims.length === 0) {
+            errors.push({ field: "verifications.github", message: "Must not be empty when provided" });
+          }
+          if (githubClaims.length > MAX_GITHUB_VERIFICATION_CLAIMS) {
+            errors.push({
+              field: "verifications.github",
+              message: `GitHub verification claim count ${githubClaims.length} exceeds max ${MAX_GITHUB_VERIFICATION_CLAIMS}`,
+            });
+          }
+          const seen = new Set<string>();
+          for (let i = 0; i < githubClaims.length; i += 1) {
+            const claim = githubClaims[i];
+            if (!claim || typeof claim !== "object" || Array.isArray(claim)) {
+              errors.push({ field: `verifications.github[${i}]`, message: "GitHub verification claim must be an object" });
+              continue;
+            }
+            const username = typeof claim.username === "string" ? claim.username.trim().toLowerCase() : "";
+            if (!isValidGithubUsername(username)) {
+              errors.push({
+                field: `verifications.github[${i}].username`,
+                message: "Username must be a valid lower-case GitHub username",
+              });
+            }
+            if (claim.repository !== undefined) {
+              const repository = typeof claim.repository === "string" ? claim.repository.trim().toLowerCase() : "";
+              if (!isValidGithubRepository(repository)) {
+                errors.push({
+                  field: `verifications.github[${i}].repository`,
+                  message: "Repository must be a valid lower-case GitHub repository name",
+                });
+              }
+            }
+            const key = `${username}/${typeof claim.repository === "string" ? claim.repository.trim().toLowerCase() : ""}`;
+            if (seen.has(key)) {
+              errors.push({
+                field: `verifications.github[${i}]`,
+                message: "GitHub verification claims must be unique",
+              });
+            }
+            seen.add(key);
+          }
+        }
+      }
+      const unknownKeys = Object.keys(metadata.verifications).filter((key) => !VERIFICATION_NAMESPACES.has(key));
       for (const key of unknownKeys) {
         errors.push({
           field: `verifications.${key}`,
           message: "Unsupported verification namespace",
         });
       }
-      if (metadata.verifications.domains === undefined && unknownKeys.length === 0) {
+      if (domainClaims === undefined && githubClaims === undefined && unknownKeys.length === 0) {
         errors.push({
           field: "verifications",
           message: "Must include at least one verification namespace when provided",

--- a/packages/node/src/discovery/peer-metadata.ts
+++ b/packages/node/src/discovery/peer-metadata.ts
@@ -41,6 +41,16 @@ export interface DomainVerificationClaim {
   methods?: DomainVerificationMethod[];
 }
 
+export interface GithubVerificationClaim {
+  /** GitHub username, lower-case. */
+  username: string;
+  /**
+   * Public repository holding the proof file, lower-case. Defaults to the
+   * profile repository `<username>/<username>` when omitted.
+   */
+  repository?: string;
+}
+
 export interface PeerVerifications {
   /**
    * Domain ownership claims. Clients verify by checking a matching DNS TXT
@@ -48,6 +58,12 @@ export interface PeerVerifications {
    * `https://<domain>/.well-known/antseed.json`.
    */
   domains?: DomainVerificationClaim[];
+  /**
+   * GitHub account ownership claims. Clients verify by fetching
+   * `https://raw.githubusercontent.com/<username>/<repository>/HEAD/antseed.json`
+   * — the username in the URL path binds the proof to the account.
+   */
+  github?: GithubVerificationClaim[];
 }
 
 export interface PeerMetadata {

--- a/packages/node/src/discovery/peer-metadata.ts
+++ b/packages/node/src/discovery/peer-metadata.ts
@@ -3,7 +3,7 @@ import type { PeerOffering } from "../types/capability.js";
 import type { ServiceApiProtocol } from "../types/service-api.js";
 import { WELL_KNOWN_SERVICE_API_PROTOCOLS } from "../types/service-api.js";
 
-export const METADATA_VERSION = 8;
+export const METADATA_VERSION = 9;
 export const WELL_KNOWN_SERVICE_CATEGORIES = [
   "privacy",
   "legal",
@@ -32,6 +32,24 @@ export interface ProviderAnnouncement {
   currentLoad: number;
 }
 
+export type DomainVerificationMethod = "dns-txt" | "https-well-known";
+
+export interface DomainVerificationClaim {
+  /** ASCII hostname only, lower-case, with no scheme, path, or port. */
+  domain: string;
+  /** Accepted proof transports. When omitted, clients may try every known method. */
+  methods?: DomainVerificationMethod[];
+}
+
+export interface PeerVerifications {
+  /**
+   * Domain ownership claims. Clients verify by checking a matching DNS TXT
+   * record at `_antseed.<domain>` or a well-known proof at
+   * `https://<domain>/.well-known/antseed.json`.
+   */
+  domains?: DomainVerificationClaim[];
+}
+
 export interface PeerMetadata {
   peerId: PeerId;
   version: number;
@@ -51,6 +69,8 @@ export interface PeerMetadata {
    * Stored as 40 lowercase hex chars (no `0x` prefix) matching `peerId` format.
    */
   sellerContract?: string;
+  /** Optional external ownership claims announced by this peer. */
+  verifications?: PeerVerifications;
   /**
    * Buyer-local observation time for this metadata fetch. Not signed and not
    * encoded in metadata; used only for diagnostics/freshness decisions.

--- a/packages/node/src/discovery/verification-utils.ts
+++ b/packages/node/src/discovery/verification-utils.ts
@@ -1,0 +1,86 @@
+// Shared internals for external-claim verifiers (domain-verification.ts,
+// github-verification.ts). Not exported from the package index.
+
+export const DEFAULT_VERIFICATION_TIMEOUT_MS = 3_000;
+// Proofs are tiny JSON documents; cap reads so a hostile host can't stream
+// an unbounded body into the verifying client.
+export const MAX_VERIFICATION_PROOF_BYTES = 4_096;
+
+export function normalizePeerId(peerId: string): string {
+  return peerId.trim().toLowerCase().replace(/^0x/, "");
+}
+
+export function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+    promise.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (err: unknown) => { clearTimeout(timer); reject(err); },
+    );
+  });
+}
+
+export function withTimeoutSignal(signal: AbortSignal | undefined, timeoutMs: number): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error("verification request timed out")), timeoutMs);
+  if (!signal) {
+    return {
+      signal: controller.signal,
+      cleanup: () => clearTimeout(timer),
+    };
+  }
+  const onAbort = () => controller.abort(signal.reason);
+  if (signal.aborted) {
+    onAbort();
+  } else {
+    signal.addEventListener("abort", onAbort, { once: true });
+  }
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+    },
+  };
+}
+
+export async function readBodyWithLimit(response: Response, maxBytes: number): Promise<string> {
+  const contentLength = Number(response.headers.get("content-length") ?? "");
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new Error(`Proof body exceeds ${maxBytes} bytes`);
+  }
+  if (!response.body) {
+    const text = await response.text();
+    if (text.length > maxBytes) {
+      throw new Error(`Proof body exceeds ${maxBytes} bytes`);
+    }
+    return text;
+  }
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => {});
+      throw new Error(`Proof body exceeds ${maxBytes} bytes`);
+    }
+    chunks.push(value);
+  }
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}

--- a/packages/node/src/discovery/verification-utils.ts
+++ b/packages/node/src/discovery/verification-utils.ts
@@ -58,7 +58,7 @@ export async function readBodyWithLimit(response: Response, maxBytes: number): P
   }
   if (!response.body) {
     const text = await response.text();
-    if (text.length > maxBytes) {
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
       throw new Error(`Proof body exceeds ${maxBytes} bytes`);
     }
     return text;

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -29,10 +29,26 @@ export { OFFICIAL_BOOTSTRAP_NODES, mergeBootstrapNodes, toBootstrapConfig } from
 export {
   WELL_KNOWN_SERVICE_CATEGORIES,
   WELL_KNOWN_SERVICE_API_PROTOCOLS,
+  type DomainVerificationClaim,
+  type DomainVerificationMethod,
   type ServiceApiProtocol,
   type PeerMetadata,
+  type PeerVerifications,
   type ProviderAnnouncement,
 } from './discovery/peer-metadata.js';
+export {
+  DOMAIN_VERIFICATION_TXT_PREFIX,
+  DOMAIN_VERIFICATION_TXT_NAME_PREFIX,
+  DOMAIN_VERIFICATION_WELL_KNOWN_PATH,
+  DOMAIN_VERIFICATION_WELL_KNOWN_TYPE,
+  buildDomainVerificationTxtValue,
+  buildDomainVerificationWellKnownProof,
+  verifyDomainVerificationClaim,
+  verifyPeerMetadataDomains,
+  type DomainVerificationAttemptResult,
+  type DomainVerificationOptions,
+  type DomainVerificationResult,
+} from './discovery/domain-verification.js';
 export { MetadataServer, type MetadataServerConfig } from './discovery/metadata-server.js';
 export { parsePublicAddress, MAX_PUBLIC_ADDRESS_LENGTH, type ParsedPublicAddress } from './discovery/public-address.js';
 export { MeteringStorage } from './metering/storage.js';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -31,6 +31,7 @@ export {
   WELL_KNOWN_SERVICE_API_PROTOCOLS,
   type DomainVerificationClaim,
   type DomainVerificationMethod,
+  type GithubVerificationClaim,
   type ServiceApiProtocol,
   type PeerMetadata,
   type PeerVerifications,
@@ -49,6 +50,16 @@ export {
   type DomainVerificationOptions,
   type DomainVerificationResult,
 } from './discovery/domain-verification.js';
+export {
+  GITHUB_VERIFICATION_PROOF_FILE,
+  GITHUB_VERIFICATION_PROOF_TYPE,
+  buildGithubVerificationProof,
+  buildGithubVerificationProofUrl,
+  verifyGithubVerificationClaim,
+  verifyPeerMetadataGithub,
+  type GithubVerificationOptions,
+  type GithubVerificationResult,
+} from './discovery/github-verification.js';
 export { MetadataServer, type MetadataServerConfig } from './discovery/metadata-server.js';
 export { parsePublicAddress, MAX_PUBLIC_ADDRESS_LENGTH, type ParsedPublicAddress } from './discovery/public-address.js';
 export { MeteringStorage } from './metering/storage.js';

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -35,6 +35,7 @@ import {
   type AnnouncerConfig,
   type SellerContractConfig,
 } from "./discovery/announcer.js";
+import type { PeerVerifications } from "./discovery/peer-metadata.js";
 import {
   PeerLookup,
   DEFAULT_LOOKUP_CONFIG,
@@ -159,6 +160,8 @@ export interface NodeConfig {
   displayName?: string;
   /** Publicly reachable seller address override ("host:port") announced in metadata. */
   publicAddress?: string;
+  /** External ownership claims announced in signed peer metadata. */
+  verifications?: PeerVerifications;
   dataDir?: string;           // Default: ~/.antseed
   dhtPort?: number;           // Default: 6881 for seller, 0 for buyer
   signalingPort?: number;     // Default: 6882 for seller
@@ -1201,6 +1204,7 @@ export class AntseedNode extends EventEmitter {
         })),
         ...(this._config.displayName ? { displayName: this._config.displayName } : {}),
         ...(this._config.publicAddress ? { publicAddress: this._config.publicAddress } : {}),
+        ...(this._config.verifications ? { verifications: this._config.verifications } : {}),
         region: "unknown",
         pricing: new Map(
           this._providers.map((p) => [

--- a/packages/node/tests/domain-verification.test.ts
+++ b/packages/node/tests/domain-verification.test.ts
@@ -58,6 +58,43 @@ describe("domain verification", () => {
     expect(result.method).toBe("https-well-known");
   });
 
+  it("rejects an HTTPS well-known proof without a domain", async () => {
+    const result = await verifyDomainVerificationClaim(
+      { domain: "example.com", methods: ["https-well-known"] },
+      PEER_ID,
+      {
+        fetch: async () => new Response(JSON.stringify({
+          type: DOMAIN_VERIFICATION_WELL_KNOWN_TYPE,
+          peerId: PEER_ID,
+        }), { status: 200 }),
+      },
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.attempts[0]).toMatchObject({
+      method: "https-well-known",
+      verified: false,
+      error: "Proof domain mismatch",
+    });
+  });
+
+  it("rejects an HTTPS well-known proof for a different domain", async () => {
+    const result = await verifyDomainVerificationClaim(
+      { domain: "example.com", methods: ["https-well-known"] },
+      PEER_ID,
+      {
+        fetch: async () => new Response(JSON.stringify({
+          type: DOMAIN_VERIFICATION_WELL_KNOWN_TYPE,
+          peerId: PEER_ID,
+          domain: "other.example.com",
+        }), { status: 200 }),
+      },
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.attempts[0]?.error).toBe("Proof domain mismatch");
+  });
+
   it("rejects oversized well-known proof bodies", async () => {
     const result = await verifyDomainVerificationClaim(
       { domain: "example.com", methods: ["https-well-known"] },

--- a/packages/node/tests/domain-verification.test.ts
+++ b/packages/node/tests/domain-verification.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DOMAIN_VERIFICATION_WELL_KNOWN_TYPE,
+  buildDomainVerificationTxtValue,
+  buildDomainVerificationWellKnownProof,
+  verifyDomainVerificationClaim,
+  verifyPeerMetadataDomains,
+} from "../src/discovery/domain-verification.js";
+import type { PeerMetadata } from "../src/discovery/peer-metadata.js";
+
+const PEER_ID = "aa".repeat(20);
+
+describe("domain verification", () => {
+  it("builds DNS TXT and well-known proof payloads", () => {
+    expect(buildDomainVerificationTxtValue(`0x${PEER_ID}`)).toBe(`antseed-peer=${PEER_ID}`);
+    expect(buildDomainVerificationWellKnownProof(PEER_ID, "Example.COM")).toEqual({
+      type: DOMAIN_VERIFICATION_WELL_KNOWN_TYPE,
+      peerId: PEER_ID,
+      domain: "example.com",
+    });
+  });
+
+  it("verifies a DNS TXT proof", async () => {
+    const result = await verifyDomainVerificationClaim(
+      { domain: "example.com", methods: ["dns-txt"] },
+      PEER_ID,
+      {
+        resolveTxt: async (hostname) => {
+          expect(hostname).toBe("_antseed.example.com");
+          return [[`antseed-peer=${PEER_ID}`]];
+        },
+      },
+    );
+
+    expect(result.verified).toBe(true);
+    expect(result.method).toBe("dns-txt");
+  });
+
+  it("verifies an HTTPS well-known proof", async () => {
+    const result = await verifyDomainVerificationClaim(
+      { domain: "example.com", methods: ["https-well-known"] },
+      PEER_ID,
+      {
+        fetch: async (input) => {
+          expect(String(input)).toBe("https://example.com/.well-known/antseed.json");
+          return new Response(JSON.stringify({
+            type: DOMAIN_VERIFICATION_WELL_KNOWN_TYPE,
+            peerId: PEER_ID,
+            domain: "example.com",
+          }), { status: 200 });
+        },
+      },
+    );
+
+    expect(result.verified).toBe(true);
+    expect(result.method).toBe("https-well-known");
+  });
+
+  it("reports failed attempts when proofs do not match", async () => {
+    const result = await verifyDomainVerificationClaim(
+      { domain: "example.com" },
+      PEER_ID,
+      {
+        resolveTxt: async () => [["antseed-peer=bb"]],
+        fetch: async () => new Response(JSON.stringify({
+          type: DOMAIN_VERIFICATION_WELL_KNOWN_TYPE,
+          peerId: "bb",
+          domain: "example.com",
+        }), { status: 200 }),
+      },
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.attempts).toHaveLength(2);
+    expect(result.attempts.every((attempt) => !attempt.verified && attempt.error)).toBe(true);
+  });
+
+  it("verifies every domain claim in peer metadata", async () => {
+    const metadata: PeerMetadata = {
+      peerId: PEER_ID,
+      version: 9,
+      providers: [],
+      region: "unknown",
+      timestamp: 1,
+      signature: "bb".repeat(65),
+      verifications: {
+        domains: [
+          { domain: "a.example.com", methods: ["dns-txt"] },
+          { domain: "b.example.com", methods: ["dns-txt"] },
+        ],
+      },
+    };
+
+    const results = await verifyPeerMetadataDomains(metadata, {
+      resolveTxt: async (hostname) => [[hostname === "_antseed.a.example.com" ? `antseed-peer=${PEER_ID}` : "nope"]],
+    });
+
+    expect(results.map((result) => result.verified)).toEqual([true, false]);
+  });
+});

--- a/packages/node/tests/domain-verification.test.ts
+++ b/packages/node/tests/domain-verification.test.ts
@@ -42,8 +42,9 @@ describe("domain verification", () => {
       { domain: "example.com", methods: ["https-well-known"] },
       PEER_ID,
       {
-        fetch: async (input) => {
+        fetch: async (input, init) => {
           expect(String(input)).toBe("https://example.com/.well-known/antseed.json");
+          expect(init?.redirect).toBe("error");
           return new Response(JSON.stringify({
             type: DOMAIN_VERIFICATION_WELL_KNOWN_TYPE,
             peerId: PEER_ID,
@@ -55,6 +56,33 @@ describe("domain verification", () => {
 
     expect(result.verified).toBe(true);
     expect(result.method).toBe("https-well-known");
+  });
+
+  it("rejects oversized well-known proof bodies", async () => {
+    const result = await verifyDomainVerificationClaim(
+      { domain: "example.com", methods: ["https-well-known"] },
+      PEER_ID,
+      {
+        fetch: async () => new Response(`"${"x".repeat(64 * 1024)}"`, { status: 200 }),
+      },
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.attempts[0]?.error).toMatch(/exceeds/);
+  });
+
+  it("times out hung DNS TXT lookups", async () => {
+    const result = await verifyDomainVerificationClaim(
+      { domain: "example.com", methods: ["dns-txt"] },
+      PEER_ID,
+      {
+        timeoutMs: 20,
+        resolveTxt: () => new Promise(() => {}),
+      },
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.attempts[0]?.error).toMatch(/timed out/);
   });
 
   it("reports failed attempts when proofs do not match", async () => {

--- a/packages/node/tests/github-verification.test.ts
+++ b/packages/node/tests/github-verification.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GITHUB_VERIFICATION_PROOF_TYPE,
+  buildGithubVerificationProof,
+  buildGithubVerificationProofUrl,
+  verifyGithubVerificationClaim,
+  verifyPeerMetadataGithub,
+} from "../src/discovery/github-verification.js";
+import type { PeerMetadata } from "../src/discovery/peer-metadata.js";
+
+const PEER_ID = "aa".repeat(20);
+
+function proofResponse(peerId: string, username: string): Response {
+  return new Response(JSON.stringify({
+    type: GITHUB_VERIFICATION_PROOF_TYPE,
+    peerId,
+    username,
+  }), { status: 200 });
+}
+
+describe("github verification", () => {
+  it("builds proof payload and URL with the profile repo default", () => {
+    expect(buildGithubVerificationProof(`0x${PEER_ID}`, "Octocat")).toEqual({
+      type: GITHUB_VERIFICATION_PROOF_TYPE,
+      peerId: PEER_ID,
+      username: "octocat",
+    });
+    expect(buildGithubVerificationProofUrl({ username: "Octocat" }))
+      .toBe("https://raw.githubusercontent.com/octocat/octocat/HEAD/antseed.json");
+    expect(buildGithubVerificationProofUrl({ username: "octocat", repository: "my-proofs" }))
+      .toBe("https://raw.githubusercontent.com/octocat/my-proofs/HEAD/antseed.json");
+  });
+
+  it("verifies a valid proof without following redirects", async () => {
+    const result = await verifyGithubVerificationClaim(
+      { username: "octocat" },
+      PEER_ID,
+      {
+        fetch: async (input, init) => {
+          expect(String(input)).toBe("https://raw.githubusercontent.com/octocat/octocat/HEAD/antseed.json");
+          expect(init?.redirect).toBe("error");
+          return proofResponse(PEER_ID, "octocat");
+        },
+      },
+    );
+
+    expect(result.verified).toBe(true);
+    expect(result.repository).toBe("octocat");
+  });
+
+  it("rejects proofs for a different peer or username", async () => {
+    const wrongPeer = await verifyGithubVerificationClaim(
+      { username: "octocat" },
+      PEER_ID,
+      { fetch: async () => proofResponse("bb".repeat(20), "octocat") },
+    );
+    expect(wrongPeer.verified).toBe(false);
+    expect(wrongPeer.error).toMatch(/peerId/);
+
+    const wrongUser = await verifyGithubVerificationClaim(
+      { username: "octocat" },
+      PEER_ID,
+      { fetch: async () => proofResponse(PEER_ID, "someone-else") },
+    );
+    expect(wrongUser.verified).toBe(false);
+    expect(wrongUser.error).toMatch(/username/);
+  });
+
+  it("rejects oversized proof bodies", async () => {
+    const result = await verifyGithubVerificationClaim(
+      { username: "octocat" },
+      PEER_ID,
+      { fetch: async () => new Response(`"${"x".repeat(64 * 1024)}"`, { status: 200 }) },
+    );
+
+    expect(result.verified).toBe(false);
+    expect(result.error).toMatch(/exceeds/);
+  });
+
+  it("verifies every github claim in peer metadata", async () => {
+    const metadata: PeerMetadata = {
+      peerId: PEER_ID,
+      version: 9,
+      providers: [],
+      region: "unknown",
+      timestamp: 1,
+      signature: "bb".repeat(65),
+      verifications: {
+        github: [
+          { username: "octocat" },
+          { username: "hubber", repository: "proofs" },
+        ],
+      },
+    };
+
+    const results = await verifyPeerMetadataGithub(metadata, {
+      fetch: async (input) => String(input).includes("/octocat/")
+        ? proofResponse(PEER_ID, "octocat")
+        : new Response("not found", { status: 404 }),
+    });
+
+    expect(results.map((result) => result.verified)).toEqual([true, false]);
+  });
+});

--- a/packages/node/tests/metadata-codec.test.ts
+++ b/packages/node/tests/metadata-codec.test.ts
@@ -219,6 +219,38 @@ describe('encodeMetadata / decodeMetadata', () => {
     });
   });
 
+  it("round-trips github verification claims", () => {
+    const original = makeMetadata({
+      verifications: {
+        github: [
+          { username: "Octocat", repository: "Proofs" },
+          { username: "hubber" },
+        ],
+      },
+    });
+    const decoded = decodeMetadata(encodeMetadata(original));
+    expect(decoded.verifications).toEqual({
+      github: [
+        { username: "hubber" },
+        { username: "octocat", repository: "proofs" },
+      ],
+    });
+  });
+
+  it("round-trips combined domain and github verification claims", () => {
+    const original = makeMetadata({
+      verifications: {
+        domains: [{ domain: "example.com", methods: ["dns-txt"] }],
+        github: [{ username: "octocat" }],
+      },
+    });
+    const decoded = decodeMetadata(encodeMetadata(original));
+    expect(decoded.verifications).toEqual({
+      domains: [{ domain: "example.com", methods: ["dns-txt"] }],
+      github: [{ username: "octocat" }],
+    });
+  });
+
   // v2/v3/v4/v5 roundtrip tests removed — pre-v6 format is rejected by the decoder.
 });
 

--- a/packages/node/tests/metadata-codec.test.ts
+++ b/packages/node/tests/metadata-codec.test.ts
@@ -201,6 +201,24 @@ describe('encodeMetadata / decodeMetadata', () => {
     expect(decoded.sellerContract).toBeUndefined();
   });
 
+  it("round-trips domain verification claims", () => {
+    const original = makeMetadata({
+      verifications: {
+        domains: [
+          { domain: "example.com", methods: ["https-well-known", "dns-txt"] },
+          { domain: "api.example.com" },
+        ],
+      },
+    });
+    const decoded = decodeMetadata(encodeMetadata(original));
+    expect(decoded.verifications).toEqual({
+      domains: [
+        { domain: "api.example.com" },
+        { domain: "example.com", methods: ["dns-txt", "https-well-known"] },
+      ],
+    });
+  });
+
   // v2/v3/v4/v5 roundtrip tests removed — pre-v6 format is rejected by the decoder.
 });
 

--- a/packages/node/tests/metadata-validator.test.ts
+++ b/packages/node/tests/metadata-validator.test.ts
@@ -8,6 +8,7 @@ import {
   MAX_REGION_LENGTH,
   MAX_DISPLAY_NAME_LENGTH,
   MAX_DOMAIN_VERIFICATION_CLAIMS,
+  MAX_GITHUB_VERIFICATION_CLAIMS,
   MAX_PUBLIC_ADDRESS_LENGTH,
   MAX_SERVICE_CATEGORY_LENGTH,
   MAX_SERVICE_API_PROTOCOLS_PER_SERVICE,
@@ -550,6 +551,47 @@ describe('validateMetadata', () => {
       },
     }));
     expect(errors.some(e => e.field === "verifications.domains")).toBe(true);
+  });
+
+  it("accepts valid github verification claims", () => {
+    const errors = validateMetadata(validMetadata({
+      verifications: {
+        github: [
+          { username: "octocat" },
+          { username: "octocat", repository: "antseed-proofs" },
+        ],
+      },
+    }));
+    expect(errors.filter(e => e.field.startsWith("verifications"))).toHaveLength(0);
+  });
+
+  it("rejects malformed github verification claims", () => {
+    const errors = validateMetadata(validMetadata({
+      verifications: {
+        github: [
+          { username: "-bad-" },
+          { username: "double--hyphen" },
+          { username: "octocat", repository: "bad repo!" },
+          { username: "octocat" },
+          { username: "octocat" },
+        ],
+      },
+    }));
+    expect(errors.some(e => e.field === "verifications.github[0].username")).toBe(true);
+    expect(errors.some(e => e.field === "verifications.github[1].username")).toBe(true);
+    expect(errors.some(e => e.field === "verifications.github[2].repository")).toBe(true);
+    expect(errors.some(e => e.field === "verifications.github[4]")).toBe(true);
+  });
+
+  it("rejects too many github verification claims", () => {
+    const errors = validateMetadata(validMetadata({
+      verifications: {
+        github: Array.from({ length: MAX_GITHUB_VERIFICATION_CLAIMS + 1 }, (_, i) => ({
+          username: `user-${i}`,
+        })),
+      },
+    }));
+    expect(errors.some(e => e.field === "verifications.github")).toBe(true);
   });
 });
 

--- a/packages/node/tests/metadata-validator.test.ts
+++ b/packages/node/tests/metadata-validator.test.ts
@@ -7,6 +7,7 @@ import {
   MAX_SERVICE_NAME_LENGTH,
   MAX_REGION_LENGTH,
   MAX_DISPLAY_NAME_LENGTH,
+  MAX_DOMAIN_VERIFICATION_CLAIMS,
   MAX_PUBLIC_ADDRESS_LENGTH,
   MAX_SERVICE_CATEGORY_LENGTH,
   MAX_SERVICE_API_PROTOCOLS_PER_SERVICE,
@@ -513,11 +514,48 @@ describe('validateMetadata', () => {
     const errors = validateMetadata(validMetadata({ sellerContract: "bb".repeat(20) }));
     expect(errors.filter(e => e.field === "sellerContract")).toHaveLength(0);
   });
+
+  it("accepts valid domain verification claims", () => {
+    const errors = validateMetadata(validMetadata({
+      verifications: {
+        domains: [
+          { domain: "example.com", methods: ["dns-txt", "https-well-known"] },
+        ],
+      },
+    }));
+    expect(errors.filter(e => e.field.startsWith("verifications"))).toHaveLength(0);
+  });
+
+  it("rejects malformed domain verification claims", () => {
+    const errors = validateMetadata(validMetadata({
+      verifications: {
+        domains: [
+          { domain: "https://example.com", methods: ["dns-txt"] },
+          { domain: "example.com", methods: ["dns-txt", "dns-txt"] },
+          { domain: "bad-method.example.com", methods: ["bogus" as any] },
+        ],
+      },
+    }));
+    expect(errors.some(e => e.field === "verifications.domains[0].domain")).toBe(true);
+    expect(errors.some(e => e.field === "verifications.domains[1].methods[1]")).toBe(true);
+    expect(errors.some(e => e.field === "verifications.domains[2].methods[0]")).toBe(true);
+  });
+
+  it("rejects too many domain verification claims", () => {
+    const errors = validateMetadata(validMetadata({
+      verifications: {
+        domains: Array.from({ length: MAX_DOMAIN_VERIFICATION_CLAIMS + 1 }, (_, i) => ({
+          domain: `example-${i}.com`,
+        })),
+      },
+    }));
+    expect(errors.some(e => e.field === "verifications.domains")).toBe(true);
+  });
 });
 
 describe('constants', () => {
   it('should export reasonable constant values', () => {
-    expect(MAX_METADATA_SIZE).toBe(1024);
+    expect(MAX_METADATA_SIZE).toBe(1400);
     expect(MAX_PROVIDERS).toBe(10);
     expect(MAX_SERVICES_PER_PROVIDER).toBe(20);
     expect(MAX_SERVICE_NAME_LENGTH).toBe(64);

--- a/packages/node/tests/verification-utils.test.ts
+++ b/packages/node/tests/verification-utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { readBodyWithLimit } from "../src/discovery/verification-utils.js";
+
+function textFallbackResponse(text: string): Response {
+  return {
+    headers: new Headers(),
+    body: null,
+    text: async () => text,
+  } as unknown as Response;
+}
+
+describe("verification utils", () => {
+  it("counts bytes in the non-streaming body fallback", async () => {
+    await expect(readBodyWithLimit(textFallbackResponse("é".repeat(2_049)), 4_096))
+      .rejects.toThrow("Proof body exceeds 4096 bytes");
+  });
+
+  it("accepts non-streaming bodies within the byte limit", async () => {
+    await expect(readBodyWithLimit(textFallbackResponse("é".repeat(2_048)), 4_096))
+      .resolves.toBe("é".repeat(2_048));
+  });
+});


### PR DESCRIPTION
## Description

Adds seller-owned domain and GitHub account verification claims to announced peer metadata. Seller config now preserves verification claims, validates their shape, and publishes normalized verification metadata for discovery clients.

## Release Notes

- Added seller domain verification claims in peer metadata
- Added seller GitHub account verification claims in peer metadata

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
