### PR TITLE
fix(node): Probe metadata endpoint recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project uses selective package publishing. Each release entry lists the pub
 
 - Reduced the default buyer response-auth evidence sample rate from 20% to 0.5% to limit local `verification_samples` growth during high-request sessions.
 
+### Fixed
+
+- Fixed buyer discovery so temporarily unreachable metadata endpoints are probed for recovery before the full exponential cooldown expires, allowing recovered peers to reappear in buyer peer lists sooner.
+
 ## 2026-06-15 — Buyer peer failure accounting and desktop stream responsiveness
 
 ### Published

--- a/packages/node/src/discovery/http-metadata-resolver.ts
+++ b/packages/node/src/discovery/http-metadata-resolver.ts
@@ -11,12 +11,19 @@ export interface HttpMetadataResolverConfig {
   failureCooldownMs?: number;
   /** Upper bound for failure cooldown backoff. Default: 1800000 (30 minutes) */
   maxFailureCooldownMs?: number;
+  /**
+   * Upper bound on how long an announcing endpoint is skipped before a recovery
+   * probe. Default: 120000 (2 minutes). Set to 0 to only use exponential
+   * cooldowns.
+   */
+  recoveryProbeIntervalMs?: number;
   /** Maximum concurrent metadata fetches. Default: 24 */
   maxConcurrent?: number;
 }
 
 type FailedEndpointState = {
   nextRetryAt: number;
+  nextProbeAt: number;
   consecutiveFailures: number;
 }
 
@@ -25,6 +32,7 @@ export class HttpMetadataResolver implements MetadataResolver {
   private readonly metadataPortOffset: number;
   private readonly failureCooldownMs: number;
   private readonly maxFailureCooldownMs: number;
+  private readonly recoveryProbeIntervalMs: number;
   private readonly maxConcurrent: number;
   private readonly failedEndpoints: Map<string, FailedEndpointState>;
   private activeCount = 0;
@@ -38,6 +46,7 @@ export class HttpMetadataResolver implements MetadataResolver {
       this.failureCooldownMs,
       config?.maxFailureCooldownMs ?? 30 * 60_000,
     );
+    this.recoveryProbeIntervalMs = Math.max(0, config?.recoveryProbeIntervalMs ?? 2 * 60_000);
     this.maxConcurrent = Math.max(1, config?.maxConcurrent ?? 24);
     this.failedEndpoints = new Map<string, FailedEndpointState>();
   }
@@ -51,12 +60,20 @@ export class HttpMetadataResolver implements MetadataResolver {
     const failedState = this.failedEndpoints.get(endpointKey);
     if (failedState !== undefined) {
       if (failedState.nextRetryAt > now) {
+        if (failedState.nextProbeAt > now) {
+          debugLog(
+            `[MetadataResolver] Skipping ${endpointKey}: failure cooldown `
+            + `${failedState.nextRetryAt - now}ms remaining after `
+            + `${failedState.consecutiveFailures} failure(s); recovery probe in `
+            + `${failedState.nextProbeAt - now}ms`,
+          );
+          return null;
+        }
         debugLog(
-          `[MetadataResolver] Skipping ${endpointKey}: failure cooldown `
+          `[MetadataResolver] Probing ${endpointKey} during failure cooldown `
           + `${failedState.nextRetryAt - now}ms remaining after `
           + `${failedState.consecutiveFailures} failure(s)`,
         );
-        return null;
       }
     }
 
@@ -136,8 +153,13 @@ export class HttpMetadataResolver implements MetadataResolver {
     const consecutiveFailures = Math.max(1, (previous?.consecutiveFailures ?? 0) + 1);
     const multiplier = 2 ** Math.max(0, consecutiveFailures - 1);
     const backoffMs = Math.min(this.maxFailureCooldownMs, this.failureCooldownMs * multiplier);
+    const probeMs = this.recoveryProbeIntervalMs > 0
+      ? Math.min(backoffMs, this.recoveryProbeIntervalMs)
+      : backoffMs;
+    const now = Date.now();
     this.failedEndpoints.set(endpointKey, {
-      nextRetryAt: Date.now() + backoffMs,
+      nextRetryAt: now + backoffMs,
+      nextProbeAt: now + probeMs,
       consecutiveFailures,
     });
   }

--- a/packages/node/tests/http-metadata-resolver.test.ts
+++ b/packages/node/tests/http-metadata-resolver.test.ts
@@ -185,4 +185,42 @@ describe('HttpMetadataResolver', () => {
     expect(third).toBeNull();
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
+
+  it('probes a failed endpoint before a long cooldown expires', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    const metadata = buildMetadata();
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(metadata), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resolver = new HttpMetadataResolver({
+      timeoutMs: 100,
+      failureCooldownMs: 10_000,
+      maxFailureCooldownMs: 10_000,
+      recoveryProbeIntervalMs: 2_000,
+    });
+    const peer = { host: '147.236.231.105', port: 6882 };
+
+    const first = await resolver.resolve(peer);
+    const skipped = await resolver.resolve(peer);
+    vi.setSystemTime(new Date('2026-01-01T00:00:02.001Z'));
+    const probed = await resolver.resolve(peer);
+
+    expect(first).toBeNull();
+    expect(skipped).toBeNull();
+    expect(probed).toEqual(expect.objectContaining({
+      ...metadata,
+      resolvedAtMs: new Date('2026-01-01T00:00:02.001Z').getTime(),
+    }));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Description

Adds bounded recovery probes for metadata endpoints that are in exponential failure cooldown. This keeps cooldown backoff for repeated failures while allowing endpoints that are announcing again to recover in buyer discovery sooner.

## Release Notes

- Fixed buyer peer discovery so recovered metadata endpoints can reappear before the full exponential cooldown expires.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Verification

- `pnpm --filter @antseed/node test -- http-metadata-resolver`
- `pnpm --filter @antseed/node typecheck`