### PR TITLE
feat(node): Add peer metadata capabilities

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -554,6 +554,7 @@ test('parsePersistedPeers preserves provider metadata so routing filters still w
         displayName: 'Alice',
         publicAddress: '1.2.3.4:1234',
         providers: ['claude-oauth'],
+        capabilities: ['verification.response-auth.v1'],
         services: ['claude-opus-4-6'],
         providerPricing: null,
         providerServiceCategories: null,
@@ -577,6 +578,8 @@ test('parsePersistedPeers preserves provider metadata so routing filters still w
   assert.equal(peer!.displayName, 'Alice')
   assert.equal(peer!.publicAddress, '1.2.3.4:1234')
   assert.deepEqual(peer!.providers, ['claude-oauth'])
+  assert.deepEqual(peer!.capabilities, ['verification.response-auth.v1'])
+  assert.deepEqual(peer!.metadata?.capabilities, ['verification.response-auth.v1'])
   assert.equal(peer!.defaultInputUsdPerMillion, 3)
   assert.equal(peer!.defaultOutputUsdPerMillion, 15)
   assert.equal(peer!.maxConcurrency, 4)

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -250,6 +250,10 @@ export function parsePersistedPeers(
       lastSeen,
       providers,
     }
+    if (Array.isArray(entry.capabilities)) {
+      const capabilities = entry.capabilities.filter((capability): capability is string => typeof capability === 'string')
+      if (capabilities.length > 0) peer.capabilities = capabilities
+    }
     if (lastReachedAt > 0) peer.lastReachedAt = lastReachedAt
     if (typeof entry.displayName === 'string') peer.displayName = entry.displayName
     if (typeof entry.publicAddress === 'string') peer.publicAddress = entry.publicAddress
@@ -318,7 +322,10 @@ export function parsePersistedPeers(
     // wallet, and `reserve()` reverts on-chain with InvalidSignature() because
     // the contract derives channelId from msg.sender (the facade).
     if (typeof entry.sellerContract === 'string' && entry.sellerContract.length > 0) {
-      peer.metadata = { sellerContract: entry.sellerContract } as PeerMetadata
+      peer.metadata = { ...(peer.metadata ?? {}), sellerContract: entry.sellerContract } as PeerMetadata
+    }
+    if (peer.capabilities && peer.capabilities.length > 0) {
+      peer.metadata = { ...(peer.metadata ?? {}), capabilities: [...peer.capabilities] } as PeerMetadata
     }
     peers.push(peer)
   }
@@ -601,6 +608,7 @@ export class BuyerProxy {
         displayName: p.displayName ?? null,
         publicAddress: p.publicAddress ?? null,
         providers: p.providers,
+        capabilities: p.capabilities ?? p.metadata?.capabilities ?? [],
         services,
         providerPricing: p.providerPricing ?? null,
         providerServiceCategories: p.providerServiceCategories ?? null,

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -29,6 +29,7 @@ import { bytesToHex } from "../utils/hex.js";
 import type { StakingClient } from "../payments/evm/staking-client.js";
 import type { ChannelsClient } from "../payments/evm/channels-client.js";
 import type { DHTHealthMonitor } from "./dht-health.js";
+import { CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 } from "../types/protocol.js";
 
 export interface SellerContractConfig {
   /**
@@ -276,6 +277,7 @@ export class PeerAnnouncer {
       ...(this.config.displayName ? { displayName: this.config.displayName } : {}),
       ...(this.config.publicAddress ? { publicAddress: this.config.publicAddress } : {}),
       providers,
+      capabilities: [CONNECTION_CAPABILITY_RESPONSE_AUTH_V1],
       region: this.config.region,
       timestamp: Date.now(),
       signature: "",

--- a/packages/node/src/discovery/metadata-codec.ts
+++ b/packages/node/src/discovery/metadata-codec.ts
@@ -10,6 +10,7 @@ const SERVICE_API_PROTOCOLS_METADATA_VERSION = 4;
 const PUBLIC_ADDRESS_METADATA_VERSION = 5;
 const SELLER_CONTRACT_METADATA_VERSION = 8;
 const DOMAIN_VERIFICATION_METADATA_VERSION = 9;
+const PEER_CAPABILITIES_METADATA_VERSION = 10;
 const DOMAIN_VERIFICATION_METHOD_IDS: Record<DomainVerificationMethod, number> = {
   "dns-txt": 0,
   "https-well-known": 1,
@@ -38,6 +39,10 @@ const DOMAIN_VERIFICATION_METHODS_BY_ID: DomainVerificationMethod[] = ["dns-txt"
  * domainVerificationEntry(v9+): [domainLen:1][domain:N][methodCount:1][methodIds...]
  * [githubVerificationCount:1][githubVerificationEntries...] (v9+ only)
  * githubVerificationEntry(v9+): [usernameLen:1][username:N][repoLen:1][repo:N] (repoLen 0 = profile repo)
+ * [offerings...]
+ * [onChainStatsFlag:1][onChainStats:10]
+ * [capabilityCount:1][capabilities...] (v10+ only)
+ * capability(v10+): [capabilityLen:1][capability:N]
  * [signature:65]
  */
 export function encodeMetadata(metadata: PeerMetadata): Uint8Array {
@@ -357,6 +362,22 @@ function encodeBody(metadata: PeerMetadata): Uint8Array {
     parts.push(new Uint8Array(repBuf));
   } else {
     parts.push(new Uint8Array([0])); // flag: absent
+  }
+
+  if (metadata.version >= PEER_CAPABILITIES_METADATA_VERSION) {
+    const capabilities = Array.from(
+      new Set(
+        (metadata.capabilities ?? [])
+          .map((capability) => capability.trim().toLowerCase())
+          .filter((capability) => capability.length > 0),
+      ),
+    ).sort();
+    parts.push(new Uint8Array([capabilities.length]));
+    for (const capability of capabilities) {
+      const capabilityBytes = new TextEncoder().encode(capability);
+      parts.push(new Uint8Array([capabilityBytes.length]));
+      parts.push(capabilityBytes);
+    }
   }
 
   // Combine all parts
@@ -769,6 +790,25 @@ export function decodeMetadata(data: Uint8Array): PeerMetadata {
     }
   }
 
+  let capabilities: string[] | undefined;
+  if (version >= PEER_CAPABILITIES_METADATA_VERSION) {
+    checkBounds(offset, 1, data.length - 65);
+    const capabilityCount = data[offset]!;
+    offset += 1;
+    if (capabilityCount > 0) {
+      capabilities = [];
+      for (let i = 0; i < capabilityCount; i++) {
+        checkBounds(offset, 1, data.length - 65);
+        const capabilityLen = data[offset]!;
+        offset += 1;
+        checkBounds(offset, capabilityLen, data.length - 65);
+        const capability = new TextDecoder().decode(data.slice(offset, offset + capabilityLen));
+        offset += capabilityLen;
+        capabilities.push(capability);
+      }
+    }
+  }
+
   // signature: 65 bytes (secp256k1 r+s+v)
   checkBounds(offset, 65, data.length);
   const signatureBytes = data.slice(offset, offset + 65);
@@ -788,6 +828,7 @@ export function decodeMetadata(data: Uint8Array): PeerMetadata {
     ...(offerings && offerings.length > 0 ? { offerings } : {}),
     ...(onChainChannelCount !== undefined ? { onChainChannelCount } : {}),
     ...(onChainGhostCount !== undefined ? { onChainGhostCount } : {}),
+    ...(capabilities && capabilities.length > 0 ? { capabilities } : {}),
     ...(sellerContract ? { sellerContract } : {}),
     ...(Object.keys(verifications).length > 0 ? { verifications } : {}),
     region,

--- a/packages/node/src/discovery/metadata-validator.ts
+++ b/packages/node/src/discovery/metadata-validator.ts
@@ -3,8 +3,8 @@ import { METADATA_VERSION, WELL_KNOWN_SERVICE_API_PROTOCOLS } from "./peer-metad
 import { encodeMetadata } from "./metadata-codec.js";
 import { MAX_PUBLIC_ADDRESS_LENGTH, parsePublicAddress } from "./public-address.js";
 
-// v9 adds signed domain verification claims. Keep enough room for several
-// normal hostnames while still bounding DHT-served metadata fetch payloads.
+// v9 adds signed verification claims and v10 adds peer capabilities. Keep
+// enough room for several normal claims while bounding DHT-served metadata.
 export const MAX_METADATA_SIZE = 1400;
 export const MAX_PROVIDERS = 10;
 export const MAX_SERVICES_PER_PROVIDER = 20;
@@ -19,12 +19,15 @@ export const MAX_GITHUB_REPOSITORY_LENGTH = 100;
 export const MAX_SERVICE_CATEGORIES_PER_SERVICE = 8;
 export const MAX_SERVICE_CATEGORY_LENGTH = 32;
 export const MAX_SERVICE_API_PROTOCOLS_PER_SERVICE = 4;
+export const MAX_PEER_CAPABILITIES = 16;
+export const MAX_PEER_CAPABILITY_LENGTH = 64;
 const SERVICE_CATEGORY_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const DOMAIN_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const DOMAIN_VERIFICATION_METHODS = new Set<DomainVerificationMethod>(["dns-txt", "https-well-known"]);
 const GITHUB_USERNAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
 const GITHUB_REPOSITORY_PATTERN = /^[a-z0-9._-]+$/;
 const VERIFICATION_NAMESPACES = new Set(["domains", "github"]);
+const PEER_CAPABILITY_PATTERN = /^[a-z0-9][a-z0-9.-]*$/;
 const SERVICE_API_PROTOCOL_SET = new Set<string>(WELL_KNOWN_SERVICE_API_PROTOCOLS);
 
 function isValidDomainName(value: string): boolean {
@@ -256,6 +259,50 @@ export function validateMetadata(metadata: PeerMetadata): ValidationError[] {
           field: "verifications",
           message: "Must include at least one verification namespace when provided",
         });
+      }
+    }
+  }
+
+  if (metadata.capabilities !== undefined) {
+    if (!Array.isArray(metadata.capabilities)) {
+      errors.push({ field: "capabilities", message: "Capabilities must be a string array" });
+    } else {
+      if (metadata.capabilities.length > MAX_PEER_CAPABILITIES) {
+        errors.push({
+          field: "capabilities",
+          message: `Capability count ${metadata.capabilities.length} exceeds max ${MAX_PEER_CAPABILITIES}`,
+        });
+      }
+      const deduped = new Set<string>();
+      for (let i = 0; i < metadata.capabilities.length; i++) {
+        const capability = metadata.capabilities[i];
+        if (typeof capability !== "string" || capability.trim().length === 0) {
+          errors.push({
+            field: `capabilities[${i}]`,
+            message: "Capability must be a non-empty string",
+          });
+          continue;
+        }
+        const normalized = capability.trim().toLowerCase();
+        if (normalized.length > MAX_PEER_CAPABILITY_LENGTH) {
+          errors.push({
+            field: `capabilities[${i}]`,
+            message: `Capability length ${normalized.length} exceeds max ${MAX_PEER_CAPABILITY_LENGTH}`,
+          });
+        }
+        if (!PEER_CAPABILITY_PATTERN.test(normalized)) {
+          errors.push({
+            field: `capabilities[${i}]`,
+            message: "Capability must use lowercase letters, digits, hyphen, or dot",
+          });
+        }
+        if (deduped.has(normalized)) {
+          errors.push({
+            field: `capabilities[${i}]`,
+            message: "Capability values must be unique",
+          });
+        }
+        deduped.add(normalized);
       }
     }
   }

--- a/packages/node/src/discovery/peer-metadata.ts
+++ b/packages/node/src/discovery/peer-metadata.ts
@@ -3,7 +3,7 @@ import type { PeerOffering } from "../types/capability.js";
 import type { ServiceApiProtocol } from "../types/service-api.js";
 import { WELL_KNOWN_SERVICE_API_PROTOCOLS } from "../types/service-api.js";
 
-export const METADATA_VERSION = 9;
+export const METADATA_VERSION = 10;
 export const WELL_KNOWN_SERVICE_CATEGORIES = [
   "privacy",
   "legal",
@@ -78,6 +78,8 @@ export interface PeerMetadata {
   stakeAmountUSDC?: number;
   onChainChannelCount?: number;
   onChainGhostCount?: number;
+  /** Protocol capabilities supported by this peer. */
+  capabilities?: string[];
   /**
    * On-chain seller contract that fronts this peer (e.g. a DiemStakingProxy).
    * Buyers resolve `seller = sellerContract` for channel flows and verify the

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1748,6 +1748,9 @@ export class AntseedNode extends EventEmitter {
       lastSeen: result.metadata.resolvedAtMs ?? Date.now(),
       metadata: result.metadata,
       providers,
+      ...(result.metadata.capabilities && result.metadata.capabilities.length > 0
+        ? { capabilities: [...result.metadata.capabilities] }
+        : {}),
       publicAddress: this._resolvePublicAddress(result),
       ...(hasProviderPricing ? { providerPricing: providerPricingEntries } : {}),
       ...(hasProviderServiceCategories ? { providerServiceCategories: providerServiceCategoryEntries } : {}),

--- a/packages/node/src/types/peer.ts
+++ b/packages/node/src/types/peer.ts
@@ -62,6 +62,8 @@ export interface PeerInfo {
   lastReachedAt?: number;
   /** LLM providers this peer is offering (empty if buyer-only). */
   providers: string[];
+  /** Protocol capabilities announced by the peer. */
+  capabilities?: string[];
   /** Seller-reported reputation score (0-100). */
   reputationScore?: number;
   /** Provider/service-aware pricing map announced by seller. */

--- a/packages/node/tests/announcer.test.ts
+++ b/packages/node/tests/announcer.test.ts
@@ -4,6 +4,7 @@ import { Wallet } from 'ethers';
 import { PeerAnnouncer, type AnnouncerConfig } from '../src/discovery/announcer.js';
 import { bytesToHex } from '../src/p2p/identity.js';
 import { toPeerId } from '../src/types/peer.js';
+import { CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 } from '../src/types/protocol.js';
 
 function makeBaseConfig(): AnnouncerConfig {
   const privateKey = randomBytes(32);
@@ -50,5 +51,14 @@ describe('PeerAnnouncer sellerContract', () => {
     await announcer.announce();
     const meta = announcer.getLatestMetadata();
     expect(meta?.sellerContract).toBeUndefined();
+  });
+});
+
+describe('PeerAnnouncer capabilities', () => {
+  it('publishes response auth support in metadata', async () => {
+    const announcer = new PeerAnnouncer(makeBaseConfig());
+    await announcer.announce();
+    const meta = announcer.getLatestMetadata();
+    expect(meta?.capabilities).toEqual([CONNECTION_CAPABILITY_RESPONSE_AUTH_V1]);
   });
 });

--- a/packages/node/tests/metadata-codec.test.ts
+++ b/packages/node/tests/metadata-codec.test.ts
@@ -251,6 +251,21 @@ describe('encodeMetadata / decodeMetadata', () => {
     });
   });
 
+  it("round-trips v10 metadata with peer capabilities", () => {
+    const meta: PeerMetadata = {
+      peerId: "aa".repeat(20),
+      version: METADATA_VERSION,
+      region: "us-east-1",
+      timestamp: 1_700_000_000_000,
+      providers: [],
+      capabilities: ["verification.response-auth.v1"],
+      signature: "dd".repeat(65),
+    };
+    const bytes = encodeMetadata(meta);
+    const decoded = decodeMetadata(bytes);
+    expect(decoded.capabilities).toEqual(["verification.response-auth.v1"]);
+  });
+
   // v2/v3/v4/v5 roundtrip tests removed — pre-v6 format is rejected by the decoder.
 });
 

--- a/packages/node/tests/metadata-validator.test.ts
+++ b/packages/node/tests/metadata-validator.test.ts
@@ -12,6 +12,7 @@ import {
   MAX_PUBLIC_ADDRESS_LENGTH,
   MAX_SERVICE_CATEGORY_LENGTH,
   MAX_SERVICE_API_PROTOCOLS_PER_SERVICE,
+  MAX_PEER_CAPABILITIES,
 } from '../src/discovery/metadata-validator.js';
 import { METADATA_VERSION, type PeerMetadata } from '../src/discovery/peer-metadata.js';
 
@@ -592,6 +593,26 @@ describe('validateMetadata', () => {
       },
     }));
     expect(errors.some(e => e.field === "verifications.github")).toBe(true);
+  });
+
+  it("accepts well-formed peer capabilities", () => {
+    const errors = validateMetadata(validMetadata({ capabilities: ["verification.response-auth.v1"] }));
+    expect(errors.filter(e => e.field.startsWith("capabilities"))).toHaveLength(0);
+  });
+
+  it("rejects duplicate or malformed peer capabilities", () => {
+    const errors = validateMetadata(validMetadata({
+      capabilities: ["verification.response-auth.v1", "Verification.Response-Auth.V1", "bad capability"],
+    }));
+    expect(errors.some(e => e.field === "capabilities[1]")).toBe(true);
+    expect(errors.some(e => e.field === "capabilities[2]")).toBe(true);
+  });
+
+  it("rejects too many peer capabilities", () => {
+    const errors = validateMetadata(validMetadata({
+      capabilities: Array.from({ length: MAX_PEER_CAPABILITIES + 1 }, (_, i) => `capability.${i}`),
+    }));
+    expect(errors.some(e => e.field === "capabilities")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Description

Adds a signed `capabilities` array to peer metadata so sellers can announce protocol capabilities such as response authorization support. This resolves the metadata conflict with seller domain/GitHub verification by keeping verification claims in metadata v9 and adding capabilities in metadata v10.

## Release Notes

- Added seller peer metadata capabilities for protocol feature discovery
- Sellers now announce `verification.response-auth.v1` when response authorization is supported

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
