### PR TITLE
fix(desktop): Honor full access mode

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: com.antseed.desktop
-productName: AntSeed Desktop
+productName: AntSeed AntStation
 copyright: Copyright © 2025-2026 AntSeed
 electronVersion: 31.7.7
 npmRebuild: false

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/desktop",
-  "productName": "AntSeed Desktop",
+  "productName": "AntSeed AntStation",
   "version": "0.1.106",
   "private": true,
   "description": "Desktop app for AntSeed",

--- a/apps/desktop/scripts/brand-electron-dev.mjs
+++ b/apps/desktop/scripts/brand-electron-dev.mjs
@@ -4,7 +4,7 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, renameSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
-const APP_NAME = 'AntSeed Desktop';
+const APP_NAME = 'AntSeed AntStation';
 const APP_BUNDLE_ID = 'com.antseed.desktop-dev';
 
 function runPlistBuddy(plistPath, command) {

--- a/apps/desktop/src/main/chat-system-prompt.test.ts
+++ b/apps/desktop/src/main/chat-system-prompt.test.ts
@@ -63,3 +63,9 @@ test('workspace dir is trimmed before injection', () => {
   const prompt = buildAntstationSystemPrompt(undefined, `  ${ws}  `);
   assert.ok(prompt.includes(`Current workspace: ${ws}`));
 });
+
+test('full access mode tells agent not to ask for command permission', () => {
+  const prompt = buildAntstationSystemPrompt(undefined, '/tmp/workspace', 'full');
+  assert.ok(prompt.includes('Full access mode is enabled'));
+  assert.ok(/do not ask.*permission.*commands/i.test(prompt));
+});

--- a/apps/desktop/src/main/chat-system-prompt.ts
+++ b/apps/desktop/src/main/chat-system-prompt.ts
@@ -60,10 +60,14 @@ AntSeed documentation (use web_fetch on these URLs only when the user asks about
 export function buildAntstationSystemPrompt(
   basePrompt: string | undefined,
   workspaceDir?: string,
+  permissionMode: 'manual' | 'full' = 'manual',
 ): string {
   const resolvedBasePrompt = basePrompt?.trim() ? basePrompt.trim() : ANTSTATION_SYSTEM_PROMPT;
   const trimmedWorkspace = workspaceDir?.trim();
   const workspaceLine = trimmedWorkspace ? `\n- Current workspace: ${trimmedWorkspace}` : '';
+  const permissionLine = permissionMode === 'full'
+    ? '\n- Full access mode is enabled for this peer. Use available tools directly when they are helpful; do not ask for separate permission before running commands or editing files.'
+    : '';
 
   return `${resolvedBasePrompt}
 
@@ -71,6 +75,6 @@ Workspace model:
 - Each chat has its own workspace (folder/repo) that is stored when the chat is created.
 - When you switch to a different chat, the workspace automatically switches to that chat's stored workspace.
 - When starting a new chat, it uses whatever workspace is currently selected.
-- The workspace indicator in the UI shows the current workspace for the active chat.${workspaceLine}
+- The workspace indicator in the UI shows the current workspace for the active chat.${workspaceLine}${permissionLine}
 `.trim();
 }

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -73,7 +73,7 @@ const __dirname = path.dirname(__filename);
 
 const isDev = Boolean(process.env['VITE_DEV_SERVER_URL']);
 const rendererUrl = process.env['VITE_DEV_SERVER_URL'] ?? `file://${path.join(__dirname, '../renderer/index.html')}`;
-const APP_NAME = 'AntStation Desktop';
+const APP_NAME = 'AntSeed AntStation';
 const DESKTOP_DEBUG_ENV = 'ANTSEED_DESKTOP_DEBUG';
 const DESKTOP_DEBUG_FLAGS = new Set(['--debug-runtime', '--desktop-debug']);
 const DEFAULT_BUYER_PROXY_PORT = 8377;

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -1980,8 +1980,12 @@ export function registerPiChatHandlers({
     const persistedPeer = extractPeerFromEntries(sessionManager);
     const peerOverrideId = normalizePeerId(peerOverride) ?? null;
     const preferredPeerId = peerOverrideId ?? preferredPeerByConversationId.get(conversationId) ?? persistedPeer?.peerId ?? null;
-    const permissionMode: ChatPermissionMode = requestedPermissionMode
-      ?? (preferredPeerId ? await getPeerPermissionMode(preferredPeerId) : 'manual');
+    const persistedPermissionMode: ChatPermissionMode = preferredPeerId
+      ? await getPeerPermissionMode(preferredPeerId)
+      : 'manual';
+    const permissionMode: ChatPermissionMode = persistedPermissionMode === 'full'
+      ? 'full'
+      : requestedPermissionMode ?? persistedPermissionMode;
     if (preferredPeerId) {
       preferredPeerByConversationId.set(conversationId, preferredPeerId);
       if (peerOverrideId && persistedPeer?.peerId !== peerOverrideId) {
@@ -2108,7 +2112,7 @@ export function registerPiChatHandlers({
       agentDir: CHAT_AGENT_DIR,
       settingsManager,
       extensionFactories: [toolApprovalExtension],
-      systemPrompt: buildAntstationSystemPrompt(userSystemPrompt, chatWorkspaceDir),
+      systemPrompt: buildAntstationSystemPrompt(userSystemPrompt, chatWorkspaceDir, permissionMode),
     });
     await resourceLoader.reload();
 

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AntSeed Desktop</title>
+    <title>AntSeed AntStation</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
## Description

Renames the Electron desktop app surfaces from AntSeed Desktop / AntStation Desktop to AntSeed AntStation.
Also fixes AntStation chat full access mode so a persisted peer-level full-access setting wins over stale per-request manual mode and is reflected in the agent system prompt.

## Release Notes

- Renamed the desktop app to AntSeed AntStation in app metadata, dev branding, and the renderer title.
- Fixed full access mode so command and file-edit approval prompts are not shown after a peer is set to full access.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Validation:
- `pnpm --filter=@antseed/desktop run build:main`
- `pnpm --filter=@antseed/desktop run typecheck:renderer`
- `node --test apps/desktop/dist/main/chat-system-prompt.test.js apps/desktop/dist/main/chat-tool-policy.test.js`
