### PR TITLE
feat(config): Configure response auth sampling

### DIFF
--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -357,6 +357,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
         configPath: globalOpts.config,
         metadataFetchTimeoutMs: effectiveBuyerConfig.metadataFetchTimeoutMs,
         payments: paymentsConfig,
+        verification: effectiveBuyerConfig.verification,
       })
 
       node.setRouter(router)

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -120,6 +120,44 @@ test('loadConfig preserves explicit buyer peerRefreshIntervalMs and metadataFetc
   );
 });
 
+test('loadConfig preserves buyer verification sampling settings', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      buyer: {
+        verification: {
+          sampleRate: 1,
+          maxSampleBytes: 1048576,
+        },
+      },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.deepEqual(config.buyer.verification, {
+        sampleRate: 1,
+        maxSampleBytes: 1048576,
+      });
+    }
+  );
+});
+
+test('loadConfig rejects invalid buyer verification sampleRate', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      buyer: {
+        verification: {
+          sampleRate: 1.1,
+        },
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        async () => loadConfig(configPath),
+        /buyer\.verification\.sampleRate/
+      );
+    }
+  );
+});
+
 test('loadConfig rejects invalid buyer peerRefreshIntervalMs', async () => {
   await withTempConfig(
     JSON.stringify({

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -311,6 +311,32 @@ function normalizeMinPeerReputation(value: unknown, fallback: number): number {
   return value === 50 ? fallback : value;
 }
 
+function cloneBuyerVerification(
+  value: AntseedConfig['buyer']['verification'],
+): AntseedConfig['buyer']['verification'] {
+  if (!value) return undefined;
+  return {
+    ...(value.sampleRate !== undefined ? { sampleRate: value.sampleRate } : {}),
+    ...(value.maxSampleBytes !== undefined ? { maxSampleBytes: value.maxSampleBytes } : {}),
+  };
+}
+
+function normalizeBuyerVerification(
+  value: unknown,
+  fallback?: AntseedConfig['buyer']['verification'],
+): { verification: NonNullable<AntseedConfig['buyer']['verification']> } | Record<string, never> {
+  if (!isRecord(value)) {
+    const cloned = cloneBuyerVerification(fallback);
+    return cloned ? { verification: cloned } : {};
+  }
+  return {
+    verification: {
+      ...(value['sampleRate'] !== undefined ? { sampleRate: toFiniteOrNaN(value['sampleRate']) } : {}),
+      ...(value['maxSampleBytes'] !== undefined ? { maxSampleBytes: toFiniteOrNaN(value['maxSampleBytes']) } : {}),
+    },
+  };
+}
+
 function mergeBuyerConfig(
   defaults: AntseedConfig['buyer'],
   value: unknown
@@ -322,6 +348,7 @@ function mergeBuyerConfig(
       proxyPort: defaults.proxyPort,
       peerRefreshIntervalMs: defaults.peerRefreshIntervalMs,
       metadataFetchTimeoutMs: defaults.metadataFetchTimeoutMs,
+      ...(normalizeBuyerVerification(undefined, defaults.verification)),
     };
   }
   return {
@@ -336,6 +363,7 @@ function mergeBuyerConfig(
     metadataFetchTimeoutMs: typeof value['metadataFetchTimeoutMs'] === 'number'
       ? value['metadataFetchTimeoutMs']
       : defaults.metadataFetchTimeoutMs,
+    ...(normalizeBuyerVerification(value['verification'], defaults.verification)),
   };
 }
 

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -88,6 +88,13 @@ export interface VerificationConfig {
   github?: GithubVerificationConfig[];
 }
 
+export interface BuyerVerificationConfig {
+  /** Random sample rate for storing full response-auth evidence, from 0 to 1. */
+  sampleRate?: number;
+  /** Maximum combined encoded request + response bytes per sample. */
+  maxSampleBytes?: number;
+}
+
 /**
  * Seller-specific configuration within the Antseed config.
  */
@@ -134,6 +141,8 @@ export interface BuyerCLIConfig {
   peerRefreshIntervalMs: number;
   /** Timeout in ms for each HTTP metadata fetch during peer discovery */
   metadataFetchTimeoutMs: number;
+  /** Buyer-side response-auth evidence sampling settings. */
+  verification?: BuyerVerificationConfig;
 }
 
 /**

--- a/apps/cli/src/config/validation.ts
+++ b/apps/cli/src/config/validation.ts
@@ -270,6 +270,30 @@ function validateVerifications(
   }
 }
 
+function validateBuyerVerification(
+  path: string,
+  verification: AntseedConfig['buyer']['verification'],
+  errors: string[],
+): void {
+  if (verification === undefined) return;
+  if (!verification || typeof verification !== 'object' || Array.isArray(verification)) {
+    errors.push(`${path} must be an object when provided`);
+    return;
+  }
+  if (
+    verification.sampleRate !== undefined &&
+    (!Number.isFinite(verification.sampleRate) || verification.sampleRate < 0 || verification.sampleRate > 1)
+  ) {
+    errors.push(`${path}.sampleRate must be a number in range 0-1`);
+  }
+  if (
+    verification.maxSampleBytes !== undefined &&
+    (!Number.isInteger(verification.maxSampleBytes) || verification.maxSampleBytes < 1)
+  ) {
+    errors.push(`${path}.maxSampleBytes must be an integer >= 1`);
+  }
+}
+
 /**
  * Validate the full config and return all issues.
  */
@@ -294,6 +318,8 @@ export function validateConfig(config: AntseedConfig): string[] {
   if (!Number.isInteger(config.buyer.metadataFetchTimeoutMs) || config.buyer.metadataFetchTimeoutMs < MIN_BUYER_METADATA_FETCH_TIMEOUT_MS) {
     errors.push('buyer.metadataFetchTimeoutMs must be an integer >= 100');
   }
+
+  validateBuyerVerification('buyer.verification', config.buyer.verification, errors);
 
   if (!Number.isInteger(config.seller.maxConcurrentBuyers) || config.seller.maxConcurrentBuyers < 1) {
     errors.push('seller.maxConcurrentBuyers must be an integer >= 1');

--- a/packages/node/src/verification/samples.ts
+++ b/packages/node/src/verification/samples.ts
@@ -6,7 +6,7 @@ import type { ResponseAuthPayload } from '../types/protocol.js';
 import { encodeHttpRequest, encodeHttpResponse } from '../proxy/request-codec.js';
 
 const SAMPLE_RANDOM_SCALE = 1_000_000;
-const DEFAULT_SAMPLE_RATE = 0.01;
+const DEFAULT_SAMPLE_RATE = 0.2;
 const DEFAULT_MAX_SAMPLE_BYTES = 16 * 1024 * 1024;
 
 export interface VerificationSampleConfig {

--- a/packages/node/tests/verification-samples.test.ts
+++ b/packages/node/tests/verification-samples.test.ts
@@ -27,6 +27,14 @@ function makeResponse(body = JSON.stringify({ content: [{ type: 'text', text: 's
 }
 
 describe('VerificationSampler', () => {
+  it('defaults to a 20 percent sample rate', () => {
+    const samplerHit = new VerificationSampler('/tmp/unused', { random: () => 0.199 });
+    const samplerMiss = new VerificationSampler('/tmp/unused', { random: () => 0.2 });
+
+    expect(samplerHit.shouldSample()).toBe(true);
+    expect(samplerMiss.shouldSample()).toBe(false);
+  });
+
   it('stores sampled request and response evidence with the response auth manifest', async () => {
     const tempDir = mkdtempSync(join(tmpdir(), 'verification-samples-test-'));
     try {


### PR DESCRIPTION
## Description

Raises the default response-auth evidence sample rate from 1% to 20%.
Adds buyer config support for overriding response-auth sampling, including 100% local sampling via `buyer.verification.sampleRate: 1`.

## Release Notes

- Increased default response-auth evidence sampling to 20%
- Added buyer config options for response-auth sample rate and max sample size

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
