### PR TITLE
fix(node): Send payment auth after responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable user-facing changes to AntSeed packages are documented here.
 
 This project uses selective package publishing. Each release entry lists the published packages affected by that release.
 
+## Unreleased
+
+### Published
+
+- `@antseed/node`
+
+### Fixed
+
+- Fixed buyer payment authorization catch-up so expensive or concurrent paid requests send updated spending authorization promptly instead of surfacing avoidable payment-required responses.
+
 ## 2026-06-15 — Buyer peer failure accounting and desktop stream responsiveness
 
 ### Published

--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -113,6 +113,25 @@ export class BuyerRequestHandler {
 
     let startTime = Date.now();
 
+    const preparePaymentForRequest = async (): Promise<void> => {
+      if (!negotiator || externalSpendingAuth) return;
+      await negotiator.preparePreRequestAuth(peer, conn);
+    };
+
+    const recordPaymentForResponse = async (response: SerializedHttpResponse): Promise<void> => {
+      if (!negotiator) return;
+      negotiator.estimateCostFromResponse(peer, response, requestedService, req.requestId);
+      if (externalSpendingAuth || response.statusCode < 200 || response.statusCode >= 400) return;
+      try {
+        await negotiator.sendPostResponseAuth(peer, conn);
+      } catch (err) {
+        debugWarn(
+          `[BuyerRequest] Failed to send post-response payment auth for ${req.requestId.slice(0, 8)} ` +
+          `to ${peer.peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    };
+
     const executeRequest = (): Promise<SerializedHttpResponse> => new Promise<SerializedHttpResponse>((resolve, reject) => {
       const timeoutMs = this._config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
       const maxStreamBufferBytes = Math.max(1, this._config.maxStreamBufferBytes ?? 16 * 1024 * 1024);
@@ -284,21 +303,21 @@ export class BuyerRequestHandler {
       );
     });
 
+    await preparePaymentForRequest();
     const response = await executeRequest();
 
     if (response.statusCode === 402 && negotiator && !externalSpendingAuth) {
       const result = await negotiator.handle402(response, peer, conn, req);
       if (result.action === 'return') return result.response;
       startTime = Date.now();
+      await preparePaymentForRequest();
       const retriedResponse = await executeRequest();
-      negotiator.estimateCostFromResponse(peer, retriedResponse, requestedService, req.requestId);
+      await recordPaymentForResponse(retriedResponse);
       this._recordResponseAuth(peer, req, retriedResponse, requestedService, verificationMux);
       return retriedResponse;
     }
 
-    if (negotiator) {
-      negotiator.estimateCostFromResponse(peer, response, requestedService, req.requestId);
-    }
+    await recordPaymentForResponse(response);
 
     this._recordResponseAuth(peer, req, response, requestedService, verificationMux);
     return response;

--- a/packages/node/tests/node-payment-mux-wiring.test.ts
+++ b/packages/node/tests/node-payment-mux-wiring.test.ts
@@ -38,6 +38,8 @@ describe('BuyerRequestHandler payment mux wiring', () => {
       }, { streamingStart: false });
     });
 
+    const preparePreRequestAuth = vi.fn();
+    const sendPostResponseAuth = vi.fn();
     const estimateCostFromResponse = vi.fn();
     const getOrCreatePaymentMux = vi.fn().mockReturnValue({});
     const registerPaymentMux = vi.fn();
@@ -47,8 +49,8 @@ describe('BuyerRequestHandler payment mux wiring', () => {
         localPeerId: 'a'.repeat(40) as PeerId,
         negotiator: {
           getOrCreatePaymentMux,
-          preparePreRequestAuth: vi.fn(),
-          sendPostResponseAuth: vi.fn(),
+          preparePreRequestAuth,
+          sendPostResponseAuth,
           estimateCostFromResponse,
           parseCostHeaders: vi.fn(),
           recordResponseContent: vi.fn(),
@@ -68,6 +70,7 @@ describe('BuyerRequestHandler payment mux wiring', () => {
     await handler.sendRequest(peer, request);
 
     expect(getOrCreatePaymentMux).toHaveBeenCalledWith(peer.peerId, conn);
+    expect(preparePreRequestAuth).toHaveBeenCalledWith(peer, conn);
     expect(sendProxyRequest).toHaveBeenCalledOnce();
     expect(estimateCostFromResponse).toHaveBeenCalledWith(
       peer,
@@ -75,9 +78,16 @@ describe('BuyerRequestHandler payment mux wiring', () => {
       undefined,
       'req-payment-mux',
     );
+    expect(sendPostResponseAuth).toHaveBeenCalledWith(peer, conn);
     expect(
       getOrCreatePaymentMux.mock.invocationCallOrder[0],
     ).toBeLessThan(sendProxyRequest.mock.invocationCallOrder[0]);
+    expect(
+      preparePreRequestAuth.mock.invocationCallOrder[0],
+    ).toBeLessThan(sendProxyRequest.mock.invocationCallOrder[0]);
+    expect(
+      sendProxyRequest.mock.invocationCallOrder[0],
+    ).toBeLessThan(sendPostResponseAuth.mock.invocationCallOrder[0]);
   });
 
   it('re-negotiates on 402 even when the peer was already locked', async () => {
@@ -119,6 +129,8 @@ describe('BuyerRequestHandler payment mux wiring', () => {
     });
 
     const estimateCostFromResponse = vi.fn();
+    const preparePreRequestAuth = vi.fn();
+    const sendPostResponseAuth = vi.fn();
     const handle402 = vi.fn(async () => ({ action: 'retry' as const }));
     const handler = new BuyerRequestHandler(
       {},
@@ -126,7 +138,8 @@ describe('BuyerRequestHandler payment mux wiring', () => {
         localPeerId: 'a'.repeat(40) as PeerId,
         negotiator: {
           getOrCreatePaymentMux: vi.fn().mockReturnValue({}),
-          preparePreRequestAuth: vi.fn(),
+          preparePreRequestAuth,
+          sendPostResponseAuth,
           handle402,
           estimateCostFromResponse,
           parseCostHeaders: vi.fn(),
@@ -147,6 +160,7 @@ describe('BuyerRequestHandler payment mux wiring', () => {
     const response = await handler.sendRequest(peer, request);
 
     expect(response.statusCode).toBe(200);
+    expect(preparePreRequestAuth).toHaveBeenCalledTimes(2);
     expect(handle402).toHaveBeenCalledOnce();
     expect(estimateCostFromResponse).toHaveBeenCalledTimes(1);
     expect(estimateCostFromResponse).toHaveBeenCalledWith(
@@ -155,5 +169,7 @@ describe('BuyerRequestHandler payment mux wiring', () => {
       undefined,
       'req-relock',
     );
+    expect(sendPostResponseAuth).toHaveBeenCalledTimes(1);
+    expect(sendPostResponseAuth).toHaveBeenCalledWith(peer, conn);
   });
 });

--- a/packages/node/tests/node-payment-mux-wiring.test.ts
+++ b/packages/node/tests/node-payment-mux-wiring.test.ts
@@ -171,5 +171,11 @@ describe('BuyerRequestHandler payment mux wiring', () => {
     );
     expect(sendPostResponseAuth).toHaveBeenCalledTimes(1);
     expect(sendPostResponseAuth).toHaveBeenCalledWith(peer, conn);
+    expect(
+      preparePreRequestAuth.mock.invocationCallOrder[1],
+    ).toBeLessThan(sendProxyRequest.mock.invocationCallOrder[1]);
+    expect(
+      sendProxyRequest.mock.invocationCallOrder[1],
+    ).toBeLessThan(sendPostResponseAuth.mock.invocationCallOrder[0]);
   });
 });


### PR DESCRIPTION
## Description

Sends buyer payment authorization before outbound paid requests and promptly after successful paid responses. This reduces avoidable payment-required responses when paid requests are expensive or overlap in time.

## Release Notes

- Fixed buyer payment authorization catch-up for expensive or concurrent paid requests.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
