### PR TITLE
feat(node): Verify external seller claims

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -621,6 +621,45 @@ test('parsePersistedPeers restores sellerContract into peer.metadata', () => {
   assert.equal(peer!.metadata?.sellerContract, facade)
 })
 
+test('parsePersistedPeers restores external verification claims and results', () => {
+  const verificationResults = {
+    verified: true,
+    checkedAtMs: NOW - 500,
+    domains: [
+      {
+        domain: 'example.com',
+        peerId: validPeerId,
+        verified: true,
+        method: 'dns-txt',
+        checkedAtMs: NOW - 500,
+        attempts: [{ method: 'dns-txt', verified: true }],
+      },
+    ],
+    github: [],
+  }
+  const [peer] = parsePersistedPeers(
+    {
+      discoveredPeers: [
+        {
+          peerId: validPeerId,
+          providers: ['openai'],
+          lastSeen: NOW - 1_000,
+          verifications: {
+            domains: [{ domain: 'example.com', methods: ['dns-txt'] }],
+          },
+          verificationResults,
+        },
+      ],
+    },
+    NOW,
+  )
+  assert.ok(peer)
+  assert.deepEqual(peer!.metadata?.verifications, {
+    domains: [{ domain: 'example.com', methods: ['dns-txt'] }],
+  })
+  assert.deepEqual(peer!.verificationResults, verificationResults)
+})
+
 test('parsePersistedPeers leaves metadata undefined when sellerContract is absent', () => {
   const [peer] = parsePersistedPeers(
     {

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -575,26 +575,15 @@ export class BuyerProxy {
       const metadata = peer.metadata || prev.metadata
         ? { ...(prev.metadata ?? {}), ...(peer.metadata ?? {}) } as PeerMetadata
         : undefined
-      return {
+      const mergedPeer: PeerInfo = {
+        ...prev,
         ...peer,
         ...(metadata ? { metadata } : {}),
-        ...(prev.lastReachedAt && (!peer.lastReachedAt || prev.lastReachedAt > peer.lastReachedAt)
-          ? { lastReachedAt: prev.lastReachedAt }
-          : {}),
-        verificationResults: peer.verificationResults ?? prev.verificationResults,
-        onChainAgentId: peer.onChainAgentId ?? prev.onChainAgentId,
-        onChainStakeUsdcMicros: peer.onChainStakeUsdcMicros ?? prev.onChainStakeUsdcMicros,
-        onChainChannelCount: peer.onChainChannelCount ?? prev.onChainChannelCount,
-        onChainGhostCount: peer.onChainGhostCount ?? prev.onChainGhostCount,
-        onChainTotalVolumeUsdcMicros: peer.onChainTotalVolumeUsdcMicros ?? prev.onChainTotalVolumeUsdcMicros,
-        onChainLastSettledAtSec: peer.onChainLastSettledAtSec ?? prev.onChainLastSettledAtSec,
-        onChainStakedAtSec: peer.onChainStakedAtSec ?? prev.onChainStakedAtSec,
-        onChainReputationScore: peer.onChainReputationScore ?? prev.onChainReputationScore,
-        onChainTrustScore: peer.onChainTrustScore ?? prev.onChainTrustScore,
-        onChainSybilRisk: peer.onChainSybilRisk ?? prev.onChainSybilRisk,
-        onChainSybilFlags: peer.onChainSybilFlags ?? prev.onChainSybilFlags,
-        onChainStatsFetchedAt: peer.onChainStatsFetchedAt ?? prev.onChainStatsFetchedAt,
       }
+      if (prev.lastReachedAt && (!peer.lastReachedAt || prev.lastReachedAt > peer.lastReachedAt)) {
+        mergedPeer.lastReachedAt = prev.lastReachedAt
+      }
+      return mergedPeer
     })
 
     // Carry forward previously known peers that are missing from this scan.

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -327,6 +327,12 @@ export function parsePersistedPeers(
     if (peer.capabilities && peer.capabilities.length > 0) {
       peer.metadata = { ...(peer.metadata ?? {}), capabilities: [...peer.capabilities] } as PeerMetadata
     }
+    if (entry.verifications && typeof entry.verifications === 'object') {
+      peer.metadata = { ...(peer.metadata ?? {}), verifications: entry.verifications as PeerMetadata['verifications'] } as PeerMetadata
+    }
+    if (entry.verificationResults && typeof entry.verificationResults === 'object') {
+      peer.verificationResults = entry.verificationResults as PeerInfo['verificationResults']
+    }
     peers.push(peer)
   }
   return peers
@@ -565,10 +571,30 @@ export class BuyerProxy {
     // and losing it on each refresh would defeat the carry-forward tracking.
     const merged: PeerInfo[] = incoming.map((peer) => {
       const prev = prevById.get(peer.peerId)
-      if (prev?.lastReachedAt && (!peer.lastReachedAt || prev.lastReachedAt > peer.lastReachedAt)) {
-        return { ...peer, lastReachedAt: prev.lastReachedAt }
+      if (!prev) return peer
+      const metadata = peer.metadata || prev.metadata
+        ? { ...(prev.metadata ?? {}), ...(peer.metadata ?? {}) } as PeerMetadata
+        : undefined
+      return {
+        ...peer,
+        ...(metadata ? { metadata } : {}),
+        ...(prev.lastReachedAt && (!peer.lastReachedAt || prev.lastReachedAt > peer.lastReachedAt)
+          ? { lastReachedAt: prev.lastReachedAt }
+          : {}),
+        verificationResults: peer.verificationResults ?? prev.verificationResults,
+        onChainAgentId: peer.onChainAgentId ?? prev.onChainAgentId,
+        onChainStakeUsdcMicros: peer.onChainStakeUsdcMicros ?? prev.onChainStakeUsdcMicros,
+        onChainChannelCount: peer.onChainChannelCount ?? prev.onChainChannelCount,
+        onChainGhostCount: peer.onChainGhostCount ?? prev.onChainGhostCount,
+        onChainTotalVolumeUsdcMicros: peer.onChainTotalVolumeUsdcMicros ?? prev.onChainTotalVolumeUsdcMicros,
+        onChainLastSettledAtSec: peer.onChainLastSettledAtSec ?? prev.onChainLastSettledAtSec,
+        onChainStakedAtSec: peer.onChainStakedAtSec ?? prev.onChainStakedAtSec,
+        onChainReputationScore: peer.onChainReputationScore ?? prev.onChainReputationScore,
+        onChainTrustScore: peer.onChainTrustScore ?? prev.onChainTrustScore,
+        onChainSybilRisk: peer.onChainSybilRisk ?? prev.onChainSybilRisk,
+        onChainSybilFlags: peer.onChainSybilFlags ?? prev.onChainSybilFlags,
+        onChainStatsFetchedAt: peer.onChainStatsFetchedAt ?? prev.onChainStatsFetchedAt,
       }
-      return peer
     })
 
     // Carry forward previously known peers that are missing from this scan.
@@ -637,6 +663,11 @@ export class BuyerProxy {
         // Persisted so cold-started buyers can still resolve the facade address
         // for channelId derivation. See parsePersistedPeers for the round-trip.
         sellerContract: p.metadata?.sellerContract ?? null,
+        // External ownership claims and buyer-computed proof results. Claim
+        // verification runs asynchronously after discovery, so this may be
+        // null on first sighting and filled by a later peers:discovered update.
+        verifications: p.metadata?.verifications ?? null,
+        verificationResults: p.verificationResults ?? null,
         lastSeen: p.lastSeen,
         lastReachedAt: p.lastReachedAt ?? null,
       }

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import type { Identity, IdentityStore } from "./p2p/identity.js";
 import { loadOrCreateIdentity } from "./p2p/identity.js";
 import type { PeerId } from "./types/peer.js";
-import type { PeerInfo, TokenPricingUsdPerMillion } from "./types/peer.js";
+import type { PeerInfo, PeerVerificationResults, TokenPricingUsdPerMillion } from "./types/peer.js";
 import { peerIdToAddress } from "./types/peer.js";
 import type {
   SerializedHttpRequest,
@@ -36,6 +36,8 @@ import {
   type SellerContractConfig,
 } from "./discovery/announcer.js";
 import type { PeerVerifications } from "./discovery/peer-metadata.js";
+import { verifyPeerMetadataDomains } from "./discovery/domain-verification.js";
+import { verifyPeerMetadataGithub } from "./discovery/github-verification.js";
 import {
   PeerLookup,
   DEFAULT_LOOKUP_CONFIG,
@@ -226,6 +228,8 @@ const EMPTY_BUYER_USAGE: BuyerUsageTotals = {
   channels: [],
 };
 
+const EXTERNAL_VERIFICATION_RESULT_TTL_MS = 15 * 60_000;
+
 export class AntseedNode extends EventEmitter {
   private _config: NodeConfig;
   private _identity: Identity | null = null;
@@ -276,6 +280,14 @@ export class AntseedNode extends EventEmitter {
   private _backgroundPeerDiscoveryPromise: Promise<PeerInfo[]> | null = null;
   /** Serializes non-blocking on-chain enrichment for incrementally discovered peers. */
   private _partialPeerEnrichmentChain: Promise<void> = Promise.resolve();
+  /** Serializes non-blocking external claim verification for discovered peers. */
+  private _externalVerificationChain: Promise<void> = Promise.resolve();
+  private _externalVerificationCache = new Map<PeerId, {
+    claimsKey: string;
+    checkedAtMs: number;
+    results: PeerVerificationResults;
+  }>();
+  private _externalVerificationInFlight = new Set<string>();
 
   constructor(config: NodeConfig) {
     super();
@@ -537,6 +549,8 @@ export class AntseedNode extends EventEmitter {
     }
 
     const filtered = service ? peers.filter((p) => peerOffersService(p, service)) : peers;
+    this._attachCachedExternalVerificationResults(filtered);
+    this._queueExternalVerification(filtered);
 
     // On-chain enrichment runs after the metadata filter so we don't waste
     // RPC calls on peers we'll discard.
@@ -575,7 +589,9 @@ export class AntseedNode extends EventEmitter {
           + `${context.subnet !== undefined ? ` ${context.subnet}/${SUBNET_COUNT - 1}` : ""}`
           + ` emitted ${peers.length} peer(s) from ${context.endpointCount} endpoint(s)`,
         );
+        this._attachCachedExternalVerificationResults(peers);
         this.emit("peers:discovered", peers);
+        this._queueExternalVerification(peers);
         this._queuePartialPeerEnrichment(peers);
       });
       debugLog(`[Node] Background DHT sweep returned ${results.length} result(s)`);
@@ -611,6 +627,120 @@ export class AntseedNode extends EventEmitter {
       this.emit("peers:discovered", enriched);
     }).catch((err) => {
       debugWarn(`[Node] Background DHT partial on-chain enrichment failed: ${err instanceof Error ? err.message : err}`);
+    });
+  }
+
+  private _attachCachedExternalVerificationResults(peers: PeerInfo[]): void {
+    const nowMs = Date.now();
+    for (const peer of peers) {
+      const claimsKey = this._externalVerificationClaimsKey(peer);
+      if (!claimsKey) continue;
+      const cached = this._externalVerificationCache.get(peer.peerId);
+      if (
+        cached
+        && cached.claimsKey === claimsKey
+        && nowMs - cached.checkedAtMs < EXTERNAL_VERIFICATION_RESULT_TTL_MS
+      ) {
+        peer.verificationResults = cached.results;
+      }
+    }
+  }
+
+  private _queueExternalVerification(peers: PeerInfo[]): void {
+    const queued: PeerInfo[] = [];
+    const nowMs = Date.now();
+    for (const peer of peers) {
+      const claimsKey = this._externalVerificationClaimsKey(peer);
+      if (!claimsKey) continue;
+      const cacheKey = `${peer.peerId}:${claimsKey}`;
+      if (this._externalVerificationInFlight.has(cacheKey)) continue;
+      const cached = this._externalVerificationCache.get(peer.peerId);
+      if (
+        cached
+        && cached.claimsKey === claimsKey
+        && nowMs - cached.checkedAtMs < EXTERNAL_VERIFICATION_RESULT_TTL_MS
+      ) {
+        continue;
+      }
+      this._externalVerificationInFlight.add(cacheKey);
+      queued.push({ ...peer });
+    }
+    if (queued.length === 0) return;
+
+    this._externalVerificationChain = this._externalVerificationChain.then(async () => {
+      if (!this._started) return;
+      const verifiedPeers = await this._verifyExternalClaimsForPeers(queued);
+      if (!this._started || verifiedPeers.length === 0) return;
+      debugLog(`[Node] External verification emitted ${verifiedPeers.length} peer update(s)`);
+      this.emit("peers:discovered", verifiedPeers);
+    }).catch((err) => {
+      debugWarn(`[Node] External verification failed: ${err instanceof Error ? err.message : err}`);
+    }).finally(() => {
+      for (const peer of queued) {
+        const claimsKey = this._externalVerificationClaimsKey(peer);
+        if (claimsKey) {
+          this._externalVerificationInFlight.delete(`${peer.peerId}:${claimsKey}`);
+        }
+      }
+    });
+  }
+
+  private async _verifyExternalClaimsForPeers(peers: PeerInfo[]): Promise<PeerInfo[]> {
+    const queue = peers.slice();
+    const verifiedPeers: PeerInfo[] = [];
+    const EXTERNAL_VERIFICATION_CONCURRENCY = 2;
+    const workers = Array.from({ length: Math.min(EXTERNAL_VERIFICATION_CONCURRENCY, queue.length) }, async () => {
+      for (;;) {
+        const peer = queue.shift();
+        if (!peer) return;
+        const verified = await this._verifyExternalClaimsForPeer(peer);
+        if (verified) {
+          verifiedPeers.push(verified);
+        }
+      }
+    });
+    await Promise.all(workers);
+    return verifiedPeers;
+  }
+
+  private async _verifyExternalClaimsForPeer(peer: PeerInfo): Promise<PeerInfo | null> {
+    const metadata = peer.metadata;
+    const claimsKey = this._externalVerificationClaimsKey(peer);
+    if (!metadata || !claimsKey) return null;
+
+    try {
+      const [domains, github] = await Promise.all([
+        verifyPeerMetadataDomains(metadata),
+        verifyPeerMetadataGithub(metadata),
+      ]);
+      const checkedAtMs = Date.now();
+      const allResults = [...domains, ...github];
+      const results: PeerVerificationResults = {
+        verified: allResults.length > 0 && allResults.every((result) => result.verified),
+        checkedAtMs,
+        domains,
+        github,
+      };
+      this._externalVerificationCache.set(peer.peerId, {
+        claimsKey,
+        checkedAtMs,
+        results,
+      });
+      return { ...peer, verificationResults: results };
+    } catch (err) {
+      debugWarn(`[Node] External verification failed for ${peer.peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
+      return null;
+    }
+  }
+
+  private _externalVerificationClaimsKey(peer: PeerInfo): string | null {
+    const verifications = peer.metadata?.verifications;
+    const domainCount = verifications?.domains?.length ?? 0;
+    const githubCount = verifications?.github?.length ?? 0;
+    if (domainCount + githubCount === 0) return null;
+    return JSON.stringify({
+      domains: verifications?.domains ?? [],
+      github: verifications?.github ?? [],
     });
   }
 
@@ -656,6 +786,8 @@ export class AntseedNode extends EventEmitter {
       r.metadata.timestamp > acc.metadata.timestamp ? r : acc,
     );
     const peer = this._lookupResultToPeerInfo(best);
+    this._attachCachedExternalVerificationResults([peer]);
+    this._queueExternalVerification([peer]);
     await this._enrichPeersWithOnChainStats([peer]);
     return peer;
   }

--- a/packages/node/src/types/peer.ts
+++ b/packages/node/src/types/peer.ts
@@ -1,5 +1,7 @@
 import type { ServiceApiProtocol } from "./service-api.js";
 import type { PeerMetadata } from "../discovery/peer-metadata.js";
+import type { DomainVerificationResult } from "../discovery/domain-verification.js";
+import type { GithubVerificationResult } from "../discovery/github-verification.js";
 
 /**
  * A PeerId is the EVM address hex (40 lowercase chars = 20 bytes, no 0x prefix).
@@ -41,6 +43,17 @@ export interface ProviderServiceCategoryMatrixEntry {
 
 export interface ProviderServiceApiProtocolMatrixEntry {
   services: Record<string, ServiceApiProtocol[]>;
+}
+
+export interface PeerVerificationResults {
+  /** True when every announced external claim verified successfully. */
+  verified: boolean;
+  /** Buyer-local time when the latest verification pass completed. */
+  checkedAtMs: number;
+  /** Domain ownership verification results, one per announced domain claim. */
+  domains: DomainVerificationResult[];
+  /** GitHub account ownership verification results, one per announced GitHub claim. */
+  github: GithubVerificationResult[];
 }
 
 /** Information about a known peer. */
@@ -117,4 +130,6 @@ export interface PeerInfo {
   onChainStatsFetchedAt?: number;
   /** Full peer metadata, if available (set after metadata resolution). */
   metadata?: PeerMetadata;
+  /** Buyer-computed results for external ownership claims announced in metadata. */
+  verificationResults?: PeerVerificationResults;
 }

--- a/packages/node/tests/incremental-enrichment.test.ts
+++ b/packages/node/tests/incremental-enrichment.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { AntseedNode, type PeerInfo } from '../src/node.js';
+import { GITHUB_VERIFICATION_PROOF_TYPE } from '../src/discovery/github-verification.js';
 
 function makePeer(peerId = 'a'.repeat(40)): PeerInfo {
   return {
@@ -44,5 +45,45 @@ describe('AntseedNode incremental discovery enrichment', () => {
     expect(peers[0]?.onChainTotalVolumeUsdcMicros).toBe(50_000_000);
     expect(peers[0]?.onChainStatsFetchedAt).toEqual(expect.any(Number));
     expect(peers[0]?.onChainReputationScore).toEqual(expect.any(Number));
+  });
+
+  it('emits external verification results without blocking initial discovery events', async () => {
+    const node = new AntseedNode({ role: 'buyer' });
+    const peer = makePeer();
+    peer.metadata = {
+      peerId: peer.peerId,
+      version: 10,
+      providers: [],
+      region: 'unknown',
+      timestamp: Date.now(),
+      signature: '00'.repeat(65),
+      verifications: {
+        github: [{ username: 'octocat' }],
+      },
+    };
+    const discovered = vi.fn();
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      type: GITHUB_VERIFICATION_PROOF_TYPE,
+      peerId: peer.peerId,
+      username: 'octocat',
+    }), { status: 200 }));
+
+    node.on('peers:discovered', discovered);
+    vi.stubGlobal('fetch', fetchMock);
+    try {
+      (node as any)._started = true;
+      (node as any)._queueExternalVerification([peer]);
+      expect(discovered).not.toHaveBeenCalled();
+
+      await (node as any)._externalVerificationChain;
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(discovered).toHaveBeenCalledTimes(1);
+      const [[peers]] = discovered.mock.calls as [[PeerInfo[]]];
+      expect(peers[0]?.verificationResults?.verified).toBe(true);
+      expect(peers[0]?.verificationResults?.github[0]?.username).toBe('octocat');
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });


### PR DESCRIPTION
## Description

Adds non-blocking buyer-side verification for seller domain and GitHub claims announced in signed peer metadata. Verification runs asynchronously after discovery, caches results, and persists both claims and buyer-computed results into `buyer.state.json`.

## Release Notes

- Added async buyer verification for seller domain and GitHub ownership claims
- Persisted seller verification claims and proof results in buyer state for desktop and CLI surfaces

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Local Verification

- `pnpm --filter @antseed/node test -- incremental-enrichment domain-verification github-verification`
- `pnpm --filter @antseed/cli test -- proxy/buyer-proxy`
- `pnpm --filter @antseed/node run build`
- `pnpm --filter @antseed/cli run build`
