### PR TITLE
fix(node): Reduce verification sample rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable user-facing changes to AntSeed packages are documented here.
 
 This project uses selective package publishing. Each release entry lists the published packages affected by that release.
 
+## Unreleased
+
+### Changed
+
+- Reduced the default buyer response-auth evidence sample rate from 20% to 0.5% to limit local `verification_samples` growth during high-request sessions.
+
 ## 2026-06-15 — Buyer peer failure accounting and desktop stream responsiveness
 
 ### Published

--- a/docs/protocol/spec/07-model-verification.md
+++ b/docs/protocol/spec/07-model-verification.md
@@ -83,7 +83,7 @@ Implemented in the `@antseed/node` package:
   - SQLite table `response_auths`;
   - indexed by seller, advertised service, and received timestamp.
 - Buyer-side full evidence sampling:
-  - random sample rate default `0.01`;
+  - random sample rate default `0.005`;
   - max encoded request + response bytes default `16 MiB`;
   - default directory `<dataDir>/verification_samples`;
   - stores `manifest.json`, `request.bin`, and `response.bin`;
@@ -1080,7 +1080,7 @@ step 9, which does not depend on the Buyer's samples at all.
 | Parameter | Symbol | Default | Notes |
 |---|---|---|---|
 | ResponseAuth wait grace | — | 30s | Implemented Buyer wait after response before logging missing auth |
-| Verification sample rate | — | 0.01 | Implemented random full evidence sample rate for verified auths |
+| Verification sample rate | — | 0.005 | Implemented random full evidence sample rate for verified auths |
 | Verification sample byte cap | — | 16 MiB | Implemented max encoded request + response bytes per sample |
 | Sample rate | `p` | 0.02 | Fraction of real requests duplicated to reference (M2) |
 | Min samples per verdict | `N` | 30 | Below this, no M2 verdict is emitted |

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -150,7 +150,7 @@ export interface NodePaymentsConfig {
 }
 
 export interface NodeVerificationConfig {
-  /** Random sample rate for storing full buyer request/response evidence. Default: 0.01. */
+  /** Random sample rate for storing full buyer request/response evidence. Default: 0.005. */
   sampleRate?: number;
   /** Maximum combined encoded request + response bytes per sample. Default: 16 MiB. */
   maxSampleBytes?: number;

--- a/packages/node/src/verification/samples.ts
+++ b/packages/node/src/verification/samples.ts
@@ -6,7 +6,7 @@ import type { ResponseAuthPayload } from '../types/protocol.js';
 import { encodeHttpRequest, encodeHttpResponse } from '../proxy/request-codec.js';
 
 const SAMPLE_RANDOM_SCALE = 1_000_000;
-const DEFAULT_SAMPLE_RATE = 0.2;
+const DEFAULT_SAMPLE_RATE = 0.005;
 const DEFAULT_MAX_SAMPLE_BYTES = 16 * 1024 * 1024;
 
 export interface VerificationSampleConfig {

--- a/packages/node/tests/verification-samples.test.ts
+++ b/packages/node/tests/verification-samples.test.ts
@@ -27,9 +27,9 @@ function makeResponse(body = JSON.stringify({ content: [{ type: 'text', text: 's
 }
 
 describe('VerificationSampler', () => {
-  it('defaults to a 20 percent sample rate', () => {
-    const samplerHit = new VerificationSampler('/tmp/unused', { random: () => 0.199 });
-    const samplerMiss = new VerificationSampler('/tmp/unused', { random: () => 0.2 });
+  it('defaults to a 0.5 percent sample rate', () => {
+    const samplerHit = new VerificationSampler('/tmp/unused', { random: () => 0.0049 });
+    const samplerMiss = new VerificationSampler('/tmp/unused', { random: () => 0.005 });
 
     expect(samplerHit.shouldSample()).toBe(true);
     expect(samplerMiss.shouldSample()).toBe(false);


### PR DESCRIPTION
## Description

Reduces the default buyer response-auth evidence sampling rate from 20% to 0.5% per verified request. This limits local `verification_samples` disk growth during long or high-volume buyer sessions while keeping explicit config overrides unchanged.

## Release Notes

- Reduced the default buyer response-auth evidence sample rate to 0.5% to limit local verification sample storage growth.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
