### PR TITLE
fix(desktop): restore low-balance warning link styling and layout

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/LowBalanceWarning.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/LowBalanceWarning.module.scss
@@ -16,7 +16,11 @@
   line-height: 1.4;
 }
 
-.add-credits-link {
+// Scoped under the container so it outranks the @antseed/ui `.as-button--ghost`
+// variant classes (which tie on specificity and would otherwise win on source order).
+.low-balance-warning .add-credits-link {
+  min-height: 0;
+  padding: 0;
   border: none;
   background: none;
   color: #fbbf24;
@@ -26,9 +30,9 @@
   cursor: pointer;
   text-decoration: underline;
   white-space: nowrap;
-  padding: 0;
 
-  &:hover {
+  &:hover:not(:disabled) {
+    background: none;
     color: #f59e0b;
   }
 }

--- a/apps/desktop/src/renderer/ui/components/chat/LowBalanceWarning.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/LowBalanceWarning.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button } from '@antseed/ui';
+import { Button } from '@antseed/ui';
 import styles from './LowBalanceWarning.module.scss';
 
 type LowBalanceWarningProps = {
@@ -11,24 +11,19 @@ export function LowBalanceWarning({ visible, availableUsdc, onAddCredits }: LowB
   if (!visible) return null;
 
   return (
-    <Alert
-      className={styles.lowBalanceWarning}
-      tone="warning"
-      action={(
-        <Button
-          className={styles.addCreditsLink}
-          size="sm"
-          variant="ghost"
-          onClick={onAddCredits}
-        >
-          Add Credits
-        </Button>
-      )}
-    >
+    <div className={styles.lowBalanceWarning}>
       <span className={styles.warningText}>
         Your balance is running low (${parseFloat(availableUsdc).toFixed(2)} remaining).
         Add credits to continue using paid services.
       </span>
-    </Alert>
+      <Button
+        className={styles.addCreditsLink}
+        size="sm"
+        variant="ghost"
+        onClick={onAddCredits}
+      >
+        Add Credits
+      </Button>
+    </div>
   );
 }


### PR DESCRIPTION
## Problem

The low-balance warning's "Add Credits" button was rendering as a default button instead of the intended amber underlined link, and the row was vertically misaligned.

## Root cause

The portal redesign refactor (`e10f6366`) swapped this component's plain `div`/`button` for the shared `@antseed/ui` `Alert` and `Button`, but kept the CSS-module classes that were written for bare elements:

- `Button variant="ghost"` brought in `.as-button--ghost`, which **ties on specificity** with the module's `.add-credits-link` and wins on source order, overriding the link's `background`/`color`. Result: a default ghost pill.
- `Alert` brought in a `display: grid` layout with `align-items: start` plus a status dot, which overrode the original flex layout and broke alignment.

Both regressions are the same root cause: adopting the shared primitives while keeping overrides that assumed a plain `div`/`button`.

## Fix

- Drop `<Alert>` back to the original flex `<div>` container (removes the unintended status dot and grid; restores `align-items: center`).
- Keep the shared `<Button>`, and scope the `.add-credits-link` override under the container so it outranks `.as-button--ghost`.

The warning now renders as the amber underlined link it did before the refactor, with text and link aligned.

## Test

- `tsc -p tsconfig.renderer.json --noEmit` passes.
- Verified visually in the desktop dev app.