### PR TITLE
feat(node): Add identity reputation points

### DIFF
--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -88,6 +88,7 @@ import {
 import {
   buildSybilContext,
   computeOnChainScore,
+  computeOnChainScoreWithRisk,
   computeOnChainSybilRisk,
   computeOnChainTrust,
   type SybilContext,
@@ -726,7 +727,12 @@ export class AntseedNode extends EventEmitter {
         checkedAtMs,
         results,
       });
-      return { ...peer, verificationResults: results };
+      const verifiedPeer: PeerInfo = { ...peer, verificationResults: results };
+      const risk = typeof verifiedPeer.onChainSybilRisk === 'number'
+        ? verifiedPeer.onChainSybilRisk
+        : 0;
+      verifiedPeer.onChainReputationScore = computeOnChainScoreWithRisk(verifiedPeer, risk) ?? verifiedPeer.onChainReputationScore;
+      return verifiedPeer;
     } catch (err) {
       debugWarn(`[Node] External verification failed for ${peer.peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
       return null;

--- a/packages/node/src/reputation/on-chain-reputation.ts
+++ b/packages/node/src/reputation/on-chain-reputation.ts
@@ -11,7 +11,24 @@ export const ON_CHAIN_TRUST_RECENCY_DORMANT_FACTOR = 0.25;
 export const ON_CHAIN_TRUST_STAKE_THRESHOLD_USDC = 1.0;
 export const ON_CHAIN_TRUST_NO_STAKE_FACTOR = 0.5;
 
-export const ON_CHAIN_SCORE_LOG_CAP_EXPONENT = 7;
+export const ON_CHAIN_TRUST_INITIAL_CREDIT_USDC = 25;
+export const ON_CHAIN_TRUST_DAILY_CREDIT_USDC = 125;
+export const ON_CHAIN_TRUST_MATURITY_DAYS = 30;
+export const ON_CHAIN_TRUST_CHANNEL_CONFIDENCE_CAP = 1_000;
+export const ON_CHAIN_TRUST_GHOST_PENALTY_WEIGHT = 2.5;
+export const ON_CHAIN_TRUST_MIN_GHOST_FACTOR = 0.25;
+export const ON_CHAIN_TRUST_LOW_TICKET_USDC = 0.25;
+export const ON_CHAIN_TRUST_LOW_TICKET_MIN_CHANNELS = 50;
+export const ON_CHAIN_TRUST_LOW_TICKET_FACTOR = 0.65;
+export const ON_CHAIN_TRUST_HIGH_TICKET_USDC = 50;
+export const ON_CHAIN_TRUST_HIGH_TICKET_MAX_CHANNELS = 20;
+export const ON_CHAIN_TRUST_HIGH_TICKET_FACTOR = 0.75;
+
+export const ON_CHAIN_SCORE_LOG_CAP_USDC = 10_000;
+export const ON_CHAIN_SCORE_LOG_CAP_EXPONENT = Math.log10(1 + ON_CHAIN_SCORE_LOG_CAP_USDC);
+export const ON_CHAIN_VERIFICATION_DOMAIN_POINTS = 5;
+export const ON_CHAIN_VERIFICATION_GITHUB_POINTS = 3;
+export const ON_CHAIN_VERIFICATION_MAX_POINTS = 8;
 
 export const SYBIL_WEIGHT_SUBFLOOR_TICKET = 0.30;
 export const SYBIL_WEIGHT_BURN_RATE       = 0.25;
@@ -49,11 +66,19 @@ export interface SybilContext {
 export interface OnChainTrustBreakdown {
   trust: number;
   volumeUsdc: number;
+  creditedVolumeUsdc: number;
+  volumeCreditCapUsdc: number;
   channels: number;
   avgChannelUsdc: number;
   ticketBonus: number;
+  ticketGate: number;
   recencyGate: number;
   stakeGate: number;
+  ageGate: number;
+  channelConfidence: number;
+  ghostGate: number;
+  scoreMultiplier: number;
+  verificationBonusPoints: number;
   daysSinceLastSettled: number | null;
   daysSinceStaked: number | null;
 }
@@ -67,6 +92,26 @@ function clamp(value: number, lo: number, hi: number): number {
 
 function nonNegativeFinite(value: number | undefined): number | null {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null;
+}
+
+function logConfidence(value: number, cap: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return clamp(Math.log10(1 + value) / Math.log10(1 + cap), 0, 1);
+}
+
+export function computeVerificationScoreBonus(
+  peer: Pick<PeerInfo, 'verificationResults'>,
+): number {
+  const results = peer.verificationResults;
+  if (!results) return 0;
+  const verifiedDomains = results.domains.filter((result) => result.verified).length;
+  const verifiedGithub = results.github.filter((result) => result.verified).length;
+  return clamp(
+    verifiedDomains * ON_CHAIN_VERIFICATION_DOMAIN_POINTS
+      + verifiedGithub * ON_CHAIN_VERIFICATION_GITHUB_POINTS,
+    0,
+    ON_CHAIN_VERIFICATION_MAX_POINTS,
+  );
 }
 
 function collectPeerServices(peer: PeerInfo): string[] {
@@ -106,14 +151,22 @@ function minAdvertisedInputUsdPerMillion(peer: PeerInfo): number | null {
   return best;
 }
 
-/** Compute raw on-chain trust, or `null` when chain stats are unavailable. */
+/**
+ * Compute raw on-chain trust, or `null` when chain stats are unavailable.
+ *
+ * Trust is anchored to settled USDC, but volume credit vests with seller age.
+ * Channel count, ghost rate, last-settled recency, stake, and ticket shape gate
+ * the displayed score instead of multiplying settled volume directly.
+ */
 export function computeOnChainTrustBreakdown(
   peer: Pick<PeerInfo,
     | 'onChainChannelCount'
+    | 'onChainGhostCount'
     | 'onChainTotalVolumeUsdcMicros'
     | 'onChainLastSettledAtSec'
     | 'onChainStakedAtSec'
     | 'onChainStakeUsdcMicros'
+    | 'verificationResults'
   >,
   nowMs: number = Date.now(),
 ): OnChainTrustBreakdown | null {
@@ -155,16 +208,56 @@ export function computeOnChainTrustBreakdown(
     ? Math.max(0, (nowMs - stakedAtSec * 1000) / 86_400_000)
     : null;
 
-  const trust = channels * volumeUsdc * ticketBonus * recencyGate * stakeGate;
+  const maturityDays = daysSinceStaked ?? 0;
+  const volumeCreditCapUsdc = ON_CHAIN_TRUST_INITIAL_CREDIT_USDC
+    + maturityDays * ON_CHAIN_TRUST_DAILY_CREDIT_USDC;
+  const creditedVolumeUsdc = Math.min(volumeUsdc, volumeCreditCapUsdc);
+
+  const ageGate = clamp(maturityDays / ON_CHAIN_TRUST_MATURITY_DAYS, 0.20, 1);
+  const channelConfidence = 0.35
+    + 0.65 * logConfidence(channels, ON_CHAIN_TRUST_CHANNEL_CONFIDENCE_CAP);
+
+  const ghosts = nonNegativeFinite(peer.onChainGhostCount) ?? 0;
+  const ghostRate = channels + ghosts > 0 ? ghosts / (channels + ghosts) : 0;
+  const ghostGate = clamp(
+    1 - ghostRate * ON_CHAIN_TRUST_GHOST_PENALTY_WEIGHT,
+    ON_CHAIN_TRUST_MIN_GHOST_FACTOR,
+    1,
+  );
+
+  let ticketGate = 1;
+  if (channels >= ON_CHAIN_TRUST_LOW_TICKET_MIN_CHANNELS && avgChannelUsdc < ON_CHAIN_TRUST_LOW_TICKET_USDC) {
+    ticketGate = ON_CHAIN_TRUST_LOW_TICKET_FACTOR;
+  } else if (channels > 0 && channels < ON_CHAIN_TRUST_HIGH_TICKET_MAX_CHANNELS && avgChannelUsdc > ON_CHAIN_TRUST_HIGH_TICKET_USDC) {
+    ticketGate = ON_CHAIN_TRUST_HIGH_TICKET_FACTOR;
+  }
+
+  const scoreMultiplier = channelConfidence
+    * ageGate
+    * ghostGate
+    * recencyGate
+    * stakeGate
+    * ticketGate;
+  const verificationBonusPoints = computeVerificationScoreBonus(peer);
+
+  const trust = creditedVolumeUsdc;
 
   return {
     trust,
     volumeUsdc,
+    creditedVolumeUsdc,
+    volumeCreditCapUsdc,
     channels,
     avgChannelUsdc,
     ticketBonus,
+    ticketGate,
     recencyGate,
     stakeGate,
+    ageGate,
+    channelConfidence,
+    ghostGate,
+    scoreMultiplier,
+    verificationBonusPoints,
     daysSinceLastSettled,
     daysSinceStaked,
   };
@@ -276,16 +369,32 @@ export function scoreFromTrust(trust: number): number {
   return Math.min(100, (100 / ON_CHAIN_SCORE_LOG_CAP_EXPONENT) * Math.log10(1 + trust));
 }
 
+function scoreFromBreakdown(breakdown: OnChainTrustBreakdown, risk: number): number {
+  const baseScore = scoreFromTrust(breakdown.trust);
+  const chainScore = baseScore * breakdown.scoreMultiplier * (1 - clamp(risk, 0, 1));
+  if (chainScore <= 0) return chainScore;
+  return Math.min(100, chainScore + breakdown.verificationBonusPoints);
+}
+
+export function computeOnChainScoreWithRisk(
+  peer: PeerInfo,
+  risk: number,
+  nowMs: number = Date.now(),
+): number | null {
+  const breakdown = computeOnChainTrustBreakdown(peer, nowMs);
+  if (breakdown === null) return null;
+  return scoreFromBreakdown(breakdown, risk);
+}
+
 export function computeOnChainScore(
   peer: PeerInfo,
   ctx?: SybilContext,
   nowMs: number = Date.now(),
 ): number | null {
-  const trust = computeOnChainTrust(peer, nowMs);
-  if (trust === null) return null;
-  const baseScore = scoreFromTrust(trust);
+  const breakdown = computeOnChainTrustBreakdown(peer, nowMs);
+  if (breakdown === null) return null;
   const risk = ctx ? computeOnChainSybilRisk(peer, ctx, nowMs).risk : 0;
-  return baseScore * (1 - risk);
+  return scoreFromBreakdown(breakdown, risk);
 }
 
 export function computeOnChainReputationScore(

--- a/packages/node/src/types/peer.ts
+++ b/packages/node/src/types/peer.ts
@@ -107,7 +107,7 @@ export interface PeerInfo {
   onChainStakeUsdcMicros?: number;
   /** Buyer-computed displayed on-chain score (0-100). */
   onChainReputationScore?: number;
-  /** Raw trust: channels × volume × ticket × recency × stake. */
+  /** Raw on-chain trust: credited settled USDC volume. */
   onChainTrustScore?: number;
   /** Sybil-risk heuristic in [0, 1]. */
   onChainSybilRisk?: number;

--- a/packages/node/tests/on-chain-reputation.test.ts
+++ b/packages/node/tests/on-chain-reputation.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildSybilContext,
+  computeVerificationScoreBonus,
   computeOnChainReputationScore,
   computeOnChainScore,
   computeOnChainSybilRisk,
   computeOnChainTrust,
   computeOnChainTrustBreakdown,
+  ON_CHAIN_VERIFICATION_DOMAIN_POINTS,
+  ON_CHAIN_VERIFICATION_GITHUB_POINTS,
+  ON_CHAIN_VERIFICATION_MAX_POINTS,
   ON_CHAIN_TRUST_NO_STAKE_FACTOR,
   ON_CHAIN_TRUST_RECENCY_DORMANT_FACTOR,
   scoreFromTrust,
@@ -26,6 +30,26 @@ function makePeer(stats: Partial<PeerInfo> & { peerId?: string }): PeerInfo {
     providers: ['openai'],
     ...rest,
   } as PeerInfo;
+}
+
+function verifiedDomain(domain: string, verified = true) {
+  return {
+    domain,
+    peerId: 'a'.repeat(40),
+    verified,
+    checkedAtMs: NOW_MS,
+    attempts: [],
+  };
+}
+
+function verifiedGithub(username: string, verified = true) {
+  return {
+    username,
+    repository: username,
+    peerId: 'a'.repeat(40),
+    verified,
+    checkedAtMs: NOW_MS,
+  };
 }
 
 describe('computeOnChainTrust', () => {
@@ -50,12 +74,14 @@ describe('computeOnChainTrust', () => {
     expect(trust).toBe(0);
   });
 
-  it('scales linearly with channels × volume (modifiers held at 1.0)', () => {
+  it('uses settled volume as raw trust instead of channels × volume', () => {
+    const stakedAt = NOW_SEC - 60 * 86_400;
     const small = computeOnChainTrust(
       makePeer({
         onChainChannelCount: 10,
         onChainTotalVolumeUsdcMicros: 20_000_000, // $20, avg $2
         onChainLastSettledAtSec: NOW_SEC,
+        onChainStakedAtSec: stakedAt,
         onChainStakeUsdcMicros: 10_000_000,
       }),
       NOW_MS,
@@ -65,13 +91,41 @@ describe('computeOnChainTrust', () => {
         onChainChannelCount: 100,
         onChainTotalVolumeUsdcMicros: 200_000_000, // $200, avg $2
         onChainLastSettledAtSec: NOW_SEC,
+        onChainStakedAtSec: stakedAt,
         onChainStakeUsdcMicros: 10_000_000,
       }),
       NOW_MS,
     );
-    expect(small).toBeCloseTo(10 * 20, 6);
-    expect(big).toBeCloseTo(100 * 200, 6);
-    expect(big! / small!).toBeCloseTo(100, 6); // 10x channels × 10x volume
+    expect(small).toBeCloseTo(20, 6);
+    expect(big).toBeCloseTo(200, 6);
+    expect(big! / small!).toBeCloseTo(10, 6); // 10x volume only
+  });
+
+  it('caps newly-staked volume credit and matures it over time', () => {
+    const young = computeOnChainTrustBreakdown(
+      makePeer({
+        onChainChannelCount: 1000,
+        onChainTotalVolumeUsdcMicros: 10_000_000_000, // $10k
+        onChainLastSettledAtSec: NOW_SEC,
+        onChainStakedAtSec: NOW_SEC - 1 * 86_400,
+        onChainStakeUsdcMicros: 10_000_000,
+      }),
+      NOW_MS,
+    )!;
+    const mature = computeOnChainTrustBreakdown(
+      makePeer({
+        onChainChannelCount: 1000,
+        onChainTotalVolumeUsdcMicros: 10_000_000_000,
+        onChainLastSettledAtSec: NOW_SEC,
+        onChainStakedAtSec: NOW_SEC - 90 * 86_400,
+        onChainStakeUsdcMicros: 10_000_000,
+      }),
+      NOW_MS,
+    )!;
+
+    expect(young.creditedVolumeUsdc).toBeCloseTo(150, 6); // $25 + 1d × $125
+    expect(mature.creditedVolumeUsdc).toBeCloseTo(10_000, 6);
+    expect(young.trust).toBeLessThan(mature.trust);
   });
 
   it('caps ticketBonus at TICKET_MAX (one fat channel cannot pump the score)', () => {
@@ -87,7 +141,8 @@ describe('computeOnChainTrust', () => {
     );
     expect(b).not.toBeNull();
     expect(b!.ticketBonus).toBe(1.5); // ON_CHAIN_TRUST_TICKET_MAX
-    expect(b!.trust).toBeCloseTo(1 * 100 * 1.5 * 1 * 1, 6);
+    expect(b!.trust).toBeCloseTo(25, 6); // no stakedAt → initial volume credit only
+    expect(b!.ticketGate).toBe(0.75); // one very large channel is penalized in score
   });
 
   it('floors ticketBonus at TICKET_MIN (microcent peers retain a meaningful score)', () => {
@@ -118,7 +173,7 @@ describe('computeOnChainTrust', () => {
     expect(dormant.recencyGate).toBe(ON_CHAIN_TRUST_RECENCY_DORMANT_FACTOR);
     expect(stale.recencyGate).toBe(0);
     expect(never.recencyGate).toBe(0);
-    expect(stale.trust).toBe(0);
+    expect(computeOnChainScore(makePeer({ ...base, onChainLastSettledAtSec: NOW_SEC - 90 * 86_400 }), undefined, NOW_MS)).toBe(0);
   });
 
   it('applies a presence-only stake gate (any stake \u2265 $1 = full credit)', () => {
@@ -135,7 +190,9 @@ describe('computeOnChainTrust', () => {
     expect(large.stakeGate).toBe(1); // amount doesn't matter
     expect(small.trust).toBeCloseTo(large.trust, 6);
     expect(noStake.stakeGate).toBe(ON_CHAIN_TRUST_NO_STAKE_FACTOR);
-    expect(noStake.trust).toBeCloseTo(large.trust * ON_CHAIN_TRUST_NO_STAKE_FACTOR, 6);
+    expect(noStake.trust).toBeCloseTo(large.trust, 6);
+    expect(computeOnChainScore(makePeer({ ...base, onChainStakeUsdcMicros: 0 }), undefined, NOW_MS)!)
+      .toBeCloseTo(computeOnChainScore(makePeer({ ...base, onChainStakeUsdcMicros: 100_000_000 }), undefined, NOW_MS)! * ON_CHAIN_TRUST_NO_STAKE_FACTOR, 6);
   });
 });
 
@@ -146,17 +203,16 @@ describe('scoreFromTrust', () => {
     expect(scoreFromTrust(Number.NaN)).toBe(0);
   });
 
-  it('hits roughly 86 at trust 1M and saturates at 100 around trust 10M', () => {
-    expect(scoreFromTrust(1_000_000)).toBeCloseTo((100 / 7) * Math.log10(1_000_001), 4);
-    expect(scoreFromTrust(1_000_000)).toBeGreaterThan(85);
-    expect(scoreFromTrust(1_000_000)).toBeLessThan(87);
-    expect(scoreFromTrust(10_000_000)).toBe(100);
-    expect(scoreFromTrust(1_000_000_000)).toBe(100);
+  it('hits roughly 75 at $1k trust and saturates at 100 around $10k', () => {
+    expect(scoreFromTrust(1_000)).toBeGreaterThan(74);
+    expect(scoreFromTrust(1_000)).toBeLessThan(76);
+    expect(scoreFromTrust(10_000)).toBe(100);
+    expect(scoreFromTrust(1_000_000)).toBe(100);
   });
 
   it('is monotonically increasing', () => {
     let prev = scoreFromTrust(1);
-    for (const t of [10, 100, 1_000, 10_000, 100_000, 1_000_000]) {
+    for (const t of [10, 100, 1_000, 10_000]) {
       const next = scoreFromTrust(t);
       expect(next).toBeGreaterThan(prev);
       prev = next;
@@ -301,6 +357,17 @@ describe('computeOnChainScore — composed display value', () => {
     expect(computeOnChainScore(makePeer({}))).toBeNull();
   });
 
+  it('returns null when only external verification is available', () => {
+    expect(computeOnChainScore(makePeer({
+      verificationResults: {
+        verified: true,
+        checkedAtMs: NOW_MS,
+        domains: [verifiedDomain('example.com')],
+        github: [verifiedGithub('octocat')],
+      },
+    }), undefined, NOW_MS)).toBeNull();
+  });
+
   it('returns sybil-attenuated score when a context is provided', () => {
     const peer = makePeer({
       onChainChannelCount: 50,
@@ -319,6 +386,91 @@ describe('computeOnChainScore — composed display value', () => {
     expect(ctxScore!).toBeLessThan(noCtxScore!);
     // narrow_custom alone weights 0.25 → expect ~25% attenuation.
     expect(ctxScore! / noCtxScore!).toBeCloseTo(0.75, 1);
+  });
+
+  it('adds a modest capped bonus for verified domain and GitHub claims', () => {
+    const base = makePeer({
+      onChainChannelCount: 100,
+      onChainTotalVolumeUsdcMicros: 1_000_000_000,
+      onChainLastSettledAtSec: NOW_SEC,
+      onChainStakedAtSec: NOW_SEC - 90 * 86_400,
+      onChainStakeUsdcMicros: 10_000_000,
+    });
+    const withDomain = makePeer({
+      ...base,
+      verificationResults: {
+        verified: true,
+        checkedAtMs: NOW_MS,
+        domains: [verifiedDomain('example.com')],
+        github: [],
+      },
+    });
+    const withGithub = makePeer({
+      ...base,
+      verificationResults: {
+        verified: true,
+        checkedAtMs: NOW_MS,
+        domains: [],
+        github: [verifiedGithub('octocat')],
+      },
+    });
+    const withBoth = makePeer({
+      ...base,
+      verificationResults: {
+        verified: true,
+        checkedAtMs: NOW_MS,
+        domains: [verifiedDomain('example.com')],
+        github: [verifiedGithub('octocat')],
+      },
+    });
+
+    const baseScore = computeOnChainScore(base, undefined, NOW_MS)!;
+    expect(computeVerificationScoreBonus(withDomain)).toBe(ON_CHAIN_VERIFICATION_DOMAIN_POINTS);
+    expect(computeVerificationScoreBonus(withGithub)).toBe(ON_CHAIN_VERIFICATION_GITHUB_POINTS);
+    expect(computeVerificationScoreBonus(withBoth)).toBe(ON_CHAIN_VERIFICATION_MAX_POINTS);
+    expect(computeOnChainScore(withDomain, undefined, NOW_MS)).toBeCloseTo(baseScore + 5, 6);
+    expect(computeOnChainScore(withGithub, undefined, NOW_MS)).toBeCloseTo(baseScore + 3, 6);
+    expect(computeOnChainScore(withBoth, undefined, NOW_MS)).toBeCloseTo(baseScore + 8, 6);
+  });
+
+  it('ignores failed verification claims and clamps final score to 100', () => {
+    const base = makePeer({
+      onChainChannelCount: 1000,
+      onChainTotalVolumeUsdcMicros: 10_000_000_000,
+      onChainLastSettledAtSec: NOW_SEC,
+      onChainStakedAtSec: NOW_SEC - 90 * 86_400,
+      onChainStakeUsdcMicros: 10_000_000,
+    });
+    const failed = makePeer({
+      ...base,
+      verificationResults: {
+        verified: false,
+        checkedAtMs: NOW_MS,
+        domains: [verifiedDomain('example.com', false)],
+        github: [verifiedGithub('octocat', false)],
+      },
+    });
+    const manyVerified = makePeer({
+      ...base,
+      verificationResults: {
+        verified: true,
+        checkedAtMs: NOW_MS,
+        domains: [
+          verifiedDomain('example.com'),
+          verifiedDomain('example.org'),
+        ],
+        github: [
+          verifiedGithub('octocat'),
+          verifiedGithub('antseed'),
+        ],
+      },
+    });
+
+    expect(computeVerificationScoreBonus(failed)).toBe(0);
+    expect(computeOnChainScore(failed, undefined, NOW_MS))
+      .toBe(computeOnChainScore(base, undefined, NOW_MS));
+    expect(computeVerificationScoreBonus(manyVerified)).toBe(ON_CHAIN_VERIFICATION_MAX_POINTS);
+    expect(computeOnChainScore(manyVerified, undefined, NOW_MS)).toBe(100);
   });
 });
 


### PR DESCRIPTION
## Description

Adds a small verified-identity bonus to buyer-computed on-chain reputation scores. Verified domain claims add 5 points, verified GitHub claims add 3 points, and the combined bonus is capped at 8 points while still requiring a positive on-chain score.

The async external verification path now recomputes reputation when verification results arrive, so CLI and desktop peer updates can reflect the bonus without waiting for another discovery cycle.

## Release Notes

- Added modest reputation score points for verified domain and GitHub ownership claims
- Kept settled on-chain activity as the required reputation anchor, so verification alone does not create a score

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
