### PR TITLE
fix(node): Silence response-auth noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ## Unreleased
 
+### Published
+
+- `@antseed/node`
+
 ### Changed
 
 - Reduced the default buyer response-auth evidence sample rate from 20% to 0.5% to limit local `verification_samples` growth during high-request sessions.
 
 ### Fixed
 
+- Fixed buyer response-auth timeout warnings for non-inference probes and sellers that do not advertise response-auth support.
 - Fixed buyer discovery so temporarily unreachable metadata endpoints are probed for recovery before the full exponential cooldown expires, allowing recovered peers to reappear in buyer peer lists sooner.
 
 ## 2026-06-15 — Buyer peer failure accounting and desktop stream responsiveness

--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -17,6 +17,7 @@ import type { VerificationStorage } from "./verification/storage.js";
 import type { VerificationSampler } from "./verification/samples.js";
 import { verifyResponseAuth } from "./verification/response-auth.js";
 import { tryParseJsonObject } from "./utils/json-codec.js";
+import { CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 } from "./types/protocol.js";
 
 export interface RequestStreamResponseMetadata {
   streaming: boolean;
@@ -311,6 +312,10 @@ export class BuyerRequestHandler {
     requestedService: string | undefined,
     verificationMux: VerificationMux,
   ): void {
+    if (!shouldExpectResponseAuth(peer, response, requestedService)) {
+      return;
+    }
+
     const storage = this._deps.verificationStorage;
     const advertisedService = requestedService ?? 'unknown';
     const expectedChannelId = this._deps.negotiator?.bpm?.getActiveSession(peer.peerId)?.sessionId ?? null;
@@ -374,6 +379,16 @@ function stripStreamingHeader(response: SerializedHttpResponse): SerializedHttpR
   const headers = { ...response.headers };
   delete headers[ANTSEED_STREAMING_RESPONSE_HEADER];
   return { ...response, headers };
+}
+
+function shouldExpectResponseAuth(
+  peer: PeerInfo,
+  response: SerializedHttpResponse,
+  requestedService: string | undefined,
+): boolean {
+  if (!requestedService) return false;
+  if (response.statusCode === 402) return false;
+  return peer.capabilities?.includes(CONNECTION_CAPABILITY_RESPONSE_AUTH_V1) === true;
 }
 
 function concatChunks(chunks: Uint8Array[]): Uint8Array {

--- a/packages/node/tests/buyer-response-auth-sampling.test.ts
+++ b/packages/node/tests/buyer-response-auth-sampling.test.ts
@@ -4,12 +4,16 @@ import { identityFromPrivateKeyHex } from '../src/p2p/identity.js';
 import { createResponseAuthPayload } from '../src/verification/index.js';
 import type { PeerInfo, PeerId } from '../src/types/peer.js';
 import type { SerializedHttpRequest, SerializedHttpResponse } from '../src/types/http.js';
+import { CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 } from '../src/types/protocol.js';
 
 describe('BuyerRequestHandler response auth sampling', () => {
   it('passes verified response auth evidence to the sampler', async () => {
     const seller = identityFromPrivateKeyHex('11'.repeat(32));
     const buyer = identityFromPrivateKeyHex('22'.repeat(32));
-    const peer = { peerId: seller.peerId } as PeerInfo;
+    const peer = {
+      peerId: seller.peerId,
+      capabilities: [CONNECTION_CAPABILITY_RESPONSE_AUTH_V1],
+    } as PeerInfo;
     const request: SerializedHttpRequest = {
       requestId: 'req-sampled',
       method: 'POST',
@@ -71,5 +75,96 @@ describe('BuyerRequestHandler response auth sampling', () => {
       verified: true,
       verificationError: null,
     }));
+  });
+
+  it('does not wait for response auth on non-inference requests', async () => {
+    const waitForResponseAuth = vi.fn(async () => {
+      throw new Error('should not wait');
+    });
+    const request: SerializedHttpRequest = {
+      requestId: 'req-models',
+      method: 'GET',
+      path: '/v1/models',
+      headers: {},
+      body: new Uint8Array(0),
+    };
+    const response: SerializedHttpResponse = {
+      requestId: request.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ data: [] })),
+    };
+    const handler = new BuyerRequestHandler(
+      {},
+      {
+        localPeerId: 'a'.repeat(40) as PeerId,
+        negotiator: null,
+        verificationStorage: null,
+        verificationSampler: null,
+        getConnection: vi.fn(async () => ({ state: 'open' })) as any,
+        getMux: vi.fn(() => ({
+          sendProxyRequest: vi.fn((
+            _request: SerializedHttpRequest,
+            onResponse: (res: SerializedHttpResponse, metadata: { streamingStart: boolean }) => void,
+          ) => {
+            onResponse(response, { streamingStart: false });
+          }),
+          cancelProxyRequest: vi.fn(),
+        })) as any,
+        getVerificationMux: vi.fn(() => ({ waitForResponseAuth })) as any,
+        registerPaymentMux: vi.fn(),
+      },
+    );
+
+    await handler.sendRequest({
+      peerId: 'b'.repeat(40),
+      capabilities: [CONNECTION_CAPABILITY_RESPONSE_AUTH_V1],
+    } as PeerInfo, request);
+
+    expect(waitForResponseAuth).not.toHaveBeenCalled();
+  });
+
+  it('does not wait for response auth when the seller has not advertised support', async () => {
+    const waitForResponseAuth = vi.fn(async () => {
+      throw new Error('should not wait');
+    });
+    const request: SerializedHttpRequest = {
+      requestId: 'req-no-capability',
+      method: 'POST',
+      path: '/v1/messages',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ model: 'sample-model' })),
+    };
+    const response: SerializedHttpResponse = {
+      requestId: request.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ ok: true })),
+    };
+    const handler = new BuyerRequestHandler(
+      {},
+      {
+        localPeerId: 'a'.repeat(40) as PeerId,
+        negotiator: null,
+        verificationStorage: null,
+        verificationSampler: null,
+        getConnection: vi.fn(async () => ({ state: 'open' })) as any,
+        getMux: vi.fn(() => ({
+          sendProxyRequest: vi.fn((
+            _request: SerializedHttpRequest,
+            onResponse: (res: SerializedHttpResponse, metadata: { streamingStart: boolean }) => void,
+          ) => {
+            onResponse(response, { streamingStart: false });
+          }),
+          cancelProxyRequest: vi.fn(),
+        })) as any,
+        getVerificationMux: vi.fn(() => ({ waitForResponseAuth })) as any,
+        registerPaymentMux: vi.fn(),
+      },
+    );
+
+    await handler.sendRequest({ peerId: 'b'.repeat(40) } as PeerInfo, request);
+
+    expect(waitForResponseAuth).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description

Stops the buyer from waiting for response-auth side messages when the response is not eligible for response auth. This prevents repeated timeout warnings for non-inference probes such as `/v1/models` and for sellers that do not advertise response-auth support.

## Release Notes

- Fixed noisy buyer `Missing ResponseAuth` timeout warnings for non-inference probes and sellers without response-auth support.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Verification

- `pnpm --filter @antseed/api-adapter build`
- `pnpm --filter @antseed/api-adapter typecheck`
- `pnpm --filter @antseed/node typecheck`
- `pnpm --filter @antseed/node test -- tests/buyer-response-auth-sampling.test.ts tests/seller-response-auth-compat.test.ts tests/node-payment-mux-wiring.test.ts tests/node-stream-security.test.ts`
