### PR TITLE
feat(desktop): Show verified seller links

### DIFF
--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -270,6 +270,7 @@ type DiscoverRowEntry = {
   peerEvmAddress: string;
   sellerEvmAddress: string;
   sellerContract: string | null;
+  verificationLinks: DiscoverVerificationLink[];
   peerDisplayName: string | null;
   peerLabel: string;
   inputUsdPerMillion: number | null;
@@ -296,6 +297,12 @@ type DiscoverRowEntry = {
   networkInputTokens: string | null;
   networkOutputTokens: string | null;
   selectionValue: string;
+};
+
+type DiscoverVerificationLink = {
+  kind: 'domain' | 'github';
+  label: string;
+  href: string;
 };
 
 const CHAT_SESSIONS_DIR = path.join(CHAT_DATA_DIR, 'sessions');
@@ -351,6 +358,65 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     return null;
   }
   return value as Record<string, unknown>;
+}
+
+function buildHttpsUrl(hostname: string): string | null {
+  const normalized = hostname.trim().toLowerCase();
+  if (!/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/i.test(normalized) || normalized.includes('..')) {
+    return null;
+  }
+  try {
+    const url = new URL(`https://${normalized}`);
+    if (url.hostname !== normalized) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function isGithubName(value: string): boolean {
+  return /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i.test(value);
+}
+
+function isGithubRepository(value: string): boolean {
+  return /^[a-z0-9._-]{1,100}$/i.test(value) && value !== '.' && value !== '..';
+}
+
+function buildVerificationLinks(rawResults: unknown): DiscoverVerificationLink[] {
+  const results = asRecord(rawResults);
+  if (!results) return [];
+  const out: DiscoverVerificationLink[] = [];
+  const seen = new Set<string>();
+
+  const add = (link: DiscoverVerificationLink) => {
+    const key = `${link.kind}\u0000${link.href}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(link);
+  };
+
+  const domains = Array.isArray(results.domains) ? results.domains : [];
+  for (const raw of domains) {
+    const rec = asRecord(raw);
+    if (rec?.verified !== true || typeof rec.domain !== 'string') continue;
+    const href = buildHttpsUrl(rec.domain);
+    if (!href) continue;
+    add({ kind: 'domain', label: rec.domain.trim().toLowerCase(), href });
+  }
+
+  const github = Array.isArray(results.github) ? results.github : [];
+  for (const raw of github) {
+    const rec = asRecord(raw);
+    if (rec?.verified !== true || typeof rec.username !== 'string') continue;
+    const username = rec.username.trim().toLowerCase();
+    if (!isGithubName(username)) continue;
+    const repository = typeof rec.repository === 'string' ? rec.repository.trim() : '';
+    const hasRepository = repository.length > 0 && isGithubRepository(repository);
+    const path = hasRepository ? `${username}/${repository}` : username;
+    add({ kind: 'github', label: `@${path}`, href: `https://github.com/${path}` });
+  }
+
+  return out;
 }
 
 function normalizeNonNegativeNumber(value: unknown): number | null {
@@ -615,6 +681,7 @@ type BuyerStateDiscoveredPeer = {
   onChainSybilRisk: number | null;
   onChainSybilFlags: string[];
   sellerContract?: string;
+  verificationLinks: DiscoverVerificationLink[];
   providerPricing?: Record<string, { services?: Record<string, { cachedInputUsdPerMillion?: number }> }>;
 };
 
@@ -679,6 +746,7 @@ async function buildDiscoverRows(
       peerEvmAddress,
       sellerEvmAddress,
       sellerContract: /^[0-9a-f]{40}$/.test(sellerHex) ? `0x${sellerHex}` : null,
+      verificationLinks: peerBlob?.verificationLinks ?? [],
       peerDisplayName: entry.peerLabel?.split(' (')[0] ?? null,
       peerLabel: entry.peerLabel ?? peerId.slice(0, 12) + '...',
       inputUsdPerMillion: entry.inputUsdPerMillion ?? null,
@@ -2721,6 +2789,7 @@ export function registerPiChatHandlers({
                 ? rec.onChainSybilFlags.filter((f: unknown): f is string => typeof f === 'string')
                 : [],
               sellerContract: typeof rec.sellerContract === 'string' ? rec.sellerContract : undefined,
+              verificationLinks: buildVerificationLinks(rec.verificationResults),
               providerPricing: rec.providerPricing as Record<string, {
                 services?: Record<string, { cachedInputUsdPerMillion?: number }>
               }> | undefined,

--- a/apps/desktop/src/renderer/core/state.ts
+++ b/apps/desktop/src/renderer/core/state.ts
@@ -71,6 +71,12 @@ export type ChatServiceOptionEntry = {
   description: string;
 };
 
+export type DiscoverVerificationLink = {
+  kind: 'domain' | 'github';
+  label: string;
+  href: string;
+};
+
 export type DiscoverRow = {
   // Identity
   rowKey: string;              // `${peerId}:${serviceId}`
@@ -92,6 +98,7 @@ export type DiscoverRow = {
    * identification badge on the Discover card. See docs/protocol/diem-proxy.md.
    */
   sellerContract: string | null;
+  verificationLinks: DiscoverVerificationLink[];
   peerDisplayName: string | null;
   peerLabel: string;
 

--- a/apps/desktop/src/renderer/modules/chat.discover-rows.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.discover-rows.test.ts
@@ -22,6 +22,7 @@ test('normalizeDiscoverRow populates all numeric defaults to 0 / null', () => {
   assert.equal(row!.onChainReputationScore, null);
   assert.equal(row!.onChainSybilRisk, null);
   assert.deepEqual(row!.onChainSybilFlags, []);
+  assert.deepEqual(row!.verificationLinks, []);
 });
 
 /* Regression: Discover must carry buyer.state.json Sybil metadata through to the UI. */
@@ -37,10 +38,28 @@ test('normalizeDiscoverRow preserves on-chain sybil risk and string flags', () =
   assert.deepEqual(row!.onChainSybilFlags, ['narrow_custom', 'subfloor_ticket']);
 });
 
+test('normalizeDiscoverRow preserves safe verified external links only', () => {
+  const row = normalizeDiscoverRow({
+    peerId: 'abc123',
+    serviceId: 'gpt-5',
+    verificationLinks: [
+      { kind: 'domain', label: 'example.com', href: 'https://example.com' },
+      { kind: 'github', label: '@antseed/test', href: 'https://github.com/antseed/test' },
+      { kind: 'domain', label: 'bad', href: 'http://example.com' },
+      { kind: 'x', label: 'bad', href: 'https://example.com' },
+    ],
+  });
+  assert.ok(row);
+  assert.deepEqual(row!.verificationLinks, [
+    { kind: 'domain', label: 'example.com', href: 'https://example.com/' },
+    { kind: 'github', label: '@antseed/test', href: 'https://github.com/antseed/test' },
+  ]);
+});
+
 test('projectRowsToChatServiceOptions dedupes by (provider, service, peer)', () => {
   const rows = [
-    { rowKey: 'p1:s1', serviceId: 's1', serviceLabel: 's1', categories: [], provider: 'openai', protocol: 'openai-chat-completions', peerId: 'p1', peerEvmAddress: '', sellerContract: null, peerDisplayName: null, peerLabel: '', inputUsdPerMillion: 1, outputUsdPerMillion: 2, cachedInputUsdPerMillion: null, lifetimeSessions: 0, lifetimeRequests: 0, lifetimeInputTokens: 0, lifetimeOutputTokens: 0, lifetimeFirstSessionAt: null, lifetimeLastSessionAt: null, onChainChannelCount: null, agentId: 1, stakeUsdc: '0', onChainActiveChannelCount: 0, onChainGhostCount: 0, onChainTotalVolumeUsdc: '0', onChainLastSettledAt: 0, onChainReputationScore: null, selectionValue: 'openai\u0001s1\u0001p1' },
-    { rowKey: 'p1:s1', serviceId: 's1', serviceLabel: 's1', categories: [], provider: 'openai', protocol: 'openai-chat-completions', peerId: 'p1', peerEvmAddress: '', sellerContract: null, peerDisplayName: null, peerLabel: '', inputUsdPerMillion: 1, outputUsdPerMillion: 2, cachedInputUsdPerMillion: null, lifetimeSessions: 0, lifetimeRequests: 0, lifetimeInputTokens: 0, lifetimeOutputTokens: 0, lifetimeFirstSessionAt: null, lifetimeLastSessionAt: null, onChainChannelCount: null, agentId: 1, stakeUsdc: '0', onChainActiveChannelCount: 0, onChainGhostCount: 0, onChainTotalVolumeUsdc: '0', onChainLastSettledAt: 0, onChainReputationScore: null, selectionValue: 'openai\u0001s1\u0001p1' },
+    { rowKey: 'p1:s1', serviceId: 's1', serviceLabel: 's1', categories: [], provider: 'openai', protocol: 'openai-chat-completions', peerId: 'p1', peerEvmAddress: '', sellerContract: null, verificationLinks: [], peerDisplayName: null, peerLabel: '', inputUsdPerMillion: 1, outputUsdPerMillion: 2, cachedInputUsdPerMillion: null, lifetimeSessions: 0, lifetimeRequests: 0, lifetimeInputTokens: 0, lifetimeOutputTokens: 0, lifetimeFirstSessionAt: null, lifetimeLastSessionAt: null, onChainChannelCount: null, agentId: 1, stakeUsdc: '0', onChainActiveChannelCount: 0, onChainGhostCount: 0, onChainTotalVolumeUsdc: '0', onChainLastSettledAt: 0, onChainReputationScore: null, selectionValue: 'openai\u0001s1\u0001p1' },
+    { rowKey: 'p1:s1', serviceId: 's1', serviceLabel: 's1', categories: [], provider: 'openai', protocol: 'openai-chat-completions', peerId: 'p1', peerEvmAddress: '', sellerContract: null, verificationLinks: [], peerDisplayName: null, peerLabel: '', inputUsdPerMillion: 1, outputUsdPerMillion: 2, cachedInputUsdPerMillion: null, lifetimeSessions: 0, lifetimeRequests: 0, lifetimeInputTokens: 0, lifetimeOutputTokens: 0, lifetimeFirstSessionAt: null, lifetimeLastSessionAt: null, onChainChannelCount: null, agentId: 1, stakeUsdc: '0', onChainActiveChannelCount: 0, onChainGhostCount: 0, onChainTotalVolumeUsdc: '0', onChainLastSettledAt: 0, onChainReputationScore: null, selectionValue: 'openai\u0001s1\u0001p1' },
   ];
   const options = projectRowsToChatServiceOptions(rows);
   assert.equal(options.length, 1);

--- a/apps/desktop/src/renderer/modules/discover-rows.ts
+++ b/apps/desktop/src/renderer/modules/discover-rows.ts
@@ -1,4 +1,5 @@
 import type { ChatServiceOptionEntry, DiscoverRow } from '../core/state';
+import type { DiscoverVerificationLink } from '../core/state';
 
 const CHAT_SERVICE_SELECTION_SEPARATOR = '\u0001';
 
@@ -8,6 +9,22 @@ function toNullableBigintString(v: unknown): string | null {
   if (typeof v === 'number' && Number.isFinite(v)) return Math.trunc(v).toString();
   if (typeof v === 'bigint') return v.toString();
   return null;
+}
+
+function normalizeVerificationLink(raw: unknown): DiscoverVerificationLink | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const kind = r.kind === 'domain' || r.kind === 'github' ? r.kind : null;
+  const label = typeof r.label === 'string' ? r.label.trim() : '';
+  const href = typeof r.href === 'string' ? r.href.trim() : '';
+  if (!kind || !label || !href) return null;
+  try {
+    const url = new URL(href);
+    if (url.protocol !== 'https:') return null;
+    return { kind, label, href: url.toString() };
+  } catch {
+    return null;
+  }
 }
 
 export function normalizeDiscoverRow(raw: unknown): DiscoverRow | null {
@@ -26,6 +43,11 @@ export function normalizeDiscoverRow(raw: unknown): DiscoverRow | null {
     peerId,
     peerEvmAddress: String(r.peerEvmAddress ?? ''),
     sellerContract: typeof r.sellerContract === 'string' && r.sellerContract.length > 0 ? r.sellerContract : null,
+    verificationLinks: Array.isArray(r.verificationLinks)
+      ? r.verificationLinks
+        .map(normalizeVerificationLink)
+        .filter((link): link is DiscoverVerificationLink => link !== null)
+      : [],
     peerDisplayName: typeof r.peerDisplayName === 'string' ? r.peerDisplayName : null,
     peerLabel: String(r.peerLabel ?? ''),
     inputUsdPerMillion: typeof r.inputUsdPerMillion === 'number' ? r.inputUsdPerMillion : null,

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
@@ -392,11 +392,22 @@
 .card-stats {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 6px;
   font-size: 11px;
   color: var(--text-muted);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.card-stats-values {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 6px;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -565,14 +576,6 @@
   min-width: 0;
 }
 
-.card-provider-by {
-  font-size: 12px;
-  font-weight: 400;
-  color: var(--text-muted);
-  line-height: 12px;
-  flex-shrink: 0;
-}
-
 .provider-avatar {
   width: 16px;
   height: 16px;
@@ -606,6 +609,13 @@
   flex-shrink: 0;
 }
 
+.card-badges {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
 /* ── Proxy / pool identification badge ───────────────────────────────
    Surfaces "this peer settles through a known on-chain pool" (e.g. the
    DIEM Staking Pool). Intentionally styled as a neutral identifier *icon*,
@@ -621,7 +631,6 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  margin-left: 4px;
   width: 16px;
   height: 16px;
   padding: 0;
@@ -641,6 +650,61 @@
   &:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 1px;
+  }
+}
+
+.verification-badges {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+}
+
+.verification-badge {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #059669;
+  line-height: 0;
+  cursor: pointer;
+  transition: color 0.12s ease, background 0.12s ease;
+
+  &:hover,
+  &:focus-visible {
+    color: #047857;
+    background: rgba(5, 150, 105, 0.08);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+}
+
+.verification-badge-domain {
+  color: #0284c7;
+
+  &:hover,
+  &:focus-visible {
+    color: #0369a1;
+    background: rgba(2, 132, 199, 0.08);
+  }
+}
+
+.verification-badge-github {
+  color: var(--text-primary);
+
+  &:hover,
+  &:focus-visible {
+    color: var(--accent);
   }
 }
 
@@ -802,6 +866,16 @@
      `var(--text-primary)` which flips automatically, so no color override is
      needed here. `.card-score-tooltip` lives in InfoTooltip.module.scss and
      carries its own dark-theme rule. */
+
+  .verification-badge-domain {
+    color: #38bdf8;
+
+    &:hover,
+    &:focus-visible {
+      color: #7dd3fc;
+      background: rgba(56, 189, 248, 0.12);
+    }
+  }
 
   .filter-trigger {
     border-color: rgba(255, 255, 255, 0.08) !important;

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -1,10 +1,10 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
 import type { CSSProperties, MouseEvent } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { Copy01Icon, Tick02Icon, ContractsIcon } from '@hugeicons/core-free-icons';
+import { Copy01Icon, Tick02Icon, ContractsIcon, GithubIcon, Globe02Icon } from '@hugeicons/core-free-icons';
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
-import type { ChatServiceOptionEntry, DiscoverRow } from '../../../core/state';
+import type { ChatServiceOptionEntry, DiscoverRow, DiscoverVerificationLink } from '../../../core/state';
 import { useUiSnapshot } from '../../hooks/useUiSnapshot';
 import { useDiscoverFilters } from '../../hooks/useDiscoverFilters';
 import {
@@ -67,6 +67,7 @@ type CardItem = {
    * derived address or the proxy is not in our known registry.
    */
   knownProxy: KnownProxy | null;
+  verificationLinks: DiscoverVerificationLink[];
   inputUsdPerMillion: number | null;
   outputUsdPerMillion: number | null;
   cachedInputUsdPerMillion: number | null;
@@ -153,6 +154,7 @@ function buildCards(options: ChatServiceOptionEntry[]): CardItem[] {
       // list therefore never light up the badge, which is fine: as soon as
       // the daemon delivers DiscoverRows the proxy gets surfaced.
       knownProxy: null,
+      verificationLinks: [],
       inputUsdPerMillion: opt.inputUsdPerMillion,
       outputUsdPerMillion: opt.outputUsdPerMillion,
       cachedInputUsdPerMillion: opt.cachedInputUsdPerMillion ?? null,
@@ -212,6 +214,7 @@ function buildCardsFromRows(rows: DiscoverRow[]): CardItem[] {
       gradient: getPeerGradient(row.peerId || peerLabel || row.provider || row.serviceId),
       description: generateDescription(row.serviceId, row.categories, peerLabel || row.provider),
       knownProxy: getKnownProxy(row.sellerContract),
+      verificationLinks: row.verificationLinks,
       inputUsdPerMillion: row.inputUsdPerMillion,
       outputUsdPerMillion: row.outputUsdPerMillion,
       cachedInputUsdPerMillion: row.cachedInputUsdPerMillion,
@@ -266,6 +269,7 @@ function matchesSearch(item: CardItem, query: string): boolean {
   if (item.name.toLowerCase().includes(q)) return true;
   if (item.displayName.toLowerCase().includes(q)) return true;
   if (item.peerLabel.toLowerCase().includes(q)) return true;
+  if (item.verificationLinks.some((link) => link.label.toLowerCase().includes(q))) return true;
   if (item.tags.some((t) => t.toLowerCase().includes(q))) return true;
   return false;
 }
@@ -301,6 +305,84 @@ function ProviderAvatar({ name, gradient }: { name: string; gradient: string }) 
   return (
     <span className={styles.providerAvatar} style={{ background: gradient }}>
       {letter}
+    </span>
+  );
+}
+
+function verificationTitle(link: DiscoverVerificationLink): string {
+  return link.kind === 'domain'
+    ? `Verified domain: ${link.label}`
+    : `Verified GitHub: ${link.label}`;
+}
+
+function VerificationLinkBadge({ link }: { link: DiscoverVerificationLink }) {
+  const title = verificationTitle(link);
+  return (
+    <InfoTooltip
+      align="left"
+      content={(
+        <>
+          <strong>{title}</strong>
+          <span>{link.href}</span>
+        </>
+      )}
+    >
+      <a
+        className={`${styles.verificationBadge} ${link.kind === 'domain' ? styles.verificationBadgeDomain : styles.verificationBadgeGithub}`}
+        href={link.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={title}
+        title={title}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <HugeiconsIcon icon={link.kind === 'domain' ? Globe02Icon : GithubIcon} size={11} strokeWidth={1.8} />
+      </a>
+    </InfoTooltip>
+  );
+}
+
+function VerificationBadges({ links }: { links: DiscoverVerificationLink[] }) {
+  if (links.length === 0) return null;
+  return (
+    <span className={styles.verificationBadges} aria-label="Verified external claims">
+      {links.map((link) => (
+        <VerificationLinkBadge key={`${link.kind}:${link.href}`} link={link} />
+      ))}
+    </span>
+  );
+}
+
+function CardBadges({ item }: { item: CardItem }) {
+  if (!item.knownProxy && item.verificationLinks.length === 0) return null;
+  return (
+    <span className={styles.cardBadges}>
+      {item.knownProxy && (
+        <InfoTooltip
+          align="left"
+          content={(
+            <>
+              <strong>{item.knownProxy.label}</strong>
+              <span>{item.knownProxy.description}</span>
+            </>
+          )}
+        >
+          <span
+            className={styles.proxyBadge}
+            tabIndex={0}
+            role="button"
+            /* The label + description live in the popover; the surface only shows
+               the icon, but screen readers still get the full sentence. */
+            aria-label={`${item.knownProxy.label} — ${item.knownProxy.description}`}
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+          >
+            <HugeiconsIcon icon={ContractsIcon} size={11} strokeWidth={1.8} />
+          </span>
+        </InfoTooltip>
+      )}
+      <VerificationBadges links={item.verificationLinks} />
     </span>
   );
 }
@@ -738,36 +820,11 @@ function Card({
       <div className={styles.cardFooter}>
         <div className={styles.cardFooterTop}>
           <div className={styles.cardProvider}>
-            <span className={styles.cardProviderBy}>By</span>
             <ProviderAvatar name={providerName} gradient={item.gradient} />
             <span className={styles.cardProviderName}>{providerName}</span>
-            {item.knownProxy && (
-              <InfoTooltip
-                align="left"
-                content={(
-                  <>
-                    <strong>{item.knownProxy.label}</strong>
-                    <span>{item.knownProxy.description}</span>
-                  </>
-                )}
-              >
-                <span
-                  className={styles.proxyBadge}
-                  tabIndex={0}
-                  role="button"
-                  /* The label + description live in the popover; the surface only shows
-                     the icon, but screen readers still get the full sentence. */
-                  aria-label={`${item.knownProxy.label} — ${item.knownProxy.description}`}
-                  onClick={(e) => e.stopPropagation()}
-                  onKeyDown={(e) => e.stopPropagation()}
-                >
-                  <HugeiconsIcon icon={ContractsIcon} size={11} strokeWidth={1.8} />
-                </span>
-              </InfoTooltip>
-            )}
+            <CardBadges item={item} />
           </div>
           <div className={styles.cardFooterMetrics}>
-            <span>{formatCompact(item.channelCount)} session{item.channelCount === 1 ? '' : 's'}</span>
             <InfoTooltip
               align="right"
               content={(
@@ -802,15 +859,17 @@ function Card({
             <span>Low reputation: limited on-chain history</span>
           ) : (
             <>
-              {item.providerCount > 1 && (
-                <span>{item.providerCount} providers</span>
-              )}
-              {item.providerCount > 1 && <span className={styles.statsDot} />}
-              <span>{formatVolumeUsdc(item.volumeUsdc)} USDC volume</span>
-              <span className={styles.statsDot} />
-              <span>{formatCompact(item.lifetimeRequests)} request{item.lifetimeRequests === 1 ? '' : 's'}</span>
-              <span className={styles.statsDot} />
-              <span>{formatCompact(item.lifetimeTokens)} token{item.lifetimeTokens === 1 ? '' : 's'}</span>
+              <span className={styles.cardStatsValues}>
+                {item.providerCount > 1 && (
+                  <span>{item.providerCount} providers</span>
+                )}
+                {item.providerCount > 1 && <span className={styles.statsDot} />}
+                <span>{formatCompact(item.channelCount)} session{item.channelCount === 1 ? '' : 's'}</span>
+                <span className={styles.statsDot} />
+                <span>{formatVolumeUsdc(item.volumeUsdc)} USDC volume</span>
+                <span className={styles.statsDot} />
+                <span>{formatCompact(item.lifetimeTokens)} token{item.lifetimeTokens === 1 ? '' : 's'}</span>
+              </span>
             </>
           )}
         </div>

--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.test.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.test.ts
@@ -15,7 +15,7 @@ function mkRow(overrides: Partial<DiscoverRow> = {}): DiscoverRow {
     rowKey: 'p:s',
     serviceId: 's', serviceLabel: 'Service', categories: [],
     provider: 'openai', protocol: 'openai-chat-completions',
-    peerId: 'p', peerEvmAddress: '0xp', peerDisplayName: 'Peer', peerLabel: 'Peer',
+    peerId: 'p', peerEvmAddress: '0xp', sellerContract: null, verificationLinks: [], peerDisplayName: 'Peer', peerLabel: 'Peer',
     inputUsdPerMillion: 1, outputUsdPerMillion: 2, cachedInputUsdPerMillion: null,
     lifetimeSessions: 0, lifetimeRequests: 0, lifetimeInputTokens: 0, lifetimeOutputTokens: 0,
     lifetimeFirstSessionAt: null, lifetimeLastSessionAt: null,

--- a/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.test.ts
+++ b/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.test.ts
@@ -11,7 +11,7 @@ function mkRow(i: number, chat: boolean): DiscoverRow {
     rowKey: `p${i}:s${i}`,
     serviceId: `s${i}`, serviceLabel: `Svc${i}`, categories: [i % 2 === 0 ? 'math' : 'coding'],
     provider: 'openai', protocol: 'openai-chat-completions',
-    peerId: `p${i}`, peerEvmAddress: `0xp${i}`, sellerContract: null, peerDisplayName: `P${i}`, peerLabel: `P${i}`,
+    peerId: `p${i}`, peerEvmAddress: `0xp${i}`, sellerContract: null, verificationLinks: [], peerDisplayName: `P${i}`, peerLabel: `P${i}`,
     inputUsdPerMillion: i, outputUsdPerMillion: i * 2, cachedInputUsdPerMillion: null,
     lifetimeSessions: chat ? i : 0, lifetimeRequests: 0, lifetimeInputTokens: 0, lifetimeOutputTokens: 0,
     lifetimeFirstSessionAt: null, lifetimeLastSessionAt: chat ? i * 1000 : null,


### PR DESCRIPTION
## Description

Adds verified seller domain and GitHub links to the Desktop Discover cards. The desktop main process converts buyer-computed verification results from buyer.state.json into safe HTTPS links, and the renderer displays them next to the peer name.

## Release Notes

- Show verified seller domain and GitHub links on Desktop Discover cards
- Keep Discover card usage stats in the footer with sessions, volume, and token counts

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
