### PR TITLE
fix(desktop): Batch chat stream rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,20 @@ All notable user-facing changes to AntSeed packages are documented here.
 
 This project uses selective package publishing. Each release entry lists the published packages affected by that release.
 
-## 2026-06-15 — Buyer peer failure accounting
+## 2026-06-15 — Buyer peer failure accounting and desktop stream responsiveness
 
 ### Published
 
 - `@antseed/cli@0.1.130`
 
+### Desktop
+
+- `@antseed/desktop`
+
 ### Fixed
 
 - Fixed buyer proxy failure accounting so transient request failures, local buyer payment errors, and `/v1/models` service probes do not make pinned peers unreachable by deleting cached discovery metadata.
+- Fixed Desktop chat sessions becoming sluggish or appearing stuck during long streamed responses by batching streaming UI updates per animation frame while preserving in-progress chat switching behavior.
 
 ## 2026-06-15 — Seller verification links and response-auth sampling
 

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -164,6 +164,7 @@ export function initChatModule({
   const streamFailedAtByConversation = new Map<string, number>();
   const localConversationMessages = new Map<string, ChatMessage[]>();
   const streamingMessagesByConversation = new Map<string, ChatMessage>();
+  const pendingStreamingUiFlushes = new Set<string>();
   let newChatDraftVersion = 0;
 
   const normalizePermissionMode = (value: unknown): ChatPermissionMode => (
@@ -979,6 +980,14 @@ export function initChatModule({
     });
   }
 
+  function queueAnimationFrame(callback: () => void): void {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(callback);
+      return;
+    }
+    setTimeout(callback, 16);
+  }
+
   function cloneStreamingMessage(message: ChatMessage): ChatMessage {
     return {
       ...message,
@@ -1008,6 +1017,32 @@ export function initChatModule({
     if (message) queueScrollChatToBottom();
   }
 
+  function publishActiveStreamingMessage(): void {
+    const activeConvId = uiState.chatActiveConversation;
+    const message = activeConvId
+      ? streamingMessagesByConversation.get(activeConvId) ?? null
+      : null;
+    uiState.chatStreamingMessage = message ? cloneStreamingMessage(message) : null;
+  }
+
+  function flushStreamingMessage(): void {
+    publishActiveStreamingMessage();
+    notifyUiStateChanged();
+    if (uiState.chatStreamingMessage) queueScrollChatToBottom();
+  }
+
+  function scheduleStreamingMessageFlush(convId: string): void {
+    if (uiState.chatActiveConversation !== convId) return;
+    if (pendingStreamingUiFlushes.has(convId)) return;
+    pendingStreamingUiFlushes.add(convId);
+    queueAnimationFrame(() => {
+      pendingStreamingUiFlushes.delete(convId);
+      if (uiState.chatActiveConversation === convId) {
+        flushStreamingMessage();
+      }
+    });
+  }
+
   function getConversationStreamingMessage(convId: string): ChatMessage | null {
     const message = streamingMessagesByConversation.get(convId);
     return message ? cloneStreamingMessage(message) : null;
@@ -1023,6 +1058,7 @@ export function initChatModule({
     } else {
       streamingMessagesByConversation.delete(convId);
     }
+    pendingStreamingUiFlushes.delete(convId);
 
     if (uiState.chatActiveConversation === convId) {
       setStreamingMessage(message);
@@ -1032,9 +1068,8 @@ export function initChatModule({
   function updateStreamingMessage(convId: string, mutator: (message: ChatMessage) => void): void {
     const current = streamingMessagesByConversation.get(convId);
     if (!current) return;
-    const next = cloneStreamingMessage(current);
-    mutator(next);
-    setConversationStreamingMessage(convId, next);
+    mutator(current);
+    scheduleStreamingMessageFlush(convId);
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Fixes Desktop chat streams that become sluggish during long streamed responses by batching visible streaming-message updates to animation frames. Streaming drafts still accumulate per conversation, so switching away and back during an in-flight session keeps the current partial response.

## Release Notes

- Fixed Desktop chat sessions appearing stuck or sluggish during long streamed responses.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Verification

- pnpm -C apps/desktop run typecheck:renderer
- pnpm -C apps/desktop run build:renderer
- pnpm -C apps/desktop run build:main && node --test apps/desktop/dist/main/*.test.js
