### PR TITLE
feat(cli): Show verified seller links

### DIFF
--- a/apps/cli/src/cli/commands/network/browse.test.ts
+++ b/apps/cli/src/cli/commands/network/browse.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { peerMatchesServiceFilter } from './browse.js';
+import { collectVerificationLinks, peerMatchesServiceFilter } from './browse.js';
 import type { PeerInfo } from '@antseed/node';
 
 function peerWithServices(services: string[], providers: string[] = ['minimax']): PeerInfo {
@@ -36,4 +36,50 @@ test('network browse service filter still matches providers', () => {
 
 test('network browse service filter rejects unrelated services', () => {
   assert.equal(peerMatchesServiceFilter(peerWithServices(['minimax-m3']), 'claude'), false);
+});
+
+test('network browse builds links for verified external claims only', () => {
+  const peer = peerWithServices(['minimax-m3']);
+  peer.verificationResults = {
+    verified: false,
+    checkedAtMs: 123,
+    domains: [
+      {
+        domain: 'Example.com',
+        peerId: peer.peerId,
+        verified: true,
+        method: 'dns-txt',
+        checkedAtMs: 123,
+        attempts: [{ method: 'dns-txt', verified: true }],
+      },
+      {
+        domain: 'unverified.example',
+        peerId: peer.peerId,
+        verified: false,
+        checkedAtMs: 123,
+        attempts: [{ method: 'dns-txt', verified: false }],
+      },
+    ],
+    github: [
+      {
+        username: 'OctoCat',
+        repository: 'antseed-proof',
+        peerId: peer.peerId,
+        verified: true,
+        checkedAtMs: 123,
+      },
+      {
+        username: 'bad user',
+        repository: 'repo',
+        peerId: peer.peerId,
+        verified: true,
+        checkedAtMs: 123,
+      },
+    ],
+  };
+
+  assert.deepEqual(collectVerificationLinks(peer), [
+    { kind: 'domain', label: 'example.com', href: 'https://example.com' },
+    { kind: 'github', label: '@octocat/antseed-proof', href: 'https://github.com/octocat/antseed-proof' },
+  ]);
 });

--- a/apps/cli/src/cli/commands/network/browse.test.ts
+++ b/apps/cli/src/cli/commands/network/browse.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { collectVerificationLinks, peerMatchesServiceFilter } from './browse.js';
+import { peerMatchesServiceFilter } from './browse.js';
+import { collectPeerVerificationLinks } from '@antseed/node/discovery';
 import type { PeerInfo } from '@antseed/node';
 
 function peerWithServices(services: string[], providers: string[] = ['minimax']): PeerInfo {
@@ -78,7 +79,7 @@ test('network browse builds links for verified external claims only', () => {
     ],
   };
 
-  assert.deepEqual(collectVerificationLinks(peer), [
+  assert.deepEqual(collectPeerVerificationLinks(peer), [
     { kind: 'domain', label: 'example.com', href: 'https://example.com' },
     { kind: 'github', label: '@octocat/antseed-proof', href: 'https://github.com/octocat/antseed-proof' },
   ]);

--- a/apps/cli/src/cli/commands/network/browse.ts
+++ b/apps/cli/src/cli/commands/network/browse.ts
@@ -12,6 +12,10 @@ import {
   type PeerInfo,
 } from '@antseed/node';
 import { parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery';
+import {
+  collectPeerVerificationLinks,
+  type PeerVerificationLink,
+} from '@antseed/node/discovery';
 import { parsePersistedPeers } from '../../../proxy/buyer-proxy.js';
 import { buildPaymentsConfig } from './chain-config-helper.js';
 import { resolveEffectiveBuyerConfig } from '../../../config/effective.js';
@@ -245,7 +249,7 @@ type PeerInfoJson = Omit<PeerInfo, 'onChainReputationScore'> & {
   onChainReputationScore: number | null;
   sellerAddress: string;
   isDelegatedSeller: boolean;
-  verificationLinks: VerificationLink[];
+  verificationLinks: PeerVerificationLink[];
 };
 
 function normalizeAddressHex(raw: string | undefined): string | null {
@@ -268,73 +272,8 @@ function delegatedSellerAddress(peer: PeerInfo): string | null {
   return sellerAddress !== peerAddress ? sellerAddress : null;
 }
 
-type VerificationLink = {
-  kind: 'domain' | 'github';
-  label: string;
-  href: string;
-};
-
-function buildHttpsUrl(hostname: string): string | null {
-  const normalized = hostname.trim().toLowerCase();
-  if (!/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/i.test(normalized) || normalized.includes('..')) {
-    return null;
-  }
-  try {
-    const url = new URL(`https://${normalized}`);
-    if (url.hostname !== normalized) return null;
-    return `https://${normalized}`;
-  } catch {
-    return null;
-  }
-}
-
-function isGithubName(value: string): boolean {
-  return /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i.test(value);
-}
-
-function isGithubRepository(value: string): boolean {
-  return /^[a-z0-9._-]{1,100}$/i.test(value) && value !== '.' && value !== '..';
-}
-
-export function collectVerificationLinks(peer: PeerInfo): VerificationLink[] {
-  const results = peer.verificationResults;
-  if (!results) return [];
-  const out: VerificationLink[] = [];
-  const seen = new Set<string>();
-
-  const add = (link: VerificationLink) => {
-    const key = `${link.kind}\u0000${link.href}`;
-    if (seen.has(key)) return;
-    seen.add(key);
-    out.push(link);
-  };
-
-  for (const result of results.domains ?? []) {
-    if (!result || typeof result !== 'object') continue;
-    const rec = result as { verified?: unknown; domain?: unknown };
-    if (rec.verified !== true || typeof rec.domain !== 'string') continue;
-    const href = buildHttpsUrl(rec.domain);
-    if (!href) continue;
-    add({ kind: 'domain', label: rec.domain.trim().toLowerCase(), href });
-  }
-
-  for (const result of results.github ?? []) {
-    if (!result || typeof result !== 'object') continue;
-    const rec = result as { verified?: unknown; username?: unknown; repository?: unknown };
-    if (rec.verified !== true || typeof rec.username !== 'string') continue;
-    const username = rec.username.trim().toLowerCase();
-    if (!isGithubName(username)) continue;
-    const repository = typeof rec.repository === 'string' ? rec.repository.trim() : '';
-    const hasRepository = repository.length > 0 && isGithubRepository(repository);
-    const path = hasRepository ? `${username}/${repository}` : username;
-    add({ kind: 'github', label: `@${path}`, href: `https://github.com/${path}` });
-  }
-
-  return out;
-}
-
 function formatVerificationLinks(peer: PeerInfo): string {
-  const links = collectVerificationLinks(peer);
+  const links = collectPeerVerificationLinks(peer);
   if (links.length === 0) return chalk.dim('—');
   return links
     .map((link) => {
@@ -353,7 +292,7 @@ function peerWithReputationScore(peer: PeerInfo): PeerInfoJson {
     onChainReputationScore: effectiveOnChainReputationScore(peer),
     sellerAddress,
     isDelegatedSeller: delegatedSellerAddress(peer) !== null,
-    verificationLinks: collectVerificationLinks(peer),
+    verificationLinks: collectPeerVerificationLinks(peer),
   };
 }
 
@@ -479,7 +418,7 @@ function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
   // Show the "Seller" column when at least one peer has a sellerContract
   // that differs from its peerId (i.e. a delegated/proxy seller).
   const anyDelegatedSeller = peers.some((peer) => delegatedSellerAddress(peer) !== null);
-  const anyVerificationLinks = peers.some((peer) => collectVerificationLinks(peer).length > 0);
+  const anyVerificationLinks = peers.some((peer) => collectPeerVerificationLinks(peer).length > 0);
 
   const head: string[] = [
     chalk.bold('Peer'),
@@ -616,7 +555,7 @@ function renderExpandedTable(peers: PeerInfo[], requestedTags: Set<string>): voi
   // Show the "Seller" column when at least one peer has a sellerContract
   // that differs from its peerId (i.e. a delegated/proxy seller).
   const anyDelegatedSeller = peers.some((peer) => delegatedSellerAddress(peer) !== null);
-  const anyVerificationLinks = peers.some((peer) => collectVerificationLinks(peer).length > 0);
+  const anyVerificationLinks = peers.some((peer) => collectPeerVerificationLinks(peer).length > 0);
 
   for (const peer of peers) {
     const pricing = peer.providerPricing;

--- a/apps/cli/src/cli/commands/network/browse.ts
+++ b/apps/cli/src/cli/commands/network/browse.ts
@@ -245,6 +245,7 @@ type PeerInfoJson = Omit<PeerInfo, 'onChainReputationScore'> & {
   onChainReputationScore: number | null;
   sellerAddress: string;
   isDelegatedSeller: boolean;
+  verificationLinks: VerificationLink[];
 };
 
 function normalizeAddressHex(raw: string | undefined): string | null {
@@ -267,6 +268,84 @@ function delegatedSellerAddress(peer: PeerInfo): string | null {
   return sellerAddress !== peerAddress ? sellerAddress : null;
 }
 
+type VerificationLink = {
+  kind: 'domain' | 'github';
+  label: string;
+  href: string;
+};
+
+function buildHttpsUrl(hostname: string): string | null {
+  const normalized = hostname.trim().toLowerCase();
+  if (!/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/i.test(normalized) || normalized.includes('..')) {
+    return null;
+  }
+  try {
+    const url = new URL(`https://${normalized}`);
+    if (url.hostname !== normalized) return null;
+    return `https://${normalized}`;
+  } catch {
+    return null;
+  }
+}
+
+function isGithubName(value: string): boolean {
+  return /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i.test(value);
+}
+
+function isGithubRepository(value: string): boolean {
+  return /^[a-z0-9._-]{1,100}$/i.test(value) && value !== '.' && value !== '..';
+}
+
+export function collectVerificationLinks(peer: PeerInfo): VerificationLink[] {
+  const results = peer.verificationResults;
+  if (!results) return [];
+  const out: VerificationLink[] = [];
+  const seen = new Set<string>();
+
+  const add = (link: VerificationLink) => {
+    const key = `${link.kind}\u0000${link.href}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(link);
+  };
+
+  for (const result of results.domains ?? []) {
+    if (!result || typeof result !== 'object') continue;
+    const rec = result as { verified?: unknown; domain?: unknown };
+    if (rec.verified !== true || typeof rec.domain !== 'string') continue;
+    const href = buildHttpsUrl(rec.domain);
+    if (!href) continue;
+    add({ kind: 'domain', label: rec.domain.trim().toLowerCase(), href });
+  }
+
+  for (const result of results.github ?? []) {
+    if (!result || typeof result !== 'object') continue;
+    const rec = result as { verified?: unknown; username?: unknown; repository?: unknown };
+    if (rec.verified !== true || typeof rec.username !== 'string') continue;
+    const username = rec.username.trim().toLowerCase();
+    if (!isGithubName(username)) continue;
+    const repository = typeof rec.repository === 'string' ? rec.repository.trim() : '';
+    const hasRepository = repository.length > 0 && isGithubRepository(repository);
+    const path = hasRepository ? `${username}/${repository}` : username;
+    add({ kind: 'github', label: `@${path}`, href: `https://github.com/${path}` });
+  }
+
+  return out;
+}
+
+function formatVerificationLinks(peer: PeerInfo): string {
+  const links = collectVerificationLinks(peer);
+  if (links.length === 0) return chalk.dim('—');
+  return links
+    .map((link) => {
+      if (link.kind === 'domain') {
+        return `${chalk.cyan('🌐')} ${chalk.underline(link.href)}`;
+      }
+      return `${chalk.magenta('GH')} ${chalk.underline(link.href)}`;
+    })
+    .join('\n');
+}
+
 function peerWithReputationScore(peer: PeerInfo): PeerInfoJson {
   const sellerAddress = sellerAddressForPeer(peer);
   return {
@@ -274,6 +353,7 @@ function peerWithReputationScore(peer: PeerInfo): PeerInfoJson {
     onChainReputationScore: effectiveOnChainReputationScore(peer),
     sellerAddress,
     isDelegatedSeller: delegatedSellerAddress(peer) !== null,
+    verificationLinks: collectVerificationLinks(peer),
   };
 }
 
@@ -399,6 +479,7 @@ function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
   // Show the "Seller" column when at least one peer has a sellerContract
   // that differs from its peerId (i.e. a delegated/proxy seller).
   const anyDelegatedSeller = peers.some((peer) => delegatedSellerAddress(peer) !== null);
+  const anyVerificationLinks = peers.some((peer) => collectVerificationLinks(peer).length > 0);
 
   const head: string[] = [
     chalk.bold('Peer'),
@@ -406,6 +487,9 @@ function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
   if (anyDelegatedSeller) head.push(chalk.bold('On-chain seller'));
   head.push(
     chalk.bold('Name'),
+  );
+  if (anyVerificationLinks) head.push(chalk.bold('Verified'));
+  head.push(
     chalk.bold('Providers'),
     chalk.bold('Services'),
     chalk.bold('Min In $/1M'),
@@ -458,6 +542,9 @@ function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
     if (anyDelegatedSeller) row.push(sellerCell);
     row.push(
       peer.displayName ?? chalk.dim('—'),
+    );
+    if (anyVerificationLinks) row.push(formatVerificationLinks(peer));
+    row.push(
       peer.providers.join(', ') || chalk.dim('—'),
       servicesCell,
       formatUsdPerMillion(pricing.input),
@@ -489,6 +576,9 @@ function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
   }
   if (anyDelegatedSeller) {
     console.log(chalk.dim(`  ${chalk.yellow('On-chain seller')} is the contract address that receives payments — differs from Peer when a delegated/proxy operator runs the node.`));
+  }
+  if (anyVerificationLinks) {
+    console.log(chalk.dim(`  Verified shows buyer-verified external claims: ${chalk.cyan('🌐')} domain, ${chalk.magenta('GH')} GitHub.`));
   }
   console.log('');
 }
@@ -526,6 +616,7 @@ function renderExpandedTable(peers: PeerInfo[], requestedTags: Set<string>): voi
   // Show the "Seller" column when at least one peer has a sellerContract
   // that differs from its peerId (i.e. a delegated/proxy seller).
   const anyDelegatedSeller = peers.some((peer) => delegatedSellerAddress(peer) !== null);
+  const anyVerificationLinks = peers.some((peer) => collectVerificationLinks(peer).length > 0);
 
   for (const peer of peers) {
     const pricing = peer.providerPricing;
@@ -594,6 +685,7 @@ function renderExpandedTable(peers: PeerInfo[], requestedTags: Set<string>): voi
     chalk.bold('Peer'),
   ];
   if (anyDelegatedSeller) head.push(chalk.bold('On-chain seller'));
+  if (anyVerificationLinks) head.push(chalk.bold('Verified'));
   head.push(
     chalk.bold('Provider'),
     chalk.bold('Service'),
@@ -615,6 +707,10 @@ function renderExpandedTable(peers: PeerInfo[], requestedTags: Set<string>): voi
       const rowPeer = peers.find((p) => p.peerId === r.peerId);
       const sellerAddress = rowPeer ? delegatedSellerAddress(rowPeer) : null;
       row.push(sellerAddress !== null ? chalk.yellow(sellerAddress) : chalk.dim('—'));
+    }
+    if (anyVerificationLinks) {
+      const rowPeer = peers.find((p) => p.peerId === r.peerId);
+      row.push(rowPeer ? formatVerificationLinks(rowPeer) : chalk.dim('—'));
     }
     row.push(
       r.provider,
@@ -644,6 +740,9 @@ function renderExpandedTable(peers: PeerInfo[], requestedTags: Set<string>): voi
   }
   if (anyDelegatedSeller) {
     console.log(chalk.dim(`  ${chalk.yellow('On-chain seller')} is the contract address that receives payments — differs from Peer when a delegated/proxy operator runs the node.`));
+  }
+  if (anyVerificationLinks) {
+    console.log(chalk.dim(`  Verified shows buyer-verified external claims: ${chalk.cyan('🌐')} domain, ${chalk.magenta('GH')} GitHub.`));
   }
   console.log('');
 }

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -72,6 +72,7 @@ import {
   type NetworkPeerAddress,
 } from './chat-service-catalog.js';
 import { resolveChainConfig } from '@antseed/node';
+import { collectPeerVerificationLinks, type PeerVerificationLink } from '@antseed/node/discovery';
 import {
   AuthStorage,
   createAgentSession,
@@ -299,11 +300,7 @@ type DiscoverRowEntry = {
   selectionValue: string;
 };
 
-type DiscoverVerificationLink = {
-  kind: 'domain' | 'github';
-  label: string;
-  href: string;
-};
+type DiscoverVerificationLink = PeerVerificationLink;
 
 const CHAT_SESSIONS_DIR = path.join(CHAT_DATA_DIR, 'sessions');
 const CHAT_AGENT_DIR = path.join(CHAT_DATA_DIR, 'pi-agent');
@@ -358,65 +355,6 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     return null;
   }
   return value as Record<string, unknown>;
-}
-
-function buildHttpsUrl(hostname: string): string | null {
-  const normalized = hostname.trim().toLowerCase();
-  if (!/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/i.test(normalized) || normalized.includes('..')) {
-    return null;
-  }
-  try {
-    const url = new URL(`https://${normalized}`);
-    if (url.hostname !== normalized) return null;
-    return url.toString();
-  } catch {
-    return null;
-  }
-}
-
-function isGithubName(value: string): boolean {
-  return /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i.test(value);
-}
-
-function isGithubRepository(value: string): boolean {
-  return /^[a-z0-9._-]{1,100}$/i.test(value) && value !== '.' && value !== '..';
-}
-
-function buildVerificationLinks(rawResults: unknown): DiscoverVerificationLink[] {
-  const results = asRecord(rawResults);
-  if (!results) return [];
-  const out: DiscoverVerificationLink[] = [];
-  const seen = new Set<string>();
-
-  const add = (link: DiscoverVerificationLink) => {
-    const key = `${link.kind}\u0000${link.href}`;
-    if (seen.has(key)) return;
-    seen.add(key);
-    out.push(link);
-  };
-
-  const domains = Array.isArray(results.domains) ? results.domains : [];
-  for (const raw of domains) {
-    const rec = asRecord(raw);
-    if (rec?.verified !== true || typeof rec.domain !== 'string') continue;
-    const href = buildHttpsUrl(rec.domain);
-    if (!href) continue;
-    add({ kind: 'domain', label: rec.domain.trim().toLowerCase(), href });
-  }
-
-  const github = Array.isArray(results.github) ? results.github : [];
-  for (const raw of github) {
-    const rec = asRecord(raw);
-    if (rec?.verified !== true || typeof rec.username !== 'string') continue;
-    const username = rec.username.trim().toLowerCase();
-    if (!isGithubName(username)) continue;
-    const repository = typeof rec.repository === 'string' ? rec.repository.trim() : '';
-    const hasRepository = repository.length > 0 && isGithubRepository(repository);
-    const path = hasRepository ? `${username}/${repository}` : username;
-    add({ kind: 'github', label: `@${path}`, href: `https://github.com/${path}` });
-  }
-
-  return out;
 }
 
 function normalizeNonNegativeNumber(value: unknown): number | null {
@@ -2789,7 +2727,7 @@ export function registerPiChatHandlers({
                 ? rec.onChainSybilFlags.filter((f: unknown): f is string => typeof f === 'string')
                 : [],
               sellerContract: typeof rec.sellerContract === 'string' ? rec.sellerContract : undefined,
-              verificationLinks: buildVerificationLinks(rec.verificationResults),
+              verificationLinks: collectPeerVerificationLinks({ verificationResults: rec.verificationResults }),
               providerPricing: rec.providerPricing as Record<string, {
                 services?: Record<string, { cachedInputUsdPerMillion?: number }>
               }> | undefined,

--- a/packages/node/src/discovery/index.ts
+++ b/packages/node/src/discovery/index.ts
@@ -50,6 +50,12 @@ export {
   type GithubVerificationOptions,
   type GithubVerificationResult,
 } from './github-verification.js';
+export {
+  collectPeerVerificationLinks,
+  isGithubName,
+  isGithubRepository,
+  type PeerVerificationLink,
+} from './verification-links.js';
 export { parsePublicAddress, MAX_PUBLIC_ADDRESS_LENGTH, type ParsedPublicAddress } from './public-address.js';
 export { type MetadataResolver, type PeerEndpoint } from './metadata-resolver.js';
 export { HttpMetadataResolver, type HttpMetadataResolverConfig } from './http-metadata-resolver.js';

--- a/packages/node/src/discovery/verification-links.ts
+++ b/packages/node/src/discovery/verification-links.ts
@@ -1,0 +1,76 @@
+export type PeerVerificationLink = {
+  kind: "domain" | "github";
+  label: string;
+  href: string;
+};
+
+function buildHttpsUrl(hostname: string): string | null {
+  const normalized = hostname.trim().toLowerCase();
+  if (!/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/i.test(normalized) || normalized.includes("..")) {
+    return null;
+  }
+  try {
+    const url = new URL(`https://${normalized}`);
+    if (url.hostname !== normalized) return null;
+    return `https://${normalized}`;
+  } catch {
+    return null;
+  }
+}
+
+export function isGithubName(value: string): boolean {
+  return /^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/i.test(value);
+}
+
+export function isGithubRepository(value: string): boolean {
+  return /^[a-z0-9._-]{1,100}$/i.test(value) && value !== "." && value !== "..";
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Convert buyer-computed verification results into display-safe links.
+ * Only successful verification results are surfaced; malformed cached data is
+ * ignored so UI/CLI rendering cannot crash on old or hand-edited state files.
+ */
+export function collectPeerVerificationLinks(peer: { verificationResults?: unknown }): PeerVerificationLink[] {
+  const results = asRecord(peer.verificationResults);
+  if (!results) return [];
+  const out: PeerVerificationLink[] = [];
+  const seen = new Set<string>();
+
+  const add = (link: PeerVerificationLink) => {
+    const key = `${link.kind}\u0000${link.href}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push(link);
+  };
+
+  const domains = Array.isArray(results.domains) ? results.domains : [];
+  for (const raw of domains) {
+    const rec = asRecord(raw);
+    if (rec?.verified !== true || typeof rec.domain !== "string") continue;
+    const href = buildHttpsUrl(rec.domain);
+    if (!href) continue;
+    add({ kind: "domain", label: rec.domain.trim().toLowerCase(), href });
+  }
+
+  const github = Array.isArray(results.github) ? results.github : [];
+  for (const raw of github) {
+    const rec = asRecord(raw);
+    if (rec?.verified !== true || typeof rec.username !== "string") continue;
+    const username = rec.username.trim().toLowerCase();
+    if (!isGithubName(username)) continue;
+    const repository = typeof rec.repository === "string" ? rec.repository.trim() : "";
+    const hasRepository = repository.length > 0 && isGithubRepository(repository);
+    const path = hasRepository ? `${username}/${repository}` : username;
+    add({ kind: "github", label: `@${path}`, href: `https://github.com/${path}` });
+  }
+
+  return out;
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -60,6 +60,12 @@ export {
   type GithubVerificationOptions,
   type GithubVerificationResult,
 } from './discovery/github-verification.js';
+export {
+  collectPeerVerificationLinks,
+  isGithubName,
+  isGithubRepository,
+  type PeerVerificationLink,
+} from './discovery/verification-links.js';
 export { MetadataServer, type MetadataServerConfig } from './discovery/metadata-server.js';
 export { parsePublicAddress, MAX_PUBLIC_ADDRESS_LENGTH, type ParsedPublicAddress } from './discovery/public-address.js';
 export { MeteringStorage } from './metering/storage.js';

--- a/packages/node/tests/verification-links.test.ts
+++ b/packages/node/tests/verification-links.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { collectPeerVerificationLinks, isGithubName, isGithubRepository } from "../src/discovery/verification-links.js";
+
+const PEER_ID = "aa".repeat(20);
+
+describe("verification links", () => {
+  it("validates GitHub account and repository names", () => {
+    expect(isGithubName("octocat")).toBe(true);
+    expect(isGithubName("octo-cat")).toBe(true);
+    expect(isGithubName("-octocat")).toBe(false);
+    expect(isGithubName("bad user")).toBe(false);
+
+    expect(isGithubRepository("antseed-proof")).toBe(true);
+    expect(isGithubRepository("proof.repo")).toBe(true);
+    expect(isGithubRepository("..")).toBe(false);
+  });
+
+  it("builds links for verified external claims only", () => {
+    expect(collectPeerVerificationLinks({
+      verificationResults: {
+        verified: false,
+        checkedAtMs: 123,
+        domains: [
+          {
+            domain: "Example.com",
+            peerId: PEER_ID,
+            verified: true,
+            method: "dns-txt",
+            checkedAtMs: 123,
+            attempts: [{ method: "dns-txt", verified: true }],
+          },
+          {
+            domain: "unverified.example",
+            peerId: PEER_ID,
+            verified: false,
+            checkedAtMs: 123,
+            attempts: [{ method: "dns-txt", verified: false }],
+          },
+        ],
+        github: [
+          {
+            username: "OctoCat",
+            repository: "antseed-proof",
+            peerId: PEER_ID,
+            verified: true,
+            checkedAtMs: 123,
+          },
+          {
+            username: "bad user",
+            repository: "repo",
+            peerId: PEER_ID,
+            verified: true,
+            checkedAtMs: 123,
+          },
+        ],
+      },
+    })).toEqual([
+      { kind: "domain", label: "example.com", href: "https://example.com" },
+      { kind: "github", label: "@octocat/antseed-proof", href: "https://github.com/octocat/antseed-proof" },
+    ]);
+  });
+
+  it("ignores malformed cached results", () => {
+    expect(collectPeerVerificationLinks({
+      verificationResults: {
+        domains: [
+          null,
+          { verified: true, domain: "bad..example" },
+          { verified: true, domain: 123 },
+        ],
+        github: [
+          null,
+          { verified: true, username: "octocat", repository: ".." },
+          { verified: true, username: 123 },
+        ],
+      },
+    })).toEqual([
+      { kind: "github", label: "@octocat", href: "https://github.com/octocat" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

Adds verified seller domain and GitHub links to `antseed network browse`. The command now surfaces buyer-verified external claims in a conditional `Verified` column for both compact and `--services` table output, and includes normalized `verificationLinks` in JSON output.

## Release Notes

- Show verified seller domain and GitHub links in `antseed network browse`
- Include normalized verification links in browse JSON output

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
