### PR TITLE
Buyer service plugins + gasless USDC auto-deposit (Circle Paymaster + EIP-7702)

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -22,6 +22,8 @@ Command-line interface and web dashboard for the AntSeed Network — a P2P netwo
 | `antseed buyer deposit <amount>` | Deposit USDC for payments |
 | `antseed buyer withdraw <amount>` | Withdraw USDC from deposits |
 | `antseed buyer balance` | Check wallet and deposit balance |
+| `antseed buyer enable-service <name>` | Turn on a service plugin (e.g. auto-deposit: sweeps wallet USDC into deposits, gas paid in USDC) |
+| `antseed buyer disable-service <name>` | Turn off a service plugin |
 | `antseed network browse` | Browse available services and pricing |
 | `antseed payments` | Launch the payments portal |
 | **Session** | |

--- a/apps/cli/src/cli/commands/buyer/index.ts
+++ b/apps/cli/src/cli/commands/buyer/index.ts
@@ -8,6 +8,7 @@ import { registerBuyerConnectionCommand } from './connection.js';
 import { registerBuyerChannelsCommand } from './channels.js';
 import { registerBuyerMeteringCommand } from './metering.js';
 import { registerBuyerEmissionsCommand } from './emissions.js';
+import { registerBuyerServiceCommands } from './services.js';
 
 export function registerBuyerCommands(program: Command): void {
   const buyerCmd = program
@@ -23,4 +24,5 @@ export function registerBuyerCommands(program: Command): void {
   registerBuyerChannelsCommand(buyerCmd);
   registerBuyerMeteringCommand(buyerCmd);
   registerBuyerEmissionsCommand(buyerCmd);
+  registerBuyerServiceCommands(buyerCmd);
 }

--- a/apps/cli/src/cli/commands/buyer/services.ts
+++ b/apps/cli/src/cli/commands/buyer/services.ts
@@ -1,0 +1,53 @@
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import { getGlobalOptions } from '../types.js';
+import { loadConfig, saveConfig } from '../../../config/loader.js';
+import { getTrustedServicePlugins } from '../../../plugins/registry.js';
+
+function availableNames(): string {
+  return getTrustedServicePlugins().map((plugin) => plugin.name).join(', ') || '(none)';
+}
+
+export function registerBuyerServiceCommands(buyerCmd: Command): void {
+  buyerCmd
+    .command('enable-service <name>')
+    .description(`Approve a service plugin so it runs while the buyer proxy is up. Available: ${availableNames()}`)
+    .action(async (name: string) => {
+      const plugin = getTrustedServicePlugins().find((candidate) => candidate.name === name);
+      if (!plugin) {
+        console.error(chalk.red(`Unknown service plugin "${name}". Available: ${availableNames()}`));
+        process.exit(1);
+      }
+      const globalOpts = getGlobalOptions(buyerCmd);
+      const config = await loadConfig(globalOpts.config);
+      config.buyer.services = {
+        ...(config.buyer.services ?? {}),
+        [name]: { enabled: true, approvedAt: new Date().toISOString() },
+      };
+      await saveConfig(globalOpts.config, config);
+
+      console.log(chalk.green(`Service "${name}" enabled.`));
+      console.log(chalk.dim(plugin.description));
+      console.log(chalk.dim('It runs only on networks that support it; otherwise it stays idle until you switch networks.'));
+    });
+
+  buyerCmd
+    .command('disable-service <name>')
+    .description('Stop a service plugin (consent only; any on-chain state, e.g. an EIP-7702 delegation, persists)')
+    .action(async (name: string) => {
+      const plugin = getTrustedServicePlugins().find((candidate) => candidate.name === name);
+      if (!plugin) {
+        console.error(chalk.red(`Unknown service plugin "${name}". Available: ${availableNames()}`));
+        process.exit(1);
+      }
+      const globalOpts = getGlobalOptions(buyerCmd);
+      const config = await loadConfig(globalOpts.config);
+      config.buyer.services = {
+        ...(config.buyer.services ?? {}),
+        [name]: { enabled: false },
+      };
+      await saveConfig(globalOpts.config, config);
+
+      console.log(chalk.green(`Service "${name}" disabled.`));
+    });
+}

--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -13,7 +13,8 @@ import { OFFICIAL_BOOTSTRAP_NODES, parseBootstrapList, toBootstrapConfig } from 
 import { setupShutdownHandler } from '../../shutdown.js'
 import { loadRouterPlugin, buildPluginConfig, getPackageVersions } from '../../../plugins/loader.js'
 import { ensurePluginsUpToDate } from '../../../plugins/drift.js'
-import { resolvePluginPackage } from '../../../plugins/registry.js'
+import { getTrustedServicePlugins, resolvePluginPackage } from '../../../plugins/registry.js'
+import { loadTrustedServicePlugins } from '../../../plugins/services.js'
 import { BuyerProxy } from '../../../proxy/buyer-proxy.js'
 import { resolveEffectiveBuyerConfig, type BuyerRuntimeOverrides } from '../../../config/effective.js'
 import type { BuyerCLIConfig } from '../../../config/types.js'
@@ -400,12 +401,32 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
 
       const proxyPort = effectiveBuyerConfig.proxyPort
       const proxySpinner = ora(`Starting local proxy on port ${proxyPort}...`).start()
+      // Service plugins declare the capabilities they need (wallet, chain, ...).
+      // Today's services rely on payment settlement being configured, so only
+      // load them when settlement is on; with payments disabled, expose none.
+      // They install + load dynamically from the plugins dir, just like routers.
+      const servicePlugins = settlementEnabled ? await loadTrustedServicePlugins() : []
       const proxy = new BuyerProxy({
         port: proxyPort,
         node,
         pinnedPeerId,
         dataDir: globalOpts.dataDir,
         backgroundRefreshIntervalMs: effectiveBuyerConfig.peerRefreshIntervalMs,
+        chainConfig,
+        configPath: globalOpts.config,
+        servicePlugins,
+        // Full catalog so the control plane can list trusted services that did
+        // not load (not installed, no network) as "available", not just the
+        // live ones. Lets the desktop show every service with a toggle.
+        serviceCatalog: getTrustedServicePlugins().map((plugin) => ({
+          name: plugin.name,
+          displayName: plugin.displayName,
+          kind: plugin.kind,
+          description: plugin.description,
+        })),
+        serviceConsent: Object.fromEntries(
+          Object.entries(config.buyer.services ?? {}).map(([name, value]) => [name, value?.enabled === true]),
+        ),
       })
       let ownsProxyListener = false
 

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -182,6 +182,18 @@ test('loadConfig preserves buyer verification sampling settings', async () => {
   );
 });
 
+test('loadConfig preserves buyer.services consent map', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      buyer: { services: { 'auto-deposit': { enabled: true, approvedAt: '2026-06-15T00:00:00.000Z' } } },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.deepEqual(config.buyer.services?.['auto-deposit'], { enabled: true, approvedAt: '2026-06-15T00:00:00.000Z' });
+    }
+  );
+});
+
 test('loadConfig rejects invalid buyer verification sampleRate', async () => {
   await withTempConfig(
     JSON.stringify({
@@ -196,6 +208,17 @@ test('loadConfig rejects invalid buyer verification sampleRate', async () => {
         async () => loadConfig(configPath),
         /buyer\.verification\.sampleRate/
       );
+    }
+  );
+});
+
+test('loadConfig drops malformed buyer.services entries but keeps valid ones', async () => {
+  await withTempConfig(
+    JSON.stringify({ buyer: { services: { 'auto-deposit': { enabled: 'yes' }, other: { enabled: false } } } }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.equal(config.buyer.services?.['auto-deposit'], undefined);
+      assert.deepEqual(config.buyer.services?.other, { enabled: false });
     }
   );
 });

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -370,6 +370,7 @@ function mergeBuyerConfig(
       'buyer.disableMetadataV2Services',
     ),
     ...(normalizeBuyerVerification(value['verification'], defaults.verification)),
+    ...(normalizeBuyerServices(value['services'])),
   };
 }
 
@@ -377,6 +378,26 @@ function normalizeBooleanConfigValue(value: unknown, defaultValue: boolean, path
   if (value === undefined) return defaultValue;
   if (typeof value === 'boolean') return value;
   throw new Error(`${path} must be a boolean`);
+}
+
+function normalizeServiceEntry(entry: unknown): { enabled: boolean; approvedAt?: string } | null {
+  if (!isRecord(entry) || typeof entry['enabled'] !== 'boolean') return null;
+  return {
+    enabled: entry['enabled'],
+    ...(typeof entry['approvedAt'] === 'string' ? { approvedAt: entry['approvedAt'] } : {}),
+  };
+}
+
+function normalizeBuyerServices(
+  servicesValue: unknown,
+): { services: NonNullable<AntseedConfig['buyer']['services']> } | Record<string, never> {
+  if (!isRecord(servicesValue)) return {};
+  const out: Record<string, { enabled: boolean; approvedAt?: string }> = {};
+  for (const [name, entry] of Object.entries(servicesValue)) {
+    const normalized = normalizeServiceEntry(entry);
+    if (normalized) out[name] = normalized;
+  }
+  return Object.keys(out).length > 0 ? { services: out } : {};
 }
 
 /**

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -145,6 +145,8 @@ export interface BuyerCLIConfig {
   disableMetadataV2Services: boolean;
   /** Buyer-side response-auth evidence sampling settings. */
   verification?: BuyerVerificationConfig;
+  /** Per-service-plugin consent, keyed by plugin name (e.g. "auto-deposit"). */
+  services?: Record<string, { enabled: boolean; approvedAt?: string }>;
 }
 
 /**

--- a/apps/cli/src/plugins/loader.ts
+++ b/apps/cli/src/plugins/loader.ts
@@ -4,7 +4,7 @@ import path, { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { getPluginsDir, installPlugin } from './manager.js'
 import { TRUSTED_PLUGINS } from './registry.js'
-import type { AntseedProviderPlugin, AntseedRouterPlugin, PluginConfigKey } from '@antseed/node'
+import type { AntseedProviderPlugin, AntseedRouterPlugin, AntseedServicePlugin, PluginConfigKey } from '@antseed/node'
 
 const NODE_BUILTINS = new Set([
   ...builtinModules,
@@ -24,12 +24,12 @@ function resolvePackageName(nameOrPackage: string): string {
   return trusted?.package ?? nameOrPackage
 }
 
-type PluginKind = 'provider' | 'router'
+type PluginKind = 'provider' | 'router' | 'service'
 
 async function loadPlugin<T>(
   nameOrPackage: string,
   kind: PluginKind,
-  methodName: keyof AntseedProviderPlugin | keyof AntseedRouterPlugin
+  methodName: keyof AntseedProviderPlugin | keyof AntseedRouterPlugin | keyof AntseedServicePlugin
 ): Promise<T> {
   const pkgName = resolvePackageName(nameOrPackage)
   const pluginsDir = getPluginsDir()
@@ -144,6 +144,10 @@ export async function loadProviderPlugin(nameOrPackage: string): Promise<Antseed
 
 export async function loadRouterPlugin(nameOrPackage: string): Promise<AntseedRouterPlugin> {
   return loadPlugin<AntseedRouterPlugin>(nameOrPackage, 'router', 'createRouter')
+}
+
+export async function loadServicePlugin(nameOrPackage: string): Promise<AntseedServicePlugin> {
+  return loadPlugin<AntseedServicePlugin>(nameOrPackage, 'service', 'createService')
 }
 
 export function buildPluginConfig(

--- a/apps/cli/src/plugins/registry.ts
+++ b/apps/cli/src/plugins/registry.ts
@@ -1,8 +1,12 @@
 export interface TrustedPlugin {
   name: string
-  type: 'provider' | 'router'
+  type: 'provider' | 'router' | 'service'
   description: string
   package: string
+  /** Human-readable label shown in UIs before the plugin is loaded. */
+  displayName?: string
+  /** Service sub-kind (e.g. 'funding'), surfaced for services not yet loaded. */
+  kind?: string
 }
 
 export const TRUSTED_PLUGINS: TrustedPlugin[] = [
@@ -48,9 +52,21 @@ export const TRUSTED_PLUGINS: TrustedPlugin[] = [
     description: 'Local router for Claude Code, Codex',
     package: '@antseed/router-local',
   },
+  {
+    name: 'auto-deposit',
+    type: 'service',
+    displayName: 'Auto Deposit',
+    kind: 'funding',
+    description: 'Gasless auto-deposit: sweeps loose USDC into the network (Circle Paymaster + EIP-7702)',
+    package: '@antseed/service-auto-deposit',
+  },
 ]
 
 export function resolvePluginPackage(nameOrPackage: string): string {
   const trusted = TRUSTED_PLUGINS.find((plugin) => plugin.name === nameOrPackage)
   return trusted?.package ?? nameOrPackage
+}
+
+export function getTrustedServicePlugins(): TrustedPlugin[] {
+  return TRUSTED_PLUGINS.filter((plugin) => plugin.type === 'service')
 }

--- a/apps/cli/src/plugins/services.ts
+++ b/apps/cli/src/plugins/services.ts
@@ -1,0 +1,27 @@
+import type { AntseedServicePlugin } from '@antseed/node'
+import { getTrustedServicePlugins } from './registry.js'
+import { loadServicePlugin } from './loader.js'
+
+/** Names of the trusted service plugins the buyer can enable (auto-deposit, …). */
+export function listServicePluginNames(): string[] {
+  return getTrustedServicePlugins().map((plugin) => plugin.name)
+}
+
+/**
+ * Load every trusted service plugin from the plugins dir, installing on demand
+ * exactly like provider/router plugins. Best-effort: a service that fails to
+ * load (e.g. not yet installed, no network) is skipped with a warning rather
+ * than aborting buyer startup.
+ */
+export async function loadTrustedServicePlugins(): Promise<AntseedServicePlugin[]> {
+  const loaded: AntseedServicePlugin[] = []
+  for (const trusted of getTrustedServicePlugins()) {
+    try {
+      loaded.push(await loadServicePlugin(trusted.name))
+    } catch (err) {
+      const cause = err instanceof Error ? err.message : String(err)
+      console.log(`Service plugin "${trusted.name}" unavailable: ${cause}`)
+    }
+  }
+  return loaded
+}

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -6,6 +6,8 @@ import { join } from 'node:path'
 import {
   computeOnChainReputationScore,
   type AntseedNode,
+  type AntseedServicePlugin,
+  type ChainConfig,
   type PeerInfo,
   type PeerMetadata,
   type RequestStreamResponseMetadata,
@@ -13,6 +15,10 @@ import {
   type SerializedHttpRequest,
   type SerializedHttpResponse,
   type SerializedHttpResponseChunk,
+  type Service,
+  type ServiceCapabilities,
+  type ServiceCapability,
+  type ServiceHost,
 } from '@antseed/node'
 import {
   createOpenAIChatToAnthropicStreamingAdapter,
@@ -51,6 +57,7 @@ import {
   attachStreamingAntseedHeaders,
 } from './telemetry.js'
 import { DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS } from '../config/defaults.js'
+import { loadConfig, saveConfig } from '../config/loader.js'
 
 // Re-export for backward compatibility (used by tests and other consumers)
 export { selectCandidatePeersForRouting, type CandidatePeerRouteSelection } from './routing.js'
@@ -76,6 +83,23 @@ export interface BuyerProxyConfig {
    * and allowed by the buyer's pricing policy. A 502 is returned if the peer cannot be reached.
    */
   pinnedPeerId?: string
+  chainConfig?: ChainConfig
+  configPath?: string
+  servicePlugins?: AntseedServicePlugin[]
+  /**
+   * Trusted service plugins the buyer knows about, whether or not they loaded.
+   * Used to list services that are available but not currently running (not
+   * installed, missing capability) so they can still be shown and toggled.
+   */
+  serviceCatalog?: ServiceCatalogEntry[]
+  serviceConsent?: Record<string, boolean>
+}
+
+export interface ServiceCatalogEntry {
+  name: string
+  displayName?: string
+  kind?: string
+  description?: string
 }
 
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504])
@@ -88,6 +112,24 @@ function isRouterSuccess(statusCode: number, path: string, retryableStatusCodes:
   return isControlPlaneServicesPath(path) || !retryableStatusCodes.has(statusCode)
 }
 
+/**
+ * True only for genuine loopback callers: the Host must be 127.0.0.1/localhost
+ * (an exact hostname match, defeating DNS-rebinding) and any Origin must also be
+ * loopback (a cross-site browser fetch always carries a non-local Origin). Used
+ * to gate fund-moving control-plane mutations against CSRF.
+ */
+function isLoopbackControlRequest(req: IncomingMessage): boolean {
+  const hostname = (req.headers.host ?? '').toLowerCase().replace(/:\d+$/, '')
+  if (hostname !== '127.0.0.1' && hostname !== 'localhost') return false
+  const origin = req.headers.origin
+  if (origin === undefined || origin === 'null' || origin === 'file://') return true
+  try {
+    const oh = new URL(origin).hostname
+    return oh === '127.0.0.1' || oh === 'localhost'
+  } catch {
+    return false
+  }
+}
 /**
  * Max age for carrying forward peers not seen in the latest DHT scan.
  * Intentionally longer than `peer-lookup.ts` `maxAnnouncementAgeMs` (30 min) so
@@ -370,6 +412,15 @@ export class BuyerProxy {
   private _peerRefreshPromise: Promise<PeerInfo[]> | null = null
   private _lastStaleCacheLogAtMs = 0
   private _bgRefreshHandle: ReturnType<typeof setInterval> | null = null
+  private readonly _chainConfig?: ChainConfig
+  private readonly _configPath?: string
+  private readonly _servicePlugins: AntseedServicePlugin[]
+  private readonly _serviceCatalog: ServiceCatalogEntry[]
+  // Why a loaded plugin did not start (missing capability, declined). Keyed by
+  // plugin name; absent when the service is live or never loaded.
+  private _serviceInactiveReason: Map<string, string> = new Map()
+  private _services: Map<string, Service> = new Map()
+  private _serviceConsent: Record<string, boolean>
   private _peerFailures: Map<string, PeerFailureEntry> = new Map()
 
   constructor(config: BuyerProxyConfig) {
@@ -380,6 +431,11 @@ export class BuyerProxy {
     this._stateDir = config.dataDir
     this._stateFile = join(config.dataDir, 'buyer.state.json')
     this._pinnedPeer = config.pinnedPeerId?.toLowerCase() ?? null
+    this._chainConfig = config.chainConfig
+    this._configPath = config.configPath
+    this._servicePlugins = config.servicePlugins ?? []
+    this._serviceCatalog = config.serviceCatalog ?? []
+    this._serviceConsent = { ...(config.serviceConsent ?? {}) }
     this._server = createServer((req, res) => {
       this._handleRequest(req, res).catch((err) => {
         log('Unhandled error:', err)
@@ -422,6 +478,7 @@ export class BuyerProxy {
       })
     })
     this._startBackgroundRefresh()
+    void this._startServices()
     // Trigger initial discovery immediately so the desktop can show services
     // without waiting for the first request or 5-minute interval. The sweep
     // emits each accepted metadata document as it arrives, so buyer.state.json
@@ -467,6 +524,8 @@ export class BuyerProxy {
       clearInterval(this._bgRefreshHandle)
       this._bgRefreshHandle = null
     }
+    for (const service of this._services.values()) service.stop()
+    this._services.clear()
     await this._writeStateFile('stopped')
     return new Promise((resolve) => {
       this._server.close(() => resolve())
@@ -548,6 +607,87 @@ export class BuyerProxy {
 
   private _startIncrementalDiscoverySweep(): void {
     this._node.startBackgroundPeerDiscoverySweep()
+  }
+
+  private async _startServices(): Promise<void> {
+    for (const plugin of this._servicePlugins) {
+      // One misbehaving plugin must not abort the rest or escape as an
+      // unhandled rejection (this runs detached during startup).
+      try {
+        const host = this._buildServiceHost(plugin)
+        if (!host) {
+          this._serviceInactiveReason.set(
+            plugin.name,
+            'Required capability unavailable (wallet/chain not configured).',
+          )
+          continue
+        }
+        const service = await plugin.createService(host)
+        if (!service) {
+          this._serviceInactiveReason.set(plugin.name, 'Service is not applicable on this network.')
+          continue
+        }
+        this._serviceInactiveReason.delete(plugin.name)
+        this._services.set(plugin.name, service)
+        service.start()
+      } catch (err) {
+        const cause = err instanceof Error ? err.message : String(err)
+        this._serviceInactiveReason.set(plugin.name, `Failed to start: ${cause}`)
+        log(`[service:${plugin.name}] failed to start:`, cause)
+      }
+    }
+  }
+
+  // Build the host for a service plugin. The plugin declares the capabilities
+  // it needs (e.g. 'wallet', 'chain') and we grant only those, so a service
+  // never receives a capability it didn't ask for. A plugin whose required
+  // capability is unavailable (no chain config / no identity) gets no host and
+  // is skipped. Consent lives in config.json (buyer.services[name]); the proxy
+  // holds the live value and the control endpoint persists changes.
+  private _buildServiceHost(plugin: AntseedServicePlugin): ServiceHost | null {
+    const consent = { isEnabled: () => this._serviceConsent[plugin.name] ?? false }
+    const onAttention = (message: string) => log(`[service:${plugin.name}] needs attention:`, message)
+    const capabilities: ServiceCapabilities = {}
+    for (const capability of plugin.capabilities ?? []) {
+      const granted = this._grantServiceCapability(capability)
+      if (!granted) return null
+      Object.assign(capabilities, granted)
+    }
+    return { consent, onAttention, capabilities }
+  }
+
+  // Resolve one declared capability from the resources the proxy owns. Returns
+  // null when the capability can't be granted (so the service is skipped) or is
+  // unknown to this host. Keyed on the capability, not the plugin, so the proxy
+  // stays agnostic to which concrete services exist.
+  private _grantServiceCapability(capability: ServiceCapability): Partial<ServiceCapabilities> | null {
+    switch (capability) {
+      case 'wallet': {
+        const identity = this._node.identity
+        if (!identity) return null
+        return {
+          wallet: {
+            privateKey: identity.wallet.privateKey as `0x${string}`,
+            address: identity.wallet.address as `0x${string}`,
+          },
+        }
+      }
+      case 'chain': {
+        if (!this._chainConfig) return null
+        return { chain: this._chainConfig }
+      }
+      default:
+        return null
+    }
+  }
+
+  private async _persistServiceConsent(name: string, enabled: boolean): Promise<void> {
+    if (!this._configPath) return
+    const config = await loadConfig(this._configPath)
+    const services = { ...(config.buyer.services ?? {}) }
+    services[name] = enabled ? { enabled: true, approvedAt: new Date().toISOString() } : { enabled: false }
+    config.buyer.services = services
+    await saveConfig(this._configPath, config)
   }
 
   private _startBackgroundRefresh(): void {
@@ -844,6 +984,111 @@ export class BuyerProxy {
       }))
       res.writeHead(200, { 'content-type': 'application/json' })
       res.end(JSON.stringify({ ok: true, peers: payload }))
+      return
+    }
+
+    if (path === '/_antseed/services' && method === 'GET') {
+      // Local control-plane data (exposes the wallet receive address); restrict
+      // to genuine loopback callers, same as the mutating POST below.
+      if (!isLoopbackControlRequest(req)) {
+        res.writeHead(403, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: 'Forbidden' }))
+        return
+      }
+      const names = new Set<string>()
+      for (const entry of this._serviceCatalog) names.add(entry.name)
+      for (const plugin of this._servicePlugins) names.add(plugin.name)
+
+      const services = [...names].map((name) => {
+        const plugin = this._servicePlugins.find((candidate) => candidate.name === name)
+        const catalog = this._serviceCatalog.find((entry) => entry.name === name)
+        const live = this._services.get(name)
+        const installed = Boolean(plugin)
+        const active = Boolean(live)
+        const enabled = this._serviceConsent[name] ?? false
+        const status = live
+          ? live.getStatus()
+          : {
+              enabled,
+              attention: false,
+              summary: installed
+                ? this._serviceInactiveReason.get(name) ?? 'Installed but not running.'
+                : 'Not installed yet. It is set up on the next app launch.',
+              receiveAddress: null,
+            }
+        return {
+          name,
+          kind: plugin?.kind ?? catalog?.kind,
+          displayName: plugin?.displayName ?? catalog?.displayName ?? name,
+          description: plugin?.description ?? catalog?.description ?? '',
+          installed,
+          active,
+          enabled,
+          status,
+        }
+      })
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, services }))
+      return
+    }
+
+    if (path === '/_antseed/services' && method === 'POST') {
+      // Mutating endpoint (enables consent, and for funding the 7702 delegation).
+      // Only accept genuine loopback callers: a strict Host/Origin check blunts
+      // CSRF and DNS-rebinding from a web page (CORS alone does not prevent the
+      // request).
+      if (!isLoopbackControlRequest(req)) {
+        res.writeHead(403, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: 'Forbidden' }))
+        return
+      }
+      const chunks: Buffer[] = []
+      let totalSize = 0
+      for await (const chunk of req) {
+        totalSize += (chunk as Buffer).length
+        if (totalSize > 8192) {
+          res.writeHead(413, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ ok: false, error: 'Request body too large' }))
+          return
+        }
+        chunks.push(chunk as Buffer)
+      }
+      let name: string
+      let enabled: boolean
+      try {
+        const body = JSON.parse(Buffer.concat(chunks).toString())
+        if (typeof body.name !== 'string' || !body.name) throw new Error('name must be a non-empty string')
+        if (typeof body.enabled !== 'boolean') throw new Error('enabled must be a boolean')
+        name = body.name
+        enabled = body.enabled
+      } catch {
+        res.writeHead(400, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: 'Body must be {"name": string, "enabled": boolean}' }))
+        return
+      }
+      const isKnown =
+        this._servicePlugins.some((plugin) => plugin.name === name) ||
+        this._serviceCatalog.some((entry) => entry.name === name)
+      if (!isKnown) {
+        res.writeHead(409, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: `Service plugin "${name}" is not available` }))
+        return
+      }
+      // Persist first; never act on consent that was not durably recorded.
+      try {
+        await this._persistServiceConsent(name, enabled)
+      } catch {
+        res.writeHead(500, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: 'Failed to persist consent' }))
+        return
+      }
+      this._serviceConsent[name] = enabled
+      // A live service reacts now; one that is not running yet picks up the
+      // persisted consent on the next buyer start.
+      const service = this._services.get(name)
+      if (enabled && service) void service.poke?.()
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, name, enabled, active: Boolean(service) }))
       return
     }
 

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -63,6 +63,20 @@ extraResources:
       - "**/*.js"
   - from: ../../packages/api-adapter/package.json
     to: bundled-plugins/@antseed/api-adapter/package.json
+  # Auto-deposit service plugin + its core. Their non-@antseed runtime deps
+  # (viem, permissionless, ...) ship via bundled-runtime below.
+  - from: ../../plugins/service-auto-deposit/dist
+    to: bundled-plugins/@antseed/service-auto-deposit/dist
+    filter:
+      - "**/*.js"
+  - from: ../../plugins/service-auto-deposit/package.json
+    to: bundled-plugins/@antseed/service-auto-deposit/package.json
+  - from: ../../packages/service-core/dist
+    to: bundled-plugins/@antseed/service-core/dist
+    filter:
+      - "**/*.js"
+  - from: ../../packages/service-core/package.json
+    to: bundled-plugins/@antseed/service-core/package.json
   # bundled-runtime contains the full transitive runtime dependency tree of
   # @antseed/node (ethers, @silentbot1/nat-api, tokenx, ...) materialized as
   # real files by scripts/prepare-dist.mjs. We expose it under bundled-plugins

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "main": "dist/main/main.js",
   "scripts": {
-    "ensure:cli-dist": "pnpm -C ../../packages/api-adapter build && pnpm -C ../../packages/router-core build && pnpm -C ../../plugins/router-local build && pnpm -C ../../packages/node build && pnpm -C ../payments build:server && pnpm -C ../cli build",
+    "ensure:cli-dist": "pnpm -C ../../packages/api-adapter build && pnpm -C ../../packages/router-core build && pnpm -C ../../plugins/router-local build && pnpm -C ../../packages/node build && pnpm -C ../../packages/service-core build && pnpm -C ../../plugins/service-auto-deposit build && pnpm -C ../payments build:server && pnpm -C ../cli build",
     "brand:electron-dev": "node ./scripts/brand-electron-dev.mjs",
     "ensure:native": "npm run ensure:runtime-native",
     "ensure:runtime-native": "node ./scripts/ensure-runtime-native-modules.mjs",
@@ -67,7 +67,8 @@
     "pdfjs-dist": "5.6.205",
     "ora": "^9.3.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-qr-code": "^2.0.15"
   },
   "devDependencies": {
     "@electron/notarize": "^3.1.1",

--- a/apps/desktop/scripts/prepare-dist.mjs
+++ b/apps/desktop/scripts/prepare-dist.mjs
@@ -173,6 +173,11 @@ const EXPLICITLY_BUNDLED_PACKAGES = new Set([
   '@antseed/router-core',
   '@antseed/node',
   '@antseed/api-adapter',
+  // The auto-deposit service plugin and its core ship their own dist/package.json
+  // via electron-builder.yml; only their non-@antseed runtime deps (viem,
+  // permissionless, ...) need materializing into bundled-runtime below.
+  '@antseed/service-auto-deposit',
+  '@antseed/service-core',
 ]);
 const NODE_BUILTINS = new Set([
   ...builtinModules,
@@ -287,18 +292,37 @@ function copyDepTree(name, parentSourceDir, parentDestDir, topDestRoot, visited)
   }
 }
 
+// Shared across both walks so a dep needed by node and the service plugin
+// (e.g. a common @noble/* version) is materialized once.
+const visited = new Set();
+
 const nodePackageDir = findPackageDirFromRequire(desktopRequire, '@antseed/node');
 if (!nodePackageDir) {
   console.warn('[prepare-dist] WARNING: could not locate @antseed/node — bundled runtime will be incomplete');
 } else {
   const nodePkg = readPackageJson(nodePackageDir);
-  const visited = new Set();
   // For top-level deps the "parent dest" is the runtime root itself — no
   // sibling can collide at this layer because each direct dep name is unique.
   for (const depName of Object.keys(nodePkg.dependencies ?? {})) {
     copyDepTree(depName, nodePackageDir, BUNDLED_RUNTIME_DIR, BUNDLED_RUNTIME_DIR, visited);
   }
   console.log(`[prepare-dist] Bundled ${visited.size} runtime dep(s) for @antseed/node into ${BUNDLED_RUNTIME_DIR}`);
+}
+
+// Materialize the auto-deposit service plugin's runtime deps (viem, permissionless,
+// and their transitive tree) so the desktop ships it offline alongside the default
+// router. Resolved by explicit monorepo path — like electron-builder.yml — since
+// the desktop itself does not depend on the service plugin.
+const servicePackageDir = path.resolve(appDir, '..', '..', 'plugins', 'service-auto-deposit');
+if (!existsSync(path.join(servicePackageDir, 'package.json'))) {
+  console.warn('[prepare-dist] WARNING: could not locate @antseed/service-auto-deposit — auto-deposit runtime will be incomplete');
+} else {
+  const servicePkg = readPackageJson(servicePackageDir);
+  const before = visited.size;
+  for (const depName of Object.keys(servicePkg?.dependencies ?? {})) {
+    copyDepTree(depName, servicePackageDir, BUNDLED_RUNTIME_DIR, BUNDLED_RUNTIME_DIR, visited);
+  }
+  console.log(`[prepare-dist] Bundled ${visited.size - before} additional runtime dep(s) for auto-deposit into ${BUNDLED_RUNTIME_DIR}`);
 }
 
 console.log('[prepare-dist] Done.');

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -27,6 +27,7 @@ import { parseRuntimeActivityFromLog } from './log-parser.js';
 import {
   setPluginAppendLog,
   ensureDefaultPlugin,
+  ensureOptionalServicePlugin,
   listInstalledPlugins,
   installPluginDependency,
   normalizePluginPackageName,
@@ -142,6 +143,10 @@ let lastRuntimeActivityHash = '';
 
 let appSetupNeeded = false;
 let appSetupComplete = false;
+// Resolves once the router and optional service plugins have been seeded. The
+// buyer spawn waits on this so it never starts before its plugins are installed
+// (otherwise a freshly seeded service shows up only after a manual restart).
+let pluginsReadyPromise: Promise<void> = Promise.resolve();
 
 function isPublicMetadataHost(rawHost: string): boolean {
   const host = rawHost.trim();
@@ -375,6 +380,15 @@ ipcMain.handle('runtime:get-state', async () => {
 
 ipcMain.handle('runtime:start', async (_event, options: StartOptions) => {
   await ensureSecureIdentity();
+
+  // Don't spawn the buyer until its plugins are seeded. Capped so a stalled
+  // install can never block startup indefinitely.
+  if (options.mode === 'connect') {
+    await Promise.race([
+      pluginsReadyPromise,
+      new Promise<void>((resolve) => setTimeout(resolve, 30_000)),
+    ]);
+  }
 
   const startOptions: StartOptions = {
     ...options,
@@ -1015,16 +1029,23 @@ app.whenReady().then(async () => {
 
   // Payments portal starts lazily on first open (via payments:open-portal IPC)
 
-  void ensureDefaultPlugin('@antseed/router-local', {
+  const pluginEnsureContext = {
     getAppSetupNeeded: () => appSetupNeeded,
-    setAppSetupNeeded: (v) => { appSetupNeeded = v; },
+    setAppSetupNeeded: (v: boolean) => { appSetupNeeded = v; },
     getAppSetupComplete: () => appSetupComplete,
-    setAppSetupComplete: (v) => { appSetupComplete = v; },
+    setAppSetupComplete: (v: boolean) => { appSetupComplete = v; },
     getMainWindow,
     appendLog,
-  }).catch(() => {
-    // Failure is already logged via appendLog inside ensureDefaultPlugin.
-  });
+  };
+  pluginsReadyPromise = ensureDefaultPlugin('@antseed/router-local', pluginEnsureContext)
+    // Best-effort, after the required router: seed the optional auto-deposit
+    // service plugin so the Services panel works. Never blocks app setup, but
+    // the buyer spawn waits on this promise so the service loads on first start.
+    .then(() => ensureOptionalServicePlugin('@antseed/service-auto-deposit', pluginEnsureContext))
+    .catch(() => {
+      // Failures are already logged via appendLog inside the ensure functions.
+    });
+  void pluginsReadyPromise;
 
   // Auto-update: check for updates silently on launch and every 30 minutes.
   // If an in-flight download stops emitting progress events for a couple of

--- a/apps/desktop/src/main/plugins.ts
+++ b/apps/desktop/src/main/plugins.ts
@@ -497,3 +497,46 @@ export async function ensureDefaultPlugin(
     throw new Error(`Required plugin "${packageName}" could not be installed: ${message}`);
   }
 }
+
+/**
+ * Seed an optional service plugin (e.g. the auto-deposit funder) into the plugins
+ * dir so the buyer can load it. Unlike {@link ensureDefaultPlugin} this is
+ * best-effort and never gates app setup or throws: a buyer runs fine without it.
+ *
+ * In production it is normally already present: the default-router ensure copies
+ * the whole app bundle (which includes this plugin) via installPluginFromBundle,
+ * so this returns immediately. Otherwise it installs from the npm registry,
+ * exactly like the router and provider plugins.
+ */
+export async function ensureOptionalServicePlugin(
+  packageName: string,
+  ctx: EnsureDefaultPluginContext,
+): Promise<void> {
+  try {
+    if (isPluginInstalled(packageName) && !hasMissingInstalledDependencyTree(packageName)) {
+      return;
+    }
+    ctx.appendLog('connect', 'system', `Service plugin "${packageName}" not found. Installing.`);
+
+    // 1. App bundle (packaged builds). Normally already done by the router
+    //    ensure, which copies the whole bundle including this plugin.
+    let installedFromBundle = false;
+    try {
+      installedFromBundle = await installPluginFromBundle(packageName);
+    } catch (bundleErr) {
+      const message = bundleErr instanceof Error ? bundleErr.message : String(bundleErr);
+      ctx.appendLog('connect', 'system', `Bundled service plugin copy failed: ${message}`);
+    }
+    if (installedFromBundle) {
+      ctx.appendLog('connect', 'system', `Installed service plugin "${packageName}" from app bundle.`);
+      return;
+    }
+
+    // 2. npm registry, exactly like the router and provider plugins.
+    await installPluginDependencies([`${packageName}@latest`]);
+    ctx.appendLog('connect', 'system', `Installed service plugin "${packageName}".`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ctx.appendLog('connect', 'system', `Optional service plugin "${packageName}" not installed (non-fatal): ${message}`);
+  }
+}

--- a/apps/desktop/src/renderer/global.scss
+++ b/apps/desktop/src/renderer/global.scss
@@ -874,6 +874,12 @@ select.form-input {
   border: 1px solid rgba(var(--danger-rgb), 0.2);
 }
 
+.settings-message.warning {
+  background: rgba(187, 128, 9, 0.1);
+  color: #d29922;
+  border: 1px solid rgba(187, 128, 9, 0.28);
+}
+
 .settings-footer {
   display: grid;
   gap: 12px;
@@ -886,6 +892,89 @@ select.form-input {
   font-size: 12px;
   line-height: 1.5;
   color: var(--text-secondary);
+}
+
+/* Service status line: separate it from the toggle row above. */
+.settings-service-status {
+  margin-top: 8px;
+}
+
+.settings-service + .settings-service {
+  margin-top: 20px;
+  padding-top: 20px;
+  border-top: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.08));
+}
+
+.settings-service-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  vertical-align: middle;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.settings-service-badge.is-active {
+  background: rgba(46, 160, 67, 0.18);
+  color: #3fb950;
+}
+
+.settings-service-badge.is-inactive {
+  background: rgba(187, 128, 9, 0.18);
+  color: #d29922;
+}
+
+.settings-service-badge.is-missing {
+  background: rgba(110, 118, 129, 0.18);
+  color: var(--text-secondary);
+}
+
+.settings-receive {
+  display: grid;
+  gap: 12px;
+  justify-items: start;
+  margin-top: 12px;
+}
+
+.settings-receive-address {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-light);
+  background: var(--bg-card-alt);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-primary);
+  max-width: 100%;
+  word-break: break-all;
+}
+
+.settings-copy-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.settings-copy-button:hover {
+  color: var(--text-primary);
+}
+
+.settings-receive-qr {
+  padding: 12px;
+  border-radius: var(--radius-sm);
+  background: #ffffff;
+  border: 1px solid var(--border-light);
+  line-height: 0;
 }
 
 .settings-save-btn {

--- a/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
+import QRCode from 'react-qr-code';
 import { Button } from '@antseed/ui';
 import { useUiSnapshot } from '../../hooks/useUiSnapshot';
 import { useActions } from '../../hooks/useActions';
+import { ChatCopyButton } from '../chat/ChatCopyButton';
 
 type ConfigViewProps = {
   active: boolean;
@@ -19,6 +21,43 @@ function isVoiceModelStatus(value: unknown): value is VoiceModelStatus {
   return Boolean(record && Array.isArray(record.models));
 }
 
+type ServiceStatus = {
+  enabled: boolean;
+  attention: boolean;
+  summary: string;
+  receiveAddress?: string | null;
+  receiveLimitUsdc?: number | null;
+};
+
+type ServicePluginView = {
+  name: string;
+  kind?: string;
+  displayName: string;
+  description: string;
+  installed?: boolean;
+  active?: boolean;
+  enabled?: boolean;
+  status: ServiceStatus;
+};
+
+function isServiceList(value: unknown): value is ServicePluginView[] {
+  return Array.isArray(value) && value.every((item) => {
+    const record = item && typeof item === 'object' ? item as Record<string, unknown> : null;
+    const status = record && typeof record.status === 'object' ? record.status as Record<string, unknown> : null;
+    return Boolean(record && typeof record.name === 'string' && status && typeof status.enabled === 'boolean');
+  });
+}
+
+function formatUsdc(amount: number): string {
+  return String(Math.round(amount * 100) / 100);
+}
+
+function chainLabel(chainId: string): string {
+  if (chainId === 'base-mainnet') return 'Base';
+  if (chainId === 'base-sepolia') return 'Base Sepolia';
+  return chainId;
+}
+
 export function ConfigView({ active }: ConfigViewProps) {
   const { configFormData, configSaving, devMode, configMessage } = useUiSnapshot();
   const actions = useActions();
@@ -32,6 +71,9 @@ export function ConfigView({ active }: ConfigViewProps) {
   const [voiceStatus, setVoiceStatus] = useState<VoiceModelStatus | null>(null);
   const [voiceInstalling, setVoiceInstalling] = useState(false);
   const [voiceMessage, setVoiceMessage] = useState<string | null>(null);
+  const [services, setServices] = useState<ServicePluginView[]>([]);
+  const [serviceBusy, setServiceBusy] = useState<string | null>(null);
+  const [serviceMessage, setServiceMessage] = useState<string | null>(null);
 
   // Sync from config on first load only
   const [initialized, setInitialized] = useState(false);
@@ -56,6 +98,26 @@ export function ConfigView({ active }: ConfigViewProps) {
     if (active) void refreshVoiceStatus();
   }, [active, refreshVoiceStatus]);
 
+  const refreshServices = useCallback(async () => {
+    const result = await window.antseedDesktop?.apiTryProxyRequest?.({
+      port: parseInt(proxyPort, 10) || 8377,
+      path: '/_antseed/services',
+      method: 'GET', headers: {}, body: '',
+    });
+    if (!result?.ok) return;
+    try {
+      const data = JSON.parse(result.body) as { services?: unknown };
+      if (isServiceList(data.services)) setServices(data.services);
+    } catch { /* ignore transient poll/parse errors */ }
+  }, [proxyPort]);
+
+  useEffect(() => {
+    if (!active) return;
+    void refreshServices();
+    const timer = setInterval(() => void refreshServices(), 5000);
+    return () => clearInterval(timer);
+  }, [active, refreshServices]);
+
   async function handleVoiceModelChange(modelId: string) {
     setVoiceMessage(null);
     const result = await window.antseedDesktop?.voiceSetModel?.(modelId) as { ok?: boolean; error?: string; status?: unknown } | undefined;
@@ -78,6 +140,28 @@ export function ConfigView({ active }: ConfigViewProps) {
       setVoiceMessage(error instanceof Error ? error.message : String(error));
     } finally {
       setVoiceInstalling(false);
+    }
+  }
+
+  async function toggleService(name: string, enabled: boolean) {
+    setServiceBusy(name);
+    setServiceMessage(null);
+    try {
+      const result = await window.antseedDesktop?.apiTryProxyRequest?.({
+        port: parseInt(proxyPort, 10) || 8377,
+        path: '/_antseed/services',
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name, enabled }),
+      });
+      if (!result?.ok) throw new Error(result?.error || `Request failed (${result?.status ?? 0})`);
+      const data = JSON.parse(result.body) as { ok?: boolean; error?: string };
+      if (!data.ok) throw new Error(data.error || 'Request rejected');
+      await refreshServices();
+    } catch (error) {
+      setServiceMessage(error instanceof Error ? error.message : String(error));
+    } finally {
+      setServiceBusy(null);
     }
   }
 
@@ -202,6 +286,87 @@ export function ConfigView({ active }: ConfigViewProps) {
               {configSaving ? 'Saving...' : 'Save & Restart'}
             </Button>
           )}
+          </div>
+        </article>
+
+        <article className="panel settings-panel">
+          <div className="panel-head">
+            <h3>Services</h3>
+          </div>
+          <div className="settings-stack">
+            {services.length === 0 ? (
+              <p className="settings-note">No services available.</p>
+            ) : services.map((plugin) => {
+              const enabled = plugin.enabled ?? plugin.status.enabled;
+              const active = plugin.active ?? false;
+              const installed = plugin.installed ?? true;
+              const stateLabel = active ? 'Active' : installed ? 'Inactive' : 'Not installed';
+              const stateClass = active ? 'is-active' : installed ? 'is-inactive' : 'is-missing';
+              return (
+              <div key={plugin.name} className="settings-service">
+                <div className="settings-item">
+                  <div className="settings-copy">
+                    <h4>
+                      {plugin.displayName}
+                      <span className={`settings-service-badge ${stateClass}`}>{stateLabel}</span>
+                    </h4>
+                    <p>{plugin.description}</p>
+                  </div>
+                  <button
+                    type="button"
+                    className={`settings-switch${enabled ? ' is-on' : ''}`}
+                    aria-pressed={enabled}
+                    onClick={() => void toggleService(plugin.name, !enabled)}
+                    disabled={serviceBusy === plugin.name}
+                  >
+                    <span className="settings-switch-track">
+                      <span className="settings-switch-thumb" />
+                    </span>
+                    <span className="settings-switch-label">{enabled ? 'On' : 'Off'}</span>
+                  </button>
+                </div>
+                {enabled && !active ? (
+                  <p className="settings-note settings-service-status">Enabled. It will start the next time the buyer runs.</p>
+                ) : plugin.status.summary ? (
+                  plugin.status.attention
+                    ? <p className="settings-message error settings-service-status">{plugin.status.summary}</p>
+                    : <p className="settings-note settings-service-status">{plugin.status.summary}</p>
+                ) : null}
+                {enabled && active && plugin.status.receiveAddress ? (
+                  <div className="settings-receive">
+                    <p className="settings-message warning">
+                      {typeof plugin.status.receiveLimitUsdc === 'number' ? (
+                        <>
+                          <strong>Do not send more than {formatUsdc(plugin.status.receiveLimitUsdc)} USDC.</strong> That is your current deposit limit; anything above it stays in your wallet.
+                        </>
+                      ) : (
+                        <>
+                          <strong>Deposits are capped.</strong> Sending more than your current deposit limit leaves the excess in your wallet.
+                        </>
+                      )}
+                    </p>
+                    <p className="settings-note">
+                      Send USDC on {chainLabel(chainId)} to this address to fund your wallet. Only send USDC on {chainLabel(chainId)}; other tokens or chains may be lost.
+                    </p>
+                    <div className="settings-receive-address">
+                      <span>{plugin.status.receiveAddress}</span>
+                      <ChatCopyButton
+                        className="settings-copy-button"
+                        text={plugin.status.receiveAddress}
+                        ariaLabel="Copy wallet address"
+                        tooltipLabel="Copy address"
+                        copiedTooltipLabel="Copied!"
+                      />
+                    </div>
+                    <div className="settings-receive-qr">
+                      <QRCode value={plugin.status.receiveAddress} size={160} bgColor="#ffffff" fgColor="#000000" />
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+              );
+            })}
+            {serviceMessage ? <p className="settings-note">{serviceMessage}</p> : null}
           </div>
         </article>
 

--- a/apps/website/docs/cli/commands.md
+++ b/apps/website/docs/cli/commands.md
@@ -37,6 +37,8 @@ antseed buyer start --router <name>   Start the buyer proxy with a non-default r
 antseed buyer deposit <amount>        Deposit USDC for payments
 antseed buyer withdraw <amount>       Withdraw USDC from deposits
 antseed buyer balance                 Check wallet and deposit balance
+antseed buyer enable-service <name>   Turn on a service plugin (e.g. auto-deposit: sweep wallet USDC into deposits)
+antseed buyer disable-service <name>  Turn off a service plugin
 antseed network browse                Browse available services and pricing
 antseed payments                      Launch the payments portal
 ```

--- a/apps/website/docs/guides/payments.md
+++ b/apps/website/docs/guides/payments.md
@@ -31,6 +31,23 @@ The contract's `deposit(buyer, amount)` pulls USDC from your connected wallet an
 Anyone can deposit on behalf of a buyer — a team treasury, a hardware wallet, or another contract. The funding source is decoupled from the node identity.
 :::
 
+### Auto-deposit (gasless)
+
+Instead of depositing by hand, you can let your node do it. With auto-deposit on, the node watches your wallet and moves any USDC it finds into the deposits contract on its own, so the funds are ready to spend.
+
+Turn it on from the CLI:
+
+```bash
+antseed buyer enable-service auto-deposit
+antseed buyer disable-service auto-deposit
+```
+
+In AntStation, open Settings and use the toggle in the Funding panel. When it is on, the panel shows your wallet address and a QR code so you can send USDC straight to it from an exchange or another wallet.
+
+You do not need any ETH. Gas is paid in USDC through the Circle Paymaster, and on the first deposit your wallet is upgraded once to a smart account (EIP-7702) at the same address. After that, every top-up is swept automatically.
+
+Send only USDC on Base. To find the address from the CLI, run `antseed buyer balance`.
+
 ### Checking Balance
 
 ```bash

--- a/e2e/tests/plugin-system.test.ts
+++ b/e2e/tests/plugin-system.test.ts
@@ -225,7 +225,7 @@ describe('Plugin Registry', () => {
   it('all trusted plugins have required fields (name, type, package, description)', () => {
     for (const plugin of TRUSTED_PLUGINS) {
       expect(plugin.name).toBeTruthy();
-      expect(['provider', 'router']).toContain(plugin.type);
+      expect(['provider', 'router', 'service']).toContain(plugin.type);
       expect(plugin.package).toBeTruthy();
       expect(plugin.description).toBeTruthy();
     }

--- a/flake.nix
+++ b/flake.nix
@@ -25,12 +25,14 @@
             packages = with pkgs; [
               cacert
               cmake
+              foundry
               git
               ninja
               nodejs_22
               pkg-config
               pnpm_9
               python311
+              solc
             ] ++ lib.optionals stdenv.isLinux [
               libsecret
             ];
@@ -38,6 +40,9 @@
             shellHook = ''
               export PATH="$PWD/node_modules/.bin:$PATH"
               export npm_config_python="${pkgs.python311}/bin/python3"
+              # forge's svm-downloaded solc is dynamically linked and won't run on
+              # NixOS; point Foundry at the nix-provided solc instead.
+              export FOUNDRY_SOLC="${pkgs.solc}/bin/solc"
             '';
           };
         });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "pnpm run build:tier0 && pnpm run build:tier1 && pnpm run build:tier2 && pnpm run build:tier3 && pnpm run build:tier4 && pnpm run build:standalone",
     "build:tier0": "pnpm --filter=@antseed/ui run build && pnpm --filter=@antseed/api-adapter run build && pnpm --filter=@antseed/node run build",
-    "build:tier1": "pnpm --filter=@antseed/provider-core --filter=@antseed/router-core --filter=@antseed/ant-agent run build",
+    "build:tier1": "pnpm --filter=@antseed/provider-core --filter=@antseed/router-core --filter=@antseed/ant-agent --filter=@antseed/service-core run build",
     "build:tier2": "pnpm --filter \"./plugins/*\" run build",
     "build:tier3": "pnpm --filter=@antseed/payments run build",
     "build:tier4": "pnpm --filter=@antseed/cli run build && pnpm --filter=@antseed/desktop run build",
@@ -27,10 +27,10 @@
     "test": "pnpm -r run test",
     "test:e2e": "pnpm --filter=@antseed/e2e run test",
     "typecheck": "pnpm -r run typecheck",
-    "clean": "node ./scripts/remove-paths.mjs apps/cli/dist apps/desktop/dist apps/diem-staking/dist apps/network-stats/dist apps/website/build e2e/dist packages/api-adapter/dist packages/bound-agent/dist packages/node/dist packages/provider-core/dist packages/router-core/dist plugins/provider-anthropic/dist plugins/provider-claude-code/dist plugins/provider-claude-oauth/dist plugins/provider-local-llm/dist plugins/provider-openai/dist plugins/provider-openai-responses/dist plugins/router-local/dist",
+    "clean": "node ./scripts/remove-paths.mjs apps/cli/dist apps/desktop/dist apps/diem-staking/dist apps/network-stats/dist apps/website/build e2e/dist packages/api-adapter/dist packages/service-core/dist packages/bound-agent/dist packages/node/dist packages/provider-core/dist packages/router-core/dist plugins/provider-anthropic/dist plugins/provider-claude-code/dist plugins/provider-claude-oauth/dist plugins/provider-local-llm/dist plugins/provider-openai/dist plugins/provider-openai-responses/dist plugins/router-local/dist plugins/service-auto-deposit/dist",
     "publish:all": "pnpm run build && pnpm -r publish --no-git-checks",
     "publish:dry": "pnpm run build && pnpm -r publish --no-git-checks --dry-run",
-    "clean:all": "node ./scripts/remove-paths.mjs node_modules apps/cli/node_modules apps/desktop/node_modules apps/diem-staking/node_modules apps/network-stats/node_modules apps/website/node_modules e2e/node_modules packages/api-adapter/node_modules packages/bound-agent/node_modules packages/node/node_modules packages/provider-core/node_modules packages/router-core/node_modules plugins/provider-anthropic/node_modules plugins/provider-claude-code/node_modules plugins/provider-claude-oauth/node_modules plugins/provider-local-llm/node_modules plugins/provider-openai/node_modules plugins/provider-openai-responses/node_modules plugins/router-local/node_modules",
+    "clean:all": "node ./scripts/remove-paths.mjs node_modules apps/cli/node_modules apps/desktop/node_modules apps/diem-staking/node_modules apps/network-stats/node_modules apps/website/node_modules e2e/node_modules packages/api-adapter/node_modules packages/service-core/node_modules packages/bound-agent/node_modules packages/node/node_modules packages/provider-core/node_modules packages/router-core/node_modules plugins/provider-anthropic/node_modules plugins/provider-claude-code/node_modules plugins/provider-claude-oauth/node_modules plugins/provider-local-llm/node_modules plugins/provider-openai/node_modules plugins/provider-openai-responses/node_modules plugins/router-local/node_modules plugins/service-auto-deposit/node_modules",
     "dev:website": "pnpm --filter=@antseed/website run dev",
     "dev:desktop": "pnpm run build:tier0 && pnpm run build:tier1 && pnpm run build:tier2 && pnpm run build:tier3 && pnpm --filter=@antseed/cli run build && pnpm --filter=@antseed/desktop run dev"
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -172,7 +172,15 @@ export {
 } from './proxy/service-api-adapter.js';
 export { DefaultRouter, type DefaultRouterConfig } from './routing/default-router.js';
 
-export type { AntseedPlugin, AntseedProviderPlugin, AntseedRouterPlugin, PluginConfigKey, ConfigField } from './interfaces/plugin.js'
+export type { AntseedPlugin, AntseedProviderPlugin, AntseedRouterPlugin, AntseedServicePlugin, PluginConfigKey, ConfigField } from './interfaces/plugin.js'
+export type {
+  Service,
+  ServiceStatus,
+  ServiceHost,
+  ServiceCapability,
+  ServiceCapabilities,
+  WalletCapability,
+} from './interfaces/service.js'
 
 // Reputation
 export { UptimeTracker } from './reputation/uptime-tracker.js';

--- a/packages/node/src/interfaces/plugin.ts
+++ b/packages/node/src/interfaces/plugin.ts
@@ -1,5 +1,6 @@
 import type { Provider } from './seller-provider.js'
 import type { Router } from './buyer-router.js'
+import type { Service, ServiceHost, ServiceCapability } from './service.js'
 
 export interface ConfigField {
   key: string
@@ -33,4 +34,20 @@ export interface AntseedRouterPlugin extends AntseedPluginBase {
   createRouter(config: Record<string, string>): Router | Promise<Router>
 }
 
-export type AntseedPlugin = AntseedProviderPlugin | AntseedRouterPlugin
+/**
+ * Host-driven background service plugin (e.g. the gasless auto-deposit funder).
+ * Unlike providers/routers it runs a start/stop lifecycle on the buyer's behalf
+ * and may need sensitive capabilities (a wallet key, chain config) rather than
+ * plain string config. It declares them via {@link capabilities} and the host
+ * grants only those.
+ */
+export interface AntseedServicePlugin extends AntseedPluginBase {
+  type: 'service'
+  /** Discriminates the family of service (e.g. "funding") for client grouping. */
+  kind: string
+  /** Sensitive capabilities the host must grant before the service can run. */
+  capabilities?: ServiceCapability[]
+  createService(host: ServiceHost): Service | null | Promise<Service | null>
+}
+
+export type AntseedPlugin = AntseedProviderPlugin | AntseedRouterPlugin | AntseedServicePlugin

--- a/packages/node/src/interfaces/service.ts
+++ b/packages/node/src/interfaces/service.ts
@@ -1,0 +1,50 @@
+import type { ChainConfig } from '../payments/chain-config.js'
+
+/** Serializable, mechanism-agnostic status a client (e.g. the desktop) renders. */
+export interface ServiceStatus {
+  enabled: boolean
+  /** True when the service is paused on a deterministic failure; drives error styling. */
+  attention: boolean
+  /** Human-readable status line. */
+  summary: string
+  /** Optional address the user can fund; present => UI shows copy + QR. */
+  receiveAddress?: string | null
+  /** Max USDC the user can deposit right now (e.g. on-chain credit-limit
+   * headroom); present => UI shows the live cap. Null when not yet known. */
+  receiveLimitUsdc?: number | null
+}
+
+/** Sensitive capabilities a service plugin may declare a need for. The host
+ * grants only the ones the plugin asks for, so a service never receives a
+ * capability (e.g. the wallet key) it did not request. */
+export type ServiceCapability = 'wallet' | 'chain'
+
+export interface WalletCapability {
+  privateKey: `0x${string}`
+  address: `0x${string}`
+}
+
+/** The capability bag a {@link ServiceHost} carries. Each field is present only
+ * when the plugin declared the matching {@link ServiceCapability} and the host
+ * was able to grant it. */
+export interface ServiceCapabilities {
+  wallet?: WalletCapability
+  chain?: ChainConfig
+}
+
+/** Context every service gets: consent, an attention logger, and the subset of
+ * capabilities it declared. The host (e.g. the CLI buyer process) owns the
+ * underlying resources and hands in only what the plugin asked for. */
+export interface ServiceHost {
+  consent: { isEnabled(): boolean }
+  onAttention?(message: string): void
+  capabilities: ServiceCapabilities
+}
+
+export interface Service {
+  start(): void
+  stop(): void
+  getStatus(): ServiceStatus
+  /** Optional: trigger an immediate evaluation, e.g. right after consent is enabled. */
+  poke?(): void | Promise<void>
+}

--- a/packages/service-core/.gitignore
+++ b/packages/service-core/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.tsbuildinfo
+package-lock.json
+.DS_Store

--- a/packages/service-core/package.json
+++ b/packages/service-core/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@antseed/service-core",
+  "version": "0.1.0",
+  "description": "Shared infrastructure for Antseed host-driven service plugins",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@antseed/node": ">=0.1.0"
+  },
+  "devDependencies": {
+    "@antseed/node": "workspace:*",
+    "typescript": "^5.5.0"
+  }
+}

--- a/packages/service-core/src/index.ts
+++ b/packages/service-core/src/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared infrastructure for Antseed service plugins.
+ *
+ * A service plugin runs a start/stop background lifecycle on the buyer's behalf
+ * (e.g. the gasless auto-deposit funder). The plugin *type* and runtime
+ * contracts live in @antseed/node alongside the provider/router plugin types;
+ * this package provides the reusable helpers concrete service plugins build on,
+ * mirroring how @antseed/provider-core and @antseed/router-core relate to node.
+ */
+import type { ChainConfig, ServiceHost, WalletCapability } from '@antseed/node'
+
+export type {
+  AntseedServicePlugin,
+  Service,
+  ServiceStatus,
+  ServiceHost,
+  ServiceCapability,
+  ServiceCapabilities,
+  WalletCapability,
+} from '@antseed/node'
+
+/** Read the wallet capability or throw. Use when the plugin declared 'wallet'
+ * in its capabilities; the host guarantees it, so absence is a misconfig. */
+export function requireWallet(host: ServiceHost): WalletCapability {
+  const wallet = host.capabilities.wallet
+  if (!wallet) {
+    throw new Error('Service host did not grant the "wallet" capability')
+  }
+  return wallet
+}
+
+/** Read the chain capability or throw. Use when the plugin declared 'chain'. */
+export function requireChain(host: ServiceHost): ChainConfig {
+  const chain = host.capabilities.chain
+  if (!chain) {
+    throw new Error('Service host did not grant the "chain" capability')
+  }
+  return chain
+}

--- a/packages/service-core/tsconfig.json
+++ b/packages/service-core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/plugins/service-auto-deposit/.gitignore
+++ b/plugins/service-auto-deposit/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+*.tsbuildinfo
+package-lock.json
+.DS_Store

--- a/plugins/service-auto-deposit/package.json
+++ b/plugins/service-auto-deposit/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@antseed/service-auto-deposit",
+  "version": "0.1.0",
+  "description": "Antseed buyer-side gasless auto-deposit service plugin: sweeps loose USDC into AntseedDeposits via Circle Paymaster + EIP-7702",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "prebuild": "node ../../scripts/remove-paths.mjs dist",
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@antseed/service-core": "workspace:*",
+    "permissionless": "^0.3.6",
+    "viem": "^2.52.2"
+  },
+  "peerDependencies": {
+    "@antseed/node": ">=0.1.0"
+  },
+  "devDependencies": {
+    "@antseed/node": "workspace:*",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/plugins/service-auto-deposit/src/chain-context.ts
+++ b/plugins/service-auto-deposit/src/chain-context.ts
@@ -1,0 +1,11 @@
+/** The slice of chain config the funding service needs. Structurally satisfied
+ * by @antseed/node's ChainConfig, so the host's granted "chain" capability can
+ * be passed straight through. */
+export interface FundingChainContext {
+  chainId: string;
+  evmChainId: number;
+  rpcUrl: string;
+  fallbackRpcUrls?: string[];
+  usdcContractAddress: string;
+  depositsContractAddress: string;
+}

--- a/plugins/service-auto-deposit/src/chains.ts
+++ b/plugins/service-auto-deposit/src/chains.ts
@@ -1,0 +1,28 @@
+/** Config for gasless USDC auto-deposit (Circle Paymaster + EIP-7702). */
+export interface AutoDepositChainConfig {
+  bundlerUrl: string;
+  paymasterAddress: string;
+  entryPointAddress: string;
+  delegateAddress: string;
+}
+
+// EntryPoint v0.8 + Simple7702Account v0.8: canonical singletons, same on every chain.
+const ENTRY_POINT_V08 = '0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108';
+const SIMPLE_7702_ACCOUNT_V08 = '0xe6Cae83BdE06E4c305530e199D7217f42808555B';
+
+/**
+ * Per-chain gasless config, keyed by AntSeed chainId. A chain absent here is not
+ * gasless-capable, so auto-deposit stays off for it.
+ *
+ * base-sepolia is intentionally omitted: its USDC is an AntSeed mock, but Circle's
+ * paymaster only charges in Circle USDC, so the gasless path would deterministically
+ * fail. Re-add once Deposits is wired to Circle Sepolia USDC.
+ */
+export const AUTO_DEPOSIT_CHAINS: Record<string, AutoDepositChainConfig> = {
+  'base-mainnet': {
+    bundlerUrl: 'https://public.pimlico.io/v2/8453/rpc',
+    paymasterAddress: '0x0578cFB241215b77442a541325d6A4E6dFE700Ec',
+    entryPointAddress: ENTRY_POINT_V08,
+    delegateAddress: SIMPLE_7702_ACCOUNT_V08,
+  },
+};

--- a/plugins/service-auto-deposit/src/codec.test.ts
+++ b/plugins/service-auto-deposit/src/codec.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { isDelegationCode, delegationTarget, encodeCirclePaymasterData } from './codec.js';
+
+const DELEGATED = '0xef0100e6cae83bde06e4c305530e199d7217f42808555b';
+const SIMPLE_7702 = '0xe6Cae83BdE06E4c305530e199D7217f42808555B';
+
+describe('isDelegationCode', () => {
+  it('detects the 7702 designator', () => {
+    expect(isDelegationCode(DELEGATED)).toBe(true);
+    expect(isDelegationCode(DELEGATED.toUpperCase() as `0x${string}`)).toBe(true);
+  });
+
+  it('is false for empty / missing / plain bytecode', () => {
+    expect(isDelegationCode('0x')).toBe(false);
+    expect(isDelegationCode(null)).toBe(false);
+    expect(isDelegationCode(undefined)).toBe(false);
+    expect(isDelegationCode('0x60806040')).toBe(false);
+  });
+});
+
+describe('delegationTarget', () => {
+  it('extracts the (checksummed) implementation address', () => {
+    expect(delegationTarget(DELEGATED)).toBe(SIMPLE_7702);
+  });
+
+  it('returns null when not delegated', () => {
+    expect(delegationTarget('0x')).toBeNull();
+    expect(delegationTarget(undefined)).toBeNull();
+  });
+});
+
+describe('encodeCirclePaymasterData', () => {
+  it('packs [mode=0, token, maxGasUsdc, sig]', () => {
+    const usdc = '0x036CbD53842c5426634e7929541eC2318f3dCF7e';
+    const out = encodeCirclePaymasterData(usdc, 1_000_000n, '0xabcd');
+    // 0x + mode(00) + token(20B, lowercased) + uint256(32B) + sig
+    expect(out.startsWith('0x00036cbd53842c5426634e7929541ec2318f3dcf7e')).toBe(true);
+    expect(out).toContain('0000000000000000000000000000000000000000000000000000000000000f4240'.slice(-64));
+    expect(out.endsWith('abcd')).toBe(true);
+  });
+});

--- a/plugins/service-auto-deposit/src/codec.ts
+++ b/plugins/service-auto-deposit/src/codec.ts
@@ -1,0 +1,24 @@
+import { encodePacked, getAddress, type Address, type Hex } from 'viem';
+
+/** EIP-7702 delegation designator seen in `eth_getCode`: `0xef0100 || <impl>`. */
+const DELEGATION_PREFIX = '0xef0100';
+
+export function isDelegationCode(code: Hex | null | undefined): boolean {
+  return typeof code === 'string' && code.toLowerCase().startsWith(DELEGATION_PREFIX);
+}
+
+export function delegationTarget(code: Hex | null | undefined): Address | null {
+  if (!isDelegationCode(code)) return null;
+  const body = (code as string).slice(DELEGATION_PREFIX.length);
+  if (body.length < 40) return null;
+  return getAddress(`0x${body.slice(0, 40)}`);
+}
+
+/**
+ * Circle Paymaster v0.8 `paymasterData`: packed `[uint8 mode=0, token, maxGasUSDC,
+ * permitSig]`. The mode byte is 0; the EIP-2612 permit lets the paymaster pull up
+ * to `maxGasUsdc` of `usdc` for gas.
+ */
+export function encodeCirclePaymasterData(usdc: Address, maxGasUsdc: bigint, permitSignature: Hex): Hex {
+  return encodePacked(['uint8', 'address', 'uint256', 'bytes'], [0, usdc, maxGasUsdc, permitSignature]);
+}

--- a/plugins/service-auto-deposit/src/debug.ts
+++ b/plugins/service-auto-deposit/src/debug.ts
@@ -1,0 +1,30 @@
+function normalizeDebugValue(value: string | undefined): string {
+  return (value ?? '').trim().toLowerCase();
+}
+
+export function isDebugEnabled(): boolean {
+  const fromAntseed = normalizeDebugValue(process.env['ANTSEED_DEBUG']);
+  if (
+    fromAntseed === '1' ||
+    fromAntseed === 'true' ||
+    fromAntseed === 'yes' ||
+    fromAntseed === 'on'
+  ) {
+    return true;
+  }
+
+  const fromDebug = normalizeDebugValue(process.env['DEBUG']);
+  return fromDebug === '*' || fromDebug.includes('antseed');
+}
+
+export function debugLog(...args: unknown[]): void {
+  if (isDebugEnabled()) {
+    console.log(...args);
+  }
+}
+
+export function debugWarn(...args: unknown[]): void {
+  if (isDebugEnabled()) {
+    console.warn(...args);
+  }
+}

--- a/plugins/service-auto-deposit/src/factory.ts
+++ b/plugins/service-auto-deposit/src/factory.ts
@@ -1,0 +1,126 @@
+import { getAddress, type Hex } from 'viem';
+import { GaslessDepositsClient, type GaslessDepositsConfig } from './gasless-deposits-client.js';
+import { AUTO_DEPOSIT_CHAINS } from './chains.js';
+import { requireChain, requireWallet, type Service, type ServiceHost, type ServiceStatus } from '@antseed/service-core';
+import type { FundingChainContext } from './chain-context.js';
+import {
+  AutoDepositManager,
+  type AutoDepositConsentView,
+  type AutoDepositManagerConfig,
+  type AutoDepositReader,
+  type AutoDepositExecutor,
+  type AutoDepositStatus,
+} from './manager.js';
+
+export function gaslessConfigFromChain(chain: FundingChainContext): GaslessDepositsConfig | null {
+  const aa = AUTO_DEPOSIT_CHAINS[chain.chainId];
+  if (!aa) return null;
+  return {
+    evmChainId: chain.evmChainId,
+    rpcUrl: chain.rpcUrl,
+    fallbackRpcUrls: chain.fallbackRpcUrls,
+    bundlerUrl: aa.bundlerUrl,
+    usdcAddress: getAddress(chain.usdcContractAddress),
+    paymasterAddress: getAddress(aa.paymasterAddress),
+    depositsAddress: getAddress(chain.depositsContractAddress),
+    delegateAddress: getAddress(aa.delegateAddress),
+    entryPointAddress: getAddress(aa.entryPointAddress),
+  };
+}
+
+/**
+ * Build an {@link AutoDepositManager} wired to a gasless executor for the given
+ * chain, or null when the chain is not gasless-capable. A single
+ * {@link GaslessDepositsClient} serves as both the balance reader and the
+ * deposit executor.
+ */
+export function createAutoDepositManager(opts: {
+  chain: FundingChainContext;
+  privateKey: Hex;
+  consent: AutoDepositConsentView;
+  config?: AutoDepositManagerConfig;
+  onAttention?: (message: string) => void;
+}): AutoDepositManager | null {
+  const gaslessConfig = gaslessConfigFromChain(opts.chain);
+  if (!gaslessConfig) return null;
+
+  const client = new GaslessDepositsClient(opts.privateKey, gaslessConfig);
+  const reader: AutoDepositReader = {
+    looseUsdc: () => client.usdcBalance(),
+    totalDeposited: async () => {
+      const { available, reserved } = await client.buyerBalance();
+      return available + reserved;
+    },
+    creditLimit: () => client.creditLimit(),
+    isDelegated: () => client.isDelegated(),
+  };
+  const executor: AutoDepositExecutor = {
+    deposit: async (amount) => {
+      const { txHash } = await client.deposit(amount);
+      return { txHash };
+    },
+  };
+  return new AutoDepositManager({ reader, executor, consent: opts.consent, config: opts.config, onAttention: opts.onAttention });
+}
+
+function formatUsdc(baseUnits: string): string {
+  return (Number(baseUnits) / 1_000_000).toFixed(2);
+}
+
+function summarize(status: AutoDepositStatus): string {
+  switch (status.state) {
+    case 'disabled': return 'Off';
+    case 'needs_attention': return `Needs attention: ${status.lastError ?? 'see logs'}`;
+    case 'backoff': return 'Retrying…';
+    case 'pending': return 'Depositing…';
+    case 'stranded': return `${formatUsdc(status.strandedBaseUnits)} USDC waiting (credit limit reached; deposits resume as it grows)`;
+    case 'idle': return status.delegated ? '' : 'Your wallet upgrades on the first deposit';
+    default: return '';
+  }
+}
+
+const USDC_DECIMALS = 1_000_000;
+
+export function toServiceStatus(status: AutoDepositStatus, receiveAddress: string): ServiceStatus {
+  return {
+    enabled: status.enabled,
+    attention: status.state === 'needs_attention',
+    summary: summarize(status),
+    receiveAddress,
+    receiveLimitUsdc: depositHeadroomUsdc(status),
+  };
+}
+
+/** Live on-chain credit-limit headroom (creditLimit - deposited) in USDC, or
+ * null before the first successful read (creditLimit still 0). Beyond this the
+ * deposit reverts and the excess stays loose in the wallet. */
+function depositHeadroomUsdc(status: AutoDepositStatus): number | null {
+  const creditLimit = BigInt(status.creditLimitBaseUnits);
+  if (creditLimit <= 0n) return null;
+  const deposited = BigInt(status.depositedBaseUnits);
+  const headroom = creditLimit > deposited ? creditLimit - deposited : 0n;
+  return Number(headroom) / USDC_DECIMALS;
+}
+
+/** Build the auto-deposit {@link Service}, or null when the chain is not
+ * gasless-capable. Reads the wallet + chain capabilities the plugin declared,
+ * wraps the manager, and maps its rich status to the generic
+ * {@link ServiceStatus} the desktop renders. */
+export function createAutoDepositService(host: ServiceHost): Service | null {
+  const wallet = requireWallet(host);
+  const chain = requireChain(host);
+  const manager = createAutoDepositManager({
+    chain,
+    privateKey: wallet.privateKey,
+    consent: host.consent,
+    onAttention: host.onAttention,
+  });
+  if (!manager) return null;
+  const receiveAddress = wallet.address;
+  return {
+    start: () => manager.start(),
+    stop: () => manager.stop(),
+    poke: () => manager.runOnce(),
+    getStatus: () => toServiceStatus(manager.getStatus(), receiveAddress),
+  };
+}

--- a/plugins/service-auto-deposit/src/funding-service.test.ts
+++ b/plugins/service-auto-deposit/src/funding-service.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { toServiceStatus } from './factory.js';
+import type { AutoDepositStatus } from './manager.js';
+
+function status(overrides: Partial<AutoDepositStatus>): AutoDepositStatus {
+  return {
+    enabled: true,
+    delegated: false,
+    state: 'idle',
+    looseBaseUnits: '0',
+    strandedBaseUnits: '0',
+    creditLimitBaseUnits: '0',
+    depositedBaseUnits: '0',
+    lastDeposit: null,
+    lastError: null,
+    ...overrides,
+  };
+}
+
+const ADDRESS = '0x1111111111111111111111111111111111111111';
+
+describe('toServiceStatus', () => {
+  it('maps disabled to Off without attention', () => {
+    const funding = toServiceStatus(status({ enabled: false, state: 'disabled' }), ADDRESS);
+    expect(funding.enabled).toBe(false);
+    expect(funding.attention).toBe(false);
+    expect(funding.summary).toBe('Off');
+    expect(funding.receiveAddress).toBe(ADDRESS);
+  });
+
+  it('flags needs_attention and surfaces the error', () => {
+    const funding = toServiceStatus(status({ state: 'needs_attention', lastError: 'boom' }), ADDRESS);
+    expect(funding.attention).toBe(true);
+    expect(funding.summary).toContain('boom');
+  });
+
+  it('summarizes stranded funds with a USDC amount', () => {
+    const funding = toServiceStatus(status({ state: 'stranded', strandedBaseUnits: '2500000' }), ADDRESS);
+    expect(funding.attention).toBe(false);
+    expect(funding.summary).toContain('2.50 USDC');
+  });
+
+  it('shows no status text when idle and delegated (the toggle conveys it)', () => {
+    expect(toServiceStatus(status({ state: 'idle', delegated: true }), ADDRESS).summary).toBe('');
+  });
+
+  it('mentions the wallet upgrade when idle and not yet delegated', () => {
+    expect(toServiceStatus(status({ state: 'idle', delegated: false }), ADDRESS).summary)
+      .toContain('upgrades on the first deposit');
+  });
+
+  it('reports null deposit limit before the credit limit is known', () => {
+    expect(toServiceStatus(status({ creditLimitBaseUnits: '0' }), ADDRESS).receiveLimitUsdc).toBeNull();
+  });
+
+  it('reports the live headroom (credit limit minus deposited) in USDC', () => {
+    const funding = toServiceStatus(
+      status({ creditLimitBaseUnits: '10000000', depositedBaseUnits: '2500000' }),
+      ADDRESS,
+    );
+    expect(funding.receiveLimitUsdc).toBe(7.5);
+  });
+
+  it('clamps the deposit limit to zero when already at the credit limit', () => {
+    const funding = toServiceStatus(
+      status({ creditLimitBaseUnits: '10000000', depositedBaseUnits: '10000000' }),
+      ADDRESS,
+    );
+    expect(funding.receiveLimitUsdc).toBe(0);
+  });
+});

--- a/plugins/service-auto-deposit/src/gasless-deposits-client.ts
+++ b/plugins/service-auto-deposit/src/gasless-deposits-client.ts
@@ -1,0 +1,249 @@
+import {
+  createPublicClient, http, fallback, getContract, maxUint256, parseErc6492Signature,
+  erc20Abi, isAddressEqual, defineChain, type Address, type Hex, type Chain, type PublicClient,
+} from 'viem';
+import { base, baseSepolia } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+import { createBundlerClient, entryPoint08Address } from 'viem/account-abstraction';
+import { to7702SimpleSmartAccount } from 'permissionless/accounts';
+import { createPimlicoClient } from 'permissionless/clients/pimlico';
+import { encodeCirclePaymasterData, delegationTarget } from './codec.js';
+
+function resolveViemChain(evmChainId: number, rpcUrl: string): Chain {
+  if (evmChainId === base.id) return base;
+  if (evmChainId === baseSepolia.id) return baseSepolia;
+  return defineChain({
+    id: evmChainId,
+    name: `evm-${evmChainId}`,
+    nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+    rpcUrls: { default: { http: [rpcUrl] } },
+  });
+}
+
+/** 1 USDC (6 decimals): default cap the paymaster may pull for gas per op. */
+const DEFAULT_MAX_GAS_USDC = 1_000_000n;
+
+const DEPOSITS_ABI = [
+  {
+    type: 'function', name: 'deposit', stateMutability: 'nonpayable',
+    inputs: [{ name: 'buyer', type: 'address' }, { name: 'amount', type: 'uint256' }], outputs: [],
+  },
+  {
+    type: 'function', name: 'getBuyerBalance', stateMutability: 'view',
+    inputs: [{ name: 'buyer', type: 'address' }],
+    outputs: [{ name: 'available', type: 'uint256' }, { name: 'reserved', type: 'uint256' }, { name: 'lastActivityAt', type: 'uint256' }],
+  },
+  {
+    type: 'function', name: 'getBuyerCreditLimit', stateMutability: 'view',
+    inputs: [{ name: 'buyer', type: 'address' }], outputs: [{ type: 'uint256' }],
+  },
+] as const;
+
+// EIP-2612 permit needs nonces() + version() on top of the standard ERC-20 set.
+const USDC_PERMIT_ABI = [
+  ...erc20Abi,
+  { type: 'function', name: 'nonces', stateMutability: 'view', inputs: [{ name: 'owner', type: 'address' }], outputs: [{ type: 'uint256' }] },
+  { type: 'function', name: 'version', stateMutability: 'view', inputs: [], outputs: [{ type: 'string' }] },
+] as const;
+
+const PERMIT_TYPES = {
+  Permit: [
+    { name: 'owner', type: 'address' },
+    { name: 'spender', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+  ],
+} as const;
+
+export interface GaslessDepositsConfig {
+  evmChainId: number;
+  rpcUrl: string;
+  /** Additional RPC endpoints tried in order if `rpcUrl` fails (viem fallback transport). */
+  fallbackRpcUrls?: string[];
+  bundlerUrl: string;
+  usdcAddress: Address;
+  paymasterAddress: Address;
+  depositsAddress: Address;
+  delegateAddress: Address;
+  /** Defaults to the canonical EntryPoint v0.8 singleton. */
+  entryPointAddress?: Address;
+  /** Permit cap the paymaster may pull for gas per op. Defaults to 1 USDC. */
+  maxGasUsdc?: bigint;
+}
+
+export interface GaslessDepositResult {
+  userOpHash: Hex;
+  txHash: Hex;
+  success: boolean;
+  delegationApplied: boolean;
+}
+
+/**
+ * Deposits USDC into AntseedDeposits with **no ETH**: gas is paid in USDC via the
+ * Circle Paymaster, and the buyer's plain EOA is upgraded in place with EIP-7702.
+ * The first deposit carries the delegation; later deposits are plain sponsored ops.
+ *
+ * Isolated from the ethers-based clients on purpose: this is the only viem +
+ * permissionless surface in the package.
+ */
+export class GaslessDepositsClient {
+  private readonly _owner: ReturnType<typeof privateKeyToAccount>;
+  private readonly _chain: Chain;
+  private readonly _client: PublicClient;
+  private readonly _cfg: GaslessDepositsConfig;
+  private readonly _entryPoint: Address;
+  private readonly _maxGasUsdc: bigint;
+  private _account?: Awaited<ReturnType<typeof to7702SimpleSmartAccount>>;
+
+  constructor(privateKey: Hex, cfg: GaslessDepositsConfig) {
+    this._owner = privateKeyToAccount(privateKey);
+    this._cfg = cfg;
+    this._entryPoint = cfg.entryPointAddress ?? entryPoint08Address;
+    this._maxGasUsdc = cfg.maxGasUsdc ?? DEFAULT_MAX_GAS_USDC;
+    this._chain = resolveViemChain(cfg.evmChainId, cfg.rpcUrl);
+    // Mirror the ethers FallbackProvider the rest of the app uses: a single public
+    // RPC rejecting a read (rate limit, transport error) must fail over, not stall
+    // the whole funding loop on a backoff against one bad endpoint.
+    const rpcUrls = [cfg.rpcUrl, ...(cfg.fallbackRpcUrls ?? [])];
+    this._client = createPublicClient({
+      chain: this._chain,
+      transport: rpcUrls.length > 1 ? fallback(rpcUrls.map((url) => http(url))) : http(cfg.rpcUrl),
+    });
+  }
+
+  get address(): Address {
+    return this._owner.address;
+  }
+
+  // Delegated specifically to OUR Simple7702Account; a delegation to any other
+  // target means the account runs unknown code, so we must (re)attach the
+  // authorization on the next op rather than send a UserOp it can't validate.
+  async isDelegated(): Promise<boolean> {
+    const code = await this._client.getCode({ address: this._owner.address });
+    const target = delegationTarget(code ?? null);
+    return target !== null && isAddressEqual(target, this._cfg.delegateAddress);
+  }
+
+  async usdcBalance(): Promise<bigint> {
+    return this._client.readContract({ address: this._cfg.usdcAddress, abi: erc20Abi, functionName: 'balanceOf', args: [this._owner.address] });
+  }
+
+  async buyerBalance(): Promise<{ available: bigint; reserved: bigint }> {
+    const [available, reserved] = await this._client.readContract({
+      address: this._cfg.depositsAddress, abi: DEPOSITS_ABI, functionName: 'getBuyerBalance', args: [this._owner.address],
+    });
+    return { available, reserved };
+  }
+
+  async creditLimit(): Promise<bigint> {
+    return this._client.readContract({ address: this._cfg.depositsAddress, abi: DEPOSITS_ABI, functionName: 'getBuyerCreditLimit', args: [this._owner.address] });
+  }
+
+  async deposit(amount: bigint): Promise<GaslessDepositResult> {
+    const account = await this._ensureAccount();
+    const delegated = await this.isDelegated();
+
+    const [paymasterData, authorization, fees] = await Promise.all([
+      this._buildPaymasterData(),
+      delegated ? Promise.resolve(undefined) : this._signDelegation(),
+      this._estimateFees(),
+    ]);
+
+    const bundler = createBundlerClient({ account, client: this._client, chain: this._chain, transport: http(this._cfg.bundlerUrl) });
+
+    const userOpHash = await bundler.sendUserOperation({
+      account,
+      calls: [
+        { to: this._cfg.usdcAddress, abi: erc20Abi, functionName: 'approve', args: [this._cfg.depositsAddress, amount] },
+        { to: this._cfg.depositsAddress, abi: DEPOSITS_ABI, functionName: 'deposit', args: [this._owner.address, amount] },
+      ],
+      paymaster: this._cfg.paymasterAddress,
+      paymasterData,
+      paymasterPostOpGasLimit: 50_000n,
+      maxFeePerGas: fees.maxFeePerGas,
+      maxPriorityFeePerGas: fees.maxPriorityFeePerGas,
+      ...(authorization ? { authorization } : {}),
+    });
+
+    // Bound the wait: if the bundler accepts the op but it never mines, time out
+    // (a transient error upstream) rather than leaving the manager stuck in-flight.
+    const receipt = await bundler.waitForUserOperationReceipt({ hash: userOpHash, timeout: 120_000 });
+    // A UserOp can be mined yet revert (success === false), e.g. the inner deposit
+    // hits CreditLimitExceeded. Throw so callers don't record a phantom deposit and
+    // retry-spin (the "revert" keyword routes it to the circuit breaker upstream).
+    if (!receipt.success) {
+      throw new Error(`Deposit UserOp reverted on-chain (tx ${receipt.receipt.transactionHash})`);
+    }
+    return {
+      userOpHash,
+      txHash: receipt.receipt.transactionHash,
+      success: true,
+      delegationApplied: !delegated,
+    };
+  }
+
+  private async _ensureAccount(): Promise<Awaited<ReturnType<typeof to7702SimpleSmartAccount>>> {
+    this._account ??= await to7702SimpleSmartAccount({
+      client: this._client,
+      owner: this._owner,
+      entryPoint: { address: this._entryPoint, version: '0.8' },
+      accountLogicAddress: this._cfg.delegateAddress,
+    });
+    return this._account;
+  }
+
+  /** EIP-2612 permit + Circle paymasterData. Permit is signed by the EOA directly
+   *  (pre-delegation there is no ERC-1271), deadline = maxUint256. */
+  private async _buildPaymasterData(): Promise<Hex> {
+    const usdc = getContract({ address: this._cfg.usdcAddress, abi: USDC_PERMIT_ABI, client: this._client });
+    const [name, version, nonce] = await Promise.all([
+      usdc.read.name(),
+      usdc.read.version(),
+      usdc.read.nonces([this._owner.address]),
+    ]);
+    const wrapped = await this._owner.signTypedData({
+      primaryType: 'Permit',
+      types: PERMIT_TYPES,
+      domain: { name, version, chainId: this._cfg.evmChainId, verifyingContract: this._cfg.usdcAddress },
+      message: {
+        owner: this._owner.address,
+        spender: this._cfg.paymasterAddress,
+        value: this._maxGasUsdc,
+        nonce,
+        deadline: maxUint256,
+      },
+    });
+    const { signature } = parseErc6492Signature(wrapped);
+    return encodeCirclePaymasterData(this._cfg.usdcAddress, this._maxGasUsdc, signature);
+  }
+
+  /** Real 7702 authorization for the first op. viem does not auto-sign it; the
+   *  bundler (not the EOA) executes, so the nonce is the plain account nonce. */
+  private async _signDelegation() {
+    const nonce = await this._client.getTransactionCount({ address: this._owner.address });
+    const signed = await this._owner.signAuthorization({
+      contractAddress: this._cfg.delegateAddress,
+      chainId: this._cfg.evmChainId,
+      nonce,
+    });
+    return {
+      address: signed.address ?? this._cfg.delegateAddress,
+      chainId: signed.chainId ?? this._cfg.evmChainId,
+      nonce: signed.nonce ?? nonce,
+      r: signed.r,
+      s: signed.s,
+      yParity: signed.yParity ?? 0,
+    };
+  }
+
+  private async _estimateFees(): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }> {
+    const pimlico = createPimlicoClient({
+      chain: this._chain,
+      transport: http(this._cfg.bundlerUrl),
+      entryPoint: { address: this._entryPoint, version: '0.8' },
+    });
+    const { fast } = await pimlico.getUserOperationGasPrice();
+    return { maxFeePerGas: fast.maxFeePerGas, maxPriorityFeePerGas: fast.maxPriorityFeePerGas };
+  }
+}

--- a/plugins/service-auto-deposit/src/index.ts
+++ b/plugins/service-auto-deposit/src/index.ts
@@ -1,0 +1,16 @@
+export { GaslessDepositsClient, type GaslessDepositsConfig, type GaslessDepositResult } from './gasless-deposits-client.js';
+export { isDelegationCode, delegationTarget, encodeCirclePaymasterData } from './codec.js';
+export { AutoDepositManager, planDeposit, isDeterministicError } from './manager.js';
+export type {
+  AutoDepositState, AutoDepositStatus, AutoDepositReader, AutoDepositExecutor,
+  AutoDepositManagerConfig, AutoDepositConsentView, DepositPlan,
+} from './manager.js';
+export {
+  createAutoDepositManager,
+  createAutoDepositService,
+  gaslessConfigFromChain,
+  toServiceStatus,
+} from './factory.js';
+export { AUTO_DEPOSIT_CHAINS, type AutoDepositChainConfig } from './chains.js';
+export type { FundingChainContext } from './chain-context.js';
+export { autoDepositPlugin, default } from './plugin.js';

--- a/plugins/service-auto-deposit/src/manager.test.ts
+++ b/plugins/service-auto-deposit/src/manager.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import {
+  planDeposit,
+  isDeterministicError,
+  AutoDepositManager,
+  type AutoDepositReader,
+  type AutoDepositExecutor,
+} from './manager.js';
+
+describe('planDeposit', () => {
+  const base = { reserve: 0n, minDeposit: 1_000_000n, dustFloor: 1_000_000n };
+
+  it('does nothing below the dust floor', () => {
+    expect(planDeposit({ ...base, loose: 500_000n, creditLimit: 10_000_000n, deposited: 0n }))
+      .toEqual({ deposit: 0n, stranded: 0n });
+  });
+
+  it('deposits the full loose amount when within the credit limit', () => {
+    expect(planDeposit({ ...base, loose: 8_000_000n, creditLimit: 10_000_000n, deposited: 0n }))
+      .toEqual({ deposit: 8_000_000n, stranded: 0n });
+  });
+
+  it('caps at the credit limit and strands the remainder', () => {
+    expect(planDeposit({ ...base, loose: 20_000_000n, creditLimit: 10_000_000n, deposited: 0n }))
+      .toEqual({ deposit: 10_000_000n, stranded: 10_000_000n });
+  });
+
+  it('accounts for already-deposited balance in the room', () => {
+    expect(planDeposit({ ...base, loose: 20_000_000n, creditLimit: 10_000_000n, deposited: 7_000_000n }))
+      .toEqual({ deposit: 3_000_000n, stranded: 17_000_000n });
+  });
+
+  it('keeps the gas reserve back', () => {
+    expect(planDeposit({ ...base, reserve: 2_000_000n, loose: 5_000_000n, creditLimit: 10_000_000n, deposited: 0n }))
+      .toEqual({ deposit: 3_000_000n, stranded: 0n });
+  });
+
+  it('skips a first deposit below MIN_BUYER_DEPOSIT', () => {
+    // loose above dust floor but depositable (after reserve) is under the min
+    expect(planDeposit({ ...base, reserve: 2_000_000n, loose: 2_500_000n, creditLimit: 10_000_000n, deposited: 0n }))
+      .toEqual({ deposit: 0n, stranded: 0n });
+  });
+
+  it('allows tiny top-ups once a balance exists (min is 1 base unit)', () => {
+    expect(planDeposit({ ...base, loose: 1_000_000n, creditLimit: 10_000_000n, deposited: 5_000_000n }))
+      .toEqual({ deposit: 1_000_000n, stranded: 0n });
+  });
+});
+
+describe('isDeterministicError', () => {
+  it('flags on-chain / validation failures', () => {
+    expect(isDeterministicError(new Error('execution reverted: CreditLimitExceeded'))).toBe(true);
+    expect(isDeterministicError(new Error('AA33 reverted: paymaster'))).toBe(true);
+  });
+  it('treats network failures as transient', () => {
+    expect(isDeterministicError(new Error('fetch failed: ETIMEDOUT'))).toBe(false);
+    expect(isDeterministicError(new Error('socket hang up'))).toBe(false);
+  });
+});
+
+function reader(state: { loose: bigint; deposited: bigint; creditLimit: bigint; delegated?: boolean }): AutoDepositReader {
+  return {
+    looseUsdc: async () => state.loose,
+    totalDeposited: async () => state.deposited,
+    creditLimit: async () => state.creditLimit,
+    isDelegated: async () => state.delegated ?? true,
+  };
+}
+
+const enabled = { isEnabled: () => true };
+const disabled = { isEnabled: () => false };
+const cfg = { pollIntervalMs: 1_000_000, dustFloorBaseUnits: 1_000_000n, gasReserveBaseUnits: 0n, minDepositBaseUnits: 1_000_000n };
+
+describe('AutoDepositManager', () => {
+  it('stays disabled without consent', async () => {
+    const calls: bigint[] = [];
+    const executor: AutoDepositExecutor = { deposit: async (a) => { calls.push(a); return { txHash: '0x' }; } };
+    const m = new AutoDepositManager({ reader: reader({ loose: 10_000_000n, deposited: 0n, creditLimit: 10_000_000n }), executor, consent: disabled, config: cfg });
+    await m.runOnce();
+    expect(m.getStatus().state).toBe('disabled');
+    expect(calls).toEqual([]);
+  });
+
+  it('deposits when enabled and within the credit limit', async () => {
+    const calls: bigint[] = [];
+    const executor: AutoDepositExecutor = { deposit: async (a) => { calls.push(a); return { txHash: '0xtx' }; } };
+    const m = new AutoDepositManager({ reader: reader({ loose: 8_000_000n, deposited: 0n, creditLimit: 10_000_000n }), executor, consent: enabled, config: cfg });
+    await m.runOnce();
+    expect(calls).toEqual([8_000_000n]);
+    const status = m.getStatus();
+    expect(status.state).toBe('idle');
+    expect(status.lastDeposit?.txHash).toBe('0xtx');
+  });
+
+  it('reports stranded when credit-limited', async () => {
+    const calls: bigint[] = [];
+    const executor: AutoDepositExecutor = { deposit: async (a) => { calls.push(a); return { txHash: '0xtx' }; } };
+    const m = new AutoDepositManager({ reader: reader({ loose: 20_000_000n, deposited: 0n, creditLimit: 10_000_000n }), executor, consent: enabled, config: cfg });
+    await m.runOnce();
+    expect(calls).toEqual([10_000_000n]);
+    expect(m.getStatus().state).toBe('stranded');
+    expect(m.getStatus().strandedBaseUnits).toBe('10000000');
+  });
+
+  it('goes idle below the dust floor without calling the executor', async () => {
+    const calls: bigint[] = [];
+    const executor: AutoDepositExecutor = { deposit: async (a) => { calls.push(a); return { txHash: '0x' }; } };
+    const m = new AutoDepositManager({ reader: reader({ loose: 500_000n, deposited: 0n, creditLimit: 10_000_000n }), executor, consent: enabled, config: cfg });
+    await m.runOnce();
+    expect(calls).toEqual([]);
+    expect(m.getStatus().state).toBe('idle');
+  });
+
+  it('backs off on a transient failure', async () => {
+    const executor: AutoDepositExecutor = { deposit: async () => { throw new Error('fetch failed'); } };
+    const m = new AutoDepositManager({ reader: reader({ loose: 8_000_000n, deposited: 0n, creditLimit: 10_000_000n }), executor, consent: enabled, config: cfg });
+    await m.runOnce();
+    expect(m.getStatus().state).toBe('backoff');
+    expect(m.getStatus().lastError).toContain('fetch failed');
+  });
+
+  it('circuit-breaks on a deterministic failure until inputs change', async () => {
+    let calls = 0;
+    const executor: AutoDepositExecutor = { deposit: async () => { calls++; throw new Error('execution reverted: CreditLimitExceeded'); } };
+    const state = { loose: 8_000_000n, deposited: 0n, creditLimit: 10_000_000n };
+    const m = new AutoDepositManager({ reader: reader(state), executor, consent: enabled, config: cfg });
+
+    await m.runOnce();
+    expect(m.getStatus().state).toBe('needs_attention');
+    expect(calls).toBe(1);
+
+    // same inputs → no retry (no extra gas burn)
+    await m.runOnce();
+    expect(calls).toBe(1);
+
+    // inputs change → retry
+    state.loose = 9_000_000n;
+    await m.runOnce();
+    expect(calls).toBe(2);
+  });
+
+  it('circuit breaker also retries when only deposited changes', async () => {
+    let calls = 0;
+    const executor: AutoDepositExecutor = { deposit: async () => { calls++; throw new Error('execution reverted'); } };
+    const state = { loose: 8_000_000n, deposited: 0n, creditLimit: 20_000_000n };
+    const m = new AutoDepositManager({ reader: reader(state), executor, consent: enabled, config: cfg });
+
+    await m.runOnce();
+    expect(m.getStatus().state).toBe('needs_attention');
+    expect(calls).toBe(1);
+
+    await m.runOnce();                 // loose + creditLimit unchanged → no retry
+    expect(calls).toBe(1);
+
+    state.deposited = 2_000_000n;      // only deposited changed → must retry
+    await m.runOnce();
+    expect(calls).toBe(2);
+  });
+
+  it('circuit breaker does NOT retry when loose only decreases (gas burn)', async () => {
+    let calls = 0;
+    const executor: AutoDepositExecutor = { deposit: async () => { calls++; throw new Error('execution reverted'); } };
+    const state = { loose: 8_000_000n, deposited: 0n, creditLimit: 20_000_000n };
+    const m = new AutoDepositManager({ reader: reader(state), executor, consent: enabled, config: cfg });
+
+    await m.runOnce();
+    expect(calls).toBe(1);
+
+    // a mined-but-reverted op still pays USDC gas → loose drops. Must NOT reopen.
+    state.loose = 7_900_000n;
+    await m.runOnce();
+    expect(calls).toBe(1);
+
+    // but new funds (loose increase) should reopen
+    state.loose = 9_000_000n;
+    await m.runOnce();
+    expect(calls).toBe(2);
+  });
+});

--- a/plugins/service-auto-deposit/src/manager.ts
+++ b/plugins/service-auto-deposit/src/manager.ts
@@ -1,0 +1,272 @@
+/**
+ * Buyer-side auto-deposit loop: sweeps loose USDC from the wallet into
+ * AntseedDeposits, capped by the on-chain credit limit, paying gas in USDC via a
+ * gasless executor. Monitoring is on by default; the first deposit is gated by
+ * the user's one-time approval (consent).
+ */
+import { debugLog, debugWarn } from './debug.js';
+
+const DEFAULT_POLL_INTERVAL_MS = 45_000;
+const DEFAULT_DUST_FLOOR = 500_000n;   // 0.5 USDC; at/above this we consider depositing
+const DEFAULT_GAS_RESERVE = 500_000n;  // 0.5 USDC kept back for the paymaster's gas pull
+const DEFAULT_MIN_DEPOSIT = 1_000_000n;  // AntseedDeposits MIN_BUYER_DEPOSIT (first deposit only)
+const DEFAULT_BACKOFF_BASE_MS = 30_000;
+const DEFAULT_BACKOFF_MAX_MS = 600_000;
+
+export type AutoDepositState =
+  | 'disabled'        // user has not approved
+  | 'idle'            // approved, nothing to deposit
+  | 'pending'         // a deposit is in flight
+  | 'stranded'        // deposited up to the credit limit; remainder left loose
+  | 'backoff'         // transient failure; retrying later
+  | 'needs_attention'; // deterministic failure; paused until inputs change
+
+export interface AutoDepositReader {
+  /** Loose USDC in the wallet (ERC-20 balanceOf). */
+  looseUsdc(): Promise<bigint>;
+  /** Total USDC credited in AntseedDeposits (available + reserved). */
+  totalDeposited(): Promise<bigint>;
+  creditLimit(): Promise<bigint>;
+  isDelegated(): Promise<boolean>;
+}
+
+export interface AutoDepositExecutor {
+  deposit(amount: bigint): Promise<{ txHash: string }>;
+}
+
+export interface AutoDepositConsentView {
+  isEnabled(): boolean;
+}
+
+export interface AutoDepositManagerConfig {
+  pollIntervalMs?: number;
+  dustFloorBaseUnits?: bigint;
+  gasReserveBaseUnits?: bigint;
+  minDepositBaseUnits?: bigint;
+  backoffBaseMs?: number;
+  backoffMaxMs?: number;
+}
+
+export interface AutoDepositStatus {
+  enabled: boolean;
+  delegated: boolean;
+  state: AutoDepositState;
+  looseBaseUnits: string;
+  strandedBaseUnits: string;
+  creditLimitBaseUnits: string;
+  depositedBaseUnits: string;
+  lastDeposit: { txHash: string; amountBaseUnits: string; at: string } | null;
+  lastError: string | null;
+}
+
+export interface DepositPlan {
+  /** Amount to deposit now (0 = nothing). */
+  deposit: bigint;
+  /** Loose USDC that cannot be deposited because of the credit limit. */
+  stranded: bigint;
+}
+
+/**
+ * Pure planning: how much to deposit and how much is credit-limit-stranded.
+ * `reserve` is kept back for gas; `deposited` is the current contract balance.
+ */
+export function planDeposit(p: {
+  loose: bigint;
+  reserve: bigint;
+  creditLimit: bigint;
+  deposited: bigint;
+  minDeposit: bigint;
+  dustFloor: bigint;
+}): DepositPlan {
+  if (p.loose < p.dustFloor) return { deposit: 0n, stranded: 0n };
+  const depositable = p.loose > p.reserve ? p.loose - p.reserve : 0n;
+  const room = p.creditLimit > p.deposited ? p.creditLimit - p.deposited : 0n;
+  const capped = depositable < room ? depositable : room;
+  const stranded = depositable - capped;
+  // The contract enforces MIN_BUYER_DEPOSIT only on the first deposit.
+  const min = p.deposited === 0n ? p.minDeposit : 1n;
+  const deposit = capped >= min ? capped : 0n;
+  return { deposit, stranded };
+}
+
+/** Heuristic: a deterministic on-chain/validation failure (don't retry-spin) vs
+ *  a transient network/bundler failure (back off and retry). */
+export function isDeterministicError(err: unknown): boolean {
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return /revert|creditlimit|insufficient|belowmin|paymaster|1271|authorization|signature|aa\d\d/.test(message);
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export class AutoDepositManager {
+  private readonly _reader: AutoDepositReader;
+  private readonly _executor: AutoDepositExecutor;
+  private readonly _consent: AutoDepositConsentView;
+  private readonly _pollIntervalMs: number;
+  private readonly _dustFloor: bigint;
+  private readonly _gasReserve: bigint;
+  private readonly _minDeposit: bigint;
+  private readonly _backoffBaseMs: number;
+  private readonly _backoffMaxMs: number;
+  private readonly _onAttention?: (message: string) => void;
+
+  private _timer: ReturnType<typeof setInterval> | null = null;
+  private _inFlight = false;
+  private _state: AutoDepositState = 'disabled';
+  private _delegated = false;
+  private _loose = 0n;
+  private _stranded = 0n;
+  private _creditLimit = 0n;
+  private _deposited = 0n;
+  private _lastDeposit: AutoDepositStatus['lastDeposit'] = null;
+  private _lastError: string | null = null;
+  private _backoffMs: number;
+  private _nextAttemptAt = 0;
+  private _attentionSnapshot: { loose: bigint; creditLimit: bigint; deposited: bigint } | null = null;
+
+  constructor(deps: {
+    reader: AutoDepositReader;
+    executor: AutoDepositExecutor;
+    consent: AutoDepositConsentView;
+    config?: AutoDepositManagerConfig;
+    onAttention?: (message: string) => void;
+  }) {
+    this._reader = deps.reader;
+    this._executor = deps.executor;
+    this._consent = deps.consent;
+    this._onAttention = deps.onAttention;
+    const cfg = deps.config ?? {};
+    this._pollIntervalMs = cfg.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this._dustFloor = cfg.dustFloorBaseUnits ?? DEFAULT_DUST_FLOOR;
+    this._gasReserve = cfg.gasReserveBaseUnits ?? DEFAULT_GAS_RESERVE;
+    this._minDeposit = cfg.minDepositBaseUnits ?? DEFAULT_MIN_DEPOSIT;
+    this._backoffBaseMs = cfg.backoffBaseMs ?? DEFAULT_BACKOFF_BASE_MS;
+    this._backoffMaxMs = cfg.backoffMaxMs ?? DEFAULT_BACKOFF_MAX_MS;
+    this._backoffMs = this._backoffBaseMs;
+  }
+
+  /** Start the loop: a catch-up sweep now, then on every interval. */
+  start(): void {
+    if (this._timer) return;
+    void this.runOnce();
+    this._timer = setInterval(() => void this.runOnce(), this._pollIntervalMs);
+  }
+
+  stop(): void {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  getStatus(): AutoDepositStatus {
+    return {
+      enabled: this._consent.isEnabled(),
+      delegated: this._delegated,
+      state: this._state,
+      looseBaseUnits: this._loose.toString(),
+      strandedBaseUnits: this._stranded.toString(),
+      creditLimitBaseUnits: this._creditLimit.toString(),
+      depositedBaseUnits: this._deposited.toString(),
+      lastDeposit: this._lastDeposit,
+      lastError: this._lastError,
+    };
+  }
+
+  /** One evaluation tick. Public so the loop and tests share the same path. */
+  async runOnce(): Promise<void> {
+    if (!this._consent.isEnabled()) {
+      this._state = 'disabled';
+      return;
+    }
+    if (this._inFlight) return;
+    if (this._state === 'backoff' && Date.now() < this._nextAttemptAt) return;
+
+    // Claim the in-flight guard synchronously, before the first await, so an
+    // immediate runOnce() (e.g. on POST enable) and an interval tick can never
+    // both pass the guard and submit two deposits.
+    this._inFlight = true;
+    try {
+      let loose: bigint;
+      let deposited: bigint;
+      let creditLimit: bigint;
+      try {
+        [loose, deposited, creditLimit, this._delegated] = await Promise.all([
+          this._reader.looseUsdc(),
+          this._reader.totalDeposited(),
+          this._reader.creditLimit(),
+          this._reader.isDelegated(),
+        ]);
+      } catch (err) {
+        this._enterBackoff(err);
+        return;
+      }
+      this._loose = loose;
+      this._creditLimit = creditLimit;
+      this._deposited = deposited;
+
+      // Circuit breaker: stay paused on a deterministic failure until inputs change
+      // in a way worth retrying. A loose DECREASE is just the failed op's own gas
+      // burn (a mined revert still pays USDC gas); retrying would burn more, so
+      // only a loose INCREASE (new funds) or a credit-limit/deposited change reopens it.
+      if (
+        this._state === 'needs_attention' &&
+        this._attentionSnapshot &&
+        loose <= this._attentionSnapshot.loose &&
+        this._attentionSnapshot.creditLimit === creditLimit &&
+        this._attentionSnapshot.deposited === deposited
+      ) {
+        return;
+      }
+
+      const { deposit, stranded } = planDeposit({
+        loose,
+        reserve: this._gasReserve,
+        creditLimit,
+        deposited,
+        minDeposit: this._minDeposit,
+        dustFloor: this._dustFloor,
+      });
+      this._stranded = stranded;
+
+      if (deposit === 0n) {
+        this._state = stranded > 0n ? 'stranded' : 'idle';
+        return;
+      }
+
+      this._state = 'pending';
+      debugLog(`[AutoDeposit] depositing ${deposit} (loose=${loose}, stranded=${stranded})`);
+      try {
+        const { txHash } = await this._executor.deposit(deposit);
+        this._lastDeposit = { txHash, amountBaseUnits: deposit.toString(), at: new Date().toISOString() };
+        this._lastError = null;
+        this._backoffMs = this._backoffBaseMs;
+        this._attentionSnapshot = null;
+        this._state = stranded > 0n ? 'stranded' : 'idle';
+        debugLog(`[AutoDeposit] deposited ${deposit} (tx ${txHash})`);
+      } catch (err) {
+        if (isDeterministicError(err)) {
+          this._attentionSnapshot = { loose, creditLimit, deposited };
+          this._lastError = errorMessage(err);
+          this._state = 'needs_attention';
+          debugWarn(`[AutoDeposit] needs attention (paused until inputs change): ${this._lastError}`);
+          this._onAttention?.(this._lastError);
+        } else {
+          this._enterBackoff(err);
+        }
+      }
+    } finally {
+      this._inFlight = false;
+    }
+  }
+
+  private _enterBackoff(err: unknown): void {
+    this._lastError = errorMessage(err);
+    this._nextAttemptAt = Date.now() + this._backoffMs;
+    debugWarn(`[AutoDeposit] transient failure, backing off ${this._backoffMs}ms: ${this._lastError}`);
+    this._backoffMs = Math.min(this._backoffMs * 2, this._backoffMaxMs);
+    this._state = 'backoff';
+  }
+}

--- a/plugins/service-auto-deposit/src/plugin.ts
+++ b/plugins/service-auto-deposit/src/plugin.ts
@@ -1,0 +1,17 @@
+import type { AntseedServicePlugin } from '@antseed/node';
+import { createAutoDepositService } from './factory.js';
+
+export const autoDepositPlugin: AntseedServicePlugin = {
+  type: 'service',
+  kind: 'funding',
+  name: 'auto-deposit',
+  displayName: 'Auto Deposit',
+  version: '0.1.0',
+  description: 'Automatically move USDC sent to your wallet into the network so it can buy services. No ETH needed: gas is paid in USDC via the Circle Paymaster, and transactions are relayed by the Pimlico bundler. Your wallet is upgraded once (EIP-7702) on the first deposit.',
+  capabilities: ['wallet', 'chain'],
+  createService(host) {
+    return createAutoDepositService(host);
+  },
+};
+
+export default autoDepositPlugin;

--- a/plugins/service-auto-deposit/tsconfig.json
+++ b/plugins/service-auto-deposit/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,10 +82,10 @@ importers:
         version: 11.2.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@mariozechner/pi-ai':
         specifier: ^0.64.0
-        version: 0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@mariozechner/pi-coding-agent':
         specifier: ^0.64.0
-        version: 0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+        version: 0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -152,6 +152,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-qr-code:
+        specifier: ^2.0.15
+        version: 2.2.0(react@18.3.1)
     devDependencies:
       '@electron/notarize':
         specifier: ^3.1.1
@@ -403,7 +406,7 @@ importers:
         version: 20.19.33
       openai:
         specifier: ^6.27.0
-        version: 6.27.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
+        version: 6.27.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6)
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -503,6 +506,15 @@ importers:
       vitest:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.7.5)(sass@1.97.3)(terser@5.46.0)
+
+  packages/service-core:
+    devDependencies:
+      '@antseed/node':
+        specifier: workspace:*
+        version: link:../node
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
 
   packages/ui:
     dependencies:
@@ -639,6 +651,28 @@ importers:
       '@antseed/router-core':
         specifier: workspace:*
         version: link:../../packages/router-core
+    devDependencies:
+      '@antseed/node':
+        specifier: workspace:*
+        version: link:../../packages/node
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.7.5)(sass@1.97.3)(terser@5.46.0)
+
+  plugins/service-auto-deposit:
+    dependencies:
+      '@antseed/service-core':
+        specifier: workspace:*
+        version: link:../../packages/service-core
+      permissionless:
+        specifier: ^0.3.6
+        version: 0.3.6(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6))
+      viem:
+        specifier: ^2.52.2
+        version: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
     devDependencies:
       '@antseed/node':
         specifier: workspace:*
@@ -8481,6 +8515,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.14.29:
+    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ox@0.6.7:
     resolution: {integrity: sha512-17Gk/eFsFRAZ80p5eKqv89a57uXjd3NgIf1CaXojATPBuujVc/fQSVhBeAU9JCRB+k7J50WQAyWTxK19T9GgbA==}
     peerDependencies:
@@ -8692,6 +8734,15 @@ packages:
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  permissionless@0.3.6:
+    resolution: {integrity: sha512-7RstRCNwJc/kO9Q/ZJpgSPclXez8CaGU77PeYNaWpHCU1kRetu+7kqEUFcIFLdz47F7jpOwtsbAU56hn27c4mg==}
+    peerDependencies:
+      ox: ^0.11.3
+      viem: ^2.44.4
+    peerDependenciesMeta:
+      ox:
+        optional: true
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -9299,6 +9350,9 @@ packages:
     resolution: {integrity: sha512-iQBvKj7MRKO+co+MY0IZpyLO+ezvttxsmV86WywrgPuAmgBkv0pytyi03wourniSoPgzffeBW6cBgIkpqcvjTg==}
     engines: {node: '>= 20.19.0'}
 
+  qrcode-generator@2.0.4:
+    resolution: {integrity: sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==}
+
   qrcode@1.5.3:
     resolution: {integrity: sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==}
     engines: {node: '>=10.13.0'}
@@ -9389,6 +9443,11 @@ packages:
     resolution: {integrity: sha512-gxxSyLbrEAdXTKgfbpBEFZCO/P153DnqSCQau2+o6lNy1jgMRr2MmRmOzMmyrwSaSYLRB8g7b0waYPmUjz7IhQ==}
     peerDependencies:
       react: '>=16.8.0'
+
+  react-qr-code@2.2.0:
+    resolution: {integrity: sha512-e5nS0UUN22K3Nf8KBRUzemfdJ6OmnN5w+kbnj1lvJaol9RyVRFeGl05bCkxSN2ZegbLxjjYjX1+mmAoX9+fAhw==}
+    peerDependencies:
+      react: '*'
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -10657,6 +10716,14 @@ packages:
       typescript:
         optional: true
 
+  viem@2.52.2:
+    resolution: {integrity: sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -10991,6 +11058,18 @@ packages:
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -12465,7 +12544,7 @@ snapshots:
       idb-keyval: 6.2.1
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@18.3.28)(immer@11.1.4)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -12494,7 +12573,7 @@ snapshots:
       jose: 6.1.3
       md5: 2.3.0
       uncrypto: 0.1.3
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
@@ -12526,7 +12605,7 @@ snapshots:
       idb-keyval: 6.2.1
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.24.2
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zustand: 5.0.3(@types/react@18.3.28)(immer@11.1.4)(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -14359,9 +14438,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@mariozechner/pi-agent-core@0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
-      '@mariozechner/pi-ai': 0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@mariozechner/pi-ai': 0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -14371,7 +14450,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@mariozechner/pi-ai@0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.996.0
@@ -14381,7 +14460,7 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       chalk: 5.6.2
-      openai: 6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      openai: 6.26.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       undici: 7.22.0
@@ -14395,11 +14474,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
+  '@mariozechner/pi-coding-agent@0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
-      '@mariozechner/pi-ai': 0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@mariozechner/pi-agent-core': 0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
+      '@mariozechner/pi-ai': 0.64.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@mariozechner/pi-tui': 0.64.0
       '@silvia-odwyer/photon-node': 0.3.4
       ajv: 8.18.0
@@ -15200,7 +15279,7 @@ snapshots:
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4)
+      viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -15211,7 +15290,7 @@ snapshots:
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -15224,7 +15303,7 @@ snapshots:
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@18.3.28)(react@18.3.1)
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15374,7 +15453,7 @@ snapshots:
       '@walletconnect/logger': 2.1.2
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(@types/react@18.3.28)(react@18.3.1)
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15428,7 +15507,7 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.1.0)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
       valtio: 1.13.2(@types/react@18.3.28)(react@18.3.1)
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15547,7 +15626,7 @@ snapshots:
   '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -16224,7 +16303,7 @@ snapshots:
       '@solana/functional': 5.5.1(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.9.3)
       '@solana/subscribable': 5.5.1(typescript@5.9.3)
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -20627,6 +20706,10 @@ snapshots:
     dependencies:
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
+  isows@1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
+    dependencies:
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -21894,14 +21977,14 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
-  openai@6.26.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
+  openai@6.26.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@3.25.76):
     optionalDependencies:
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 3.25.76
 
-  openai@6.27.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6):
+  openai@6.27.0(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))(zod@4.3.6):
     optionalDependencies:
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       zod: 4.3.6
 
   openapi-fetch@0.13.8:
@@ -21937,7 +22020,22 @@ snapshots:
       stdin-discarder: 0.3.1
       string-width: 8.2.0
 
-  ox@0.14.13(typescript@5.9.3)(zod@3.22.4):
+  ox@0.14.13(typescript@5.9.3)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.29(typescript@5.9.3)(zod@3.22.4):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -21952,7 +22050,7 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
-  ox@0.14.13(typescript@5.9.3)(zod@3.25.76):
+  ox@0.14.29(typescript@5.9.3)(zod@3.25.76):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -21961,6 +22059,21 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.29(typescript@5.9.3)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -22197,6 +22310,10 @@ snapshots:
   pe-library@0.4.1: {}
 
   pend@1.2.0: {}
+
+  permissionless@0.3.6(viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)):
+    dependencies:
+      viem: 2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6)
 
   picocolors@1.1.1: {}
 
@@ -22875,6 +22992,8 @@ snapshots:
 
   qr@0.5.5: {}
 
+  qrcode-generator@2.0.4: {}
+
   qrcode@1.5.3:
     dependencies:
       dijkstrajs: 1.0.3
@@ -22964,6 +23083,12 @@ snapshots:
 
   react-loading-skeleton@3.5.0(react@18.3.1):
     dependencies:
+      react: 18.3.1
+
+  react-qr-code@2.2.0(react@18.3.1):
+    dependencies:
+      prop-types: 15.8.1
+      qrcode-generator: 2.0.4
       react: 18.3.1
 
   react-refresh@0.17.0: {}
@@ -23352,7 +23477,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.1
       uuid: 8.3.2
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10
@@ -24329,23 +24454,6 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4):
-    dependencies:
-      '@noble/curves': 1.9.1
-      '@noble/hashes': 1.8.0
-      '@scure/bip32': 1.7.0
-      '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.3)(zod@3.22.4)
-      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ox: 0.14.13(typescript@5.9.3)(zod@3.22.4)
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - zod
-
   viem@2.47.12(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
     dependencies:
       '@noble/curves': 1.9.1
@@ -24356,6 +24464,57 @@ snapshots:
       isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.14.13(typescript@5.9.3)(zod@3.25.76)
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.22.4):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.22.4)
+      isows: 1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.29(typescript@5.9.3)(zod@3.22.4)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@3.25.76)
+      isows: 1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.29(typescript@5.9.3)(zod@3.25.76)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.52.2(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.3.6):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.3.6)
+      isows: 1.0.7(ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.29(typescript@5.9.3)(zod@4.3.6)
+      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -24875,6 +25034,11 @@ snapshots:
       utf-8-validate: 5.0.10
 
   ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.1.0
+      utf-8-validate: 5.0.10
+
+  ws@8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 5.0.10


### PR DESCRIPTION
## What this does

Introduces a third plugin type, **`service`**, alongside `provider` and `router`, and ships the gasless **auto-deposit** funder as the first service plugin. A service is a host-driven background task that runs on the buyer's behalf and declares the sensitive capabilities it needs (e.g. `wallet`, `chain`), which the host grants explicitly. The desktop gets a generic **Services** settings panel to view and toggle them.

This started as a single auto-deposit feature and grew into a reusable plugin contract so future buyer-side services (not just funding) can plug in the same way.

## Highlights

### New `service` plugin type (`@antseed/node`)
- `AntseedServicePlugin` added to the plugin union, with a `kind`, declared `capabilities`, and a `createService(host)` factory.
- Generic capability injection: the plugin declares what it needs; the host grants only those (`wallet` -> identity key, `chain` -> chain config). A service never receives a capability it did not request, and is skipped (with a reason) when a required capability is unavailable.
- New shared package **`@antseed/service-core`** with the runtime contracts and `requireWallet`/`requireChain` helpers.

### Auto-deposit as an installable plugin (`@antseed/service-auto-deposit`)
- Moved from `packages/auto-deposit` into `plugins/service-auto-deposit`; it is now loaded dynamically from the plugins dir like provider/router plugins (no longer compiled into the CLI).
- Sweeps loose USDC in the buyer wallet into `AntseedDeposits` with **no ETH**: gas is paid in USDC via the Circle Paymaster, transactions are relayed by the Pimlico bundler, and the wallet is upgraded once via EIP-7702 on the first deposit.
- Respects the on-chain credit limit (deposits beyond it are left as loose funds, never lost) and a circuit breaker that pauses on deterministic failures.

### CLI / buyer proxy
- Dynamic service-plugin loading (`registry`, `loader`, `services`); services load only when settlement is enabled.
- `GET/POST /_antseed/services` control endpoint (loopback-guarded): the GET merges the trusted catalog with live plugins so a service that is available but not yet running is still listed with a reason; the POST persists consent and activates/pokes the service.

### Desktop
- New generic **Services** panel (replaces the funding-only block): each service shows a status badge (Active / Inactive / Not installed), a toggle, its live status, and for funding the receive address + QR.
- The deposit warning is driven by the live on-chain credit-limit headroom rather than a hardcoded cap.
- Friendly "Auto Deposit" label is shown in every state, including before the plugin is installed.
- The service is seeded on launch and the buyer spawn waits on plugin readiness so a freshly installed service is not missed until a restart. Production bundling mirrors the router (offline install).

## Testing

Exercised end to end on Base mainnet: the buyer proxy loads the service, the Services endpoint reports the live deposit limit, real USDC sent to the wallet was swept into `AntseedDeposits` gaslessly, and the funds were later withdrawn gaslessly back out. Unit tests cover the deposit planner, status mapping, and the credit-limit headroom.

## Follow-ups

- `@antseed/service-core` and `@antseed/service-auto-deposit` are not published to npm yet. The desktop installs trusted plugins from the registry (dev) or the app bundle (production), so both packages need publishing for the dev install path to work without the app bundle.
- `CHANGELOG.md` is intentionally left untouched until those packages are published.
- The 10 USDC figure in earlier discussion is the base credit limit; the actual cap grows per buyer, which is why the UI reads it live.
