### PR TITLE
docs: Document seller verification

### DIFF
--- a/apps/website/docs/getting-started/configuration.md
+++ b/apps/website/docs/getting-started/configuration.md
@@ -62,6 +62,7 @@ Use `config.json` for durable node behavior. Use env vars for secrets and tempor
 | `baseUrl` for OpenAI-compatible providers | `ANTSEED_IDENTITY_HEX` |
 | Service list and categories | `ANTSEED_DEBUG=1` |
 | Pricing defaults and per-service pricing | One-off runtime overrides in deployment scripts |
+| Domain/GitHub verification claims | |
 | `payments.crypto.rpcUrl` for durable RPC config | `ANTSEED_BASE_RPC_URL` for deployment-specific Base RPC endpoints |
 | Buyer proxy port and peer refresh interval | `ANTSEED_DATA_DIR` for per-process buyer state isolation |
 | Bootstrap nodes | |
@@ -284,6 +285,85 @@ ANTSEED_BUYER_METADATA_FETCH_TIMEOUT_MS=1500 antseed buyer start
 antseed config set identity.displayName "Acme Inference - us-east-1"
 antseed config seller set publicAddress "peer.example.com:6882"
 ```
+
+## Domain and GitHub Verification
+
+Sellers can publish optional ownership claims in signed peer metadata. These claims let buyers and directories show that a peer is connected to a public domain or GitHub account controlled by the operator.
+
+Verification claims bind to the seller **peer ID** — the EVM address derived from the seller identity key. If your deployment also advertises a seller contract, such as a staking proxy, the external proof still contains the peer ID, not the contract address. Buyers verify the seller-contract relationship separately on-chain.
+
+Add claims under `seller.verifications`:
+
+```json
+{
+  "seller": {
+    "verifications": {
+      "domains": [
+        {
+          "domain": "provider.example.com",
+          "methods": ["dns-txt"]
+        }
+      ],
+      "github": [
+        {
+          "username": "example-org",
+          "repository": "antseed-verification"
+        }
+      ]
+    }
+  }
+}
+```
+
+### Domain proof
+
+For DNS TXT verification, create a TXT record at `_antseed.<domain>`:
+
+```text
+Name:  _antseed.provider.example.com
+Type:  TXT
+Value: antseed-peer=<peer-id-without-0x>
+```
+
+Example:
+
+```text
+antseed-peer=9e8f9aaee684298b7f2af2ae008e3692f0e9f4f7
+```
+
+If you prefer HTTPS verification, serve this JSON at `https://<domain>/.well-known/antseed.json` and configure the claim with `"methods": ["https-well-known"]`:
+
+```json
+{
+  "type": "antseed-domain-verification",
+  "peerId": "9e8f9aaee684298b7f2af2ae008e3692f0e9f4f7",
+  "domain": "provider.example.com"
+}
+```
+
+Do not redirect the well-known URL; verifiers require the proof to be served directly from the claimed domain.
+
+### GitHub proof
+
+Create a public repository and place `antseed.json` at the repository root. AntSeed fetches:
+
+```text
+https://raw.githubusercontent.com/<username>/<repository>/HEAD/antseed.json
+```
+
+The file must contain:
+
+```json
+{
+  "type": "antseed-github-verification",
+  "peerId": "9e8f9aaee684298b7f2af2ae008e3692f0e9f4f7",
+  "username": "example-org"
+}
+```
+
+The `repository` field is configured in `config.json`; it is not included in the proof file. If `repository` is omitted, verifiers use the profile repository named after the username.
+
+After updating config and publishing proofs, restart the seller. Startup logs will print the configured verification claims, and `/metadata` will include `verifications`.
 
 ## Provider Authentication
 

--- a/apps/website/docs/guides/become-a-provider.md
+++ b/apps/website/docs/guides/become-a-provider.md
@@ -110,6 +110,66 @@ export ANTSEED_IDENTITY_HEX=<your-64-char-hex-private-key>
 Use a dedicated key for your provider node. Generate one with any EVM wallet tool. The corresponding address is where you'll receive USDC earnings.
 :::
 
+### Optional: Verify your domain and GitHub account
+
+Production providers can attach public ownership proofs to their signed peer metadata. This helps buyers and directories recognize that a peer is operated by the same party that controls a domain or GitHub account.
+
+These proofs bind to your **peer ID** — the EVM address derived from `ANTSEED_IDENTITY_HEX`. If your deployment uses a seller contract or staking proxy, do not put the contract address in the proof. Buyers verify seller-contract delegation separately.
+
+To verify a domain with DNS, create a TXT record at `_antseed.<domain>`:
+
+```text
+Name:  _antseed.provider.example.com
+Type:  TXT
+Value: antseed-peer=<your-peer-id-without-0x>
+```
+
+Then add the claim to `~/.antseed/config.json`:
+
+```json
+{
+  "seller": {
+    "verifications": {
+      "domains": [
+        {
+          "domain": "provider.example.com",
+          "methods": ["dns-txt"]
+        }
+      ]
+    }
+  }
+}
+```
+
+To verify GitHub, create a public repository containing `antseed.json` at the root:
+
+```json
+{
+  "type": "antseed-github-verification",
+  "peerId": "<your-peer-id-without-0x>",
+  "username": "example-org"
+}
+```
+
+Then add:
+
+```json
+{
+  "seller": {
+    "verifications": {
+      "github": [
+        {
+          "username": "example-org",
+          "repository": "antseed-verification"
+        }
+      ]
+    }
+  }
+}
+```
+
+You can combine both `domains` and `github` under the same `seller.verifications` object. See [Configuration](/docs/config#domain-and-github-verification) for the full proof formats, including HTTPS well-known domain verification.
+
 ## 4. Recommended: Set a Custom Base RPC URL
 
 Production sellers should use their own Base JSON-RPC endpoint instead of relying on public defaults. Public RPCs are useful for testing, but they can be rate limited, slow during traffic spikes, or unavailable when your node needs to reserve, settle, register, or stake on-chain.

--- a/apps/website/docs/protocol/discovery.md
+++ b/apps/website/docs/protocol/discovery.md
@@ -56,7 +56,7 @@ By default, metadata is fetched from `http://{host}:{port}/metadata` (`metadataP
 ```json title="metadata structure"
 {
   "peerId": "a1b2c3d4...40 hex chars (EVM address)",
-  "version": 5,
+  "version": 10,
   "displayName": "Acme Inference - us-east-1",
   "publicAddress": "peer.example.com:6882",
   "providers": [{
@@ -82,6 +82,16 @@ By default, metadata is fetched from `http://{host}:{port}/metadata` (`metadataP
   }],
   "region": "us-east",
   "timestamp": 1708272000000,
+  "capabilities": ["verification.response-auth.v1"],
+  "sellerContract": "1f228613116e2d08014dfdcc198377c8dedf18c9",
+  "verifications": {
+    "domains": [
+      { "domain": "provider.example.com", "methods": ["dns-txt"] }
+    ],
+    "github": [
+      { "username": "example-org", "repository": "antseed-verification" }
+    ]
+  },
   "signature": "eip191...130 hex chars"
 }
 ```
@@ -89,6 +99,62 @@ By default, metadata is fetched from `http://{host}:{port}/metadata` (`metadataP
 Recommended category tags: `privacy`, `legal`, `uncensored`, `coding`, `finance`, `tee` (custom tags are allowed).
 
 `publicAddress` is optional. When present, buyers should prefer it over the raw host learned from the DHT announcement. This is intended for deployments where DHT traffic exits from one IP but buyers must connect to another address, such as a Kubernetes load balancer.
+
+`sellerContract` is optional. When present, buyers use the contract as the on-chain seller address and verify separately that the peer identity is an authorized operator of that contract.
+
+`verifications` is optional. It carries external ownership claims that are included in the signed metadata. Domain and GitHub proofs bind to `peerId` — not to `sellerContract` — because the peer identity is the key that signs discovery metadata and operates the node.
+
+## Domain and GitHub Verification Claims
+
+Domain verification supports two proof transports:
+
+- DNS TXT at `_antseed.<domain>` with value `antseed-peer=<peer-id-without-0x>`
+- HTTPS well-known JSON at `https://<domain>/.well-known/antseed.json`
+
+A DNS-backed claim looks like:
+
+```json
+{
+  "domain": "provider.example.com",
+  "methods": ["dns-txt"]
+}
+```
+
+The matching DNS record is:
+
+```text
+_antseed.provider.example.com TXT "antseed-peer=a1b2c3d4...40hex"
+```
+
+An HTTPS well-known proof uses this JSON shape:
+
+```json
+{
+  "type": "antseed-domain-verification",
+  "peerId": "a1b2c3d4...40hex",
+  "domain": "provider.example.com"
+}
+```
+
+GitHub verification fetches a public file from:
+
+```text
+https://raw.githubusercontent.com/<username>/<repository>/HEAD/antseed.json
+```
+
+The proof file shape is:
+
+```json
+{
+  "type": "antseed-github-verification",
+  "peerId": "a1b2c3d4...40hex",
+  "username": "example-org"
+}
+```
+
+The repository name is part of the metadata claim, not the proof file. If no repository is provided, verifiers use the profile repository named after the username.
+
+Verifiers reject redirected proof URLs. Domain and GitHub proofs must be served directly from the claimed domain or GitHub account path.
 
 ## Peer Scoring
 

--- a/docs/protocol/spec/01-discovery.md
+++ b/docs/protocol/spec/01-discovery.md
@@ -67,7 +67,7 @@ Custom bootstrap nodes can be supplied and are merged (deduplicated by `host:por
 **Source:** `node/src/discovery/peer-metadata.ts`
 
 ```
-METADATA_VERSION = 8
+METADATA_VERSION = 10
 ```
 
 ### Data Structures
@@ -77,12 +77,19 @@ METADATA_VERSION = 8
 | Field       | Type                    | Description                             |
 |-------------|-------------------------|-----------------------------------------|
 | peerId      | PeerId (string)         | 40 hex chars (20-byte EVM address)      |
-| version     | number                  | Must equal `METADATA_VERSION` (8)       |
+| version     | number                  | Must equal `METADATA_VERSION` (10)      |
 | displayName | string                  | Optional human-readable node label      |
 | publicAddress | string                | Optional public `host:port` buyers should dial instead of the raw DHT source address |
 | providers   | ProviderAnnouncement[]  | List of provider offerings              |
+| offerings   | PeerOffering[]          | Optional higher-level capability offerings |
 | region      | string                  | Geographic region identifier            |
 | timestamp   | number                  | Unix epoch milliseconds                 |
+| stakeAmountUSDC | number              | Optional stake amount, when available   |
+| onChainChannelCount | number          | Optional on-chain channel count         |
+| onChainGhostCount | number            | Optional on-chain ghost count           |
+| capabilities | string[]               | Optional peer-level protocol capabilities |
+| sellerContract | string               | Optional 40-hex-char on-chain seller contract used for payment channels |
+| verifications | PeerVerifications     | Optional signed domain/GitHub ownership claims |
 | signature   | string                  | 130 hex chars (65-byte secp256k1 signature) |
 
 #### ProviderAnnouncement
@@ -156,10 +163,23 @@ Post-provider sections:
   [publicAddressFlag:1]                           // v5+
   if publicAddressFlag == 1:
     [publicAddressLen:1][publicAddress:N]
+  [sellerContractFlag:1]                          // v8+
+  if sellerContractFlag == 1:
+    [sellerContract:20]
+  [domainVerificationCount:1]                     // v9+
+  Per domain verification entry:
+    [domainLen:1][domain:N][methodCount:1][methodIds...]
+    method id 0 = dns-txt, 1 = https-well-known
+  [githubVerificationCount:1]                     // v9+
+  Per GitHub verification entry:
+    [usernameLen:1][username:N][repositoryLen:1][repository:N]
+    repositoryLen 0 means the profile repository `<username>/<username>`
   [offeringCount:2]                               // uint16
   [offeringEntries...]
-  [evmAddressFlag:1] + [evmAddress:20 if present]
   [onChainStatsFlag:1] + [statsData:10 if present]
+  [capabilityCount:1]                             // v10+
+  Per capability entry:
+    [capabilityLen:1][capability:N]
 
 Trailer:
   [signature     : 65 bytes        ]   // secp256k1 signature
@@ -173,24 +193,36 @@ The body (everything except the trailing 65-byte signature) is the data that is 
 
 | Constant                  | Value | Description                                 |
 |---------------------------|-------|---------------------------------------------|
-| MAX_METADATA_SIZE         | 1000  | Maximum encoded size in bytes               |
+| MAX_METADATA_SIZE         | 1400  | Maximum encoded size in bytes               |
 | MAX_PROVIDERS             | 10    | Maximum provider entries per metadata       |
 | MAX_SERVICES_PER_PROVIDER | 20    | Maximum services per provider entry         |
 | MAX_SERVICE_NAME_LENGTH   | 64    | Maximum service name length in characters   |
 | MAX_REGION_LENGTH         | 32    | Maximum region string length in characters  |
 | MAX_DISPLAY_NAME_LENGTH   | 64    | Maximum display name length in characters   |
 | MAX_PUBLIC_ADDRESS_LENGTH | 255   | Maximum public address length in characters |
+| MAX_DOMAIN_VERIFICATION_CLAIMS | 5 | Maximum domain verification claims          |
+| MAX_DOMAIN_LENGTH         | 253   | Maximum domain claim length in characters   |
+| MAX_GITHUB_VERIFICATION_CLAIMS | 5 | Maximum GitHub verification claims          |
+| MAX_GITHUB_USERNAME_LENGTH | 39   | Maximum GitHub username length              |
+| MAX_GITHUB_REPOSITORY_LENGTH | 100 | Maximum GitHub repository name length       |
 | MAX_SERVICE_CATEGORIES_PER_SERVICE | 8 | Maximum categories per service           |
 | MAX_SERVICE_CATEGORY_LENGTH | 32  | Maximum category length in characters       |
 | MAX_SERVICE_API_PROTOCOLS_PER_SERVICE | 4 | Maximum protocol entries per service |
+| MAX_PEER_CAPABILITIES     | 16    | Maximum peer-level capability entries       |
+| MAX_PEER_CAPABILITY_LENGTH | 64   | Maximum peer-level capability length        |
 
 Additional validation rules enforced by `validateMetadata()`:
 
-- `version` must equal `METADATA_VERSION` (8).
+- `version` must equal `METADATA_VERSION` (10).
 - `peerId` must be exactly 40 lowercase hex characters.
 - `region` must not be empty.
 - `displayName` is optional, but when present it must be non-empty and <= 64 chars.
 - `publicAddress` is optional, but when present it must be a valid `host:port` and is signed as part of the metadata.
+- `sellerContract` is optional, but when present it must be exactly 40 lowercase hex characters and is signed as part of the metadata.
+- `verifications` is optional, but when present it must contain at least one supported namespace: `domains` or `github`.
+- Domain verification claims must be unique, lower-case hostnames with at least two labels, and may list unique methods from `dns-txt` and `https-well-known`. When `methods` is omitted, clients may try every known method.
+- GitHub verification claims must be unique. Usernames must be valid lower-case GitHub usernames, and repository names must be valid lower-case GitHub repository names when provided.
+- `capabilities` is optional, but when present values must be unique lower-case strings using letters, digits, hyphen, or dot.
 - `timestamp` must be a positive finite number.
 - At least one provider must be present.
 - `defaultPricing.inputUsdPerMillion` and `defaultPricing.outputUsdPerMillion` must be non-negative.
@@ -209,6 +241,71 @@ Additional validation rules enforced by `validateMetadata()`:
 - The full encoded payload must not exceed `MAX_METADATA_SIZE`.
 
 ---
+
+## External Verification Claims
+
+External verification claims are signed inside `PeerMetadata.verifications`, but the actual ownership proof is fetched outside the DHT metadata document. Proofs bind to `peerId`, not to `sellerContract`. When `sellerContract` is present, buyers verify the peer-to-contract delegation separately on-chain, for example by calling `sellerContract.isOperator(peerAddress)`.
+
+### Domain verification
+
+A domain claim has this metadata shape:
+
+```json
+{
+  "domain": "provider.example.com",
+  "methods": ["dns-txt"]
+}
+```
+
+Supported methods:
+
+- `dns-txt`: resolve `_antseed.<domain>` and look for `antseed-peer=<peerId>`.
+- `https-well-known`: fetch `https://<domain>/.well-known/antseed.json` without following redirects.
+
+The DNS TXT proof is:
+
+```text
+_antseed.provider.example.com TXT "antseed-peer=a1b2c3d4...40hex"
+```
+
+The HTTPS well-known proof body is:
+
+```json
+{
+  "type": "antseed-domain-verification",
+  "peerId": "a1b2c3d4...40hex",
+  "domain": "provider.example.com"
+}
+```
+
+### GitHub verification
+
+A GitHub claim has this metadata shape:
+
+```json
+{
+  "username": "example-org",
+  "repository": "antseed-verification"
+}
+```
+
+The verifier fetches the proof from:
+
+```text
+https://raw.githubusercontent.com/<username>/<repository>/HEAD/antseed.json
+```
+
+If `repository` is omitted, the profile repository named after the username is used. Redirects are rejected, so renamed or transferred repositories must republish the proof under the claimed account path.
+
+The proof body is:
+
+```json
+{
+  "type": "antseed-github-verification",
+  "peerId": "a1b2c3d4...40hex",
+  "username": "example-org"
+}
+```
 
 ## Metadata HTTP Endpoint
 
@@ -287,10 +384,11 @@ The `PeerLookup` class orchestrates the full discovery flow:
 The `PeerAnnouncer` class handles the seller-side announcement lifecycle:
 
 1. Build a `PeerMetadata` object from the configured providers, current pricing, current load, and region.
-2. Set `version` to `METADATA_VERSION` (8) and `timestamp` to `Date.now()`.
-3. Encode the body (without signature) via `encodeMetadataForSigning()`.
-4. Sign the body with the seller's secp256k1 private key (via EIP-191 personal_sign).
-5. Announce DHT topics in parallel at the configured signaling port (constant in service count):
+2. Set `version` to `METADATA_VERSION` (10) and `timestamp` to `Date.now()`.
+3. Include configured seller contract, verification claims, and peer capabilities when present.
+4. Encode the body (without signature) via `encodeMetadataForSigning()`.
+5. Sign the body with the seller's secp256k1 private key (via EIP-191 personal_sign).
+6. Announce DHT topics in parallel at the configured signaling port (constant in service count):
    - subnet topic (`subnetTopic(subnetOf(peerId))`)
    - wildcard topic (`ANTSEED_WILDCARD_TOPIC`) — kept during the subnet rollout so older buyers still find this peer
    - per-peer topic (`peerTopic(peerId)`)

--- a/docs/protocol/spec/README.md
+++ b/docs/protocol/spec/README.md
@@ -1,6 +1,6 @@
 # Antseed Network Protocol Specification
 
-**Version:** 1.7 (current discovery metadata format uses `METADATA_VERSION = 8`)
+**Version:** 1.8 (current discovery metadata format uses `METADATA_VERSION = 10`)
 
 ## Overview
 
@@ -110,6 +110,7 @@ See: [08-fingerprint-swarm.md](./08-fingerprint-swarm.md)
 
 | Version | Date | Notes |
 |---|---|---|
+| 1.8 | 2026-06-15 | Updated discovery spec for metadata v10, seller contracts, peer capabilities, and domain/GitHub verification claims |
 | 1.7 | 2026-06-15 | Added Real Money, Fake Models as model-substitution motivation for model verification |
 | 1.6 | 2026-06-15 | Added READER-style passive proxy-reader provenance to the model-verification verifier suite |
 | 1.5 | 2026-06-14 | Updated model-verification spec with implemented ResponseAuth, verification storage, and evidence sampling status |


### PR DESCRIPTION
## Description

Documents how seller peers can publish domain and GitHub ownership claims in signed metadata. Updates both public website docs and the protocol spec to cover metadata v10 verification fields, proof formats, and the peer ID versus seller contract distinction.

## Release Notes

- Added seller documentation for DNS TXT, HTTPS well-known, and GitHub verification proofs
- Updated discovery documentation to describe metadata v10 verification claims and seller contract handling

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Validation: `pnpm --filter @antseed/website run build`
