### PR TITLE
feat(node): Add free usage auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project uses selective package publishing. Each release entry lists the pub
 - `@antseed/cli`
 - `@antseed/node`
 
+### Added
+
+- Added zero-price free usage authorization for advertised free services, including buyer-signed P2P usage records, seller on-chain reporting through `AntseedFreeUsage`, and CLI configuration for the deployed free usage contract address.
+
 ### Removed
 
 - Removed the legacy subpool/subscription payment surface, including the `antseed buyer subscribe` command, subpool payment client/config exports, and the `AntseedSubPool` contract deployment path.

--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -277,6 +277,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
         rpcUrl: cryptoOverrides?.rpcUrl,
         depositsContractAddress: cryptoOverrides?.depositsContractAddress,
         channelsContractAddress: cryptoOverrides?.channelsContractAddress,
+        freeUsageContractAddress: cryptoOverrides?.freeUsageContractAddress,
         usdcContractAddress: cryptoOverrides?.usdcContractAddress,
       })
       let settlementEnabled = settlementEnv ?? true
@@ -297,6 +298,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
           ...(chainConfig.fallbackRpcUrls ? { fallbackRpcUrls: chainConfig.fallbackRpcUrls } : {}),
           depositsAddress: chainConfig.depositsContractAddress,
           channelsAddress: chainConfig.channelsContractAddress,
+          ...(chainConfig.freeUsageContractAddress ? { freeUsageAddress: chainConfig.freeUsageContractAddress } : {}),
           usdcAddress: chainConfig.usdcContractAddress,
           // Staking + identity registry addresses let the buyer-side node wire
           // a StakingClient and IdentityClient. Without stakingAddress, the

--- a/apps/cli/src/cli/commands/network/chain-config-helper.ts
+++ b/apps/cli/src/cli/commands/network/chain-config-helper.ts
@@ -14,6 +14,7 @@ export interface ChainCryptoOverrides {
   fallbackRpcUrls?: string[];
   depositsContractAddress?: string;
   channelsContractAddress?: string;
+  freeUsageContractAddress?: string;
   usdcContractAddress?: string;
   stakingContractAddress?: string;
   identityRegistryAddress?: string;
@@ -45,6 +46,7 @@ export function buildPaymentsConfig(
       rpcUrl: cryptoOverrides?.rpcUrl,
       depositsContractAddress: cryptoOverrides?.depositsContractAddress,
       channelsContractAddress: cryptoOverrides?.channelsContractAddress,
+      freeUsageContractAddress: cryptoOverrides?.freeUsageContractAddress,
       usdcContractAddress: cryptoOverrides?.usdcContractAddress,
     });
     const paymentsConfig: NodePaymentsConfig = {
@@ -53,6 +55,7 @@ export function buildPaymentsConfig(
       ...(resolved.fallbackRpcUrls ? { fallbackRpcUrls: resolved.fallbackRpcUrls } : {}),
       depositsAddress: resolved.depositsContractAddress,
       channelsAddress: resolved.channelsContractAddress,
+      ...(resolved.freeUsageContractAddress ? { freeUsageAddress: resolved.freeUsageContractAddress } : {}),
       usdcAddress: resolved.usdcContractAddress,
       chainId: resolved.evmChainId,
       ...(resolved.stakingContractAddress ? { stakingAddress: resolved.stakingContractAddress } : {}),

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -432,6 +432,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
           fallbackRpcUrls: config.payments.crypto?.fallbackRpcUrls,
           depositsContractAddress: config.payments.crypto?.depositsContractAddress,
           channelsContractAddress: config.payments.crypto?.channelsContractAddress,
+          freeUsageContractAddress: config.payments.crypto?.freeUsageContractAddress,
           stakingContractAddress: config.payments.crypto?.stakingContractAddress,
           usdcContractAddress: config.payments.crypto?.usdcContractAddress,
           identityRegistryAddress: config.payments.crypto?.identityRegistryAddress,
@@ -447,6 +448,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
           ...(cc.fallbackRpcUrls ? { fallbackRpcUrls: cc.fallbackRpcUrls } : {}),
           depositsContractAddress: cc.depositsContractAddress,
           channelsContractAddress: cc.channelsContractAddress,
+          ...(cc.freeUsageContractAddress ? { freeUsageContractAddress: cc.freeUsageContractAddress } : {}),
           usdcAddress: cc.usdcContractAddress,
           defaultLockAmountUSDC: defaultLockAmountUSDCBaseUnits,
         }
@@ -597,6 +599,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
             ...(paymentConfig.crypto.fallbackRpcUrls ? { fallbackRpcUrls: paymentConfig.crypto.fallbackRpcUrls } : {}),
             depositsAddress: paymentConfig.crypto.depositsContractAddress,
             channelsAddress: paymentConfig.crypto.channelsContractAddress,
+            ...(paymentConfig.crypto.freeUsageContractAddress ? { freeUsageAddress: paymentConfig.crypto.freeUsageContractAddress } : {}),
             usdcAddress: paymentConfig.crypto.usdcAddress,
             identityRegistryAddress: resolveChainConfig({ chainId: paymentConfig.crypto.chainId }).identityRegistryAddress,
             stakingAddress: resolveChainConfig({ chainId: paymentConfig.crypto.chainId }).stakingContractAddress,

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -196,6 +196,8 @@ export interface PaymentsCLIConfig {
     depositsContractAddress?: string;
     /** Deployed AntseedChannels contract address override */
     channelsContractAddress?: string;
+    /** Deployed AntseedFreeUsage contract address override */
+    freeUsageContractAddress?: string;
     /** Deployed AntseedStaking contract address */
     stakingContractAddress?: string;
     /** USDC token contract address override */

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -97,6 +97,29 @@ channelId = keccak256(abi.encode(buyer, seller, salt))
 **Owner functions:**
 - `pause()` / `unpause()` — emergency circuit breaker
 
+### AntseedFreeUsage.sol
+
+Zero-price usage channel lifecycle with buyer-signed EIP-712 proofs. Holds NO USDC and never locks or charges buyer funds. Sellers still need to be staked, and each usage update must be signed by the buyer.
+
+**Seller operations:**
+- `open(address buyer, bytes32 salt, uint256 deadline, bytes calldata buyerSig)` — validates `FreeUsageOpen` and starts a free usage channel
+- `record(bytes32 channelId, uint256 sequence, bytes calldata metadata, uint256 deadline, bytes calldata buyerSig)` — validates `FreeUsageAuth`, enforces a monotonic sequence, and stores/emits raw metadata
+- `close(bytes32 channelId, uint256 sequence, bytes calldata metadata, uint256 deadline, bytes calldata buyerSig)` — records the final signed usage and closes the free channel
+
+**EIP-712 types (domain: name="AntseedFreeUsage", version="1"):**
+```
+FreeUsageOpen(bytes32 channelId,uint256 deadline)
+FreeUsageAuth(bytes32 channelId,uint256 sequence,bytes32 metadataHash,uint256 deadline)
+```
+
+Metadata is buyer-signed opaque bytes, bound only by `metadataHash`. Indexers parse the metadata version and service attribution off-chain. If `AntseedStats` is configured and this contract is granted writer access, free usage metadata is forwarded there with the same optional `try/catch` behavior used by paid channels.
+
+Free usage channel IDs are domain-separated from paid channels:
+`keccak256(abi.encode(FREE_USAGE_CHANNEL_DOMAIN, buyer, seller, salt))`.
+Buyers send `FreeUsageOpen` before a free request and answer seller
+`NeedFreeUsageAuth` messages after the response, allowing sellers to report
+buyer signatures on-chain even when the buyer has no USDC deposit.
+
 ### AntseedStats.sol
 
 Optional external metadata sink keyed by ERC-8004 agentId plus buyer address. Writers are managed with `AccessControl`.
@@ -138,7 +161,8 @@ ANTS emission controller using the Synthetix reward-per-point pattern. O(1) gas 
 2. **MockERC8004Registry** — deploy for local testing (on mainnet use deployed ERC-8004)
 3. **AntseedDeposits** — deploy with `(usdcAddress)`
 4. **AntseedStaking** — deploy with `(usdcAddress, registryAddress)`
-5. **AntseedStats** — optional: deploy, set in `AntseedRegistry`, and grant `WRITER_ROLE` to Channels
+5. **AntseedStats** — optional: deploy, set in `AntseedRegistry`, and grant writer access to Channels and FreeUsage
+6. **AntseedFreeUsage** — optional zero-price signed usage recorder; deploy with the AntseedRegistry address
 6. **AntseedChannels** — deploy with `(registryAddress)`
 7. **AntseedEmissions** — deploy with `(antsTokenAddress, channelsAddress)`, then call `antsToken.setEmissionsContract(emissions)`
 

--- a/packages/contracts/interfaces/IAntseedFreeUsage.sol
+++ b/packages/contracts/interfaces/IAntseedFreeUsage.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IAntseedFreeUsage {
+    enum ChannelStatus {
+        None,
+        Active,
+        Closed
+    }
+
+    struct AgentStats {
+        uint64 channelCount;
+        uint64 lastSettledAt;
+    }
+
+    function activeChannelCount(address seller) external view returns (uint256);
+    function computeChannelId(address buyer, address seller, bytes32 salt) external pure returns (bytes32);
+    function getAgentStats(uint256 agentId) external view returns (AgentStats memory);
+
+    function open(address buyer, bytes32 salt, uint256 deadline, bytes calldata buyerSig) external;
+
+    function record(
+        bytes32 channelId,
+        uint256 sequence,
+        bytes calldata metadata,
+        uint256 deadline,
+        bytes calldata buyerSig
+    ) external;
+
+    function close(
+        bytes32 channelId,
+        uint256 sequence,
+        bytes calldata metadata,
+        uint256 deadline,
+        bytes calldata buyerSig
+    ) external;
+}

--- a/packages/contracts/interfaces/IAntseedFreeUsage.sol
+++ b/packages/contracts/interfaces/IAntseedFreeUsage.sol
@@ -14,6 +14,16 @@ interface IAntseedFreeUsage {
     }
 
     function activeChannelCount(address seller) external view returns (uint256);
+    function channels(bytes32 channelId) external view returns (
+        address buyer,
+        address seller,
+        uint256 latestSequence,
+        bytes32 metadataHash,
+        uint256 deadline,
+        uint256 updatedAt,
+        uint256 closedAt,
+        ChannelStatus status
+    );
     function computeChannelId(address buyer, address seller, bytes32 salt) external pure returns (bytes32);
     function getAgentStats(uint256 agentId) external view returns (AgentStats memory);
 

--- a/packages/contracts/payments/AntseedFreeUsage.sol
+++ b/packages/contracts/payments/AntseedFreeUsage.sol
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import {IAntseedRegistry} from "../interfaces/IAntseedRegistry.sol";
+import {IAntseedStaking} from "../interfaces/IAntseedStaking.sol";
+import {IAntseedStats} from "../interfaces/IAntseedStats.sol";
+import {IAntseedFreeUsage} from "../interfaces/IAntseedFreeUsage.sol";
+
+/**
+ * @title AntseedFreeUsage
+ * @notice Free usage channel lifecycle with buyer-signed EIP-712 usage proofs.
+ *         This contract holds no funds and never charges the buyer. It records
+ *         signed usage metadata for seller/buyer auditability and can
+ *         optionally forward metadata into AntseedStats when authorized there.
+ *         Metadata is opaque to this contract; indexers parse the raw bytes.
+ */
+contract AntseedFreeUsage is IAntseedFreeUsage, EIP712, Pausable, Ownable, ReentrancyGuard {
+    // ─── EIP-712 ─────────────────────────────────────────────────────
+    bytes32 public constant FREE_USAGE_CHANNEL_DOMAIN = keccak256("ANTSEED_FREE_USAGE_CHANNEL");
+
+    bytes32 public constant FREE_USAGE_OPEN_TYPEHASH = keccak256(
+        "FreeUsageOpen(bytes32 channelId,uint256 deadline)"
+    );
+
+    bytes32 public constant FREE_USAGE_AUTH_TYPEHASH = keccak256(
+        "FreeUsageAuth(bytes32 channelId,uint256 sequence,bytes32 metadataHash,uint256 deadline)"
+    );
+
+    // ─── Structs ────────────────────────────────────────────────────
+    struct Channel {
+        address buyer;
+        address seller;
+        uint256 latestSequence;
+        bytes32 metadataHash;
+        uint256 deadline;
+        uint256 updatedAt;
+        uint256 closedAt;
+        ChannelStatus status;
+    }
+
+    // ─── State ──────────────────────────────────────────────────────
+    IAntseedRegistry public registry;
+
+    mapping(bytes32 => Channel) public channels;
+    mapping(address => uint256) public override activeChannelCount;
+    mapping(uint256 => AgentStats) private _agentStats;
+
+    // ─── Events ─────────────────────────────────────────────────────
+    event FreeUsageOpened(bytes32 indexed channelId, address indexed buyer, address indexed seller, uint256 deadline);
+    event FreeUsageRecorded(
+        bytes32 indexed channelId,
+        address indexed buyer,
+        address indexed seller,
+        uint256 sequence,
+        bytes metadata
+    );
+    event FreeUsageClosed(bytes32 indexed channelId, address indexed buyer, address indexed seller);
+
+    // ─── Errors ─────────────────────────────────────────────────────
+    error InvalidAddress();
+    error InvalidAmount();
+    error InvalidSignature();
+    error ChannelExists();
+    error ChannelNotActive();
+    error ChannelExpired();
+    error NotAuthorized();
+    error SellerNotStaked();
+
+    // ─── Constructor ────────────────────────────────────────────────
+    constructor(address _registry)
+        EIP712("AntseedFreeUsage", "1")
+        Ownable(msg.sender)
+    {
+        if (_registry == address(0)) revert InvalidAddress();
+        registry = IAntseedRegistry(_registry);
+    }
+
+    // ─── Views ──────────────────────────────────────────────────────
+    function domainSeparator() external view returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+
+    function computeChannelId(address buyer, address seller, bytes32 salt) public pure override returns (bytes32) {
+        return keccak256(abi.encode(FREE_USAGE_CHANNEL_DOMAIN, buyer, seller, salt));
+    }
+
+    function getAgentStats(uint256 agentId) external view override returns (AgentStats memory) {
+        return _agentStats[agentId];
+    }
+
+    // ─── Core ───────────────────────────────────────────────────────
+    function open(
+        address buyer,
+        bytes32 salt,
+        uint256 deadline,
+        bytes calldata buyerSig
+    ) external override nonReentrant whenNotPaused {
+        if (buyer == address(0)) revert InvalidAddress();
+        if (block.timestamp > deadline) revert ChannelExpired();
+        if (!IAntseedStaking(registry.staking()).isStakedAboveMin(msg.sender)) revert SellerNotStaked();
+
+        bytes32 channelId = computeChannelId(buyer, msg.sender, salt);
+        if (channels[channelId].status != ChannelStatus.None) revert ChannelExists();
+
+        _verifyOpenAuth(channelId, deadline, buyer, buyerSig);
+
+        channels[channelId] = Channel({
+            buyer: buyer,
+            seller: msg.sender,
+            latestSequence: 0,
+            metadataHash: bytes32(0),
+            deadline: deadline,
+            updatedAt: 0,
+            closedAt: 0,
+            status: ChannelStatus.Active
+        });
+
+        activeChannelCount[msg.sender]++;
+
+        emit FreeUsageOpened(channelId, buyer, msg.sender, deadline);
+    }
+
+    function record(
+        bytes32 channelId,
+        uint256 sequence,
+        bytes calldata metadata,
+        uint256 deadline,
+        bytes calldata buyerSig
+    ) external override nonReentrant whenNotPaused {
+        Channel storage channel = channels[channelId];
+        if (channel.status != ChannelStatus.Active) revert ChannelNotActive();
+        if (msg.sender != channel.seller) revert NotAuthorized();
+
+        _recordUsage(channelId, channel, sequence, metadata, deadline, buyerSig, false);
+    }
+
+    function close(
+        bytes32 channelId,
+        uint256 sequence,
+        bytes calldata metadata,
+        uint256 deadline,
+        bytes calldata buyerSig
+    ) external override nonReentrant whenNotPaused {
+        Channel storage channel = channels[channelId];
+        if (channel.status != ChannelStatus.Active) revert ChannelNotActive();
+        if (msg.sender != channel.seller) revert NotAuthorized();
+
+        _recordUsage(channelId, channel, sequence, metadata, deadline, buyerSig, true);
+
+        channel.status = ChannelStatus.Closed;
+        channel.closedAt = block.timestamp;
+        activeChannelCount[channel.seller]--;
+
+        emit FreeUsageClosed(channelId, channel.buyer, channel.seller);
+    }
+
+    // ─── Internal Helpers ───────────────────────────────────────────
+    function _recordUsage(
+        bytes32 channelId,
+        Channel storage channel,
+        uint256 sequence,
+        bytes calldata metadata,
+        uint256 deadline,
+        bytes calldata buyerSig,
+        bool allowSameSequence
+    ) internal {
+        if (block.timestamp > channel.deadline || block.timestamp > deadline) revert ChannelExpired();
+
+        if (sequence < channel.latestSequence) revert InvalidAmount();
+        if (!allowSameSequence && sequence == channel.latestSequence) revert InvalidAmount();
+
+        bytes32 metadataHash = keccak256(metadata);
+        _verifyUsageAuth(channelId, sequence, metadataHash, deadline, channel.buyer, buyerSig);
+
+        uint256 sequenceDelta = sequence - channel.latestSequence;
+        bool firstUsage = channel.updatedAt == 0 && sequence > 0;
+
+        channel.latestSequence = sequence;
+        channel.metadataHash = metadataHash;
+        channel.updatedAt = block.timestamp;
+
+        if (sequenceDelta > 0) {
+            uint256 agentId = IAntseedStaking(registry.staking()).getAgentId(channel.seller);
+            if (agentId > 0) {
+                AgentStats storage s = _agentStats[agentId];
+                if (firstUsage) {
+                    s.channelCount++;
+                }
+                s.lastSettledAt = uint64(block.timestamp);
+                _syncExternalMetadata(agentId, channel.buyer, channelId, metadata);
+            }
+        }
+
+        emit FreeUsageRecorded(
+            channelId,
+            channel.buyer,
+            channel.seller,
+            sequence,
+            metadata
+        );
+    }
+
+    function _syncExternalMetadata(
+        uint256 agentId,
+        address buyer,
+        bytes32 channelId,
+        bytes calldata metadata
+    ) internal {
+        address statsContract = registry.stats();
+        if (statsContract == address(0)) return;
+        try IAntseedStats(statsContract).recordMetadata(agentId, buyer, channelId, metadata) {}
+        catch {}
+    }
+
+    function _verifyOpenAuth(
+        bytes32 channelId,
+        uint256 deadline,
+        address buyer,
+        bytes calldata signature
+    ) internal view {
+        bytes32 structHash = keccak256(abi.encode(FREE_USAGE_OPEN_TYPEHASH, channelId, deadline));
+        _verifySignature(structHash, signature, buyer);
+    }
+
+    function _verifyUsageAuth(
+        bytes32 channelId,
+        uint256 sequence,
+        bytes32 metadataHash,
+        uint256 deadline,
+        address buyer,
+        bytes calldata signature
+    ) internal view {
+        bytes32 structHash = keccak256(
+            abi.encode(FREE_USAGE_AUTH_TYPEHASH, channelId, sequence, metadataHash, deadline)
+        );
+        _verifySignature(structHash, signature, buyer);
+    }
+
+    function _verifySignature(
+        bytes32 structHash,
+        bytes calldata signature,
+        address signer
+    ) internal view {
+        bytes32 digest = _hashTypedDataV4(structHash);
+        address recovered = ECDSA.recover(digest, signature);
+        if (recovered != signer) revert InvalidSignature();
+    }
+
+    // ─── Admin ──────────────────────────────────────────────────────
+    function setRegistry(address _registry) external onlyOwner {
+        if (_registry == address(0)) revert InvalidAddress();
+        registry = IAntseedRegistry(_registry);
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+}

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -100,16 +100,6 @@ contract Deploy is Script {
         require(emissions != address(0), "Emissions deploy failed");
         console.log("AntseedEmissions:     ", emissions);
 
-        // 10. AntseedFreeUsage(registry)
-        bytes memory freeUsageBytecode = abi.encodePacked(
-            vm.getCode("AntseedFreeUsage.sol:AntseedFreeUsage"),
-            abi.encode(address(antseedRegistry))
-        );
-        address freeUsage;
-        assembly { freeUsage := create(0, add(freeUsageBytecode, 0x20), mload(freeUsageBytecode)) }
-        require(freeUsage != address(0), "FreeUsage deploy failed");
-        console.log("AntseedFreeUsage:     ", freeUsage);
-
         // ---- Wire registry ----
         antseedRegistry.setChannels(channels);
         antseedRegistry.setStats(stats);
@@ -128,11 +118,9 @@ contract Deploy is Script {
         ISetRegistry(staking).setRegistry(address(antseedRegistry));
         ISetRegistry(emissions).setRegistry(address(antseedRegistry));
         ISetRegistry(antsToken).setRegistry(address(antseedRegistry));
-        ISetRegistry(freeUsage).setRegistry(address(antseedRegistry));
 
-        // ---- Authorize Channels and FreeUsage as Stats writers ----
+        // ---- Authorize Channels as Stats writer ----
         ISetWriter(stats).setWriter(channels, true);
-        ISetWriter(stats).setWriter(freeUsage, true);
 
         vm.stopBroadcast();
 

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -100,6 +100,16 @@ contract Deploy is Script {
         require(emissions != address(0), "Emissions deploy failed");
         console.log("AntseedEmissions:     ", emissions);
 
+        // 10. AntseedFreeUsage(registry)
+        bytes memory freeUsageBytecode = abi.encodePacked(
+            vm.getCode("AntseedFreeUsage.sol:AntseedFreeUsage"),
+            abi.encode(address(antseedRegistry))
+        );
+        address freeUsage;
+        assembly { freeUsage := create(0, add(freeUsageBytecode, 0x20), mload(freeUsageBytecode)) }
+        require(freeUsage != address(0), "FreeUsage deploy failed");
+        console.log("AntseedFreeUsage:     ", freeUsage);
+
         // ---- Wire registry ----
         antseedRegistry.setChannels(channels);
         antseedRegistry.setStats(stats);
@@ -118,9 +128,11 @@ contract Deploy is Script {
         ISetRegistry(staking).setRegistry(address(antseedRegistry));
         ISetRegistry(emissions).setRegistry(address(antseedRegistry));
         ISetRegistry(antsToken).setRegistry(address(antseedRegistry));
+        ISetRegistry(freeUsage).setRegistry(address(antseedRegistry));
 
-        // ---- Authorize Channels as Stats writer ----
+        // ---- Authorize Channels and FreeUsage as Stats writers ----
         ISetWriter(stats).setWriter(channels, true);
+        ISetWriter(stats).setWriter(freeUsage, true);
 
         vm.stopBroadcast();
 

--- a/packages/contracts/script/DeployBaseMainnet.s.sol
+++ b/packages/contracts/script/DeployBaseMainnet.s.sol
@@ -104,16 +104,6 @@ contract DeployBaseMainnet is Script {
         require(emissions != address(0), "Emissions deploy failed");
         console.log("AntseedEmissions:     ", emissions);
 
-        // 8. AntseedFreeUsage(registry)
-        bytes memory freeUsageBytecode = abi.encodePacked(
-            vm.getCode("AntseedFreeUsage.sol:AntseedFreeUsage"),
-            abi.encode(address(antseedRegistry))
-        );
-        address freeUsage;
-        assembly { freeUsage := create(0, add(freeUsageBytecode, 0x20), mload(freeUsageBytecode)) }
-        require(freeUsage != address(0), "FreeUsage deploy failed");
-        console.log("AntseedFreeUsage:     ", freeUsage);
-
         // ---- Wire registry ----
         antseedRegistry.setChannels(channels);
         antseedRegistry.setStats(stats);
@@ -131,11 +121,9 @@ contract DeployBaseMainnet is Script {
         ISetRegistry(staking).setRegistry(address(antseedRegistry));
         ISetRegistry(emissions).setRegistry(address(antseedRegistry));
         ISetRegistry(antsToken).setRegistry(address(antseedRegistry));
-        ISetRegistry(freeUsage).setRegistry(address(antseedRegistry));
 
-        // ---- Authorize Channels and FreeUsage as Stats writers ----
+        // ---- Authorize Channels as Stats writer ----
         ISetWriter(stats).setWriter(channels, true);
-        ISetWriter(stats).setWriter(freeUsage, true);
 
         vm.stopBroadcast();
 
@@ -146,7 +134,6 @@ contract DeployBaseMainnet is Script {
         console.log("  usdcContractAddress:      ", USDC);
         console.log("  depositsContractAddress:   ", deposits);
         console.log("  channelsContractAddress:   ", channels);
-        console.log("  freeUsageContractAddress:  ", freeUsage);
         console.log("  stakingContractAddress:    ", staking);
         console.log("  emissionsContractAddress:  ", emissions);
         console.log("  identityRegistryAddress:   ", IDENTITY_REGISTRY);

--- a/packages/contracts/script/DeployBaseMainnet.s.sol
+++ b/packages/contracts/script/DeployBaseMainnet.s.sol
@@ -104,6 +104,16 @@ contract DeployBaseMainnet is Script {
         require(emissions != address(0), "Emissions deploy failed");
         console.log("AntseedEmissions:     ", emissions);
 
+        // 8. AntseedFreeUsage(registry)
+        bytes memory freeUsageBytecode = abi.encodePacked(
+            vm.getCode("AntseedFreeUsage.sol:AntseedFreeUsage"),
+            abi.encode(address(antseedRegistry))
+        );
+        address freeUsage;
+        assembly { freeUsage := create(0, add(freeUsageBytecode, 0x20), mload(freeUsageBytecode)) }
+        require(freeUsage != address(0), "FreeUsage deploy failed");
+        console.log("AntseedFreeUsage:     ", freeUsage);
+
         // ---- Wire registry ----
         antseedRegistry.setChannels(channels);
         antseedRegistry.setStats(stats);
@@ -121,9 +131,11 @@ contract DeployBaseMainnet is Script {
         ISetRegistry(staking).setRegistry(address(antseedRegistry));
         ISetRegistry(emissions).setRegistry(address(antseedRegistry));
         ISetRegistry(antsToken).setRegistry(address(antseedRegistry));
+        ISetRegistry(freeUsage).setRegistry(address(antseedRegistry));
 
-        // ---- Authorize Channels as Stats writer ----
+        // ---- Authorize Channels and FreeUsage as Stats writers ----
         ISetWriter(stats).setWriter(channels, true);
+        ISetWriter(stats).setWriter(freeUsage, true);
 
         vm.stopBroadcast();
 
@@ -134,6 +146,7 @@ contract DeployBaseMainnet is Script {
         console.log("  usdcContractAddress:      ", USDC);
         console.log("  depositsContractAddress:   ", deposits);
         console.log("  channelsContractAddress:   ", channels);
+        console.log("  freeUsageContractAddress:  ", freeUsage);
         console.log("  stakingContractAddress:    ", staking);
         console.log("  emissionsContractAddress:  ", emissions);
         console.log("  identityRegistryAddress:   ", IDENTITY_REGISTRY);

--- a/packages/contracts/script/DeployBaseSepolia.s.sol
+++ b/packages/contracts/script/DeployBaseSepolia.s.sol
@@ -105,6 +105,16 @@ contract DeployBaseSepolia is Script {
         require(emissions != address(0), "Emissions deploy failed");
         console.log("AntseedEmissions:     ", emissions);
 
+        // 9. AntseedFreeUsage(registry)
+        bytes memory freeUsageBytecode = abi.encodePacked(
+            vm.getCode("AntseedFreeUsage.sol:AntseedFreeUsage"),
+            abi.encode(address(antseedRegistry))
+        );
+        address freeUsage;
+        assembly { freeUsage := create(0, add(freeUsageBytecode, 0x20), mload(freeUsageBytecode)) }
+        require(freeUsage != address(0), "FreeUsage deploy failed");
+        console.log("AntseedFreeUsage:     ", freeUsage);
+
         // ---- Wire registry ----
         antseedRegistry.setChannels(channels);
         antseedRegistry.setStats(stats);
@@ -122,9 +132,11 @@ contract DeployBaseSepolia is Script {
         ISetRegistry(staking).setRegistry(address(antseedRegistry));
         ISetRegistry(emissions).setRegistry(address(antseedRegistry));
         ISetRegistry(antsToken).setRegistry(address(antseedRegistry));
+        ISetRegistry(freeUsage).setRegistry(address(antseedRegistry));
 
-        // ---- Authorize Channels as Stats writer ----
+        // ---- Authorize Channels and FreeUsage as Stats writers ----
         ISetWriter(stats).setWriter(channels, true);
+        ISetWriter(stats).setWriter(freeUsage, true);
 
         vm.stopBroadcast();
 
@@ -135,6 +147,7 @@ contract DeployBaseSepolia is Script {
         console.log("  usdcContractAddress:    ", usdc);
         console.log("  depositsContractAddress:", deposits);
         console.log("  channelsContractAddress:", channels);
+        console.log("  freeUsageContractAddress:", freeUsage);
         console.log("  stakingContractAddress: ", staking);
         console.log("  emissionsContractAddress:", emissions);
         console.log("  identityRegistryAddress:", IDENTITY_REGISTRY);

--- a/packages/contracts/script/DeployBaseSepolia.s.sol
+++ b/packages/contracts/script/DeployBaseSepolia.s.sol
@@ -105,16 +105,6 @@ contract DeployBaseSepolia is Script {
         require(emissions != address(0), "Emissions deploy failed");
         console.log("AntseedEmissions:     ", emissions);
 
-        // 9. AntseedFreeUsage(registry)
-        bytes memory freeUsageBytecode = abi.encodePacked(
-            vm.getCode("AntseedFreeUsage.sol:AntseedFreeUsage"),
-            abi.encode(address(antseedRegistry))
-        );
-        address freeUsage;
-        assembly { freeUsage := create(0, add(freeUsageBytecode, 0x20), mload(freeUsageBytecode)) }
-        require(freeUsage != address(0), "FreeUsage deploy failed");
-        console.log("AntseedFreeUsage:     ", freeUsage);
-
         // ---- Wire registry ----
         antseedRegistry.setChannels(channels);
         antseedRegistry.setStats(stats);
@@ -132,11 +122,9 @@ contract DeployBaseSepolia is Script {
         ISetRegistry(staking).setRegistry(address(antseedRegistry));
         ISetRegistry(emissions).setRegistry(address(antseedRegistry));
         ISetRegistry(antsToken).setRegistry(address(antseedRegistry));
-        ISetRegistry(freeUsage).setRegistry(address(antseedRegistry));
 
-        // ---- Authorize Channels and FreeUsage as Stats writers ----
+        // ---- Authorize Channels as Stats writer ----
         ISetWriter(stats).setWriter(channels, true);
-        ISetWriter(stats).setWriter(freeUsage, true);
 
         vm.stopBroadcast();
 
@@ -147,7 +135,6 @@ contract DeployBaseSepolia is Script {
         console.log("  usdcContractAddress:    ", usdc);
         console.log("  depositsContractAddress:", deposits);
         console.log("  channelsContractAddress:", channels);
-        console.log("  freeUsageContractAddress:", freeUsage);
         console.log("  stakingContractAddress: ", staking);
         console.log("  emissionsContractAddress:", emissions);
         console.log("  identityRegistryAddress:", IDENTITY_REGISTRY);

--- a/packages/contracts/script/DeployFreeUsage.s.sol
+++ b/packages/contracts/script/DeployFreeUsage.s.sol
@@ -5,7 +5,7 @@ import "forge-std/Script.sol";
 
 import { AntseedFreeUsage } from "../payments/AntseedFreeUsage.sol";
 import { IAntseedRegistry } from "../interfaces/IAntseedRegistry.sol";
-import { ISetRegistry, ISetWriter } from "../interfaces/IAntseedWiring.sol";
+import { ISetWriter } from "../interfaces/IAntseedWiring.sol";
 
 /**
  * @title DeployFreeUsage
@@ -54,10 +54,6 @@ contract DeployFreeUsage is Script {
 
         AntseedFreeUsage freeUsage = new AntseedFreeUsage(registryAddress);
         console.log("AntseedFreeUsage:     ", address(freeUsage));
-
-        // Constructor already stores the registry; keep this explicit so
-        // deployment logs match the protocol-wide wiring checks.
-        ISetRegistry(address(freeUsage)).setRegistry(registryAddress);
 
         if (authorizeStats && stats != address(0)) {
             ISetWriter(stats).setWriter(address(freeUsage), true);

--- a/packages/contracts/script/DeployFreeUsage.s.sol
+++ b/packages/contracts/script/DeployFreeUsage.s.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+
+import { AntseedFreeUsage } from "../payments/AntseedFreeUsage.sol";
+import { IAntseedRegistry } from "../interfaces/IAntseedRegistry.sol";
+import { ISetRegistry, ISetWriter } from "../interfaces/IAntseedWiring.sol";
+
+/**
+ * @title DeployFreeUsage
+ * @notice Deploys only AntseedFreeUsage against an existing AntSeed registry.
+ *
+ * Required env:
+ *   DEPLOYER_PRIVATE_KEY   Broadcaster private key.
+ *   ANTSEED_REGISTRY       Deployed AntseedRegistry address.
+ *
+ * Optional env:
+ *   FREE_USAGE_AUTHORIZE_STATS  Defaults to true. Grants the deployed
+ *                               FreeUsage contract writer access on the
+ *                               registry's AntseedStats contract.
+ *
+ * Usage:
+ *   cd packages/contracts
+ *   source .env
+ *   forge script script/DeployFreeUsage.s.sol \
+ *     --rpc-url $BASE_MAINNET_RPC_URL \
+ *     --broadcast \
+ *     --verify \
+ *     --etherscan-api-key $BASESCAN_API_KEY \
+ *     --via-ir
+ */
+contract DeployFreeUsage is Script {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerPrivateKey);
+        address registryAddress = vm.envAddress("ANTSEED_REGISTRY");
+        bool authorizeStats = vm.envOr("FREE_USAGE_AUTHORIZE_STATS", true);
+
+        IAntseedRegistry registry = IAntseedRegistry(registryAddress);
+        address staking = registry.staking();
+        address stats = registry.stats();
+
+        require(staking != address(0), "registry staking not set");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        console.log("=== AntseedFreeUsage Deployment ===");
+        console.log("Deployer:             ", deployer);
+        console.log("AntseedRegistry:      ", registryAddress);
+        console.log("AntseedStaking:       ", staking);
+        console.log("AntseedStats:         ", stats);
+        console.log("");
+
+        AntseedFreeUsage freeUsage = new AntseedFreeUsage(registryAddress);
+        console.log("AntseedFreeUsage:     ", address(freeUsage));
+
+        // Constructor already stores the registry; keep this explicit so
+        // deployment logs match the protocol-wide wiring checks.
+        ISetRegistry(address(freeUsage)).setRegistry(registryAddress);
+
+        if (authorizeStats && stats != address(0)) {
+            ISetWriter(stats).setWriter(address(freeUsage), true);
+            console.log("Stats writer granted: ", true);
+        } else {
+            console.log("Stats writer granted: ", false);
+        }
+
+        vm.stopBroadcast();
+
+        console.log("");
+        console.log("=== AntseedFreeUsage deployment complete ===");
+        console.log("Update chain config:");
+        console.log("  freeUsageContractAddress:", address(freeUsage));
+    }
+}

--- a/packages/contracts/test/AntseedFreeUsage.t.sol
+++ b/packages/contracts/test/AntseedFreeUsage.t.sol
@@ -164,6 +164,143 @@ contract AntseedFreeUsageTest is Test {
         assertEq(buyerStats.totalRequestCount, 2);
     }
 
+    function test_open_revert_expired() public {
+        vm.warp(1000);
+        bytes32 salt = keccak256("expired-open");
+        bytes32 channelId = freeUsage.computeChannelId(buyer, seller, salt);
+        uint256 deadline = block.timestamp - 1;
+        bytes memory openSig = signOpen(BUYER_PK, channelId, deadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedFreeUsage.ChannelExpired.selector);
+        freeUsage.open(buyer, salt, deadline, openSig);
+    }
+
+    function test_open_revert_paused() public {
+        bytes32 salt = keccak256("paused-open");
+        bytes32 channelId = freeUsage.computeChannelId(buyer, seller, salt);
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory openSig = signOpen(BUYER_PK, channelId, deadline);
+
+        freeUsage.pause();
+
+        vm.prank(seller);
+        vm.expectRevert();
+        freeUsage.open(buyer, salt, deadline, openSig);
+    }
+
+    function test_open_revert_sellerNotStaked() public {
+        bytes32 salt = keccak256("unstaked-open");
+        bytes32 channelId = freeUsage.computeChannelId(buyer, randomUser, salt);
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory openSig = signOpen(BUYER_PK, channelId, deadline);
+
+        vm.prank(randomUser);
+        vm.expectRevert(AntseedFreeUsage.SellerNotStaked.selector);
+        freeUsage.open(buyer, salt, deadline, openSig);
+    }
+
+    function test_open_revert_channelExists() public {
+        bytes32 salt = keccak256("double-open");
+        bytes32 channelId = freeUsage.computeChannelId(buyer, seller, salt);
+        uint256 deadline = block.timestamp + 1 hours;
+        bytes memory openSig = signOpen(BUYER_PK, channelId, deadline);
+
+        vm.startPrank(seller);
+        freeUsage.open(buyer, salt, deadline, openSig);
+        vm.expectRevert(AntseedFreeUsage.ChannelExists.selector);
+        freeUsage.open(buyer, salt, deadline, openSig);
+        vm.stopPrank();
+    }
+
+    function test_record_revert_expiredChannel() public {
+        bytes32 salt = keccak256("expired-record");
+        bytes32 channelId = freeUsage.computeChannelId(buyer, seller, salt);
+        uint256 channelDeadline = block.timestamp + 1;
+        bytes memory openSig = signOpen(BUYER_PK, channelId, channelDeadline);
+        vm.prank(seller);
+        freeUsage.open(buyer, salt, channelDeadline, openSig);
+
+        vm.warp(channelDeadline + 1);
+        bytes memory metadata = encodeMetadata(100, 40, 1, oneService(), zeroPrices());
+        uint256 usageDeadline = block.timestamp + 1 hours;
+        bytes memory usageSig = signUsage(BUYER_PK, channelId, 1, metadata, usageDeadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedFreeUsage.ChannelExpired.selector);
+        freeUsage.record(channelId, 1, metadata, usageDeadline, usageSig);
+    }
+
+    function test_close_revert_expiredChannel() public {
+        bytes32 salt = keccak256("expired-close");
+        bytes32 channelId = freeUsage.computeChannelId(buyer, seller, salt);
+        uint256 channelDeadline = block.timestamp + 1;
+        bytes memory openSig = signOpen(BUYER_PK, channelId, channelDeadline);
+        vm.prank(seller);
+        freeUsage.open(buyer, salt, channelDeadline, openSig);
+
+        vm.warp(channelDeadline + 1);
+        bytes memory metadata = encodeMetadata(100, 40, 1, oneService(), zeroPrices());
+        uint256 usageDeadline = block.timestamp + 1 hours;
+        bytes memory usageSig = signUsage(BUYER_PK, channelId, 1, metadata, usageDeadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedFreeUsage.ChannelExpired.selector);
+        freeUsage.close(channelId, 1, metadata, usageDeadline, usageSig);
+    }
+
+    function test_recordAndClose_revert_notAuthorized() public {
+        (bytes32 channelId, uint256 deadline) = openFreeChannel();
+        bytes memory metadata = encodeMetadata(100, 40, 1, oneService(), zeroPrices());
+        bytes memory usageSig = signUsage(BUYER_PK, channelId, 1, metadata, deadline);
+
+        vm.prank(randomUser);
+        vm.expectRevert(AntseedFreeUsage.NotAuthorized.selector);
+        freeUsage.record(channelId, 1, metadata, deadline, usageSig);
+
+        vm.prank(randomUser);
+        vm.expectRevert(AntseedFreeUsage.NotAuthorized.selector);
+        freeUsage.close(channelId, 1, metadata, deadline, usageSig);
+    }
+
+    function test_record_revert_afterClose() public {
+        (bytes32 channelId, uint256 deadline) = openFreeChannel();
+        bytes memory metadata = encodeMetadata(100, 40, 1, oneService(), zeroPrices());
+        bytes memory usageSig = signUsage(BUYER_PK, channelId, 1, metadata, deadline);
+
+        vm.prank(seller);
+        freeUsage.close(channelId, 1, metadata, deadline, usageSig);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedFreeUsage.ChannelNotActive.selector);
+        freeUsage.record(channelId, 1, metadata, deadline, usageSig);
+    }
+
+    function test_record_revert_crossChannelSignature() public {
+        (bytes32 channelId, uint256 deadline) = openFreeChannel();
+        bytes32 otherChannelId = freeUsage.computeChannelId(buyer, seller, keccak256("other-channel"));
+        bytes memory metadata = encodeMetadata(100, 40, 1, oneService(), zeroPrices());
+        bytes memory usageSig = signUsage(BUYER_PK, otherChannelId, 1, metadata, deadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedFreeUsage.InvalidSignature.selector);
+        freeUsage.record(channelId, 1, metadata, deadline, usageSig);
+    }
+
+    function test_close_sequenceZeroDoesNotIncrementStats() public {
+        (bytes32 channelId, uint256 deadline) = openFreeChannel();
+        bytes memory metadata = encodeMetadata(0, 0, 0, oneService(), zeroPrices());
+        bytes memory usageSig = signUsage(BUYER_PK, channelId, 0, metadata, deadline);
+
+        vm.prank(seller);
+        freeUsage.close(channelId, 0, metadata, deadline, usageSig);
+
+        AntseedFreeUsage.AgentStats memory agentStats = freeUsage.getAgentStats(sellerAgentId);
+        assertEq(agentStats.channelCount, 0);
+        assertEq(agentStats.lastSettledAt, 0);
+        assertEq(freeUsage.activeChannelCount(seller), 0);
+    }
+
     function test_computeChannelId_isSeparatedFromPaidChannels() public view {
         bytes32 salt = keccak256("shared-salt");
         bytes32 paidChannelId = keccak256(abi.encode(buyer, seller, salt));

--- a/packages/contracts/test/AntseedFreeUsage.t.sol
+++ b/packages/contracts/test/AntseedFreeUsage.t.sol
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../payments/AntseedFreeUsage.sol";
+import "../interfaces/IAntseedFreeUsage.sol";
+import "../interfaces/IAntseedStats.sol";
+import "../staking/AntseedStaking.sol";
+import "../core/AntseedRegistry.sol";
+import "../stats/AntseedStats.sol";
+import "./mocks/MockERC8004Registry.sol";
+import "./mocks/MockUSDC.sol";
+
+contract AntseedFreeUsageTest is Test {
+    MockUSDC public usdc;
+    MockERC8004Registry public identityRegistry;
+    AntseedRegistry public registry;
+    AntseedStaking public staking;
+    AntseedStats public stats;
+    AntseedFreeUsage public freeUsage;
+
+    uint256 constant BUYER_PK = 0xA11CE;
+    uint256 constant SELLER_PK = 0xB0B;
+    uint256 constant RANDOM_PK = 0xDEAD;
+    uint256 constant STAKE_AMOUNT = 10_000_000;
+
+    bytes32 constant FREE_USAGE_OPEN_TYPEHASH = keccak256(
+        "FreeUsageOpen(bytes32 channelId,uint256 deadline)"
+    );
+    bytes32 constant FREE_USAGE_AUTH_TYPEHASH = keccak256(
+        "FreeUsageAuth(bytes32 channelId,uint256 sequence,bytes32 metadataHash,uint256 deadline)"
+    );
+
+    address public buyer;
+    address public seller;
+    address public randomUser;
+    uint256 public sellerAgentId;
+
+    function setUp() public {
+        buyer = vm.addr(BUYER_PK);
+        seller = vm.addr(SELLER_PK);
+        randomUser = vm.addr(RANDOM_PK);
+
+        usdc = new MockUSDC();
+        identityRegistry = new MockERC8004Registry();
+        registry = new AntseedRegistry();
+        staking = new AntseedStaking(address(usdc), address(registry));
+        stats = new AntseedStats();
+        freeUsage = new AntseedFreeUsage(address(registry));
+
+        registry.setStaking(address(staking));
+        registry.setIdentityRegistry(address(identityRegistry));
+        registry.setStats(address(stats));
+
+        vm.prank(seller);
+        sellerAgentId = identityRegistry.register();
+
+        usdc.mint(seller, STAKE_AMOUNT);
+        vm.startPrank(seller);
+        usdc.approve(address(staking), STAKE_AMOUNT);
+        staking.stake(sellerAgentId, STAKE_AMOUNT);
+        vm.stopPrank();
+    }
+
+    function test_openRecordAndCloseFreeUsage() public {
+        bytes32 salt = keccak256("free-session-1");
+        bytes32 channelId = freeUsage.computeChannelId(buyer, seller, salt);
+        uint256 openDeadline = block.timestamp + 1 hours;
+        bytes memory openSig = signOpen(BUYER_PK, channelId, openDeadline);
+
+        vm.prank(seller);
+        freeUsage.open(buyer, salt, openDeadline, openSig);
+
+        bytes memory metadata = encodeMetadata(100, 40, 1, oneService(), zeroPrices());
+        uint256 usageDeadline = block.timestamp + 30 minutes;
+        bytes memory usageSig = signUsage(BUYER_PK, channelId, 1, metadata, usageDeadline);
+        vm.prank(seller);
+        freeUsage.record(channelId, 1, metadata, usageDeadline, usageSig);
+
+        (
+            address storedBuyer,
+            address storedSeller,
+            uint256 latestSequence,
+            bytes32 metadataHash,
+            ,
+            ,
+            ,
+            IAntseedFreeUsage.ChannelStatus status
+        ) = freeUsage.channels(channelId);
+
+        assertEq(storedBuyer, buyer);
+        assertEq(storedSeller, seller);
+        assertEq(latestSequence, 1);
+        assertEq(metadataHash, keccak256(metadata));
+        assertEq(uint256(status), uint256(IAntseedFreeUsage.ChannelStatus.Active));
+
+        AntseedFreeUsage.AgentStats memory agentStats = freeUsage.getAgentStats(sellerAgentId);
+        assertEq(agentStats.channelCount, 1);
+        assertEq(agentStats.lastSettledAt, block.timestamp);
+
+        bytes memory closeMetadata = encodeMetadata(150, 80, 2, oneService(), zeroPrices());
+        bytes memory closeSig = signUsage(BUYER_PK, channelId, 2, closeMetadata, usageDeadline);
+        vm.prank(seller);
+        freeUsage.close(channelId, 2, closeMetadata, usageDeadline, closeSig);
+
+        agentStats = freeUsage.getAgentStats(sellerAgentId);
+        assertEq(agentStats.channelCount, 1);
+        assertEq(agentStats.lastSettledAt, block.timestamp);
+        assertEq(freeUsage.activeChannelCount(seller), 0);
+    }
+
+    function test_record_acceptsOpaqueMetadataWithoutPriceValidation() public {
+        (bytes32 channelId, uint256 deadline) = openFreeChannel();
+        uint256[] memory prices = new uint256[](1);
+        prices[0] = 1;
+        bytes memory metadata = encodeMetadata(100, 40, 1, oneService(), prices);
+        bytes memory usageSig = signUsage(BUYER_PK, channelId, 1, metadata, deadline);
+
+        vm.prank(seller);
+        freeUsage.record(channelId, 1, metadata, deadline, usageSig);
+
+        (, , uint256 latestSequence, bytes32 metadataHash, , , , ) = freeUsage.channels(channelId);
+        assertEq(latestSequence, 1);
+        assertEq(metadataHash, keccak256(metadata));
+    }
+
+    function test_record_revert_badSignature() public {
+        (bytes32 channelId, uint256 deadline) = openFreeChannel();
+        bytes memory metadata = encodeMetadata(100, 40, 1, oneService(), zeroPrices());
+        bytes memory usageSig = signUsage(RANDOM_PK, channelId, 1, metadata, deadline);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedFreeUsage.InvalidSignature.selector);
+        freeUsage.record(channelId, 1, metadata, deadline, usageSig);
+    }
+
+    function test_record_revert_nonMonotonicSequence() public {
+        (bytes32 channelId, uint256 deadline) = openFreeChannel();
+        bytes memory metadata1 = encodeMetadata(100, 40, 1, oneService(), zeroPrices());
+        bytes memory usageSig1 = signUsage(BUYER_PK, channelId, 1, metadata1, deadline);
+        vm.prank(seller);
+        freeUsage.record(channelId, 1, metadata1, deadline, usageSig1);
+
+        bytes memory metadata2 = encodeMetadata(110, 50, 1, oneService(), zeroPrices());
+        bytes memory usageSig2 = signUsage(BUYER_PK, channelId, 1, metadata2, deadline);
+        vm.prank(seller);
+        vm.expectRevert(AntseedFreeUsage.InvalidAmount.selector);
+        freeUsage.record(channelId, 1, metadata2, deadline, usageSig2);
+    }
+
+    function test_record_syncsOptionalExternalStatsWhenAuthorized() public {
+        stats.setWriter(address(freeUsage), true);
+
+        (bytes32 channelId, uint256 deadline) = openFreeChannel();
+        bytes memory metadata = encodeMetadata(100, 40, 2, oneService(), zeroPrices());
+        bytes memory usageSig = signUsage(BUYER_PK, channelId, 2, metadata, deadline);
+
+        vm.prank(seller);
+        freeUsage.record(channelId, 2, metadata, deadline, usageSig);
+
+        IAntseedStats.BuyerMetadataStats memory buyerStats = stats.getBuyerMetadataStats(sellerAgentId, buyer);
+        assertEq(buyerStats.totalInputTokens, 100);
+        assertEq(buyerStats.totalOutputTokens, 40);
+        assertEq(buyerStats.totalRequestCount, 2);
+    }
+
+    function test_computeChannelId_isSeparatedFromPaidChannels() public view {
+        bytes32 salt = keccak256("shared-salt");
+        bytes32 paidChannelId = keccak256(abi.encode(buyer, seller, salt));
+        bytes32 freeChannelId = freeUsage.computeChannelId(buyer, seller, salt);
+
+        assertTrue(freeChannelId != paidChannelId);
+    }
+
+    function openFreeChannel() internal returns (bytes32 channelId, uint256 deadline) {
+        bytes32 salt = keccak256("free-session");
+        channelId = freeUsage.computeChannelId(buyer, seller, salt);
+        deadline = block.timestamp + 1 hours;
+        bytes memory openSig = signOpen(BUYER_PK, channelId, deadline);
+        vm.prank(seller);
+        freeUsage.open(buyer, salt, deadline, openSig);
+    }
+
+    function signOpen(uint256 pk, bytes32 channelId, uint256 deadline) internal view returns (bytes memory) {
+        bytes32 structHash = keccak256(abi.encode(FREE_USAGE_OPEN_TYPEHASH, channelId, deadline));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", freeUsage.domainSeparator(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function signUsage(
+        uint256 pk,
+        bytes32 channelId,
+        uint256 sequence,
+        bytes memory metadata,
+        uint256 deadline
+    ) internal view returns (bytes memory) {
+        bytes32 structHash = keccak256(
+            abi.encode(FREE_USAGE_AUTH_TYPEHASH, channelId, sequence, keccak256(metadata), deadline)
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", freeUsage.domainSeparator(), structHash));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function encodeMetadata(
+        uint256 cumulativeInputTokens,
+        uint256 cumulativeOutputTokens,
+        uint256 cumulativeRequestCount,
+        bytes32[] memory services,
+        uint256[] memory prices
+    ) internal pure returns (bytes memory) {
+        return abi.encode(uint256(1), cumulativeInputTokens, cumulativeOutputTokens, cumulativeRequestCount, services, prices);
+    }
+
+    function oneService() internal pure returns (bytes32[] memory services) {
+        services = new bytes32[](1);
+        services[0] = keccak256("gpt-free");
+    }
+
+    function zeroPrices() internal pure returns (uint256[] memory prices) {
+        prices = new uint256[](1);
+        prices[0] = 0;
+    }
+}

--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -8,13 +8,14 @@ import {
 import type { PeerInfo, PeerId } from "./types/peer.js";
 import type { PeerConnection } from "./p2p/connection-manager.js";
 import type { ProxyMux } from "./proxy/proxy-mux.js";
-import type { PaymentMux } from "./p2p/payment-mux.js";
+import { PaymentMux } from "./p2p/payment-mux.js";
 import { ConnectionState } from "./types/connection.js";
 import type { BuyerPaymentNegotiator } from "./payments/buyer-payment-negotiator.js";
 import { debugLog, debugWarn } from "./utils/debug.js";
 import type { VerificationMux } from "./verification/verification-mux.js";
 import type { VerificationStorage } from "./verification/storage.js";
 import type { VerificationSampler } from "./verification/samples.js";
+import type { BuyerFreeUsageManager } from "./payments/buyer-free-usage-manager.js";
 import { verifyResponseAuth } from "./verification/response-auth.js";
 import { tryParseJsonObject } from "./utils/json-codec.js";
 import { CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 } from "./types/protocol.js";
@@ -48,6 +49,7 @@ const DEFAULT_RESPONSE_AUTH_GRACE_MS = 30_000;
 export interface BuyerRequestHandlerDeps {
   localPeerId: PeerId;
   negotiator: BuyerPaymentNegotiator | null;
+  freeUsageManager?: BuyerFreeUsageManager | null;
   verificationStorage: VerificationStorage | null;
   verificationSampler: VerificationSampler | null;
   getConnection: (peer: PeerInfo) => Promise<PeerConnection>;
@@ -119,6 +121,13 @@ export class BuyerRequestHandler {
         }
       } else {
         negotiator.bpm.trackRequestService(req.requestId, requestedService);
+      }
+    } else if (requestedService && isFreeService && this._deps.freeUsageManager) {
+      this._deps.freeUsageManager.trackRequestService(req.requestId, requestedService);
+      try {
+        this._prepareDirectFreeUsageOpen(peer, conn);
+      } catch (err) {
+        debugWarn(`[BuyerRequest] Failed to prepare free usage channel for ${peer.peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
       }
     }
 
@@ -315,6 +324,28 @@ export class BuyerRequestHandler {
 
     this._recordResponseAuth(peer, req, response, requestedService, verificationMux);
     return response;
+  }
+
+  private _prepareDirectFreeUsageOpen(peer: PeerInfo, conn: PeerConnection): void {
+    const freeUsage = this._deps.freeUsageManager;
+    if (!freeUsage) return;
+
+    const pmux = new PaymentMux(conn);
+    pmux.onFreeUsageAck((payload) => {
+      freeUsage.handleAck(peer.peerId, payload);
+    });
+    pmux.onNeedFreeUsageAuth((payload) => {
+      const p = freeUsage.handleNeedAuth(peer.peerId, payload, pmux);
+      p.catch((err) => {
+        debugWarn(`[BuyerRequest] Failed to handle free usage auth request from ${peer.peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
+      });
+    });
+    this._deps.registerPaymentMux(peer.peerId, pmux);
+    void freeUsage.prepareOpen(peer, pmux)
+      .then(() => freeUsage.waitForOpenAck(peer.peerId))
+      .catch((err) => {
+        debugWarn(`[BuyerRequest] Free usage open ack unavailable for ${peer.peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
+      });
   }
 
   private _recordResponseAuth(

--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -112,9 +112,12 @@ export class BuyerRequestHandler {
     if (negotiator && requestedService) {
       if (isFreeService) {
         negotiator.trackFreeUsageRequestService(req.requestId, requestedService);
-        await negotiator.prepareFreeUsageOpen(peer, conn).catch((err) => {
+        try {
+          await negotiator.prepareFreeUsageOpen(peer, conn);
+        } catch (err) {
           debugWarn(`[BuyerRequest] Failed to prepare free usage channel for ${peer.peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
-        });
+          throw err;
+        }
       } else {
         negotiator.bpm.trackRequestService(req.requestId, requestedService);
       }

--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -106,10 +106,18 @@ export class BuyerRequestHandler {
       await negotiator.applyExternalSpendingAuth(peer, conn, externalSpendingAuth);
     }
 
-    // Track which service the buyer requested so NeedAuth validation uses buyer's own pricing
+    // Track which service the buyer requested so auth validation uses buyer's own pricing.
     const requestedService = extractServiceFromBody(req.body);
+    const isFreeService = requestedService ? isPeerServiceFree(peer, requestedService) : false;
     if (negotiator && requestedService) {
-      negotiator.bpm.trackRequestService(req.requestId, requestedService);
+      if (isFreeService) {
+        negotiator.trackFreeUsageRequestService(req.requestId, requestedService);
+        await negotiator.prepareFreeUsageOpen(peer, conn).catch((err) => {
+          debugWarn(`[BuyerRequest] Failed to prepare free usage channel for ${peer.peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
+        });
+      } else {
+        negotiator.bpm.trackRequestService(req.requestId, requestedService);
+      }
     }
 
     let startTime = Date.now();
@@ -292,12 +300,14 @@ export class BuyerRequestHandler {
       if (result.action === 'return') return result.response;
       startTime = Date.now();
       const retriedResponse = await executeRequest();
-      negotiator.estimateCostFromResponse(peer, retriedResponse, requestedService, req.requestId);
+      if (!isFreeService) {
+        negotiator.estimateCostFromResponse(peer, retriedResponse, requestedService, req.requestId);
+      }
       this._recordResponseAuth(peer, req, retriedResponse, requestedService, verificationMux);
       return retriedResponse;
     }
 
-    if (negotiator) {
+    if (negotiator && !isFreeService) {
       negotiator.estimateCostFromResponse(peer, response, requestedService, req.requestId);
     }
 
@@ -389,6 +399,33 @@ function shouldExpectResponseAuth(
   if (!requestedService) return false;
   if (response.statusCode === 402) return false;
   return peer.capabilities?.includes(CONNECTION_CAPABILITY_RESPONSE_AUTH_V1) === true;
+}
+
+function isPeerServiceFree(peer: PeerInfo, service: string): boolean {
+  const servicePricing = findPeerServicePricing(peer, service);
+  if (!servicePricing) return false;
+  return (servicePricing.inputUsdPerMillion ?? 0) === 0
+    && (servicePricing.outputUsdPerMillion ?? 0) === 0
+    && (servicePricing.cachedInputUsdPerMillion ?? 0) === 0;
+}
+
+function findPeerServicePricing(peer: PeerInfo, service: string): {
+  inputUsdPerMillion?: number;
+  outputUsdPerMillion?: number;
+  cachedInputUsdPerMillion?: number;
+} | null {
+  for (const providerPricing of Object.values(peer.providerPricing ?? {})) {
+    const servicePricing = providerPricing.services?.[service];
+    if (servicePricing) return servicePricing;
+  }
+  if (peer.defaultInputUsdPerMillion != null || peer.defaultOutputUsdPerMillion != null) {
+    return {
+      inputUsdPerMillion: peer.defaultInputUsdPerMillion ?? 0,
+      outputUsdPerMillion: peer.defaultOutputUsdPerMillion ?? 0,
+      cachedInputUsdPerMillion: peer.defaultCachedInputUsdPerMillion,
+    };
+  }
+  return null;
 }
 
 function concatChunks(chunks: Uint8Array[]): Uint8Array {

--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -116,7 +116,6 @@ export class BuyerRequestHandler {
           await negotiator.prepareFreeUsageOpen(peer, conn);
         } catch (err) {
           debugWarn(`[BuyerRequest] Failed to prepare free usage channel for ${peer.peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
-          throw err;
         }
       } else {
         negotiator.bpm.trackRequestService(req.requestId, requestedService);

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -72,6 +72,12 @@ export { MeteringStorage } from './metering/storage.js';
 export { BalanceManager } from './payments/balance-manager.js';
 export { DepositsClient, type DepositsClientConfig, type BuyerBalanceInfo } from './payments/evm/deposits-client.js';
 export { ChannelsClient, type ChannelsClientConfig, type ChannelInfo, type AgentStats } from './payments/evm/channels-client.js';
+export {
+  FreeUsageClient,
+  type FreeUsageClientConfig,
+  type FreeUsageChannelInfo,
+  type FreeUsageAgentStats,
+} from './payments/evm/free-usage-client.js';
 export { IdentityClient, type IdentityClientConfig } from './payments/evm/identity-client.js';
 export { StakingClient, type StakingClientConfig } from './payments/evm/staking-client.js';
 export { EmissionsClient, type EmissionsClientConfig, type EmissionsEpochParams } from './payments/evm/emissions-client.js';
@@ -85,23 +91,48 @@ export { signData, verifySignature, signUtf8, verifyUtf8 } from './p2p/identity.
 export {
   signSpendingAuth,
   signReserveAuth,
+  signFreeUsageOpen,
+  signFreeUsageAuth,
   signSetOperator,
   makeChannelsDomain,
   makeDepositsDomain,
+  makeFreeUsageDomain,
   SPENDING_AUTH_TYPES,
   RESERVE_AUTH_TYPES,
+  FREE_USAGE_OPEN_TYPES,
+  FREE_USAGE_AUTH_TYPES,
   SET_OPERATOR_TYPES,
   computeMetadataHash,
   encodeMetadata,
+  computeFreeUsageMetadataHash,
+  encodeFreeUsageMetadata,
   getServiceMetadataId,
   computeChannelId,
+  computeFreeUsageChannelId,
+  FREE_USAGE_CHANNEL_DOMAIN,
   ZERO_METADATA,
   ZERO_METADATA_HASH,
+  ZERO_FREE_USAGE_METADATA,
+  ZERO_FREE_USAGE_METADATA_HASH,
 } from './payments/evm/signatures.js';
-export type { SpendingAuthMessage, ReserveAuthMessage, SetOperatorMessage, SpendingAuthMetadata, SpendingAuthServiceMetadata } from './payments/evm/signatures.js';
+export type {
+  SpendingAuthMessage,
+  ReserveAuthMessage,
+  SetOperatorMessage,
+  FreeUsageOpenMessage,
+  FreeUsageAuthMessage,
+  SpendingAuthMetadata,
+  SpendingAuthServiceMetadata,
+  FreeUsageMetadata,
+  FreeUsageServiceMetadata,
+} from './payments/evm/signatures.js';
 export { NatTraversal, type NatMapping, type NatTraversalResult } from './p2p/nat-traversal.js';
 export { BuyerPaymentManager } from './payments/buyer-payment-manager.js';
 export type { BuyerPaymentConfig } from './payments/buyer-payment-manager.js';
+export { BuyerFreeUsageManager } from './payments/buyer-free-usage-manager.js';
+export type { BuyerFreeUsageConfig } from './payments/buyer-free-usage-manager.js';
+export { SellerFreeUsageManager } from './payments/seller-free-usage-manager.js';
+export type { SellerFreeUsageConfig } from './payments/seller-free-usage-manager.js';
 export { SellerPaymentManager } from './payments/seller-payment-manager.js';
 export type { SellerPaymentConfig } from './payments/seller-payment-manager.js';
 export { ChannelStore } from './payments/channel-store.js';

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1520,6 +1520,7 @@ export class AntseedNode extends EventEmitter {
       {
         localPeerId: identity.peerId,
         negotiator: this._buyerNegotiator,
+        freeUsageManager: this._buyerFreeUsageManager,
         verificationStorage: this._verificationStorage,
         verificationSampler: this._verificationSampler,
         getConnection: (peer) => this._getOrCreateConnection(peer),

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -66,6 +66,9 @@ import {
   type PaymentMethod,
   DepositsClient,
   ChannelsClient,
+  FreeUsageClient,
+  BuyerFreeUsageManager,
+  SellerFreeUsageManager,
   StakingClient,
   ChannelStore,
   CHANNEL_STATUS,
@@ -125,6 +128,8 @@ export interface NodePaymentsConfig {
   depositsAddress?: string;
   /** Deployed AntseedChannels contract address */
   channelsAddress?: string;
+  /** Optional deployed AntseedFreeUsage contract address */
+  freeUsageAddress?: string;
   /** USDC token contract address */
   usdcAddress?: string;
   /** ERC-8004 IdentityRegistry contract address */
@@ -250,6 +255,9 @@ export class AntseedNode extends EventEmitter {
   private _balanceManager: BalanceManager | null = null;
   private _depositsClient: DepositsClient | null = null;
   private _channelsClient: ChannelsClient | null = null;
+  private _freeUsageClient: FreeUsageClient | null = null;
+  private _buyerFreeUsageManager: BuyerFreeUsageManager | null = null;
+  private _sellerFreeUsageManager: SellerFreeUsageManager | null = null;
   private _stakingClient: StakingClient | null = null;
   private _sellerAddressResolver: SellerAddressResolver | null = null;
   private _identityClient: IdentityClient | null = null;
@@ -340,6 +348,20 @@ export class AntseedNode extends EventEmitter {
     return this._identityClient;
   }
 
+  /** AntseedFreeUsage client (null if not configured). */
+  get freeUsageClient(): FreeUsageClient | null {
+    return this._freeUsageClient;
+  }
+
+  /** Buyer-side free usage manager (null if free usage is not configured). */
+  get buyerFreeUsageManager(): BuyerFreeUsageManager | null {
+    return this._buyerFreeUsageManager;
+  }
+
+  /** Seller-side free usage manager (null if free usage is not configured). */
+  get sellerFreeUsageManager(): SellerFreeUsageManager | null {
+    return this._sellerFreeUsageManager;
+  }
 
   /** Current connection state for a peer if a connection exists, otherwise null. */
   getPeerConnectionState(peerId: PeerId): ConnectionState | null {
@@ -503,6 +525,9 @@ export class AntseedNode extends EventEmitter {
     this._balanceManager = null;
     this._depositsClient = null;
     this._channelsClient = null;
+    this._freeUsageClient = null;
+    this._buyerFreeUsageManager = null;
+    this._sellerFreeUsageManager = null;
     this._stakingClient = null;
     this._identityClient = null;
     this._sellerAddressResolver = null;
@@ -1376,6 +1401,7 @@ export class AntseedNode extends EventEmitter {
       identity,
       providers: this._providers,
       sellerPaymentManager: this._sellerPaymentManager,
+      sellerFreeUsageManager: this._sellerFreeUsageManager,
       sessionTracker: this._sessionTracker,
       channelsClient: this._channelsClient,
       announcer: this._announcer,
@@ -1471,6 +1497,7 @@ export class AntseedNode extends EventEmitter {
           {},
           this,
           this._sellerAddressResolver ?? undefined,
+          this._buyerFreeUsageManager,
         );
         debugLog(`[Node] Buyer payment negotiator initialized`);
       }
@@ -1524,6 +1551,22 @@ export class AntseedNode extends EventEmitter {
         debugWarn(`[Node] SpendingAuth rejected — SellerPaymentManager not configured`);
       });
     }
+    if (this._sellerFreeUsageManager) {
+      const freeUsage = this._sellerFreeUsageManager;
+      paymentMux.onFreeUsageOpen((payload) => {
+        freeUsage.handleOpen(buyerPeerId, payload, paymentMux);
+      });
+      paymentMux.onFreeUsageAuth((payload) => {
+        freeUsage.handleAuth(buyerPeerId, payload, paymentMux);
+      });
+    } else {
+      paymentMux.onFreeUsageOpen(() => {
+        debugWarn(`[Node] FreeUsageOpen ignored — SellerFreeUsageManager not configured`);
+      });
+      paymentMux.onFreeUsageAuth(() => {
+        debugWarn(`[Node] FreeUsageAuth ignored — SellerFreeUsageManager not configured`);
+      });
+    }
     this._paymentMuxes.set(buyerPeerId, paymentMux);
     this._verificationMuxes.set(buyerPeerId, verificationMux);
 
@@ -1541,6 +1584,17 @@ export class AntseedNode extends EventEmitter {
     }
 
     const fallbackRpcUrls = payments.fallbackRpcUrls;
+    const paymentsDir = join(dataDir, "payments");
+
+    // Shared store for paid and free channel accounting.
+    if (!this._channelStore) {
+      try {
+        this._channelStore = new ChannelStore(paymentsDir);
+        debugLog("[Node] ChannelStore initialized");
+      } catch (err) {
+        debugWarn(`[Node] ChannelStore unavailable: ${err instanceof Error ? err.message : err}`);
+      }
+    }
 
     // Initialize DepositsClient
     if (payments.rpcUrl && payments.depositsAddress && payments.usdcAddress) {
@@ -1588,6 +1642,39 @@ export class AntseedNode extends EventEmitter {
       debugLog(`[Node] SellerAddressResolver initialized`);
     }
 
+    // Initialize FreeUsageClient
+    if (payments.rpcUrl && payments.freeUsageAddress) {
+      this._freeUsageClient = new FreeUsageClient({
+        rpcUrl: payments.rpcUrl,
+        ...(fallbackRpcUrls ? { fallbackRpcUrls } : {}),
+        contractAddress: payments.freeUsageAddress,
+        ...(payments.chainId ? { evmChainId: payments.chainId } : {}),
+      });
+      debugLog(`[Node] FreeUsageClient initialized (contract=${payments.freeUsageAddress.slice(0, 10)}...)`);
+
+      if (this._identity) {
+        const freeUsageConfig = {
+          rpcUrl: payments.rpcUrl,
+          ...(fallbackRpcUrls ? { fallbackRpcUrls } : {}),
+          freeUsageContractAddress: payments.freeUsageAddress,
+          chainId: payments.chainId ?? 8453,
+        };
+        this._buyerFreeUsageManager = new BuyerFreeUsageManager(
+          this._identity,
+          {
+            chainId: freeUsageConfig.chainId,
+            freeUsageContractAddress: freeUsageConfig.freeUsageContractAddress,
+            defaultAuthDurationSecs: payments.defaultAuthDurationSecs ?? 900,
+          },
+          this._sellerAddressResolver ?? undefined,
+          this._channelStore ?? undefined,
+        );
+        if (this._config.role === 'seller') {
+          this._sellerFreeUsageManager = new SellerFreeUsageManager(this._identity, freeUsageConfig);
+        }
+      }
+    }
+
     // Initialize StakingClient
     if (payments.rpcUrl && payments.stakingAddress && payments.usdcAddress) {
       this._stakingClient = new StakingClient({
@@ -1609,17 +1696,6 @@ export class AntseedNode extends EventEmitter {
         ...(payments.chainId ? { evmChainId: payments.chainId } : {}),
       });
       debugLog(`[Node] IdentityClient initialized (contract=${payments.identityRegistryAddress.slice(0, 10)}...)`);
-    }
-
-    // Initialize ChannelStore for persistent payment channels (shared instance)
-    const paymentsDir = join(dataDir, "payments");
-    if (!this._channelStore) {
-      try {
-        this._channelStore = new ChannelStore(paymentsDir);
-        debugLog("[Node] ChannelStore initialized");
-      } catch (err) {
-        debugWarn(`[Node] ChannelStore unavailable: ${err instanceof Error ? err.message : err}`);
-      }
     }
 
     // Initialize SellerPaymentManager for seller role

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -430,6 +430,9 @@ export class AntseedNode extends EventEmitter {
     if (this._buyerNegotiator) {
       this._buyerNegotiator.cleanup();
     }
+    if (this._sellerFreeUsageManager) {
+      await this._sellerFreeUsageManager.flushAllPendingRecords();
+    }
 
     if (this._sessionTracker) {
       await this._sessionTracker.finalizeAllSessions("node-stop");

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1227,6 +1227,8 @@ export class AntseedNode extends EventEmitter {
         this._decoders.delete(peerId);
         // Clean up buyer-side payment state on disconnect
         this._buyerNegotiator?.onPeerDisconnect(peerId);
+        this._buyerFreeUsageManager?.onPeerDisconnect(peerId);
+        this._sellerFreeUsageManager?.onPeerDisconnect(peerId);
         // Handle buyer disconnect (seller side)
         if (this._sellerPaymentManager) {
           this._sellerPaymentManager.onBuyerDisconnect(peerId);
@@ -1296,6 +1298,7 @@ export class AntseedNode extends EventEmitter {
     );
 
     await this._initializePayments(dataDir);
+    this._warnIfFreeUsageMeteringUnavailable();
 
     // Wire idle session events to on-chain settlement
     if (this._sellerPaymentManager) {
@@ -1983,6 +1986,33 @@ export class AntseedNode extends EventEmitter {
     };
   }
 
+  private _warnIfFreeUsageMeteringUnavailable(): void {
+    if (this._sellerFreeUsageManager || !this._hasFreePricedService()) return;
+    const missingAddress = !this._config.payments?.freeUsageAddress;
+    debugWarn(
+      `[Node] Zero-priced service advertised but AntseedFreeUsage is not configured` +
+      `${missingAddress ? ' (payments.freeUsageAddress missing)' : ''}. ` +
+      `Free requests will be served without on-chain usage proofs.`,
+    );
+  }
+
+  private _hasFreePricedService(): boolean {
+    for (const provider of this._providers) {
+      if (provider.services.length === 0 && this._isZeroPricing(provider.pricing.defaults)) return true;
+      for (const service of provider.services) {
+        const servicePricing = provider.pricing.services?.[service] ?? provider.pricing.defaults;
+        if (this._isZeroPricing(servicePricing)) return true;
+      }
+    }
+    return false;
+  }
+
+  private _isZeroPricing(pricing: { inputUsdPerMillion: number; outputUsdPerMillion: number; cachedInputUsdPerMillion?: number }): boolean {
+    const cachedPrice = pricing.cachedInputUsdPerMillion ?? pricing.inputUsdPerMillion;
+    return pricing.inputUsdPerMillion === 0
+      && pricing.outputUsdPerMillion === 0
+      && cachedPrice === 0;
+  }
 }
 
 function parsePeerAddress(address: string): { host: string; port: number } {

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -71,6 +71,7 @@ import {
   SellerFreeUsageManager,
   StakingClient,
   ChannelStore,
+  CHANNEL_ROLE,
   CHANNEL_STATUS,
 } from "./payments/index.js";
 import { debugLog, debugWarn } from "./utils/debug.js";
@@ -960,18 +961,18 @@ export class AntseedNode extends EventEmitter {
     const buyerAddress = this._identity?.wallet.address ?? null;
     const channel = (buyerAddress != null)
       ? (
-        this._channelStore?.getActiveChannelByPeerAndBuyer(sellerPeerId, 'buyer', buyerAddress)
-        ?? this._channelStore?.getLatestChannelByPeerAndBuyer(sellerPeerId, 'buyer', buyerAddress)
+        this._channelStore?.getActiveChannelByPeerAndBuyer(sellerPeerId, CHANNEL_ROLE.BUYER, buyerAddress)
+        ?? this._channelStore?.getLatestChannelByPeerAndBuyer(sellerPeerId, CHANNEL_ROLE.BUYER, buyerAddress)
       )
       : (
-        this._channelStore?.getActiveChannelByPeer(sellerPeerId, 'buyer')
-        ?? this._channelStore?.getLatestChannel(sellerPeerId, 'buyer')
+        this._channelStore?.getActiveChannelByPeer(sellerPeerId, CHANNEL_ROLE.BUYER)
+        ?? this._channelStore?.getLatestChannel(sellerPeerId, CHANNEL_ROLE.BUYER)
       )
       ?? null;
 
     const lifetime = (buyerAddress != null)
-      ? this._channelStore?.getTotalsByPeerAndBuyer(sellerPeerId, 'buyer', buyerAddress)
-      : this._channelStore?.getTotalsByPeer(sellerPeerId, 'buyer')
+      ? this._channelStore?.getTotalsByPeerAndBuyer(sellerPeerId, CHANNEL_ROLE.BUYER, buyerAddress)
+      : this._channelStore?.getTotalsByPeer(sellerPeerId, CHANNEL_ROLE.BUYER)
       ?? null;
 
     const liveTotals = this._buyerPaymentManager?.getResponseTokenTotals(sellerPeerId);
@@ -1029,7 +1030,7 @@ export class AntseedNode extends EventEmitter {
   }> {
     const buyerAddress = this._identity?.wallet.address ?? null;
     if (!buyerAddress || !this._channelStore) return [];
-    const stored = this._channelStore.getActiveChannelsByBuyer('buyer', buyerAddress);
+    const stored = this._channelStore.getActiveChannelsByBuyer(CHANNEL_ROLE.BUYER, buyerAddress);
     return stored.map((c) => {
       const liveReserve = this._buyerPaymentManager?.getReserveCeiling(c.peerId);
       const reserveMax = (liveReserve != null && liveReserve > 0n)

--- a/packages/node/src/p2p/payment-codec.ts
+++ b/packages/node/src/p2p/payment-codec.ts
@@ -2,6 +2,10 @@ import {
   PAYMENT_CODE_CHANNEL_EXHAUSTED,
   type SpendingAuthPayload,
   type AuthAckPayload,
+  type FreeUsageOpenPayload,
+  type FreeUsageAuthPayload,
+  type FreeUsageAckPayload,
+  type NeedFreeUsageAuthPayload,
   type PaymentRequiredPayload,
   type NeedAuthPayload,
 } from '../types/protocol.js';
@@ -27,6 +31,22 @@ export function encodeSpendingAuth(payload: SpendingAuthPayload): Uint8Array {
 }
 
 export function encodeAuthAck(payload: AuthAckPayload): Uint8Array {
+  return encoder.encode(JSON.stringify(payload));
+}
+
+export function encodeFreeUsageOpen(payload: FreeUsageOpenPayload): Uint8Array {
+  return encoder.encode(JSON.stringify(payload));
+}
+
+export function encodeFreeUsageAuth(payload: FreeUsageAuthPayload): Uint8Array {
+  return encoder.encode(JSON.stringify(payload));
+}
+
+export function encodeFreeUsageAck(payload: FreeUsageAckPayload): Uint8Array {
+  return encoder.encode(JSON.stringify(payload));
+}
+
+export function encodeNeedFreeUsageAuth(payload: NeedFreeUsageAuthPayload): Uint8Array {
   return encoder.encode(JSON.stringify(payload));
 }
 
@@ -61,6 +81,53 @@ export function decodeAuthAck(data: Uint8Array): AuthAckPayload {
   return {
     channelId: requireStringField(obj, 'channelId'),
   };
+}
+
+export function decodeFreeUsageOpen(data: Uint8Array): FreeUsageOpenPayload {
+  const obj = parsePaymentJson(data);
+  return {
+    channelId: requireStringField(obj, 'channelId'),
+    salt: requireStringField(obj, 'salt'),
+    deadline: typeof obj.deadline === 'number' ? obj.deadline : Number(requireStringField(obj, 'deadline')),
+    openSig: requireStringField(obj, 'openSig'),
+  };
+}
+
+export function decodeFreeUsageAuth(data: Uint8Array): FreeUsageAuthPayload {
+  const obj = parsePaymentJson(data);
+  return {
+    channelId: requireStringField(obj, 'channelId'),
+    cumulativeInputTokens: requireStringField(obj, 'cumulativeInputTokens'),
+    cumulativeOutputTokens: requireStringField(obj, 'cumulativeOutputTokens'),
+    sequence: requireStringField(obj, 'sequence'),
+    metadataHash: requireStringField(obj, 'metadataHash'),
+    metadata: requireStringField(obj, 'metadata'),
+    deadline: typeof obj.deadline === 'number' ? obj.deadline : Number(requireStringField(obj, 'deadline')),
+    usageSig: requireStringField(obj, 'usageSig'),
+  };
+}
+
+export function decodeFreeUsageAck(data: Uint8Array): FreeUsageAckPayload {
+  const obj = parsePaymentJson(data);
+  const result: FreeUsageAckPayload = {
+    channelId: requireStringField(obj, 'channelId'),
+  };
+  if (typeof obj.acceptedSequence === 'string') result.acceptedSequence = obj.acceptedSequence;
+  return result;
+}
+
+export function decodeNeedFreeUsageAuth(data: Uint8Array): NeedFreeUsageAuthPayload {
+  const obj = parsePaymentJson(data);
+  const result: NeedFreeUsageAuthPayload = {
+    channelId: requireStringField(obj, 'channelId'),
+    requiredSequence: requireStringField(obj, 'requiredSequence'),
+    currentAcceptedSequence: requireStringField(obj, 'currentAcceptedSequence'),
+  };
+  if (typeof obj.requestId === 'string') result.requestId = obj.requestId;
+  if (typeof obj.inputTokens === 'string') result.inputTokens = obj.inputTokens;
+  if (typeof obj.outputTokens === 'string') result.outputTokens = obj.outputTokens;
+  if (typeof obj.service === 'string') result.service = obj.service;
+  return result;
 }
 
 export function decodePaymentRequired(data: Uint8Array): PaymentRequiredPayload {

--- a/packages/node/src/p2p/payment-codec.ts
+++ b/packages/node/src/p2p/payment-codec.ts
@@ -24,6 +24,14 @@ function parsePaymentJson(data: Uint8Array): Record<string, unknown> {
   });
 }
 
+function requireFiniteNumberField(obj: Record<string, unknown>, field: string): number {
+  const value = typeof obj[field] === 'number' ? obj[field] : Number(requireStringField(obj, field));
+  if (!Number.isFinite(value)) {
+    throw new Error(`Payment payload field "${field}" must be a finite number`);
+  }
+  return value;
+}
+
 // --- Encoders ---
 
 export function encodeSpendingAuth(payload: SpendingAuthPayload): Uint8Array {
@@ -88,7 +96,7 @@ export function decodeFreeUsageOpen(data: Uint8Array): FreeUsageOpenPayload {
   return {
     channelId: requireStringField(obj, 'channelId'),
     salt: requireStringField(obj, 'salt'),
-    deadline: typeof obj.deadline === 'number' ? obj.deadline : Number(requireStringField(obj, 'deadline')),
+    deadline: requireFiniteNumberField(obj, 'deadline'),
     openSig: requireStringField(obj, 'openSig'),
   };
 }
@@ -102,7 +110,7 @@ export function decodeFreeUsageAuth(data: Uint8Array): FreeUsageAuthPayload {
     sequence: requireStringField(obj, 'sequence'),
     metadataHash: requireStringField(obj, 'metadataHash'),
     metadata: requireStringField(obj, 'metadata'),
-    deadline: typeof obj.deadline === 'number' ? obj.deadline : Number(requireStringField(obj, 'deadline')),
+    deadline: requireFiniteNumberField(obj, 'deadline'),
     usageSig: requireStringField(obj, 'usageSig'),
   };
 }

--- a/packages/node/src/p2p/payment-mux.ts
+++ b/packages/node/src/p2p/payment-mux.ts
@@ -3,6 +3,10 @@ import { MessageType } from '../types/protocol.js';
 import type {
   SpendingAuthPayload,
   AuthAckPayload,
+  FreeUsageOpenPayload,
+  FreeUsageAuthPayload,
+  FreeUsageAckPayload,
+  NeedFreeUsageAuthPayload,
   PaymentRequiredPayload,
   NeedAuthPayload,
 } from '../types/protocol.js';
@@ -14,6 +18,10 @@ import { debugLog } from '../utils/debug.js';
 const MESSAGE_TYPE_NAME: Record<number, string> = {
   [MessageType.SpendingAuth]: 'SpendingAuth',
   [MessageType.AuthAck]: 'AuthAck',
+  [MessageType.FreeUsageOpen]: 'FreeUsageOpen',
+  [MessageType.FreeUsageAuth]: 'FreeUsageAuth',
+  [MessageType.FreeUsageAck]: 'FreeUsageAck',
+  [MessageType.NeedFreeUsageAuth]: 'NeedFreeUsageAuth',
   [MessageType.PaymentRequired]: 'PaymentRequired',
   [MessageType.NeedAuth]: 'NeedAuth',
 };
@@ -32,6 +40,10 @@ export class PaymentMux {
   // Handler registrations
   private _onSpendingAuth?: PaymentMessageHandler<SpendingAuthPayload>;
   private _onAuthAck?: PaymentMessageHandler<AuthAckPayload>;
+  private _onFreeUsageOpen?: PaymentMessageHandler<FreeUsageOpenPayload>;
+  private _onFreeUsageAuth?: PaymentMessageHandler<FreeUsageAuthPayload>;
+  private _onFreeUsageAck?: PaymentMessageHandler<FreeUsageAckPayload>;
+  private _onNeedFreeUsageAuth?: PaymentMessageHandler<NeedFreeUsageAuthPayload>;
   private _onPaymentRequired?: PaymentMessageHandler<PaymentRequiredPayload>;
   private _onNeedAuth?: PaymentMessageHandler<NeedAuthPayload>;
 
@@ -46,6 +58,18 @@ export class PaymentMux {
   onAuthAck(handler: PaymentMessageHandler<AuthAckPayload>): void {
     this._onAuthAck = handler;
   }
+  onFreeUsageOpen(handler: PaymentMessageHandler<FreeUsageOpenPayload>): void {
+    this._onFreeUsageOpen = handler;
+  }
+  onFreeUsageAuth(handler: PaymentMessageHandler<FreeUsageAuthPayload>): void {
+    this._onFreeUsageAuth = handler;
+  }
+  onFreeUsageAck(handler: PaymentMessageHandler<FreeUsageAckPayload>): void {
+    this._onFreeUsageAck = handler;
+  }
+  onNeedFreeUsageAuth(handler: PaymentMessageHandler<NeedFreeUsageAuthPayload>): void {
+    this._onNeedFreeUsageAuth = handler;
+  }
   onPaymentRequired(handler: PaymentMessageHandler<PaymentRequiredPayload>): void {
     this._onPaymentRequired = handler;
   }
@@ -59,6 +83,18 @@ export class PaymentMux {
   }
   sendAuthAck(payload: AuthAckPayload): void {
     this._send(MessageType.AuthAck, codec.encodeAuthAck(payload));
+  }
+  sendFreeUsageOpen(payload: FreeUsageOpenPayload): void {
+    this._send(MessageType.FreeUsageOpen, codec.encodeFreeUsageOpen(payload));
+  }
+  sendFreeUsageAuth(payload: FreeUsageAuthPayload): void {
+    this._send(MessageType.FreeUsageAuth, codec.encodeFreeUsageAuth(payload));
+  }
+  sendFreeUsageAck(payload: FreeUsageAckPayload): void {
+    this._send(MessageType.FreeUsageAck, codec.encodeFreeUsageAck(payload));
+  }
+  sendNeedFreeUsageAuth(payload: NeedFreeUsageAuthPayload): void {
+    this._send(MessageType.NeedFreeUsageAuth, codec.encodeNeedFreeUsageAuth(payload));
   }
   sendPaymentRequired(payload: PaymentRequiredPayload): void {
     this._send(MessageType.PaymentRequired, codec.encodePaymentRequired(payload));
@@ -81,6 +117,18 @@ export class PaymentMux {
         return true;
       case MessageType.AuthAck:
         await this._onAuthAck?.(codec.decodeAuthAck(frame.payload));
+        return true;
+      case MessageType.FreeUsageOpen:
+        await this._onFreeUsageOpen?.(codec.decodeFreeUsageOpen(frame.payload));
+        return true;
+      case MessageType.FreeUsageAuth:
+        await this._onFreeUsageAuth?.(codec.decodeFreeUsageAuth(frame.payload));
+        return true;
+      case MessageType.FreeUsageAck:
+        await this._onFreeUsageAck?.(codec.decodeFreeUsageAck(frame.payload));
+        return true;
+      case MessageType.NeedFreeUsageAuth:
+        await this._onNeedFreeUsageAuth?.(codec.decodeNeedFreeUsageAuth(frame.payload));
         return true;
       case MessageType.PaymentRequired:
         await this._onPaymentRequired?.(codec.decodePaymentRequired(frame.payload));

--- a/packages/node/src/payments/buyer-free-usage-manager.ts
+++ b/packages/node/src/payments/buyer-free-usage-manager.ts
@@ -37,6 +37,7 @@ interface FreeUsageSession {
   services: FreeUsageMetadata['services'];
   openedAck: boolean;
   latestMetadata: FreeUsageMetadata;
+  openSig: string | null;
 }
 
 interface OpenAckWaiter {
@@ -77,6 +78,7 @@ export class BuyerFreeUsageManager {
     if (!this._channelStore) return;
     const activeChannels = this._channelStore.getActiveChannelsByBuyer(CHANNEL_ROLE.BUYER, this._identity.wallet.address, CHANNEL_KIND.FREE);
     for (const channel of activeChannels) {
+      if (this._sessions.has(channel.peerId)) continue;
       const metadata = this._channelStore.getChannelMetadata(channel);
       this._sessions.set(channel.peerId, {
         channelId: channel.sessionId,
@@ -92,6 +94,7 @@ export class BuyerFreeUsageManager {
         services: metadata.services,
         openedAck: true,
         latestMetadata: metadata,
+        openSig: channel.latestBuyerSig,
       });
     }
   }
@@ -132,11 +135,19 @@ export class BuyerFreeUsageManager {
       services: [],
       openedAck: false,
       latestMetadata: metadata,
+      openSig,
     };
     this._sessions.set(peer.peerId, session);
-    this._persistSession(peer.peerId, session, openSig, null, null);
-
-    paymentMux.sendFreeUsageOpen({ channelId, salt, deadline, openSig });
+    try {
+      paymentMux.sendFreeUsageOpen({ channelId, salt, deadline, openSig });
+    } catch (err) {
+      if (existing) {
+        this._sessions.set(peer.peerId, existing);
+      } else {
+        this._sessions.delete(peer.peerId);
+      }
+      throw err;
+    }
     debugLog(`[BuyerFreeUsage] Open sent to ${peer.peerId.slice(0, 12)}... channel=${channelId.slice(0, 18)}...`);
   }
 
@@ -174,6 +185,8 @@ export class BuyerFreeUsageManager {
     const session = this._sessions.get(sellerPeerId);
     if (!session || session.channelId !== payload.channelId) return;
     session.openedAck = true;
+    this._persistSession(sellerPeerId, session, session.openSig, null, null);
+    this._retireOtherActiveSessions(sellerPeerId, session.channelId);
     this._resolveOpenAckWaiters(sellerPeerId, session);
     debugLog(
       `[BuyerFreeUsage] Ack from ${sellerPeerId.slice(0, 12)}... channel=${payload.channelId.slice(0, 18)}...` +
@@ -290,6 +303,19 @@ export class BuyerFreeUsageManager {
     if (!waiters) return;
     waiters.delete(waiter);
     if (waiters.size === 0) this._openAckWaiters.delete(sellerPeerId);
+  }
+
+  private _retireOtherActiveSessions(sellerPeerId: string, keepSessionId: string): void {
+    if (!this._channelStore) return;
+    const activeChannels = this._channelStore.getActiveChannelsByBuyer(
+      CHANNEL_ROLE.BUYER,
+      this._identity.wallet.address,
+      CHANNEL_KIND.FREE,
+    );
+    for (const channel of activeChannels) {
+      if (channel.peerId !== sellerPeerId || channel.sessionId === keepSessionId) continue;
+      this._channelStore.updateChannelStatus(channel.sessionId, CHANNEL_STATUS.GHOST);
+    }
   }
 
   private _persistSession(

--- a/packages/node/src/payments/buyer-free-usage-manager.ts
+++ b/packages/node/src/payments/buyer-free-usage-manager.ts
@@ -45,6 +45,7 @@ export class BuyerFreeUsageManager {
   private readonly _channelStore?: ChannelStore;
   private readonly _domain: ReturnType<typeof makeFreeUsageDomain>;
   private readonly _sessions = new Map<string, FreeUsageSession>();
+  private readonly _sellerLocks = new Map<string, Promise<void>>();
   private readonly _requestService = new RequestServiceTracker();
 
   constructor(
@@ -138,9 +139,22 @@ export class BuyerFreeUsageManager {
 
   onPeerDisconnect(sellerPeerId: string): void {
     this._sessions.delete(sellerPeerId);
+    this._sellerLocks.delete(sellerPeerId);
   }
 
   async handleNeedAuth(
+    sellerPeerId: string,
+    payload: NeedFreeUsageAuthPayload,
+    paymentMux: PaymentMux,
+  ): Promise<void> {
+    const lock = (this._sellerLocks.get(sellerPeerId) ?? Promise.resolve()).then(async () => {
+      await this._handleNeedAuthInner(sellerPeerId, payload, paymentMux);
+    });
+    this._sellerLocks.set(sellerPeerId, lock.catch(() => {}));
+    return lock;
+  }
+
+  private async _handleNeedAuthInner(
     sellerPeerId: string,
     payload: NeedFreeUsageAuthPayload,
     paymentMux: PaymentMux,

--- a/packages/node/src/payments/buyer-free-usage-manager.ts
+++ b/packages/node/src/payments/buyer-free-usage-manager.ts
@@ -1,0 +1,240 @@
+import { randomBytes } from 'node:crypto';
+import type { Identity } from '../p2p/identity.js';
+import type { PaymentMux } from '../p2p/payment-mux.js';
+import type { PeerInfo } from '../types/peer.js';
+import type { FreeUsageAckPayload, NeedFreeUsageAuthPayload } from '../types/protocol.js';
+import type { SellerAddressResolver } from '../discovery/seller-address-resolver.js';
+import { peerIdToAddress } from '../types/peer.js';
+import { debugLog, debugWarn } from '../utils/debug.js';
+import {
+  computeFreeUsageChannelId,
+  computeFreeUsageMetadataHash,
+  encodeFreeUsageMetadata,
+  makeFreeUsageDomain,
+  signFreeUsageAuth,
+  signFreeUsageOpen,
+  type FreeUsageMetadata,
+} from './evm/signatures.js';
+import type { ChannelStore } from './channel-store.js';
+import { advanceUsageMetadata, RequestServiceTracker } from './channel-usage-accounting.js';
+
+export interface BuyerFreeUsageConfig {
+  chainId: number;
+  freeUsageContractAddress: string;
+  defaultAuthDurationSecs: number;
+}
+
+interface FreeUsageSession {
+  channelId: string;
+  salt: string;
+  deadline: number;
+  sellerEvmAddr: string;
+  cumulativeInputTokens: bigint;
+  cumulativeOutputTokens: bigint;
+  cumulativeRequestCount: bigint;
+  latestSequence: bigint;
+  services: FreeUsageMetadata['services'];
+  openedAck: boolean;
+  latestMetadata: FreeUsageMetadata;
+}
+
+export class BuyerFreeUsageManager {
+  private readonly _identity: Identity;
+  private readonly _config: BuyerFreeUsageConfig;
+  private readonly _sellerAddressResolver?: SellerAddressResolver;
+  private readonly _channelStore?: ChannelStore;
+  private readonly _domain: ReturnType<typeof makeFreeUsageDomain>;
+  private readonly _sessions = new Map<string, FreeUsageSession>();
+  private readonly _requestService = new RequestServiceTracker();
+
+  constructor(
+    identity: Identity,
+    config: BuyerFreeUsageConfig,
+    sellerAddressResolver?: SellerAddressResolver,
+    channelStore?: ChannelStore,
+  ) {
+    this._identity = identity;
+    this._config = config;
+    this._sellerAddressResolver = sellerAddressResolver;
+    this._channelStore = channelStore;
+    this._domain = makeFreeUsageDomain(config.chainId, config.freeUsageContractAddress);
+    this._hydrateFromStore();
+  }
+
+  private _hydrateFromStore(): void {
+    if (!this._channelStore) return;
+    const activeChannels = this._channelStore.getActiveChannelsByBuyer('buyer', this._identity.wallet.address, 'free');
+    for (const channel of activeChannels) {
+      const metadata = this._channelStore.getChannelMetadata(channel);
+      this._sessions.set(channel.peerId, {
+        channelId: channel.sessionId,
+        salt: '0x' + '00'.repeat(32),
+        deadline: channel.deadline,
+        sellerEvmAddr: channel.sellerEvmAddr,
+        cumulativeInputTokens: metadata.cumulativeInputTokens,
+        cumulativeOutputTokens: metadata.cumulativeOutputTokens,
+        cumulativeRequestCount: metadata.cumulativeRequestCount,
+        latestSequence: BigInt(channel.requestCount),
+        services: metadata.services,
+        openedAck: true,
+        latestMetadata: metadata,
+      });
+    }
+  }
+
+  trackRequestService(requestId: string, service: string): void {
+    this._requestService.track(requestId, service);
+  }
+
+  async prepareOpen(peer: PeerInfo, paymentMux: PaymentMux): Promise<void> {
+    const existing = this._sessions.get(peer.peerId);
+    const nowSec = Math.floor(Date.now() / 1000);
+    if (existing && existing.deadline > nowSec + 30) return;
+
+    const sellerEvmAddr = await this._resolveSellerAddr(peer);
+    const salt = '0x' + randomBytes(32).toString('hex');
+    const channelId = computeFreeUsageChannelId(this._identity.wallet.address, sellerEvmAddr, salt);
+    const deadline = nowSec + this._config.defaultAuthDurationSecs;
+    const openSig = await signFreeUsageOpen(this._identity.wallet, this._domain, {
+      channelId,
+      deadline: BigInt(deadline),
+    });
+    const metadata: FreeUsageMetadata = {
+      cumulativeInputTokens: 0n,
+      cumulativeOutputTokens: 0n,
+      cumulativeRequestCount: 0n,
+      services: [],
+    };
+
+    const session: FreeUsageSession = {
+      channelId,
+      salt,
+      deadline,
+      sellerEvmAddr,
+      cumulativeInputTokens: 0n,
+      cumulativeOutputTokens: 0n,
+      cumulativeRequestCount: 0n,
+      latestSequence: 0n,
+      services: [],
+      openedAck: false,
+      latestMetadata: metadata,
+    };
+    this._sessions.set(peer.peerId, session);
+    this._persistSession(peer.peerId, session, openSig, null, null);
+
+    paymentMux.sendFreeUsageOpen({ channelId, salt, deadline, openSig });
+    debugLog(`[BuyerFreeUsage] Open sent to ${peer.peerId.slice(0, 12)}... channel=${channelId.slice(0, 18)}...`);
+  }
+
+  handleAck(sellerPeerId: string, payload: FreeUsageAckPayload): void {
+    const session = this._sessions.get(sellerPeerId);
+    if (!session || session.channelId !== payload.channelId) return;
+    session.openedAck = true;
+    debugLog(
+      `[BuyerFreeUsage] Ack from ${sellerPeerId.slice(0, 12)}... channel=${payload.channelId.slice(0, 18)}...` +
+      `${payload.acceptedSequence ? ` sequence=${payload.acceptedSequence}` : ''}`,
+    );
+  }
+
+  async handleNeedAuth(
+    sellerPeerId: string,
+    payload: NeedFreeUsageAuthPayload,
+    paymentMux: PaymentMux,
+  ): Promise<void> {
+    const session = this._sessions.get(sellerPeerId);
+    if (!session || session.channelId !== payload.channelId) {
+      debugWarn(`[BuyerFreeUsage] NeedFreeUsageAuth for unknown channel ${payload.channelId.slice(0, 18)}...`);
+      return;
+    }
+
+    const requiredSequence = BigInt(payload.requiredSequence);
+    if (requiredSequence <= session.latestSequence) {
+      return;
+    }
+
+    const inputTokens = BigInt(payload.inputTokens ?? '0');
+    const outputTokens = BigInt(payload.outputTokens ?? '0');
+    const attributedService = this._requestService.take(payload.requestId) ?? payload.service;
+    session.latestSequence = requiredSequence;
+
+    const metadata = advanceUsageMetadata(session.latestMetadata, attributedService, {
+      amount: 0n,
+      inputTokens,
+      cachedInputTokens: 0n,
+      outputTokens,
+      requests: 1n,
+    });
+    session.cumulativeInputTokens = metadata.cumulativeInputTokens;
+    session.cumulativeOutputTokens = metadata.cumulativeOutputTokens;
+    session.cumulativeRequestCount = metadata.cumulativeRequestCount;
+    session.services = metadata.services;
+    session.latestMetadata = metadata;
+    const metadataHash = computeFreeUsageMetadataHash(metadata);
+    const encodedMetadata = encodeFreeUsageMetadata(metadata);
+    const usageSig = await signFreeUsageAuth(this._identity.wallet, this._domain, {
+      channelId: session.channelId,
+      sequence: session.latestSequence,
+      metadataHash,
+      deadline: BigInt(session.deadline),
+    });
+
+    this._persistSession(sellerPeerId, session, null, usageSig, encodedMetadata);
+
+    paymentMux.sendFreeUsageAuth({
+      channelId: session.channelId,
+      cumulativeInputTokens: session.cumulativeInputTokens.toString(),
+      cumulativeOutputTokens: session.cumulativeOutputTokens.toString(),
+      sequence: session.latestSequence.toString(),
+      metadataHash,
+      metadata: encodedMetadata,
+      deadline: session.deadline,
+      usageSig,
+    });
+    debugLog(
+      `[BuyerFreeUsage] UsageAuth sent to ${sellerPeerId.slice(0, 12)}... ` +
+      `channel=${session.channelId.slice(0, 18)}... sequence=${session.latestSequence}`,
+    );
+  }
+
+  private async _resolveSellerAddr(peer: PeerInfo): Promise<string> {
+    if (!this._sellerAddressResolver) return peerIdToAddress(peer.peerId);
+    return this._sellerAddressResolver.resolveSellerAddress(peer.peerId, peer.metadata);
+  }
+
+  private _persistSession(
+    sellerPeerId: string,
+    session: FreeUsageSession,
+    openSig: string | null,
+    usageSig: string | null,
+    encodedMetadata: string | null,
+  ): void {
+    if (!this._channelStore) return;
+    const now = Date.now();
+    const existing = this._channelStore.getChannel(session.channelId);
+    this._channelStore.upsertChannel({
+      sessionId: session.channelId,
+      peerId: sellerPeerId,
+      role: 'buyer',
+      channelKind: 'free',
+      sellerEvmAddr: session.sellerEvmAddr,
+      buyerEvmAddr: this._identity.wallet.address,
+      nonce: 0,
+      authMax: '0',
+      deadline: session.deadline,
+      previousSessionId: '0x' + '00'.repeat(32),
+      previousConsumption: session.cumulativeOutputTokens.toString(),
+      tokensDelivered: session.cumulativeInputTokens.toString(),
+      requestCount: Number(session.cumulativeRequestCount),
+      reservedAt: existing?.reservedAt ?? now,
+      settledAt: null,
+      settledAmount: null,
+      status: 'active',
+      latestBuyerSig: openSig ?? existing?.latestBuyerSig ?? null,
+      latestSpendingAuthSig: usageSig ?? existing?.latestSpendingAuthSig ?? null,
+      latestMetadata: encodedMetadata ?? existing?.latestMetadata ?? null,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    });
+    this._channelStore.replaceMetadataServiceTotals(session.channelId, session.services);
+  }
+}

--- a/packages/node/src/payments/buyer-free-usage-manager.ts
+++ b/packages/node/src/payments/buyer-free-usage-manager.ts
@@ -136,6 +136,10 @@ export class BuyerFreeUsageManager {
     );
   }
 
+  onPeerDisconnect(sellerPeerId: string): void {
+    this._sessions.delete(sellerPeerId);
+  }
+
   async handleNeedAuth(
     sellerPeerId: string,
     payload: NeedFreeUsageAuthPayload,
@@ -154,8 +158,7 @@ export class BuyerFreeUsageManager {
 
     const inputTokens = BigInt(payload.inputTokens ?? '0');
     const outputTokens = BigInt(payload.outputTokens ?? '0');
-    const attributedService = this._requestService.take(payload.requestId) ?? payload.service;
-    session.latestSequence = requiredSequence;
+    const attributedService = this._requestService.get(payload.requestId) ?? payload.service;
 
     const metadata = advanceUsageMetadata(session.latestMetadata, attributedService, {
       amount: 0n,
@@ -164,32 +167,34 @@ export class BuyerFreeUsageManager {
       outputTokens,
       requests: 1n,
     });
-    session.cumulativeInputTokens = metadata.cumulativeInputTokens;
-    session.cumulativeOutputTokens = metadata.cumulativeOutputTokens;
-    session.cumulativeRequestCount = metadata.cumulativeRequestCount;
-    session.services = metadata.services;
-    session.latestMetadata = metadata;
     const metadataHash = computeFreeUsageMetadataHash(metadata);
     const encodedMetadata = encodeFreeUsageMetadata(metadata);
     const usageSig = await signFreeUsageAuth(this._identity.wallet, this._domain, {
       channelId: session.channelId,
-      sequence: session.latestSequence,
+      sequence: requiredSequence,
       metadataHash,
       deadline: BigInt(session.deadline),
     });
 
-    this._persistSession(sellerPeerId, session, null, usageSig, encodedMetadata);
-
     paymentMux.sendFreeUsageAuth({
       channelId: session.channelId,
-      cumulativeInputTokens: session.cumulativeInputTokens.toString(),
-      cumulativeOutputTokens: session.cumulativeOutputTokens.toString(),
-      sequence: session.latestSequence.toString(),
+      cumulativeInputTokens: metadata.cumulativeInputTokens.toString(),
+      cumulativeOutputTokens: metadata.cumulativeOutputTokens.toString(),
+      sequence: requiredSequence.toString(),
       metadataHash,
       metadata: encodedMetadata,
       deadline: session.deadline,
       usageSig,
     });
+
+    session.latestSequence = requiredSequence;
+    session.cumulativeInputTokens = metadata.cumulativeInputTokens;
+    session.cumulativeOutputTokens = metadata.cumulativeOutputTokens;
+    session.cumulativeRequestCount = metadata.cumulativeRequestCount;
+    session.services = metadata.services;
+    session.latestMetadata = metadata;
+    this._requestService.take(payload.requestId);
+    this._persistSession(sellerPeerId, session, null, usageSig, encodedMetadata);
     debugLog(
       `[BuyerFreeUsage] UsageAuth sent to ${sellerPeerId.slice(0, 12)}... ` +
       `channel=${session.channelId.slice(0, 18)}... sequence=${session.latestSequence}`,

--- a/packages/node/src/payments/buyer-free-usage-manager.ts
+++ b/packages/node/src/payments/buyer-free-usage-manager.ts
@@ -15,7 +15,7 @@ import {
   signFreeUsageOpen,
   type FreeUsageMetadata,
 } from './evm/signatures.js';
-import type { ChannelStore } from './channel-store.js';
+import { CHANNEL_KIND, CHANNEL_ROLE, CHANNEL_STATUS, type ChannelStore } from './channel-store.js';
 import { advanceUsageMetadata, RequestServiceTracker } from './channel-usage-accounting.js';
 
 export interface BuyerFreeUsageConfig {
@@ -64,7 +64,7 @@ export class BuyerFreeUsageManager {
 
   private _hydrateFromStore(): void {
     if (!this._channelStore) return;
-    const activeChannels = this._channelStore.getActiveChannelsByBuyer('buyer', this._identity.wallet.address, 'free');
+    const activeChannels = this._channelStore.getActiveChannelsByBuyer(CHANNEL_ROLE.BUYER, this._identity.wallet.address, CHANNEL_KIND.FREE);
     for (const channel of activeChannels) {
       const metadata = this._channelStore.getChannelMetadata(channel);
       this._sessions.set(channel.peerId, {
@@ -233,8 +233,8 @@ export class BuyerFreeUsageManager {
     this._channelStore.upsertChannel({
       sessionId: session.channelId,
       peerId: sellerPeerId,
-      role: 'buyer',
-      channelKind: 'free',
+      role: CHANNEL_ROLE.BUYER,
+      channelKind: CHANNEL_KIND.FREE,
       sellerEvmAddr: session.sellerEvmAddr,
       buyerEvmAddr: this._identity.wallet.address,
       nonce: 0,
@@ -247,7 +247,7 @@ export class BuyerFreeUsageManager {
       reservedAt: existing?.reservedAt ?? now,
       settledAt: null,
       settledAmount: null,
-      status: 'active',
+      status: CHANNEL_STATUS.ACTIVE,
       latestBuyerSig: openSig ?? existing?.latestBuyerSig ?? null,
       latestSpendingAuthSig: usageSig ?? existing?.latestSpendingAuthSig ?? null,
       latestMetadata: encodedMetadata ?? existing?.latestMetadata ?? null,

--- a/packages/node/src/payments/buyer-free-usage-manager.ts
+++ b/packages/node/src/payments/buyer-free-usage-manager.ts
@@ -22,6 +22,7 @@ export interface BuyerFreeUsageConfig {
   chainId: number;
   freeUsageContractAddress: string;
   defaultAuthDurationSecs: number;
+  openAckTimeoutMs?: number;
 }
 
 interface FreeUsageSession {
@@ -38,6 +39,15 @@ interface FreeUsageSession {
   latestMetadata: FreeUsageMetadata;
 }
 
+interface OpenAckWaiter {
+  session: FreeUsageSession;
+  resolve: () => void;
+  reject: (err: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const DEFAULT_OPEN_ACK_TIMEOUT_MS = 30_000;
+
 export class BuyerFreeUsageManager {
   private readonly _identity: Identity;
   private readonly _config: BuyerFreeUsageConfig;
@@ -46,6 +56,7 @@ export class BuyerFreeUsageManager {
   private readonly _domain: ReturnType<typeof makeFreeUsageDomain>;
   private readonly _sessions = new Map<string, FreeUsageSession>();
   private readonly _sellerLocks = new Map<string, Promise<void>>();
+  private readonly _openAckWaiters = new Map<string, Set<OpenAckWaiter>>();
   private readonly _requestService = new RequestServiceTracker();
 
   constructor(
@@ -69,6 +80,8 @@ export class BuyerFreeUsageManager {
       const metadata = this._channelStore.getChannelMetadata(channel);
       this._sessions.set(channel.peerId, {
         channelId: channel.sessionId,
+        // Salt is only needed to create a fresh open signature; hydrated
+        // sessions are already opened and only sign usage auths.
         salt: '0x' + '00'.repeat(32),
         deadline: channel.deadline,
         sellerEvmAddr: channel.sellerEvmAddr,
@@ -127,10 +140,41 @@ export class BuyerFreeUsageManager {
     debugLog(`[BuyerFreeUsage] Open sent to ${peer.peerId.slice(0, 12)}... channel=${channelId.slice(0, 18)}...`);
   }
 
+  async waitForOpenAck(sellerPeerId: string, timeoutMs = this._config.openAckTimeoutMs ?? DEFAULT_OPEN_ACK_TIMEOUT_MS): Promise<void> {
+    const session = this._sessions.get(sellerPeerId);
+    if (!session) {
+      throw new Error(`free usage channel for ${sellerPeerId.slice(0, 12)}... was not prepared`);
+    }
+    if (session.openedAck) return;
+
+    await new Promise<void>((resolve, reject) => {
+      const waiter: OpenAckWaiter = {
+        session,
+        resolve,
+        reject,
+        timer: setTimeout(() => {
+          this._removeOpenAckWaiter(sellerPeerId, waiter);
+          if (this._sessions.get(sellerPeerId) === session && !session.openedAck) {
+            this._sessions.delete(sellerPeerId);
+            this._channelStore?.updateChannelStatus(session.channelId, CHANNEL_STATUS.TIMEOUT);
+          }
+          reject(new Error(`timed out waiting for free usage open ack from ${sellerPeerId.slice(0, 12)}...`));
+        }, timeoutMs),
+      };
+      let waiters = this._openAckWaiters.get(sellerPeerId);
+      if (!waiters) {
+        waiters = new Set();
+        this._openAckWaiters.set(sellerPeerId, waiters);
+      }
+      waiters.add(waiter);
+    });
+  }
+
   handleAck(sellerPeerId: string, payload: FreeUsageAckPayload): void {
     const session = this._sessions.get(sellerPeerId);
     if (!session || session.channelId !== payload.channelId) return;
     session.openedAck = true;
+    this._resolveOpenAckWaiters(sellerPeerId, session);
     debugLog(
       `[BuyerFreeUsage] Ack from ${sellerPeerId.slice(0, 12)}... channel=${payload.channelId.slice(0, 18)}...` +
       `${payload.acceptedSequence ? ` sequence=${payload.acceptedSequence}` : ''}`,
@@ -140,6 +184,7 @@ export class BuyerFreeUsageManager {
   onPeerDisconnect(sellerPeerId: string): void {
     this._sessions.delete(sellerPeerId);
     this._sellerLocks.delete(sellerPeerId);
+    this._rejectOpenAckWaiters(sellerPeerId, new Error(`peer ${sellerPeerId.slice(0, 12)}... disconnected before free usage open ack`));
   }
 
   async handleNeedAuth(
@@ -218,6 +263,33 @@ export class BuyerFreeUsageManager {
   private async _resolveSellerAddr(peer: PeerInfo): Promise<string> {
     if (!this._sellerAddressResolver) return peerIdToAddress(peer.peerId);
     return this._sellerAddressResolver.resolveSellerAddress(peer.peerId, peer.metadata);
+  }
+
+  private _resolveOpenAckWaiters(sellerPeerId: string, session: FreeUsageSession): void {
+    const waiters = this._openAckWaiters.get(sellerPeerId);
+    if (!waiters) return;
+    for (const waiter of [...waiters]) {
+      if (waiter.session !== session) continue;
+      this._removeOpenAckWaiter(sellerPeerId, waiter);
+      waiter.resolve();
+    }
+  }
+
+  private _rejectOpenAckWaiters(sellerPeerId: string, err: Error): void {
+    const waiters = this._openAckWaiters.get(sellerPeerId);
+    if (!waiters) return;
+    for (const waiter of [...waiters]) {
+      this._removeOpenAckWaiter(sellerPeerId, waiter);
+      waiter.reject(err);
+    }
+  }
+
+  private _removeOpenAckWaiter(sellerPeerId: string, waiter: OpenAckWaiter): void {
+    clearTimeout(waiter.timer);
+    const waiters = this._openAckWaiters.get(sellerPeerId);
+    if (!waiters) return;
+    waiters.delete(waiter);
+    if (waiters.size === 0) this._openAckWaiters.delete(sellerPeerId);
   }
 
   private _persistSession(

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -23,7 +23,7 @@ import { debugLog, debugWarn } from '../utils/debug.js';
 import { peerIdToAddress, type PeerId } from '../types/peer.js';
 import type { SellerAddressResolver } from '../discovery/seller-address-resolver.js';
 import type { PeerMetadata } from '../discovery/peer-metadata.js';
-import { ChannelStore, type StoredChannel } from './channel-store.js';
+import { ChannelStore, CHANNEL_ROLE, CHANNEL_STATUS, type StoredChannel } from './channel-store.js';
 import { advanceUsageMetadata, CountedRequestTracker, RequestServiceTracker } from './channel-usage-accounting.js';
 import { estimateCostFromBytes, computeCostUsdc, type ServicePricing } from './pricing.js';
 
@@ -130,7 +130,7 @@ export class BuyerPaymentManager {
 
   /** Hydrate cumulative tracking maps from persisted active buyer sessions. */
   private _hydrateFromStore(): void {
-    const activeChannels = this._channelStore.getActiveChannelsByBuyer('buyer', this._identity.wallet.address);
+    const activeChannels = this._channelStore.getActiveChannelsByBuyer(CHANNEL_ROLE.BUYER, this._identity.wallet.address);
     for (const channel of activeChannels) {
       const peerId = channel.peerId;
       const persistedCumulative = BigInt(channel.authMax);
@@ -182,12 +182,12 @@ export class BuyerPaymentManager {
   }
 
   getActiveSession(sellerPeerId: string): StoredChannel | null {
-    return this._channelStore.getActiveChannelByPeerAndBuyer(sellerPeerId, 'buyer', this._identity.wallet.address);
+    return this._channelStore.getActiveChannelByPeerAndBuyer(sellerPeerId, CHANNEL_ROLE.BUYER, this._identity.wallet.address);
   }
 
   retireSession(
     sellerPeerId: string,
-    status: Extract<StoredChannel['status'], 'settled' | 'timeout' | 'ghost'>,
+    status: typeof CHANNEL_STATUS.SETTLED | typeof CHANNEL_STATUS.TIMEOUT | typeof CHANNEL_STATUS.GHOST,
     settledAmount?: bigint,
   ): void {
     const session = this.getActiveSession(sellerPeerId);
@@ -515,7 +515,7 @@ export class BuyerPaymentManager {
     const session: StoredChannel = {
       sessionId: channelId,
       peerId: sellerPeerId,
-      role: 'buyer',
+      role: CHANNEL_ROLE.BUYER,
       sellerEvmAddr,
       buyerEvmAddr: this._identity.wallet.address,
       nonce: 0,
@@ -528,7 +528,7 @@ export class BuyerPaymentManager {
       reservedAt: now,
       settledAt: null,
       settledAmount: null,
-      status: 'active',
+      status: CHANNEL_STATUS.ACTIVE,
       latestBuyerSig: null,
       latestSpendingAuthSig: null,
       latestMetadata: null,

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -14,17 +14,17 @@ import {
   makeChannelsDomain,
   computeMetadataHash,
   encodeMetadata,
-  getServiceMetadataId,
   ZERO_METADATA,
   ZERO_METADATA_HASH,
   computeChannelId,
 } from './evm/signatures.js';
-import type { SpendingAuthMessage, ReserveAuthMessage, SpendingAuthMetadata, SpendingAuthServiceMetadata } from './evm/signatures.js';
+import type { SpendingAuthMessage, ReserveAuthMessage, SpendingAuthMetadata } from './evm/signatures.js';
 import { debugLog, debugWarn } from '../utils/debug.js';
 import { peerIdToAddress, type PeerId } from '../types/peer.js';
 import type { SellerAddressResolver } from '../discovery/seller-address-resolver.js';
 import type { PeerMetadata } from '../discovery/peer-metadata.js';
 import { ChannelStore, type StoredChannel } from './channel-store.js';
+import { advanceUsageMetadata, CountedRequestTracker, RequestServiceTracker } from './channel-usage-accounting.js';
 import { estimateCostFromBytes, computeCostUsdc, type ServicePricing } from './pricing.js';
 
 /** Default tolerance: accept seller claims up to 1.4x buyer's estimate. */
@@ -92,7 +92,7 @@ export class BuyerPaymentManager {
   /** requestId -> service/model the buyer requested (from its own request body).
    *  Used in handleNeedAuth to validate cost with the correct pricing tier
    *  without trusting the seller's claim of which service was used. */
-  private readonly _requestService = new Map<string, string>();
+  private readonly _requestService = new RequestServiceTracker();
 
   /** sellerPeerId -> full pricing map (defaults + per-service overrides from peer metadata / 402) */
   private readonly _sessionPricing = new Map<string, { defaults: ServicePricing; services: Record<string, ServicePricing> }>();
@@ -134,21 +134,8 @@ export class BuyerPaymentManager {
     for (const channel of activeChannels) {
       const peerId = channel.peerId;
       const persistedCumulative = BigInt(channel.authMax);
-      const persistedServiceTotals = this._channelStore.getServiceTotals(channel.sessionId);
       this._cumulativeAmount.set(peerId, persistedCumulative);
-      this._metadata.set(peerId, {
-        cumulativeInputTokens: BigInt(channel.tokensDelivered),
-        cumulativeOutputTokens: BigInt(channel.previousConsumption),
-        cumulativeRequestCount: BigInt(channel.requestCount),
-        services: persistedServiceTotals.map((total) => ({
-          serviceId: total.serviceId,
-          cumulativeAmount: BigInt(total.cumulativeAmount),
-          cumulativeInputTokens: BigInt(total.cumulativeInputTokens),
-          cumulativeCachedInputTokens: BigInt(total.cumulativeCachedInputTokens),
-          cumulativeOutputTokens: BigInt(total.cumulativeOutputTokens),
-          cumulativeRequestCount: BigInt(total.cumulativeRequestCount),
-        })),
-      });
+      this._metadata.set(peerId, this._channelStore.getChannelMetadata(channel));
       // Hydrate verifiedCost to authMax so _maxSignable can grow beyond maxPerRequestUsdc.
       // Without this, maxSignable = 0 + maxPerRequestUsdc after restart, permanently capping
       // the cumulative and causing non-monotonic SpendingAuth rejections on the seller.
@@ -380,79 +367,16 @@ export class BuyerPaymentManager {
     return requestedAmount > maxSignable && maxSignable >= ceiling;
   }
 
-  private _withServiceMetadata(
-    metadata: SpendingAuthMetadata,
-    service: string | undefined,
-    delta: {
-      amount: bigint;
-      inputTokens: bigint;
-      cachedInputTokens: bigint;
-      outputTokens: bigint;
-      requests: bigint;
-    },
-  ): SpendingAuthMetadata {
-    if (!service || service.trim().length === 0) return metadata;
-
-    const serviceId = getServiceMetadataId(service);
-    const byServiceId = new Map<string, SpendingAuthServiceMetadata>();
-    for (const entry of metadata.services ?? []) {
-      byServiceId.set(entry.serviceId, { ...entry });
-    }
-
-    const existing = byServiceId.get(serviceId) ?? {
-      serviceId,
-      cumulativeAmount: 0n,
-      cumulativeInputTokens: 0n,
-      cumulativeCachedInputTokens: 0n,
-      cumulativeOutputTokens: 0n,
-      cumulativeRequestCount: 0n,
-    };
-
-    byServiceId.set(serviceId, {
-      serviceId,
-      cumulativeAmount: existing.cumulativeAmount + delta.amount,
-      cumulativeInputTokens: existing.cumulativeInputTokens + delta.inputTokens,
-      cumulativeCachedInputTokens: existing.cumulativeCachedInputTokens + delta.cachedInputTokens,
-      cumulativeOutputTokens: existing.cumulativeOutputTokens + delta.outputTokens,
-      cumulativeRequestCount: existing.cumulativeRequestCount + delta.requests,
-    });
-
-    return {
-      ...metadata,
-      services: [...byServiceId.values()].sort((a, b) =>
-        a.serviceId < b.serviceId ? -1 : a.serviceId > b.serviceId ? 1 : 0,
-      ),
-    };
-  }
-
   /**
    * Both signPerRequestAuth (buyer-initiated) and handleNeedAuth (seller-initiated)
    * can fire for the same request when the proactive auth doesn't fully cover the
    * seller's required cumulative. Whichever path counts a request's tokens first
    * records its requestId here so the other path attributes only the amount delta.
    */
-  private readonly _serviceTokensCounted = new Set<string>();
-
-  private _markServiceTokensCounted(requestId: string): void {
-    if (this._serviceTokensCounted.size >= 512) {
-      const oldest = this._serviceTokensCounted.values().next().value;
-      if (oldest !== undefined) this._serviceTokensCounted.delete(oldest);
-    }
-    this._serviceTokensCounted.add(requestId);
-  }
+  private readonly _serviceTokensCounted = new CountedRequestTracker();
 
   private _persistServiceMetadata(sessionId: string, metadata: SpendingAuthMetadata): void {
-    this._channelStore.replaceServiceTotals(
-      sessionId,
-      (metadata.services ?? []).map((service) => ({
-        serviceId: service.serviceId,
-        cumulativeAmount: service.cumulativeAmount.toString(),
-        cumulativeInputTokens: service.cumulativeInputTokens.toString(),
-        cumulativeCachedInputTokens: service.cumulativeCachedInputTokens.toString(),
-        cumulativeOutputTokens: service.cumulativeOutputTokens.toString(),
-        cumulativeRequestCount: service.cumulativeRequestCount.toString(),
-      })),
-    );
+    this._channelStore.replaceMetadataServiceTotals(sessionId, metadata.services);
   }
 
   private async _sendUpdatedSpendingAuth(
@@ -851,30 +775,22 @@ export class BuyerPaymentManager {
     const signedDelta = newAmount - prevAmount;
 
     // Update cumulative metadata
-    const prev = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
-    const totalsMeta: SpendingAuthMetadata = {
-      cumulativeInputTokens: prev.cumulativeInputTokens + estimatedInputTokens,
-      cumulativeOutputTokens: prev.cumulativeOutputTokens + estimatedOutputTokens,
-      cumulativeRequestCount: prev.cumulativeRequestCount + 1n,
-      services: prev.services ?? [],
-    };
     // If handleNeedAuth already counted this request (seller-initiated NeedAuth
     // raced ahead), skip service attribution entirely: service totals are
     // documented as lower bounds, so undercounting beats double-counting.
-    const alreadyCounted =
-      responseStats.requestId != null && this._serviceTokensCounted.has(responseStats.requestId);
-    const newMeta = alreadyCounted
-      ? totalsMeta
-      : this._withServiceMetadata(totalsMeta, responseStats.service, {
-          amount: signedDelta,
-          inputTokens: estimatedInputTokens,
-          cachedInputTokens: estimatedCachedInputTokens,
-          outputTokens: estimatedOutputTokens,
-          requests: 1n,
-        });
-    if (responseStats.requestId != null && !alreadyCounted) {
-      this._markServiceTokensCounted(responseStats.requestId);
-    }
+    const alreadyCounted = this._serviceTokensCounted.has(responseStats.requestId);
+    const newMeta = advanceUsageMetadata(
+      this._metadata.get(sellerPeerId),
+      alreadyCounted ? undefined : responseStats.service,
+      {
+        amount: signedDelta,
+        inputTokens: estimatedInputTokens,
+        cachedInputTokens: estimatedCachedInputTokens,
+        outputTokens: estimatedOutputTokens,
+        requests: 1n,
+      },
+    );
+    if (!alreadyCounted) this._serviceTokensCounted.mark(responseStats.requestId);
     this._metadata.set(sellerPeerId, newMeta);
     this._persistServiceMetadata(session.sessionId, newMeta);
 
@@ -938,7 +854,7 @@ export class BuyerPaymentManager {
       return;
     }
 
-    const buyerService = payload.requestId ? this._requestService.get(payload.requestId) : undefined;
+    const buyerService = this._requestService.get(payload.requestId);
 
     const requiredCumulativeAmount = BigInt(payload.requiredCumulativeAmount);
     const currentCumulative = this._cumulativeAmount.get(sellerPeerId) ?? 0n;
@@ -950,8 +866,7 @@ export class BuyerPaymentManager {
       );
       return;
     }
-    if (payload.requestId) this._requestService.delete(payload.requestId);
-
+    this._requestService.take(payload.requestId);
     let acceptedServiceCost = 0n;
     const reportedInputTokens = BigInt(payload.inputTokens ?? '0');
     const reportedCachedInputTokens = BigInt(payload.cachedInputTokens ?? '0');
@@ -1048,31 +963,23 @@ export class BuyerPaymentManager {
     const serviceAmountDelta = acceptedServiceCost > 0n
       ? (acceptedServiceCost < signedDelta ? acceptedServiceCost : signedDelta)
       : 0n;
-    const prevMeta = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
-    const totalsMeta: SpendingAuthMetadata = {
-      cumulativeInputTokens: prevMeta.cumulativeInputTokens + reportedInputTokens,
-      cumulativeOutputTokens: prevMeta.cumulativeOutputTokens + reportedOutputTokens,
-      cumulativeRequestCount: prevMeta.cumulativeRequestCount + 1n,
-      services: prevMeta.services ?? [],
-    };
     // If signPerRequestAuth already counted this request (buyer-initiated auth
     // raced ahead but didn't fully cover the seller's required cumulative), skip
     // service attribution entirely: service totals are documented as lower
     // bounds, so undercounting beats double-counting.
-    const alreadyCounted =
-      payload.requestId != null && this._serviceTokensCounted.has(payload.requestId);
-    const newMeta = alreadyCounted
-      ? totalsMeta
-      : this._withServiceMetadata(totalsMeta, buyerService, {
-          amount: serviceAmountDelta,
-          inputTokens: reportedInputTokens,
-          cachedInputTokens: reportedCachedInputTokens,
-          outputTokens: reportedOutputTokens,
-          requests: 1n,
-        });
-    if (payload.requestId != null && !alreadyCounted) {
-      this._markServiceTokensCounted(payload.requestId);
-    }
+    const alreadyCounted = this._serviceTokensCounted.has(payload.requestId);
+    const newMeta = advanceUsageMetadata(
+      this._metadata.get(sellerPeerId),
+      alreadyCounted ? undefined : buyerService,
+      {
+        amount: serviceAmountDelta,
+        inputTokens: reportedInputTokens,
+        cachedInputTokens: reportedCachedInputTokens,
+        outputTokens: reportedOutputTokens,
+        requests: 1n,
+      },
+    );
+    if (!alreadyCounted) this._serviceTokensCounted.mark(payload.requestId);
     this._metadata.set(sellerPeerId, newMeta);
 
     // Send via PaymentMux
@@ -1241,7 +1148,7 @@ export class BuyerPaymentManager {
 
   /** Register which service the buyer requested for a given requestId. */
   trackRequestService(requestId: string, service: string): void {
-    this._requestService.set(requestId, service);
+    this._requestService.track(requestId, service);
   }
 
   /** Get the live response token totals for a seller, or null if none recorded this session. */

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -5,6 +5,7 @@ import type { PeerInfo, PeerId } from '../types/peer.js';
 import type { SerializedHttpRequest, SerializedHttpResponse } from '../types/http.js';
 import { PAYMENT_CODE_CHANNEL_EXHAUSTED, type PaymentRequiredPayload } from '../types/protocol.js';
 import type { BuyerPaymentManager } from './buyer-payment-manager.js';
+import type { BuyerFreeUsageManager } from './buyer-free-usage-manager.js';
 import type { DepositsClient } from './evm/deposits-client.js';
 import type { ChannelsClient } from './evm/channels-client.js';
 import type { ChannelStore } from './channel-store.js';
@@ -68,6 +69,7 @@ export class BuyerPaymentNegotiator {
   private readonly _depositsClient: DepositsClient | null;
   private readonly _channelsClient: ChannelsClient | null;
   private readonly _channelStore: ChannelStore | null;
+  private readonly _freeUsageManager: BuyerFreeUsageManager | null;
   private readonly _identity: Identity;
   private readonly _emit: NegotiationEmitter;
   private readonly _sellerAddressResolver?: SellerAddressResolver;
@@ -102,12 +104,14 @@ export class BuyerPaymentNegotiator {
     _config: BuyerNegotiatorConfig,
     emitter: NegotiationEmitter,
     sellerAddressResolver?: SellerAddressResolver,
+    freeUsageManager?: BuyerFreeUsageManager | null,
   ) {
     this._identity = identity;
     this._bpm = bpm;
     this._depositsClient = depositsClient;
     this._channelsClient = channelsClient;
     this._channelStore = channelStore;
+    this._freeUsageManager = freeUsageManager ?? null;
     this._emit = emitter;
     this._sellerAddressResolver = sellerAddressResolver;
   }
@@ -139,6 +143,20 @@ export class BuyerPaymentNegotiator {
       this._bpm.handleAuthAck(peerId, payload);
     });
 
+    pmux.onFreeUsageAck((payload) => {
+      this._freeUsageManager?.handleAck(peerId, payload);
+    });
+
+    pmux.onNeedFreeUsageAuth((payload) => {
+      const p = this._freeUsageManager?.handleNeedAuth(peerId, payload, pmux);
+      if (p) {
+        this._pendingNeedAuth.set(peerId, p);
+        p.finally(() => {
+          if (this._pendingNeedAuth.get(peerId) === p) this._pendingNeedAuth.delete(peerId);
+        });
+      }
+    });
+
     pmux.onNeedAuth((payload) => {
       const p = this._bpm.handleNeedAuth(peerId, payload, pmux);
       this._pendingNeedAuth.set(peerId, p);
@@ -164,6 +182,16 @@ export class BuyerPaymentNegotiator {
 
   getPaymentMux(peerId: PeerId): PaymentMux | undefined {
     return this._muxes.get(peerId);
+  }
+
+  trackFreeUsageRequestService(requestId: string, service: string): void {
+    this._freeUsageManager?.trackRequestService(requestId, service);
+  }
+
+  async prepareFreeUsageOpen(peer: PeerInfo, conn: PeerConnection): Promise<void> {
+    if (!this._freeUsageManager) return;
+    const pmux = this.getOrCreatePaymentMux(peer.peerId, conn);
+    await this._freeUsageManager.prepareOpen(peer, pmux);
   }
 
   // ── Pre-request auth ────────────────────────────────────────

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -8,7 +8,7 @@ import type { BuyerPaymentManager } from './buyer-payment-manager.js';
 import type { BuyerFreeUsageManager } from './buyer-free-usage-manager.js';
 import type { DepositsClient } from './evm/deposits-client.js';
 import type { ChannelsClient } from './evm/channels-client.js';
-import type { ChannelStore } from './channel-store.js';
+import { CHANNEL_ROLE, CHANNEL_STATUS, type ChannelStore } from './channel-store.js';
 import { classifyOnChainChannel } from './channel-session-state.js';
 import { peerIdToAddress } from '../types/peer.js';
 import { debugLog, debugWarn } from '../utils/debug.js';
@@ -389,7 +389,7 @@ export class BuyerPaymentNegotiator {
       );
       // 'ghost' rather than 'settled' — buyer hasn't observed the on-chain
       // settle land. Matches the other buyer-side give-up-locally callsites.
-      this._bpm.retireSession(peer.peerId, 'ghost');
+      this._bpm.retireSession(peer.peerId, CHANNEL_STATUS.GHOST);
       this._lockedPeers.delete(peer.peerId);
       this._firstRequestSent.delete(peer.peerId);
     } else if (hasActiveSession) {
@@ -406,7 +406,7 @@ export class BuyerPaymentNegotiator {
 
       if (this._bpm.getActiveSession(peer.peerId)) {
         if (await this._canRetireStaleSessionWithoutOnChainProof()) {
-          this._bpm.retireSession(peer.peerId, 'ghost');
+          this._bpm.retireSession(peer.peerId, CHANNEL_STATUS.GHOST);
         }
       }
 
@@ -559,7 +559,7 @@ export class BuyerPaymentNegotiator {
       this._channelStore.upsertChannel({
         sessionId: payload.channelId,
         peerId: peer.peerId,
-        role: 'buyer',
+        role: CHANNEL_ROLE.BUYER,
         sellerEvmAddr: sellerEvmAddrExternal,
         buyerEvmAddr: this._identity.wallet.address,
         nonce: 0,
@@ -572,7 +572,7 @@ export class BuyerPaymentNegotiator {
         reservedAt: Date.now(),
         settledAt: null,
         settledAmount: null,
-        status: 'active',
+        status: CHANNEL_STATUS.ACTIVE,
         latestBuyerSig: null,
         latestSpendingAuthSig: null,
         latestMetadata: null,
@@ -874,7 +874,7 @@ export class BuyerPaymentNegotiator {
     }
 
     if (!this._channelsClient) {
-      this._bpm.retireSession(peer.peerId, 'ghost');
+      this._bpm.retireSession(peer.peerId, CHANNEL_STATUS.GHOST);
       return false;
     }
 
@@ -894,22 +894,22 @@ export class BuyerPaymentNegotiator {
         return true;
       }
 
-      this._bpm.retireSession(peer.peerId, 'ghost');
+      this._bpm.retireSession(peer.peerId, CHANNEL_STATUS.GHOST);
       return false;
     }
 
-    if (onChain.status === 'settled') {
-      this._bpm.retireSession(peer.peerId, 'settled', onChain.channel.settled);
+    if (onChain.status === CHANNEL_STATUS.SETTLED) {
+      this._bpm.retireSession(peer.peerId, CHANNEL_STATUS.SETTLED, onChain.channel.settled);
       return false;
     }
 
-    if (onChain.status === 'timeout') {
-      this._bpm.retireSession(peer.peerId, 'timeout');
+    if (onChain.status === CHANNEL_STATUS.TIMEOUT) {
+      this._bpm.retireSession(peer.peerId, CHANNEL_STATUS.TIMEOUT);
       return false;
     }
 
     if (onChain.status !== 'active') {
-      this._bpm.retireSession(peer.peerId, 'ghost');
+      this._bpm.retireSession(peer.peerId, CHANNEL_STATUS.GHOST);
       return false;
     }
 
@@ -939,7 +939,7 @@ export class BuyerPaymentNegotiator {
           `[BuyerNegotiator] extendCurrentSpendingAuth made no progress for ${peer.peerId.slice(0, 12)}... ` +
           `(cumulative=${cumulativeAfter}); retiring session`,
         );
-        this._bpm.retireSession(peer.peerId, 'ghost');
+        this._bpm.retireSession(peer.peerId, CHANNEL_STATUS.GHOST);
         this._lockedPeers.delete(peer.peerId);
         this._firstRequestSent.delete(peer.peerId);
         return false;

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -192,7 +192,9 @@ export class BuyerPaymentNegotiator {
     if (!this._freeUsageManager) return;
     const pmux = this.getOrCreatePaymentMux(peer.peerId, conn);
     await this._freeUsageManager.prepareOpen(peer, pmux);
-    await this._freeUsageManager.waitForOpenAck(peer.peerId);
+    void this._freeUsageManager.waitForOpenAck(peer.peerId).catch((err) => {
+      debugWarn(`[BuyerNegotiator] Free usage open ack unavailable for ${peer.peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
+    });
   }
 
   // ── Pre-request auth ────────────────────────────────────────

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -192,6 +192,7 @@ export class BuyerPaymentNegotiator {
     if (!this._freeUsageManager) return;
     const pmux = this.getOrCreatePaymentMux(peer.peerId, conn);
     await this._freeUsageManager.prepareOpen(peer, pmux);
+    await this._freeUsageManager.waitForOpenAck(peer.peerId);
   }
 
   // ── Pre-request auth ────────────────────────────────────────

--- a/packages/node/src/payments/chain-config.ts
+++ b/packages/node/src/payments/chain-config.ts
@@ -49,6 +49,7 @@ const CHAIN_CONFIGS: Record<ChainId, ChainConfig> = {
     usdcContractAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
     depositsContractAddress: '0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2',
     channelsContractAddress: '0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d',
+    freeUsageContractAddress: '0xB24DcDE777C4ad9AC385Ec9500b3Dc527a4F91Ad',
     stakingContractAddress: '0x3652E6B22919bd322A25723B94BB207602E5c8e6',
     emissionsContractAddress: '0xF13bE52c4A3afC6AE29536f073588d01A0564088',
     legacyEmissionsContractAddress: '0x36877fBa8Fa333aa46a1c57b66D132E4995C86b5',

--- a/packages/node/src/payments/chain-config.ts
+++ b/packages/node/src/payments/chain-config.ts
@@ -13,6 +13,8 @@ export interface ChainConfig {
   fallbackRpcUrls?: string[];
   depositsContractAddress: string;
   channelsContractAddress: string;
+  /** Optional AntseedFreeUsage contract address for zero-price signed usage. */
+  freeUsageContractAddress?: string;
   stakingContractAddress?: string;
   usdcContractAddress: string;
   identityRegistryAddress?: string;
@@ -104,6 +106,7 @@ export function resolveChainConfig(overrides?: {
   fallbackRpcUrls?: string[];
   depositsContractAddress?: string;
   channelsContractAddress?: string;
+  freeUsageContractAddress?: string;
   stakingContractAddress?: string;
   usdcContractAddress?: string;
   identityRegistryAddress?: string;
@@ -124,6 +127,7 @@ export function resolveChainConfig(overrides?: {
     ...(resolvedFallbacks !== undefined ? { fallbackRpcUrls: resolvedFallbacks } : {}),
     ...(overrides?.depositsContractAddress ? { depositsContractAddress: overrides.depositsContractAddress } : {}),
     ...(overrides?.channelsContractAddress ? { channelsContractAddress: overrides.channelsContractAddress } : {}),
+    ...(overrides?.freeUsageContractAddress ? { freeUsageContractAddress: overrides.freeUsageContractAddress } : {}),
     ...(overrides?.stakingContractAddress ? { stakingContractAddress: overrides.stakingContractAddress } : {}),
     ...(overrides?.usdcContractAddress ? { usdcContractAddress: overrides.usdcContractAddress } : {}),
     ...(overrides?.identityRegistryAddress ? { identityRegistryAddress: overrides.identityRegistryAddress } : {}),

--- a/packages/node/src/payments/channel-session-state.ts
+++ b/packages/node/src/payments/channel-session-state.ts
@@ -1,6 +1,12 @@
 import type { ChannelInfo } from './evm/channels-client.js';
+import { CHANNEL_STATUS } from './channel-store.js';
 
-export type OnChainChannelStatus = 'missing' | 'active' | 'settled' | 'timeout' | 'unknown';
+export type OnChainChannelStatus =
+  | 'missing'
+  | typeof CHANNEL_STATUS.ACTIVE
+  | typeof CHANNEL_STATUS.SETTLED
+  | typeof CHANNEL_STATUS.TIMEOUT
+  | 'unknown';
 
 export type OnChainChannelState =
   | { exists: false; status: 'missing' }
@@ -19,13 +25,13 @@ export function classifyOnChainChannel(channel: ChannelInfo): OnChainChannelStat
   }
 
   if (channel.status === 1) {
-    return { exists: true, status: 'active', channel };
+    return { exists: true, status: CHANNEL_STATUS.ACTIVE, channel };
   }
   if (channel.status === 2) {
-    return { exists: true, status: 'settled', channel };
+    return { exists: true, status: CHANNEL_STATUS.SETTLED, channel };
   }
   if (channel.status === 3) {
-    return { exists: true, status: 'timeout', channel };
+    return { exists: true, status: CHANNEL_STATUS.TIMEOUT, channel };
   }
 
   return { exists: true, status: 'unknown', channel };

--- a/packages/node/src/payments/channel-store.ts
+++ b/packages/node/src/payments/channel-store.ts
@@ -3,6 +3,7 @@ import { mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { runMigrations } from '../storage/migrate.js';
 import { channelMigrations } from '../storage/migrations/channels/index.js';
+import type { SpendingAuthMetadata, SpendingAuthServiceMetadata } from './evm/signatures.js';
 
 export const CHANNEL_STATUS = {
   ACTIVE: 'active',
@@ -11,10 +12,13 @@ export const CHANNEL_STATUS = {
   GHOST: 'ghost',
 } as const;
 
+export type ChannelKind = 'paid' | 'free';
+
 export interface StoredChannel {
   sessionId: string;
   peerId: string;
   role: 'buyer' | 'seller';
+  channelKind?: ChannelKind;
   sellerEvmAddr: string;
   buyerEvmAddr: string;
   nonce: number;
@@ -127,19 +131,20 @@ export class ChannelStore {
     return {
       upsert: this._db.prepare(`
         INSERT INTO payment_channels (
-          session_id, peer_id, role, seller_evm_addr, buyer_evm_addr,
+          session_id, peer_id, role, channel_kind, seller_evm_addr, buyer_evm_addr,
           nonce, auth_max, deadline, previous_session_id, previous_consumption,
           tokens_delivered, request_count, reserved_at, settled_at, settled_amount,
           status, latest_buyer_sig, latest_metadata_auth_sig, latest_metadata,
           created_at, updated_at
         ) VALUES (
-          @sessionId, @peerId, @role, @sellerEvmAddr, @buyerEvmAddr,
+          @sessionId, @peerId, @role, @channelKind, @sellerEvmAddr, @buyerEvmAddr,
           @nonce, @authMax, @deadline, @previousSessionId, @previousConsumption,
           @tokensDelivered, @requestCount, @reservedAt, @settledAt, @settledAmount,
           @status, @latestBuyerSig, @latestSpendingAuthSig, @latestMetadata,
           @createdAt, @updatedAt
         )
         ON CONFLICT(session_id) DO UPDATE SET
+          channel_kind = @channelKind,
           auth_max = @authMax,
           previous_consumption = @previousConsumption,
           tokens_delivered = @tokensDelivered,
@@ -156,16 +161,16 @@ export class ChannelStore {
         'SELECT * FROM payment_channels WHERE session_id = ?',
       ),
       getActiveByPeer: this._db.prepare(
-        'SELECT * FROM payment_channels WHERE peer_id = ? AND role = ? AND status = ? ORDER BY created_at DESC LIMIT 1',
+        'SELECT * FROM payment_channels WHERE peer_id = ? AND role = ? AND channel_kind = ? AND status = ? ORDER BY created_at DESC LIMIT 1',
       ),
       getActiveByPeerAndBuyer: this._db.prepare(
-        'SELECT * FROM payment_channels WHERE peer_id = ? AND role = ? AND buyer_evm_addr = ? AND status = ? ORDER BY created_at DESC LIMIT 1',
+        'SELECT * FROM payment_channels WHERE peer_id = ? AND role = ? AND buyer_evm_addr = ? AND channel_kind = ? AND status = ? ORDER BY created_at DESC LIMIT 1',
       ),
       getLatestByPeer: this._db.prepare(
-        'SELECT * FROM payment_channels WHERE peer_id = ? AND role = ? ORDER BY created_at DESC LIMIT 1',
+        'SELECT * FROM payment_channels WHERE peer_id = ? AND role = ? AND channel_kind = ? ORDER BY created_at DESC LIMIT 1',
       ),
       getLatestByPeerAndBuyer: this._db.prepare(
-        'SELECT * FROM payment_channels WHERE peer_id = ? AND role = ? AND buyer_evm_addr = ? ORDER BY created_at DESC LIMIT 1',
+        'SELECT * FROM payment_channels WHERE peer_id = ? AND role = ? AND buyer_evm_addr = ? AND channel_kind = ? ORDER BY created_at DESC LIMIT 1',
       ),
       updateStatusWithAmount: this._db.prepare(
         'UPDATE payment_channels SET status = ?, settled_at = ?, settled_amount = ?, updated_at = ? WHERE session_id = ?',
@@ -180,10 +185,10 @@ export class ChannelStore {
         'SELECT MAX(nonce) as max_nonce FROM payment_channels WHERE role = ?',
       ),
       listAll: this._db.prepare(
-        'SELECT * FROM payment_channels ORDER BY updated_at DESC LIMIT ?',
+        'SELECT * FROM payment_channels WHERE channel_kind = ? ORDER BY updated_at DESC LIMIT ?',
       ),
       getTimedOut: this._db.prepare(
-        'SELECT * FROM payment_channels WHERE status = ? AND updated_at < ? ORDER BY updated_at LIMIT 100',
+        'SELECT * FROM payment_channels WHERE channel_kind = ? AND status = ? AND updated_at < ? ORDER BY updated_at LIMIT 100',
       ),
       insertReceipt: this._db.prepare(`
         INSERT INTO payment_receipts (
@@ -201,10 +206,10 @@ export class ChannelStore {
         'UPDATE payment_receipts SET buyer_ack_sig = ? WHERE session_id = ? AND running_total = ? AND request_count = ?',
       ),
       getActiveChannels: this._db.prepare(
-        'SELECT * FROM payment_channels WHERE role = ? AND status = ? ORDER BY created_at DESC',
+        'SELECT * FROM payment_channels WHERE role = ? AND channel_kind = ? AND status = ? ORDER BY created_at DESC',
       ),
       getActiveChannelsByBuyer: this._db.prepare(
-        'SELECT * FROM payment_channels WHERE role = ? AND buyer_evm_addr = ? AND status = ? ORDER BY created_at DESC',
+        'SELECT * FROM payment_channels WHERE role = ? AND buyer_evm_addr = ? AND channel_kind = ? AND status = ? ORDER BY created_at DESC',
       ),
       getTotalsByPeerAndBuyer: this._db.prepare(`
         SELECT
@@ -216,7 +221,7 @@ export class ChannelStore {
           MIN(reserved_at) as first_session_at,
           MAX(updated_at) as last_session_at
         FROM payment_channels
-        WHERE peer_id = ? AND role = ? AND buyer_evm_addr = ?
+        WHERE peer_id = ? AND role = ? AND buyer_evm_addr = ? AND channel_kind = ?
       `),
       deleteServiceTotals: this._db.prepare(
         'DELETE FROM payment_channel_service_totals WHERE session_id = ?',
@@ -245,6 +250,7 @@ export class ChannelStore {
       sessionId: channel.sessionId,
       peerId: channel.peerId,
       role: channel.role,
+      channelKind: channel.channelKind ?? 'paid',
       sellerEvmAddr: channel.sellerEvmAddr,
       buyerEvmAddr: channel.buyerEvmAddr,
       nonce: channel.nonce,
@@ -271,28 +277,29 @@ export class ChannelStore {
     return row ? rowToChannel(row) : null;
   }
 
-  getActiveChannelByPeer(peerId: string, role: string): StoredChannel | null {
-    const row = this._stmts.getActiveByPeer.get(peerId, role, CHANNEL_STATUS.ACTIVE) as ChannelRow | undefined;
+  getActiveChannelByPeer(peerId: string, role: string, channelKind: ChannelKind = 'paid'): StoredChannel | null {
+    const row = this._stmts.getActiveByPeer.get(peerId, role, channelKind, CHANNEL_STATUS.ACTIVE) as ChannelRow | undefined;
     return row ? rowToChannel(row) : null;
   }
 
-  getActiveChannelByPeerAndBuyer(peerId: string, role: string, buyerEvmAddr: string): StoredChannel | null {
+  getActiveChannelByPeerAndBuyer(peerId: string, role: string, buyerEvmAddr: string, channelKind: ChannelKind = 'paid'): StoredChannel | null {
     const row = this._stmts.getActiveByPeerAndBuyer.get(
       peerId,
       role,
       buyerEvmAddr,
+      channelKind,
       CHANNEL_STATUS.ACTIVE,
     ) as ChannelRow | undefined;
     return row ? rowToChannel(row) : null;
   }
 
-  getLatestChannel(peerId: string, role: string): StoredChannel | null {
-    const row = this._stmts.getLatestByPeer.get(peerId, role) as ChannelRow | undefined;
+  getLatestChannel(peerId: string, role: string, channelKind: ChannelKind = 'paid'): StoredChannel | null {
+    const row = this._stmts.getLatestByPeer.get(peerId, role, channelKind) as ChannelRow | undefined;
     return row ? rowToChannel(row) : null;
   }
 
-  getLatestChannelByPeerAndBuyer(peerId: string, role: string, buyerEvmAddr: string): StoredChannel | null {
-    const row = this._stmts.getLatestByPeerAndBuyer.get(peerId, role, buyerEvmAddr) as ChannelRow | undefined;
+  getLatestChannelByPeerAndBuyer(peerId: string, role: string, buyerEvmAddr: string, channelKind: ChannelKind = 'paid'): StoredChannel | null {
+    const row = this._stmts.getLatestByPeerAndBuyer.get(peerId, role, buyerEvmAddr, channelKind) as ChannelRow | undefined;
     return row ? rowToChannel(row) : null;
   }
 
@@ -315,34 +322,34 @@ export class ChannelStore {
   }
 
   /** List all channels ordered by most recent first. */
-  listAllChannels(limit = 100): StoredChannel[] {
-    const rows = this._stmts.listAll.all(limit) as ChannelRow[];
+  listAllChannels(limit = 100, channelKind: ChannelKind = 'paid'): StoredChannel[] {
+    const rows = this._stmts.listAll.all(channelKind, limit) as ChannelRow[];
     return rows.map(rowToChannel);
   }
 
   /** Get all active channels for a given role (buyer or seller). */
-  getActiveChannels(role: string): StoredChannel[] {
-    const rows = this._stmts.getActiveChannels.all(role, CHANNEL_STATUS.ACTIVE) as ChannelRow[];
+  getActiveChannels(role: string, channelKind: ChannelKind = 'paid'): StoredChannel[] {
+    const rows = this._stmts.getActiveChannels.all(role, channelKind, CHANNEL_STATUS.ACTIVE) as ChannelRow[];
     return rows.map(rowToChannel);
   }
 
-  getActiveChannelsByBuyer(role: string, buyerEvmAddr: string): StoredChannel[] {
-    const rows = this._stmts.getActiveChannelsByBuyer.all(role, buyerEvmAddr, CHANNEL_STATUS.ACTIVE) as ChannelRow[];
+  getActiveChannelsByBuyer(role: string, buyerEvmAddr: string, channelKind: ChannelKind = 'paid'): StoredChannel[] {
+    const rows = this._stmts.getActiveChannelsByBuyer.all(role, buyerEvmAddr, channelKind, CHANNEL_STATUS.ACTIVE) as ChannelRow[];
     return rows.map(rowToChannel);
   }
 
   /** All channels for a given buyer (any status), ordered by most recent first. */
-  getAllChannelsByBuyer(role: string, buyerEvmAddr: string): StoredChannel[] {
+  getAllChannelsByBuyer(role: string, buyerEvmAddr: string, channelKind: ChannelKind = 'paid'): StoredChannel[] {
     const rows = this._db
       .prepare(
-        'SELECT * FROM payment_channels WHERE role = ? AND buyer_evm_addr = ? ORDER BY created_at DESC',
+        'SELECT * FROM payment_channels WHERE role = ? AND buyer_evm_addr = ? AND channel_kind = ? ORDER BY created_at DESC',
       )
-      .all(role, buyerEvmAddr) as ChannelRow[];
+      .all(role, buyerEvmAddr, channelKind) as ChannelRow[];
     return rows.map(rowToChannel);
   }
 
   /** Aggregate totals across all channels for a given peer and role. */
-  getTotalsByPeer(peerId: string, role: string): {
+  getTotalsByPeer(peerId: string, role: string, channelKind: ChannelKind = 'paid'): {
     totalSessions: number;
     totalRequests: number;
     totalInputTokens: number;
@@ -361,8 +368,8 @@ export class ChannelStore {
         MIN(reserved_at) as first_session_at,
         MAX(updated_at) as last_session_at
       FROM payment_channels
-      WHERE peer_id = ? AND role = ?
-    `).get(peerId, role) as {
+      WHERE peer_id = ? AND role = ? AND channel_kind = ?
+    `).get(peerId, role, channelKind) as {
       total_sessions: number;
       total_requests: number;
       total_input_tokens: number;
@@ -382,7 +389,7 @@ export class ChannelStore {
     };
   }
 
-  getTotalsByPeerAndBuyer(peerId: string, role: string, buyerEvmAddr: string): {
+  getTotalsByPeerAndBuyer(peerId: string, role: string, buyerEvmAddr: string, channelKind: ChannelKind = 'paid'): {
     totalSessions: number;
     totalRequests: number;
     totalInputTokens: number;
@@ -391,7 +398,7 @@ export class ChannelStore {
     firstSessionAt: number | null;
     lastSessionAt: number | null;
   } {
-    const row = this._stmts.getTotalsByPeerAndBuyer.get(peerId, role, buyerEvmAddr) as {
+    const row = this._stmts.getTotalsByPeerAndBuyer.get(peerId, role, buyerEvmAddr, channelKind) as {
       total_sessions: number;
       total_requests: number;
       total_input_tokens: number;
@@ -413,9 +420,9 @@ export class ChannelStore {
 
   // ── Timeout queries ───────────────────────────────────────────
 
-  getTimedOutChannels(timeoutSeconds: number): StoredChannel[] {
+  getTimedOutChannels(timeoutSeconds: number, channelKind: ChannelKind = 'paid'): StoredChannel[] {
     const cutoff = Date.now() - timeoutSeconds * 1000;
-    const rows = this._stmts.getTimedOut.all(CHANNEL_STATUS.ACTIVE, cutoff) as ChannelRow[];
+    const rows = this._stmts.getTimedOut.all(channelKind, CHANNEL_STATUS.ACTIVE, cutoff) as ChannelRow[];
     return rows.map(rowToChannel);
   }
 
@@ -467,9 +474,43 @@ export class ChannelStore {
     );
   }
 
+  replaceMetadataServiceTotals(sessionId: string, services: readonly SpendingAuthServiceMetadata[] = []): void {
+    this.replaceServiceTotals(
+      sessionId,
+      services.map((service) => ({
+        serviceId: service.serviceId,
+        cumulativeAmount: service.cumulativeAmount.toString(),
+        cumulativeInputTokens: service.cumulativeInputTokens.toString(),
+        cumulativeCachedInputTokens: service.cumulativeCachedInputTokens.toString(),
+        cumulativeOutputTokens: service.cumulativeOutputTokens.toString(),
+        cumulativeRequestCount: service.cumulativeRequestCount.toString(),
+      })),
+    );
+  }
+
   getServiceTotals(sessionId: string): StoredChannelServiceTotal[] {
     const rows = this._stmts.getServiceTotals.all(sessionId) as ServiceTotalRow[];
     return rows.map(rowToServiceTotal);
+  }
+
+  getMetadataServiceTotals(sessionId: string): SpendingAuthServiceMetadata[] {
+    return this.getServiceTotals(sessionId).map((total) => ({
+      serviceId: total.serviceId,
+      cumulativeAmount: BigInt(total.cumulativeAmount),
+      cumulativeInputTokens: BigInt(total.cumulativeInputTokens),
+      cumulativeCachedInputTokens: BigInt(total.cumulativeCachedInputTokens),
+      cumulativeOutputTokens: BigInt(total.cumulativeOutputTokens),
+      cumulativeRequestCount: BigInt(total.cumulativeRequestCount),
+    }));
+  }
+
+  getChannelMetadata(channel: StoredChannel): SpendingAuthMetadata {
+    return {
+      cumulativeInputTokens: BigInt(channel.tokensDelivered),
+      cumulativeOutputTokens: BigInt(channel.previousConsumption),
+      cumulativeRequestCount: BigInt(channel.requestCount),
+      services: this.getMetadataServiceTotals(channel.sessionId),
+    };
   }
 
   // ── Lifecycle ─────────────────────────────────────────────────
@@ -485,6 +526,7 @@ interface ChannelRow {
   session_id: string;
   peer_id: string;
   role: string;
+  channel_kind: string;
   seller_evm_addr: string;
   buyer_evm_addr: string;
   nonce: number;
@@ -532,6 +574,7 @@ function rowToChannel(row: ChannelRow): StoredChannel {
     sessionId: row.session_id,
     peerId: row.peer_id,
     role: row.role as 'buyer' | 'seller',
+    channelKind: (row.channel_kind ?? 'paid') as ChannelKind,
     sellerEvmAddr: row.seller_evm_addr,
     buyerEvmAddr: row.buyer_evm_addr,
     nonce: row.nonce,

--- a/packages/node/src/payments/channel-store.ts
+++ b/packages/node/src/payments/channel-store.ts
@@ -12,12 +12,24 @@ export const CHANNEL_STATUS = {
   GHOST: 'ghost',
 } as const;
 
-export type ChannelKind = 'paid' | 'free';
+export const CHANNEL_KIND = {
+  PAID: 'paid',
+  FREE: 'free',
+} as const;
+
+export const CHANNEL_ROLE = {
+  BUYER: 'buyer',
+  SELLER: 'seller',
+} as const;
+
+export type ChannelStatus = typeof CHANNEL_STATUS[keyof typeof CHANNEL_STATUS];
+export type ChannelKind = typeof CHANNEL_KIND[keyof typeof CHANNEL_KIND];
+export type ChannelRole = typeof CHANNEL_ROLE[keyof typeof CHANNEL_ROLE];
 
 export interface StoredChannel {
   sessionId: string;
   peerId: string;
-  role: 'buyer' | 'seller';
+  role: ChannelRole;
   channelKind?: ChannelKind;
   sellerEvmAddr: string;
   buyerEvmAddr: string;
@@ -31,7 +43,7 @@ export interface StoredChannel {
   reservedAt: number;
   settledAt: number | null;
   settledAmount: string | null; // bigint as string
-  status: 'active' | 'settled' | 'timeout' | 'ghost';
+  status: ChannelStatus;
   latestBuyerSig: string | null;
   latestSpendingAuthSig: string | null;
   latestMetadata: string | null;       // hex-encoded
@@ -250,7 +262,7 @@ export class ChannelStore {
       sessionId: channel.sessionId,
       peerId: channel.peerId,
       role: channel.role,
-      channelKind: channel.channelKind ?? 'paid',
+      channelKind: channel.channelKind ?? CHANNEL_KIND.PAID,
       sellerEvmAddr: channel.sellerEvmAddr,
       buyerEvmAddr: channel.buyerEvmAddr,
       nonce: channel.nonce,
@@ -277,12 +289,12 @@ export class ChannelStore {
     return row ? rowToChannel(row) : null;
   }
 
-  getActiveChannelByPeer(peerId: string, role: string, channelKind: ChannelKind = 'paid'): StoredChannel | null {
+  getActiveChannelByPeer(peerId: string, role: ChannelRole, channelKind: ChannelKind = CHANNEL_KIND.PAID): StoredChannel | null {
     const row = this._stmts.getActiveByPeer.get(peerId, role, channelKind, CHANNEL_STATUS.ACTIVE) as ChannelRow | undefined;
     return row ? rowToChannel(row) : null;
   }
 
-  getActiveChannelByPeerAndBuyer(peerId: string, role: string, buyerEvmAddr: string, channelKind: ChannelKind = 'paid'): StoredChannel | null {
+  getActiveChannelByPeerAndBuyer(peerId: string, role: ChannelRole, buyerEvmAddr: string, channelKind: ChannelKind = CHANNEL_KIND.PAID): StoredChannel | null {
     const row = this._stmts.getActiveByPeerAndBuyer.get(
       peerId,
       role,
@@ -293,17 +305,17 @@ export class ChannelStore {
     return row ? rowToChannel(row) : null;
   }
 
-  getLatestChannel(peerId: string, role: string, channelKind: ChannelKind = 'paid'): StoredChannel | null {
+  getLatestChannel(peerId: string, role: ChannelRole, channelKind: ChannelKind = CHANNEL_KIND.PAID): StoredChannel | null {
     const row = this._stmts.getLatestByPeer.get(peerId, role, channelKind) as ChannelRow | undefined;
     return row ? rowToChannel(row) : null;
   }
 
-  getLatestChannelByPeerAndBuyer(peerId: string, role: string, buyerEvmAddr: string, channelKind: ChannelKind = 'paid'): StoredChannel | null {
+  getLatestChannelByPeerAndBuyer(peerId: string, role: ChannelRole, buyerEvmAddr: string, channelKind: ChannelKind = CHANNEL_KIND.PAID): StoredChannel | null {
     const row = this._stmts.getLatestByPeerAndBuyer.get(peerId, role, buyerEvmAddr, channelKind) as ChannelRow | undefined;
     return row ? rowToChannel(row) : null;
   }
 
-  updateChannelStatus(sessionId: string, status: string, settledAmount?: string): void {
+  updateChannelStatus(sessionId: string, status: ChannelStatus, settledAmount?: string): void {
     const now = Date.now();
     if (settledAmount !== undefined) {
       this._stmts.updateStatusWithAmount.run(status, now, settledAmount, now, sessionId);
@@ -316,30 +328,30 @@ export class ChannelStore {
     this._stmts.updateTokens.run(tokens, requestCount, Date.now(), sessionId);
   }
 
-  getMaxNonce(role: string): number {
+  getMaxNonce(role: ChannelRole): number {
     const row = this._stmts.getMaxNonce.get(role) as { max_nonce: number | null } | undefined;
     return row?.max_nonce ?? 0;
   }
 
   /** List all channels ordered by most recent first. */
-  listAllChannels(limit = 100, channelKind: ChannelKind = 'paid'): StoredChannel[] {
+  listAllChannels(limit = 100, channelKind: ChannelKind = CHANNEL_KIND.PAID): StoredChannel[] {
     const rows = this._stmts.listAll.all(channelKind, limit) as ChannelRow[];
     return rows.map(rowToChannel);
   }
 
   /** Get all active channels for a given role (buyer or seller). */
-  getActiveChannels(role: string, channelKind: ChannelKind = 'paid'): StoredChannel[] {
+  getActiveChannels(role: ChannelRole, channelKind: ChannelKind = CHANNEL_KIND.PAID): StoredChannel[] {
     const rows = this._stmts.getActiveChannels.all(role, channelKind, CHANNEL_STATUS.ACTIVE) as ChannelRow[];
     return rows.map(rowToChannel);
   }
 
-  getActiveChannelsByBuyer(role: string, buyerEvmAddr: string, channelKind: ChannelKind = 'paid'): StoredChannel[] {
+  getActiveChannelsByBuyer(role: ChannelRole, buyerEvmAddr: string, channelKind: ChannelKind = CHANNEL_KIND.PAID): StoredChannel[] {
     const rows = this._stmts.getActiveChannelsByBuyer.all(role, buyerEvmAddr, channelKind, CHANNEL_STATUS.ACTIVE) as ChannelRow[];
     return rows.map(rowToChannel);
   }
 
   /** All channels for a given buyer (any status), ordered by most recent first. */
-  getAllChannelsByBuyer(role: string, buyerEvmAddr: string, channelKind: ChannelKind = 'paid'): StoredChannel[] {
+  getAllChannelsByBuyer(role: ChannelRole, buyerEvmAddr: string, channelKind: ChannelKind = CHANNEL_KIND.PAID): StoredChannel[] {
     const rows = this._db
       .prepare(
         'SELECT * FROM payment_channels WHERE role = ? AND buyer_evm_addr = ? AND channel_kind = ? ORDER BY created_at DESC',
@@ -349,7 +361,7 @@ export class ChannelStore {
   }
 
   /** Aggregate totals across all channels for a given peer and role. */
-  getTotalsByPeer(peerId: string, role: string, channelKind: ChannelKind = 'paid'): {
+  getTotalsByPeer(peerId: string, role: ChannelRole, channelKind: ChannelKind = CHANNEL_KIND.PAID): {
     totalSessions: number;
     totalRequests: number;
     totalInputTokens: number;
@@ -389,7 +401,7 @@ export class ChannelStore {
     };
   }
 
-  getTotalsByPeerAndBuyer(peerId: string, role: string, buyerEvmAddr: string, channelKind: ChannelKind = 'paid'): {
+  getTotalsByPeerAndBuyer(peerId: string, role: ChannelRole, buyerEvmAddr: string, channelKind: ChannelKind = CHANNEL_KIND.PAID): {
     totalSessions: number;
     totalRequests: number;
     totalInputTokens: number;
@@ -420,7 +432,7 @@ export class ChannelStore {
 
   // ── Timeout queries ───────────────────────────────────────────
 
-  getTimedOutChannels(timeoutSeconds: number, channelKind: ChannelKind = 'paid'): StoredChannel[] {
+  getTimedOutChannels(timeoutSeconds: number, channelKind: ChannelKind = CHANNEL_KIND.PAID): StoredChannel[] {
     const cutoff = Date.now() - timeoutSeconds * 1000;
     const rows = this._stmts.getTimedOut.all(channelKind, CHANNEL_STATUS.ACTIVE, cutoff) as ChannelRow[];
     return rows.map(rowToChannel);
@@ -573,8 +585,8 @@ function rowToChannel(row: ChannelRow): StoredChannel {
   return {
     sessionId: row.session_id,
     peerId: row.peer_id,
-    role: row.role as 'buyer' | 'seller',
-    channelKind: (row.channel_kind ?? 'paid') as ChannelKind,
+    role: row.role as ChannelRole,
+    channelKind: (row.channel_kind ?? CHANNEL_KIND.PAID) as ChannelKind,
     sellerEvmAddr: row.seller_evm_addr,
     buyerEvmAddr: row.buyer_evm_addr,
     nonce: row.nonce,

--- a/packages/node/src/payments/channel-usage-accounting.ts
+++ b/packages/node/src/payments/channel-usage-accounting.ts
@@ -1,0 +1,74 @@
+import {
+  withServiceMetadata,
+  ZERO_METADATA,
+  type ServiceMetadataDelta,
+  type SpendingAuthMetadata,
+} from './evm/signatures.js';
+
+const DEFAULT_REQUEST_TRACKER_LIMIT = 512;
+
+function trimOldestMapEntry<K, V>(map: Map<K, V>, limit: number): void {
+  if (map.size < limit) return;
+  const oldest = map.keys().next().value;
+  if (oldest !== undefined) map.delete(oldest);
+}
+
+function trimOldestSetEntry<T>(set: Set<T>, limit: number): void {
+  if (set.size < limit) return;
+  const oldest = set.values().next().value;
+  if (oldest !== undefined) set.delete(oldest);
+}
+
+export class RequestServiceTracker {
+  private readonly _services = new Map<string, string>();
+
+  constructor(private readonly _limit = DEFAULT_REQUEST_TRACKER_LIMIT) {}
+
+  track(requestId: string, service: string): void {
+    trimOldestMapEntry(this._services, this._limit);
+    this._services.set(requestId, service);
+  }
+
+  get(requestId: string | undefined): string | undefined {
+    if (!requestId) return undefined;
+    return this._services.get(requestId);
+  }
+
+  take(requestId: string | undefined): string | undefined {
+    if (!requestId) return undefined;
+    const service = this._services.get(requestId);
+    this._services.delete(requestId);
+    return service;
+  }
+}
+
+export class CountedRequestTracker {
+  private readonly _requestIds = new Set<string>();
+
+  constructor(private readonly _limit = DEFAULT_REQUEST_TRACKER_LIMIT) {}
+
+  has(requestId: string | undefined): boolean {
+    return requestId != null && this._requestIds.has(requestId);
+  }
+
+  mark(requestId: string | undefined): void {
+    if (!requestId) return;
+    trimOldestSetEntry(this._requestIds, this._limit);
+    this._requestIds.add(requestId);
+  }
+}
+
+export function advanceUsageMetadata(
+  previous: SpendingAuthMetadata | undefined,
+  service: string | undefined,
+  delta: ServiceMetadataDelta,
+): SpendingAuthMetadata {
+  const prev = previous ?? ZERO_METADATA;
+  const totals: SpendingAuthMetadata = {
+    cumulativeInputTokens: prev.cumulativeInputTokens + delta.inputTokens,
+    cumulativeOutputTokens: prev.cumulativeOutputTokens + delta.outputTokens,
+    cumulativeRequestCount: prev.cumulativeRequestCount + delta.requests,
+    services: prev.services ?? [],
+  };
+  return withServiceMetadata(totals, service, delta);
+}

--- a/packages/node/src/payments/evm/free-usage-client.ts
+++ b/packages/node/src/payments/evm/free-usage-client.ts
@@ -1,0 +1,113 @@
+import { type AbstractSigner, Contract } from 'ethers';
+import { BaseEvmClient } from './base-evm-client.js';
+import { computeFreeUsageChannelId } from './signatures.js';
+
+export interface FreeUsageClientConfig {
+  rpcUrl: string;
+  fallbackRpcUrls?: string[];
+  contractAddress: string;
+  evmChainId?: number;
+}
+
+export interface FreeUsageAgentStats {
+  channelCount: number;
+  lastSettledAt: number;
+}
+
+export interface FreeUsageChannelInfo {
+  buyer: string;
+  seller: string;
+  latestSequence: bigint;
+  metadataHash: string;
+  deadline: bigint;
+  updatedAt: bigint;
+  closedAt: bigint;
+  status: number;
+}
+
+const FREE_USAGE_ABI = [
+  'function open(address buyer, bytes32 salt, uint256 deadline, bytes buyerSig) external',
+  'function record(bytes32 channelId, uint256 sequence, bytes metadata, uint256 deadline, bytes buyerSig) external',
+  'function close(bytes32 channelId, uint256 sequence, bytes metadata, uint256 deadline, bytes buyerSig) external',
+  'function channels(bytes32 channelId) external view returns (address buyer, address seller, uint256 latestSequence, bytes32 metadataHash, uint256 deadline, uint256 updatedAt, uint256 closedAt, uint8 status)',
+  'function computeChannelId(address buyer, address seller, bytes32 salt) external pure returns (bytes32)',
+  'function getAgentStats(uint256 agentId) external view returns (uint64 channelCount, uint64 lastSettledAt)',
+  'function activeChannelCount(address seller) external view returns (uint256)',
+  'function domainSeparator() external view returns (bytes32)',
+] as const;
+
+export class FreeUsageClient extends BaseEvmClient {
+  constructor(config: FreeUsageClientConfig) {
+    super(config.rpcUrl, config.contractAddress, config.fallbackRpcUrls, config.evmChainId);
+  }
+
+  async open(
+    signer: AbstractSigner,
+    buyer: string,
+    salt: string,
+    deadline: bigint,
+    buyerSig: string,
+  ): Promise<string> {
+    return this._execWrite(signer, FREE_USAGE_ABI, 'open', buyer, salt, deadline, buyerSig);
+  }
+
+  async record(
+    signer: AbstractSigner,
+    channelId: string,
+    sequence: bigint,
+    metadata: string,
+    deadline: bigint,
+    buyerSig: string,
+  ): Promise<string> {
+    return this._execWrite(signer, FREE_USAGE_ABI, 'record', channelId, sequence, metadata, deadline, buyerSig);
+  }
+
+  async close(
+    signer: AbstractSigner,
+    channelId: string,
+    sequence: bigint,
+    metadata: string,
+    deadline: bigint,
+    buyerSig: string,
+  ): Promise<string> {
+    return this._execWrite(signer, FREE_USAGE_ABI, 'close', channelId, sequence, metadata, deadline, buyerSig);
+  }
+
+  async getSession(channelId: string): Promise<FreeUsageChannelInfo> {
+    const contract = new Contract(this._contractAddress, FREE_USAGE_ABI, this._provider);
+    const result = await contract.getFunction('channels')(channelId);
+    return {
+      buyer: result[0],
+      seller: result[1],
+      latestSequence: result[2],
+      metadataHash: result[3],
+      deadline: result[4],
+      updatedAt: result[5],
+      closedAt: result[6],
+      status: Number(result[7]),
+    };
+  }
+
+  async computeChannelId(buyer: string, seller: string, salt: string): Promise<string> {
+    return computeFreeUsageChannelId(buyer, seller, salt);
+  }
+
+  async getAgentStats(agentId: number): Promise<FreeUsageAgentStats> {
+    const contract = new Contract(this._contractAddress, FREE_USAGE_ABI, this._provider);
+    const result = await contract.getFunction('getAgentStats')(agentId);
+    return {
+      channelCount: Number(result[0]),
+      lastSettledAt: Number(result[1]),
+    };
+  }
+
+  async activeChannelCount(seller: string): Promise<bigint> {
+    const contract = new Contract(this._contractAddress, FREE_USAGE_ABI, this._provider);
+    return contract.getFunction('activeChannelCount')(seller) as Promise<bigint>;
+  }
+
+  async domainSeparator(): Promise<string> {
+    const contract = new Contract(this._contractAddress, FREE_USAGE_ABI, this._provider);
+    return contract.getFunction('domainSeparator')() as Promise<string>;
+  }
+}

--- a/packages/node/src/payments/evm/free-usage-client.ts
+++ b/packages/node/src/payments/evm/free-usage-client.ts
@@ -88,7 +88,7 @@ export class FreeUsageClient extends BaseEvmClient {
     };
   }
 
-  async computeChannelId(buyer: string, seller: string, salt: string): Promise<string> {
+  computeChannelId(buyer: string, seller: string, salt: string): string {
     return computeFreeUsageChannelId(buyer, seller, salt);
   }
 

--- a/packages/node/src/payments/evm/signatures.ts
+++ b/packages/node/src/payments/evm/signatures.ts
@@ -27,6 +27,22 @@ export const SET_OPERATOR_TYPES = {
   ],
 };
 
+export const FREE_USAGE_OPEN_TYPES = {
+  FreeUsageOpen: [
+    { name: 'channelId', type: 'bytes32' },
+    { name: 'deadline', type: 'uint256' },
+  ],
+};
+
+export const FREE_USAGE_AUTH_TYPES = {
+  FreeUsageAuth: [
+    { name: 'channelId', type: 'bytes32' },
+    { name: 'sequence', type: 'uint256' },
+    { name: 'metadataHash', type: 'bytes32' },
+    { name: 'deadline', type: 'uint256' },
+  ],
+};
+
 // =========================================================================
 // Message interfaces
 // =========================================================================
@@ -46,6 +62,18 @@ export interface ReserveAuthMessage {
 export interface SetOperatorMessage {
   operator: string;
   nonce: bigint;
+}
+
+export interface FreeUsageOpenMessage {
+  channelId: string;
+  deadline: bigint;
+}
+
+export interface FreeUsageAuthMessage {
+  channelId: string;
+  sequence: bigint;
+  metadataHash: string;
+  deadline: bigint;
 }
 
 // =========================================================================
@@ -117,6 +145,53 @@ export function getServiceMetadataId(service: string): string {
   return id(service.trim());
 }
 
+export interface ServiceMetadataDelta {
+  amount: bigint;
+  inputTokens: bigint;
+  cachedInputTokens: bigint;
+  outputTokens: bigint;
+  requests: bigint;
+}
+
+export function withServiceMetadata<T extends { services?: SpendingAuthServiceMetadata[] }>(
+  metadata: T,
+  service: string | undefined,
+  delta: ServiceMetadataDelta,
+): T {
+  if (!service || service.trim().length === 0) return metadata;
+
+  const serviceId = getServiceMetadataId(service);
+  const byServiceId = new Map<string, SpendingAuthServiceMetadata>();
+  for (const entry of metadata.services ?? []) {
+    byServiceId.set(entry.serviceId, { ...entry });
+  }
+
+  const existing = byServiceId.get(serviceId) ?? {
+    serviceId,
+    cumulativeAmount: 0n,
+    cumulativeInputTokens: 0n,
+    cumulativeCachedInputTokens: 0n,
+    cumulativeOutputTokens: 0n,
+    cumulativeRequestCount: 0n,
+  };
+
+  byServiceId.set(serviceId, {
+    serviceId,
+    cumulativeAmount: existing.cumulativeAmount + delta.amount,
+    cumulativeInputTokens: existing.cumulativeInputTokens + delta.inputTokens,
+    cumulativeCachedInputTokens: existing.cumulativeCachedInputTokens + delta.cachedInputTokens,
+    cumulativeOutputTokens: existing.cumulativeOutputTokens + delta.outputTokens,
+    cumulativeRequestCount: existing.cumulativeRequestCount + delta.requests,
+  });
+
+  return {
+    ...metadata,
+    services: [...byServiceId.values()].sort((a, b) =>
+      a.serviceId < b.serviceId ? -1 : a.serviceId > b.serviceId ? 1 : 0,
+    ),
+  };
+}
+
 export function computeMetadataHash(metadata: SpendingAuthMetadata): string {
   return keccak256(encodeMetadata(metadata));
 }
@@ -129,6 +204,63 @@ export const ZERO_METADATA: SpendingAuthMetadata = {
 };
 
 export const ZERO_METADATA_HASH: string = computeMetadataHash(ZERO_METADATA);
+
+/**
+ * FreeUsage metadata v1.
+ *
+ * ABI layout:
+ *   abi.encode(
+ *     uint256 version,
+ *     uint256 cumulativeInputTokens,
+ *     uint256 cumulativeOutputTokens,
+ *     uint256 cumulativeRequestCount,
+ *     ServiceTotal[] services
+ *   )
+ *
+ * Uses the same service tuple as paid SpendingAuth metadata so indexers can
+ * decode per-service attribution uniformly. cumulativeAmount is always zero
+ * for free usage.
+ */
+export interface FreeUsageMetadata {
+  cumulativeInputTokens: bigint;
+  cumulativeOutputTokens: bigint;
+  cumulativeRequestCount: bigint;
+  services?: SpendingAuthServiceMetadata[];
+}
+
+export type FreeUsageServiceMetadata = SpendingAuthServiceMetadata;
+
+export const FREE_USAGE_METADATA_VERSION = 1n;
+
+export function encodeFreeUsageMetadata(metadata: FreeUsageMetadata): string {
+  const coder = AbiCoder.defaultAbiCoder();
+  const services = [...(metadata.services ?? [])].sort((a, b) =>
+    a.serviceId < b.serviceId ? -1 : a.serviceId > b.serviceId ? 1 : 0,
+  );
+  return coder.encode(
+    ['uint256', 'uint256', 'uint256', 'uint256', SERVICE_METADATA_ABI_TYPE],
+    [
+      FREE_USAGE_METADATA_VERSION,
+      metadata.cumulativeInputTokens,
+      metadata.cumulativeOutputTokens,
+      metadata.cumulativeRequestCount,
+      services,
+    ],
+  );
+}
+
+export function computeFreeUsageMetadataHash(metadata: FreeUsageMetadata): string {
+  return keccak256(encodeFreeUsageMetadata(metadata));
+}
+
+export const ZERO_FREE_USAGE_METADATA: FreeUsageMetadata = {
+  cumulativeInputTokens: 0n,
+  cumulativeOutputTokens: 0n,
+  cumulativeRequestCount: 0n,
+  services: [],
+};
+
+export const ZERO_FREE_USAGE_METADATA_HASH: string = computeFreeUsageMetadataHash(ZERO_FREE_USAGE_METADATA);
 
 // =========================================================================
 // Channel ID computation (must match AntseedChannels.computeChannelId)
@@ -150,6 +282,25 @@ export function computeChannelId(
   ));
 }
 
+export const FREE_USAGE_CHANNEL_DOMAIN = id('ANTSEED_FREE_USAGE_CHANNEL');
+
+/**
+ * Compute the deterministic free usage channelId.
+ * Domain-separated from AntseedChannels.computeChannelId so a paid and free
+ * channel cannot share an ID even if buyer, seller, and salt are identical.
+ */
+export function computeFreeUsageChannelId(
+  buyer: string,
+  seller: string,
+  salt: string,
+): string {
+  const coder = AbiCoder.defaultAbiCoder();
+  return keccak256(coder.encode(
+    ['bytes32', 'address', 'address', 'bytes32'],
+    [FREE_USAGE_CHANNEL_DOMAIN, buyer, seller, salt],
+  ));
+}
+
 // =========================================================================
 // EIP-712 Domain helpers
 // =========================================================================
@@ -166,6 +317,15 @@ export function makeChannelsDomain(chainId: number, contractAddress: string): Ty
 export function makeDepositsDomain(chainId: number, contractAddress: string): TypedDataDomain {
   return {
     name: 'AntseedDeposits',
+    version: '1',
+    chainId,
+    verifyingContract: contractAddress,
+  };
+}
+
+export function makeFreeUsageDomain(chainId: number, contractAddress: string): TypedDataDomain {
+  return {
+    name: 'AntseedFreeUsage',
     version: '1',
     chainId,
     verifyingContract: contractAddress,
@@ -198,4 +358,20 @@ export async function signSetOperator(
   msg: SetOperatorMessage,
 ): Promise<string> {
   return signer.signTypedData(domain, SET_OPERATOR_TYPES, msg);
+}
+
+export async function signFreeUsageOpen(
+  signer: AbstractSigner,
+  domain: TypedDataDomain,
+  msg: FreeUsageOpenMessage,
+): Promise<string> {
+  return signer.signTypedData(domain, FREE_USAGE_OPEN_TYPES, msg);
+}
+
+export async function signFreeUsageAuth(
+  signer: AbstractSigner,
+  domain: TypedDataDomain,
+  msg: FreeUsageAuthMessage,
+): Promise<string> {
+  return signer.signTypedData(domain, FREE_USAGE_AUTH_TYPES, msg);
 }

--- a/packages/node/src/payments/index.ts
+++ b/packages/node/src/payments/index.ts
@@ -24,6 +24,10 @@ export type { DepositsClientConfig, BuyerBalanceInfo } from './evm/deposits-clie
 export { ChannelsClient } from './evm/channels-client.js';
 export type { ChannelsClientConfig, ChannelInfo, AgentStats, CloseRequestedEvent } from './evm/channels-client.js';
 
+// Free usage client (zero-price signed usage)
+export { FreeUsageClient } from './evm/free-usage-client.js';
+export type { FreeUsageClientConfig, FreeUsageChannelInfo, FreeUsageAgentStats } from './evm/free-usage-client.js';
+
 // Identity client (ERC-8004 IdentityRegistry)
 export { IdentityClient } from './evm/identity-client.js';
 export type { IdentityClientConfig } from './evm/identity-client.js';
@@ -35,21 +39,43 @@ export type { StakingClientConfig } from './evm/staking-client.js';
 export {
   signSpendingAuth,
   signReserveAuth,
+  signFreeUsageOpen,
+  signFreeUsageAuth,
   signSetOperator,
   makeChannelsDomain,
   makeDepositsDomain,
+  makeFreeUsageDomain,
   SPENDING_AUTH_TYPES,
   RESERVE_AUTH_TYPES,
+  FREE_USAGE_OPEN_TYPES,
+  FREE_USAGE_AUTH_TYPES,
   SET_OPERATOR_TYPES,
   computeMetadataHash,
   encodeMetadata,
+  computeFreeUsageMetadataHash,
+  encodeFreeUsageMetadata,
   getServiceMetadataId,
   METADATA_VERSION,
+  FREE_USAGE_METADATA_VERSION,
   computeChannelId,
+  computeFreeUsageChannelId,
+  FREE_USAGE_CHANNEL_DOMAIN,
   ZERO_METADATA,
   ZERO_METADATA_HASH,
+  ZERO_FREE_USAGE_METADATA,
+  ZERO_FREE_USAGE_METADATA_HASH,
 } from './evm/signatures.js';
-export type { SpendingAuthMessage, ReserveAuthMessage, SetOperatorMessage, SpendingAuthMetadata, SpendingAuthServiceMetadata } from './evm/signatures.js';
+export type {
+  SpendingAuthMessage,
+  ReserveAuthMessage,
+  SetOperatorMessage,
+  FreeUsageOpenMessage,
+  FreeUsageAuthMessage,
+  SpendingAuthMetadata,
+  SpendingAuthServiceMetadata,
+  FreeUsageMetadata,
+  FreeUsageServiceMetadata,
+} from './evm/signatures.js';
 
 // ANTS token
 export { ANTSTokenClient } from './evm/ants-token-client.js';
@@ -66,6 +92,12 @@ export type { StoredChannel, StoredReceipt } from './channel-store.js';
 // Buyer payment manager
 export { BuyerPaymentManager } from './buyer-payment-manager.js';
 export type { BuyerPaymentConfig, PerRequestAuthResult } from './buyer-payment-manager.js';
+
+// Free usage managers
+export { BuyerFreeUsageManager } from './buyer-free-usage-manager.js';
+export type { BuyerFreeUsageConfig } from './buyer-free-usage-manager.js';
+export { SellerFreeUsageManager } from './seller-free-usage-manager.js';
+export type { SellerFreeUsageConfig } from './seller-free-usage-manager.js';
 
 // Buyer payment negotiator (402 handling, SpendingAuth flow, cost tracking)
 export { BuyerPaymentNegotiator } from './buyer-payment-negotiator.js';

--- a/packages/node/src/payments/index.ts
+++ b/packages/node/src/payments/index.ts
@@ -86,8 +86,8 @@ export { EmissionsClient } from './evm/emissions-client.js';
 export type { EmissionsClientConfig, EmissionsEpochParams } from './evm/emissions-client.js';
 
 // Channel persistence
-export { ChannelStore, CHANNEL_STATUS } from './channel-store.js';
-export type { StoredChannel, StoredReceipt } from './channel-store.js';
+export { ChannelStore, CHANNEL_KIND, CHANNEL_ROLE, CHANNEL_STATUS } from './channel-store.js';
+export type { ChannelKind, ChannelRole, ChannelStatus, StoredChannel, StoredReceipt } from './channel-store.js';
 
 // Buyer payment manager
 export { BuyerPaymentManager } from './buyer-payment-manager.js';

--- a/packages/node/src/payments/seller-free-usage-manager.ts
+++ b/packages/node/src/payments/seller-free-usage-manager.ts
@@ -1,0 +1,241 @@
+import { keccak256, verifyTypedData } from 'ethers';
+import type { Identity } from '../p2p/identity.js';
+import type { PaymentMux } from '../p2p/payment-mux.js';
+import type {
+  FreeUsageAuthPayload,
+  FreeUsageOpenPayload,
+  NeedFreeUsageAuthPayload,
+} from '../types/protocol.js';
+import { peerIdToAddress } from '../types/peer.js';
+import { debugLog, debugWarn } from '../utils/debug.js';
+import { FreeUsageClient } from './evm/free-usage-client.js';
+import {
+  computeFreeUsageChannelId,
+  FREE_USAGE_AUTH_TYPES,
+  FREE_USAGE_OPEN_TYPES,
+  makeFreeUsageDomain,
+} from './evm/signatures.js';
+
+export interface SellerFreeUsageConfig {
+  rpcUrl: string;
+  fallbackRpcUrls?: string[];
+  freeUsageContractAddress: string;
+  chainId: number;
+}
+
+interface SellerFreeUsageSession {
+  channelId: string;
+  buyerEvmAddr: string;
+  salt: string;
+  deadline: number;
+  acceptedSequence: bigint;
+  requestedSequence: bigint;
+  openPromise: Promise<void>;
+}
+
+export class SellerFreeUsageManager {
+  private readonly _signer;
+  private readonly _client: FreeUsageClient;
+  private readonly _domain: ReturnType<typeof makeFreeUsageDomain>;
+  private readonly _sellerEvmAddr: string;
+  private readonly _sessions = new Map<string, SellerFreeUsageSession>();
+  private readonly _buyerLocks = new Map<string, Promise<void>>();
+
+  constructor(identity: Identity, config: SellerFreeUsageConfig) {
+    this._signer = identity.wallet;
+    this._sellerEvmAddr = identity.wallet.address;
+    this._domain = makeFreeUsageDomain(config.chainId, config.freeUsageContractAddress);
+    this._client = new FreeUsageClient({
+      rpcUrl: config.rpcUrl,
+      ...(config.fallbackRpcUrls ? { fallbackRpcUrls: config.fallbackRpcUrls } : {}),
+      contractAddress: config.freeUsageContractAddress,
+      evmChainId: config.chainId,
+    });
+  }
+
+  get client(): FreeUsageClient {
+    return this._client;
+  }
+
+  handleOpen(buyerPeerId: string, payload: FreeUsageOpenPayload, paymentMux: PaymentMux): void {
+    const lock = (this._buyerLocks.get(buyerPeerId) ?? Promise.resolve()).then(async () => {
+      await this._handleOpenInner(buyerPeerId, payload, paymentMux);
+    });
+    this._buyerLocks.set(buyerPeerId, lock.catch(() => {}));
+    void lock.catch((err) => {
+      debugWarn(`[SellerFreeUsage] Open failed for ${buyerPeerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
+    });
+  }
+
+  handleAuth(buyerPeerId: string, payload: FreeUsageAuthPayload, paymentMux: PaymentMux): void {
+    const lock = (this._buyerLocks.get(buyerPeerId) ?? Promise.resolve()).then(async () => {
+      await this._handleAuthInner(buyerPeerId, payload, paymentMux);
+    });
+    this._buyerLocks.set(buyerPeerId, lock.catch(() => {}));
+    void lock.catch((err) => {
+      debugWarn(`[SellerFreeUsage] UsageAuth failed for ${buyerPeerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
+    });
+  }
+
+  reportUsageRequest(
+    buyerPeerId: string,
+    paymentMux: PaymentMux,
+    usage: { requestId?: string; inputTokens: number; outputTokens: number; service?: string },
+  ): void {
+    const session = this._sessions.get(buyerPeerId);
+    if (!session) {
+      debugWarn(`[SellerFreeUsage] Cannot request usage auth for ${buyerPeerId.slice(0, 12)}...: no free usage channel`);
+      return;
+    }
+
+    const nextSequence = (session.requestedSequence > session.acceptedSequence
+      ? session.requestedSequence
+      : session.acceptedSequence) + 1n;
+    session.requestedSequence = nextSequence;
+
+    const payload: NeedFreeUsageAuthPayload = {
+      channelId: session.channelId,
+      requiredSequence: nextSequence.toString(),
+      currentAcceptedSequence: session.acceptedSequence.toString(),
+      ...(usage.requestId ? { requestId: usage.requestId } : {}),
+      inputTokens: String(Math.max(0, usage.inputTokens)),
+      outputTokens: String(Math.max(0, usage.outputTokens)),
+      ...(usage.service ? { service: usage.service } : {}),
+    };
+
+    try {
+      paymentMux.sendNeedFreeUsageAuth(payload);
+      debugLog(
+        `[SellerFreeUsage] NeedFreeUsageAuth sent to ${buyerPeerId.slice(0, 12)}... ` +
+        `channel=${session.channelId.slice(0, 18)}... sequence=${nextSequence}`,
+      );
+    } catch (err) {
+      debugWarn(`[SellerFreeUsage] NeedFreeUsageAuth send failed: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  private async _handleOpenInner(
+    buyerPeerId: string,
+    payload: FreeUsageOpenPayload,
+    paymentMux: PaymentMux,
+  ): Promise<void> {
+    const buyerEvmAddr = peerIdToAddress(buyerPeerId);
+    const expectedChannelId = computeFreeUsageChannelId(buyerEvmAddr, this._sellerEvmAddr, payload.salt);
+    if (expectedChannelId.toLowerCase() !== payload.channelId.toLowerCase()) {
+      throw new Error(`channelId mismatch expected=${expectedChannelId} got=${payload.channelId}`);
+    }
+    if (payload.deadline <= Math.floor(Date.now() / 1000)) {
+      throw new Error('free usage open expired');
+    }
+
+    const recovered = verifyTypedData(
+      this._domain,
+      FREE_USAGE_OPEN_TYPES,
+      { channelId: payload.channelId, deadline: BigInt(payload.deadline) },
+      payload.openSig,
+    );
+    if (recovered.toLowerCase() !== buyerEvmAddr.toLowerCase()) {
+      throw new Error(`invalid FreeUsageOpen signer recovered=${recovered} expected=${buyerEvmAddr}`);
+    }
+
+    const openPromise = this._openOnChain(buyerEvmAddr, payload);
+    const session: SellerFreeUsageSession = {
+      channelId: payload.channelId,
+      buyerEvmAddr,
+      salt: payload.salt,
+      deadline: payload.deadline,
+      acceptedSequence: 0n,
+      requestedSequence: 0n,
+      openPromise,
+    };
+    this._sessions.set(buyerPeerId, session);
+
+    await openPromise;
+    paymentMux.sendFreeUsageAck({ channelId: payload.channelId, acceptedSequence: '0' });
+    debugLog(`[SellerFreeUsage] Open reported on-chain channel=${payload.channelId.slice(0, 18)}...`);
+  }
+
+  private async _openOnChain(buyerEvmAddr: string, payload: FreeUsageOpenPayload): Promise<void> {
+    try {
+      await this._client.open(this._signer, buyerEvmAddr, payload.salt, BigInt(payload.deadline), payload.openSig);
+    } catch (err) {
+      const existing = await this._tryGetExistingSession(payload.channelId);
+      if (
+        existing
+        && existing.status === 1
+        && existing.buyer.toLowerCase() === buyerEvmAddr.toLowerCase()
+        && existing.seller.toLowerCase() === this._sellerEvmAddr.toLowerCase()
+      ) {
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private async _handleAuthInner(
+    buyerPeerId: string,
+    payload: FreeUsageAuthPayload,
+    paymentMux: PaymentMux,
+  ): Promise<void> {
+    const session = this._sessions.get(buyerPeerId);
+    if (!session || session.channelId.toLowerCase() !== payload.channelId.toLowerCase()) {
+      throw new Error(`unknown free usage channel ${payload.channelId}`);
+    }
+
+    const sequence = BigInt(payload.sequence);
+    if (sequence <= session.acceptedSequence) {
+      paymentMux.sendFreeUsageAck({
+        channelId: payload.channelId,
+        acceptedSequence: session.acceptedSequence.toString(),
+      });
+      return;
+    }
+
+    const metadataHash = keccak256(payload.metadata);
+    if (metadataHash.toLowerCase() !== payload.metadataHash.toLowerCase()) {
+      throw new Error('metadataHash mismatch');
+    }
+    const recovered = verifyTypedData(
+      this._domain,
+      FREE_USAGE_AUTH_TYPES,
+      {
+        channelId: payload.channelId,
+        sequence,
+        metadataHash: payload.metadataHash,
+        deadline: BigInt(payload.deadline),
+      },
+      payload.usageSig,
+    );
+    if (recovered.toLowerCase() !== session.buyerEvmAddr.toLowerCase()) {
+      throw new Error(`invalid FreeUsageAuth signer recovered=${recovered} expected=${session.buyerEvmAddr}`);
+    }
+
+    await session.openPromise;
+    await this._client.record(
+      this._signer,
+      payload.channelId,
+      sequence,
+      payload.metadata,
+      BigInt(payload.deadline),
+      payload.usageSig,
+    );
+
+    session.acceptedSequence = sequence;
+    paymentMux.sendFreeUsageAck({
+      channelId: payload.channelId,
+      acceptedSequence: sequence.toString(),
+    });
+    debugLog(
+      `[SellerFreeUsage] Usage reported on-chain channel=${payload.channelId.slice(0, 18)}... ` +
+      `sequence=${sequence}`,
+    );
+  }
+
+  private async _tryGetExistingSession(channelId: string) {
+    try {
+      return await this._client.getSession(channelId);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/node/src/payments/seller-free-usage-manager.ts
+++ b/packages/node/src/payments/seller-free-usage-manager.ts
@@ -12,6 +12,7 @@ import { FreeUsageClient } from './evm/free-usage-client.js';
 import {
   computeFreeUsageChannelId,
   FREE_USAGE_AUTH_TYPES,
+  FREE_USAGE_METADATA_VERSION,
   FREE_USAGE_OPEN_TYPES,
   makeFreeUsageDomain,
 } from './evm/signatures.js';
@@ -21,6 +22,8 @@ export interface SellerFreeUsageConfig {
   fallbackRpcUrls?: string[];
   freeUsageContractAddress: string;
   chainId: number;
+  recordBatchSize?: number;
+  recordFlushIntervalMs?: number;
 }
 
 interface SellerFreeUsageSession {
@@ -35,12 +38,23 @@ interface SellerFreeUsageSession {
   requestedRequestCount: bigint;
   expectedUsageBySequence: Map<string, ExpectedFreeUsage>;
   openPromise: Promise<void>;
+  pendingRecord: PendingFreeUsageRecord | null;
+  recordsSinceFlush: number;
+  flushTimer: ReturnType<typeof setTimeout> | null;
+  flushPromise: Promise<void> | null;
 }
 
 interface ExpectedFreeUsage {
   cumulativeInputTokens: bigint;
   cumulativeOutputTokens: bigint;
   cumulativeRequestCount: bigint;
+}
+
+interface PendingFreeUsageRecord {
+  sequence: bigint;
+  metadata: string;
+  deadline: bigint;
+  usageSig: string;
 }
 
 const FREE_USAGE_METADATA_ABI = [
@@ -51,7 +65,8 @@ const FREE_USAGE_METADATA_ABI = [
   'tuple(bytes32 serviceId,uint256 cumulativeAmount,uint256 cumulativeInputTokens,uint256 cumulativeCachedInputTokens,uint256 cumulativeOutputTokens,uint256 cumulativeRequestCount)[]',
 ] as const;
 
-const FREE_USAGE_METADATA_VERSION = 1n;
+const DEFAULT_RECORD_BATCH_SIZE = 16;
+const DEFAULT_RECORD_FLUSH_INTERVAL_MS = 10_000;
 
 function normalizeTokenCount(value: number): bigint {
   if (!Number.isFinite(value) || value <= 0) return 0n;
@@ -63,6 +78,8 @@ export class SellerFreeUsageManager {
   private readonly _client: FreeUsageClient;
   private readonly _domain: ReturnType<typeof makeFreeUsageDomain>;
   private readonly _sellerEvmAddr: string;
+  private readonly _recordBatchSize: number;
+  private readonly _recordFlushIntervalMs: number;
   private readonly _sessions = new Map<string, SellerFreeUsageSession>();
   private readonly _buyerLocks = new Map<string, Promise<void>>();
 
@@ -70,6 +87,8 @@ export class SellerFreeUsageManager {
     this._signer = identity.wallet;
     this._sellerEvmAddr = identity.wallet.address;
     this._domain = makeFreeUsageDomain(config.chainId, config.freeUsageContractAddress);
+    this._recordBatchSize = Math.max(1, Math.trunc(config.recordBatchSize ?? DEFAULT_RECORD_BATCH_SIZE));
+    this._recordFlushIntervalMs = Math.max(1, Math.trunc(config.recordFlushIntervalMs ?? DEFAULT_RECORD_FLUSH_INTERVAL_MS));
     this._client = new FreeUsageClient({
       rpcUrl: config.rpcUrl,
       ...(config.fallbackRpcUrls ? { fallbackRpcUrls: config.fallbackRpcUrls } : {}),
@@ -103,8 +122,31 @@ export class SellerFreeUsageManager {
   }
 
   onPeerDisconnect(buyerPeerId: string): void {
-    this._sessions.delete(buyerPeerId);
+    const session = this._sessions.get(buyerPeerId);
+    if (session) {
+      this._clearFlushTimer(session);
+      if (session.pendingRecord || session.flushPromise) {
+        void this._flushPendingRecord(buyerPeerId, session).finally(() => {
+          if (this._sessions.get(buyerPeerId) === session) {
+            this._sessions.delete(buyerPeerId);
+          }
+        });
+      } else {
+        this._sessions.delete(buyerPeerId);
+      }
+    } else {
+      this._sessions.delete(buyerPeerId);
+    }
     this._buyerLocks.delete(buyerPeerId);
+  }
+
+  async flushAllPendingRecords(): Promise<void> {
+    await Promise.all(
+      [...this._sessions.entries()].map(([buyerPeerId, session]) => {
+        this._clearFlushTimer(session);
+        return this._flushPendingRecord(buyerPeerId, session);
+      }),
+    );
   }
 
   reportUsageRequest(
@@ -190,10 +232,21 @@ export class SellerFreeUsageManager {
       requestedRequestCount: 0n,
       expectedUsageBySequence: new Map(),
       openPromise,
+      pendingRecord: null,
+      recordsSinceFlush: 0,
+      flushTimer: null,
+      flushPromise: null,
     };
     this._sessions.set(buyerPeerId, session);
 
-    await openPromise;
+    try {
+      await openPromise;
+    } catch (err) {
+      if (this._sessions.get(buyerPeerId) === session) {
+        this._sessions.delete(buyerPeerId);
+      }
+      throw err;
+    }
     paymentMux.sendFreeUsageAck({ channelId: payload.channelId, acceptedSequence: '0' });
     debugLog(`[SellerFreeUsage] Open reported on-chain channel=${payload.channelId.slice(0, 18)}...`);
   }
@@ -276,16 +329,13 @@ export class SellerFreeUsageManager {
       throw new Error(`invalid FreeUsageAuth signer recovered=${recovered} expected=${session.buyerEvmAddr}`);
     }
 
-    await session.openPromise;
-    await this._client.record(
-      this._signer,
-      payload.channelId,
+    session.pendingRecord = {
       sequence,
-      payload.metadata,
-      BigInt(payload.deadline),
-      payload.usageSig,
-    );
-
+      metadata: payload.metadata,
+      deadline: BigInt(payload.deadline),
+      usageSig: payload.usageSig,
+    };
+    session.recordsSinceFlush += 1;
     session.acceptedSequence = sequence;
     for (const key of session.expectedUsageBySequence.keys()) {
       if (BigInt(key) <= sequence) session.expectedUsageBySequence.delete(key);
@@ -294,10 +344,95 @@ export class SellerFreeUsageManager {
       channelId: payload.channelId,
       acceptedSequence: sequence.toString(),
     });
+    this._scheduleRecordFlush(buyerPeerId, session);
     debugLog(
-      `[SellerFreeUsage] Usage reported on-chain channel=${payload.channelId.slice(0, 18)}... ` +
+      `[SellerFreeUsage] Usage auth accepted channel=${payload.channelId.slice(0, 18)}... ` +
       `sequence=${sequence}`,
     );
+  }
+
+  private _scheduleRecordFlush(
+    buyerPeerId: string,
+    session: SellerFreeUsageSession,
+    opts: { retry?: boolean } = {},
+  ): void {
+    if (!session.pendingRecord || session.flushPromise) return;
+    if (!opts.retry && session.recordsSinceFlush >= this._recordBatchSize) {
+      this._clearFlushTimer(session);
+      void this._flushPendingRecord(buyerPeerId, session);
+      return;
+    }
+    if (session.flushTimer) return;
+    session.flushTimer = setTimeout(() => {
+      session.flushTimer = null;
+      void this._flushPendingRecord(buyerPeerId, session);
+    }, this._recordFlushIntervalMs);
+    (session.flushTimer as { unref?: () => void }).unref?.();
+  }
+
+  private _clearFlushTimer(session: SellerFreeUsageSession): void {
+    if (!session.flushTimer) return;
+    clearTimeout(session.flushTimer);
+    session.flushTimer = null;
+  }
+
+  private _flushPendingRecord(buyerPeerId: string, session: SellerFreeUsageSession): Promise<void> {
+    if (!session.pendingRecord) return Promise.resolve();
+    if (session.flushPromise) return session.flushPromise;
+
+    let promise!: Promise<void>;
+    promise = (async () => {
+      const flushed = await this._doFlushPendingRecord(buyerPeerId, session);
+      if (session.flushPromise === promise) {
+        session.flushPromise = null;
+      }
+      if (session.pendingRecord) {
+        this._scheduleRecordFlush(buyerPeerId, session, flushed ? {} : { retry: true });
+      }
+    })();
+    session.flushPromise = promise;
+    return promise;
+  }
+
+  private async _doFlushPendingRecord(
+    buyerPeerId: string,
+    session: SellerFreeUsageSession,
+  ): Promise<boolean> {
+    const record = session.pendingRecord;
+    if (!record) return true;
+
+    this._clearFlushTimer(session);
+    try {
+      await session.openPromise;
+      await this._client.record(
+        this._signer,
+        session.channelId,
+        record.sequence,
+        record.metadata,
+        record.deadline,
+        record.usageSig,
+      );
+      const pending = session.pendingRecord;
+      if (!pending || pending.sequence <= record.sequence) {
+        session.pendingRecord = null;
+        session.recordsSinceFlush = 0;
+      } else {
+        const delta = pending.sequence - record.sequence;
+        session.recordsSinceFlush = Number(delta > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : delta);
+      }
+      debugLog(
+        `[SellerFreeUsage] Usage reported on-chain channel=${session.channelId.slice(0, 18)}... ` +
+        `sequence=${record.sequence}`,
+      );
+      return true;
+    } catch (err) {
+      debugWarn(
+        `[SellerFreeUsage] Deferred record failed for ${buyerPeerId.slice(0, 12)}... ` +
+        `channel=${session.channelId.slice(0, 18)}... sequence=${record.sequence}: ` +
+        `${err instanceof Error ? err.message : err}`,
+      );
+      return false;
+    }
   }
 
   private async _tryGetExistingSession(channelId: string) {

--- a/packages/node/src/payments/seller-free-usage-manager.ts
+++ b/packages/node/src/payments/seller-free-usage-manager.ts
@@ -243,6 +243,8 @@ export class SellerFreeUsageManager {
     if (!expectedUsage) {
       throw new Error(`unexpected free usage sequence ${sequence}`);
     }
+    // The seller enforces aggregate counters it measured; per-service tuples
+    // remain buyer-attributed audit metadata.
     const signedUsage = this._decodeFreeUsageMetadata(payload.metadata);
     const payloadInputTokens = BigInt(payload.cumulativeInputTokens);
     const payloadOutputTokens = BigInt(payload.cumulativeOutputTokens);

--- a/packages/node/src/payments/seller-free-usage-manager.ts
+++ b/packages/node/src/payments/seller-free-usage-manager.ts
@@ -1,4 +1,4 @@
-import { keccak256, verifyTypedData } from 'ethers';
+import { AbiCoder, keccak256, verifyTypedData } from 'ethers';
 import type { Identity } from '../p2p/identity.js';
 import type { PaymentMux } from '../p2p/payment-mux.js';
 import type {
@@ -30,7 +30,32 @@ interface SellerFreeUsageSession {
   deadline: number;
   acceptedSequence: bigint;
   requestedSequence: bigint;
+  requestedInputTokens: bigint;
+  requestedOutputTokens: bigint;
+  requestedRequestCount: bigint;
+  expectedUsageBySequence: Map<string, ExpectedFreeUsage>;
   openPromise: Promise<void>;
+}
+
+interface ExpectedFreeUsage {
+  cumulativeInputTokens: bigint;
+  cumulativeOutputTokens: bigint;
+  cumulativeRequestCount: bigint;
+}
+
+const FREE_USAGE_METADATA_ABI = [
+  'uint256',
+  'uint256',
+  'uint256',
+  'uint256',
+  'tuple(bytes32 serviceId,uint256 cumulativeAmount,uint256 cumulativeInputTokens,uint256 cumulativeCachedInputTokens,uint256 cumulativeOutputTokens,uint256 cumulativeRequestCount)[]',
+] as const;
+
+const FREE_USAGE_METADATA_VERSION = 1n;
+
+function normalizeTokenCount(value: number): bigint {
+  if (!Number.isFinite(value) || value <= 0) return 0n;
+  return BigInt(Math.trunc(value));
 }
 
 export class SellerFreeUsageManager {
@@ -77,6 +102,11 @@ export class SellerFreeUsageManager {
     });
   }
 
+  onPeerDisconnect(buyerPeerId: string): void {
+    this._sessions.delete(buyerPeerId);
+    this._buyerLocks.delete(buyerPeerId);
+  }
+
   reportUsageRequest(
     buyerPeerId: string,
     paymentMux: PaymentMux,
@@ -91,20 +121,29 @@ export class SellerFreeUsageManager {
     const nextSequence = (session.requestedSequence > session.acceptedSequence
       ? session.requestedSequence
       : session.acceptedSequence) + 1n;
-    session.requestedSequence = nextSequence;
-
     const payload: NeedFreeUsageAuthPayload = {
       channelId: session.channelId,
       requiredSequence: nextSequence.toString(),
       currentAcceptedSequence: session.acceptedSequence.toString(),
       ...(usage.requestId ? { requestId: usage.requestId } : {}),
-      inputTokens: String(Math.max(0, usage.inputTokens)),
-      outputTokens: String(Math.max(0, usage.outputTokens)),
+      inputTokens: normalizeTokenCount(usage.inputTokens).toString(),
+      outputTokens: normalizeTokenCount(usage.outputTokens).toString(),
       ...(usage.service ? { service: usage.service } : {}),
     };
 
     try {
       paymentMux.sendNeedFreeUsageAuth(payload);
+      const inputTokens = normalizeTokenCount(usage.inputTokens);
+      const outputTokens = normalizeTokenCount(usage.outputTokens);
+      session.requestedSequence = nextSequence;
+      session.requestedInputTokens += inputTokens;
+      session.requestedOutputTokens += outputTokens;
+      session.requestedRequestCount += 1n;
+      session.expectedUsageBySequence.set(nextSequence.toString(), {
+        cumulativeInputTokens: session.requestedInputTokens,
+        cumulativeOutputTokens: session.requestedOutputTokens,
+        cumulativeRequestCount: session.requestedRequestCount,
+      });
       debugLog(
         `[SellerFreeUsage] NeedFreeUsageAuth sent to ${buyerPeerId.slice(0, 12)}... ` +
         `channel=${session.channelId.slice(0, 18)}... sequence=${nextSequence}`,
@@ -146,6 +185,10 @@ export class SellerFreeUsageManager {
       deadline: payload.deadline,
       acceptedSequence: 0n,
       requestedSequence: 0n,
+      requestedInputTokens: 0n,
+      requestedOutputTokens: 0n,
+      requestedRequestCount: 0n,
+      expectedUsageBySequence: new Map(),
       openPromise,
     };
     this._sessions.set(buyerPeerId, session);
@@ -195,6 +238,27 @@ export class SellerFreeUsageManager {
     if (metadataHash.toLowerCase() !== payload.metadataHash.toLowerCase()) {
       throw new Error('metadataHash mismatch');
     }
+    const sequenceKey = sequence.toString();
+    const expectedUsage = session.expectedUsageBySequence.get(sequenceKey);
+    if (!expectedUsage) {
+      throw new Error(`unexpected free usage sequence ${sequence}`);
+    }
+    const signedUsage = this._decodeFreeUsageMetadata(payload.metadata);
+    const payloadInputTokens = BigInt(payload.cumulativeInputTokens);
+    const payloadOutputTokens = BigInt(payload.cumulativeOutputTokens);
+    if (
+      payloadInputTokens !== signedUsage.cumulativeInputTokens
+      || payloadOutputTokens !== signedUsage.cumulativeOutputTokens
+      || signedUsage.cumulativeInputTokens !== expectedUsage.cumulativeInputTokens
+      || signedUsage.cumulativeOutputTokens !== expectedUsage.cumulativeOutputTokens
+      || signedUsage.cumulativeRequestCount !== expectedUsage.cumulativeRequestCount
+    ) {
+      throw new Error(
+        `free usage totals mismatch sequence=${sequence} ` +
+        `expected(in=${expectedUsage.cumulativeInputTokens},out=${expectedUsage.cumulativeOutputTokens},requests=${expectedUsage.cumulativeRequestCount}) ` +
+        `got(in=${signedUsage.cumulativeInputTokens},out=${signedUsage.cumulativeOutputTokens},requests=${signedUsage.cumulativeRequestCount})`,
+      );
+    }
     const recovered = verifyTypedData(
       this._domain,
       FREE_USAGE_AUTH_TYPES,
@@ -221,6 +285,9 @@ export class SellerFreeUsageManager {
     );
 
     session.acceptedSequence = sequence;
+    for (const key of session.expectedUsageBySequence.keys()) {
+      if (BigInt(key) <= sequence) session.expectedUsageBySequence.delete(key);
+    }
     paymentMux.sendFreeUsageAck({
       channelId: payload.channelId,
       acceptedSequence: sequence.toString(),
@@ -237,5 +304,20 @@ export class SellerFreeUsageManager {
     } catch {
       return null;
     }
+  }
+
+  private _decodeFreeUsageMetadata(metadata: string): ExpectedFreeUsage {
+    const [version, inputTokens, outputTokens, requestCount] = AbiCoder.defaultAbiCoder().decode(
+      FREE_USAGE_METADATA_ABI,
+      metadata,
+    );
+    if (BigInt(version) !== FREE_USAGE_METADATA_VERSION) {
+      throw new Error(`unsupported free usage metadata version ${version}`);
+    }
+    return {
+      cumulativeInputTokens: BigInt(inputTokens),
+      cumulativeOutputTokens: BigInt(outputTokens),
+      cumulativeRequestCount: BigInt(requestCount),
+    };
   }
 }

--- a/packages/node/src/payments/seller-free-usage-manager.ts
+++ b/packages/node/src/payments/seller-free-usage-manager.ts
@@ -42,6 +42,7 @@ interface SellerFreeUsageSession {
   recordsSinceFlush: number;
   flushTimer: ReturnType<typeof setTimeout> | null;
   flushPromise: Promise<void> | null;
+  closeRequested: boolean;
 }
 
 interface ExpectedFreeUsage {
@@ -125,6 +126,7 @@ export class SellerFreeUsageManager {
     const session = this._sessions.get(buyerPeerId);
     if (session) {
       this._clearFlushTimer(session);
+      session.closeRequested = true;
       if (session.pendingRecord || session.flushPromise) {
         void this._flushPendingRecord(buyerPeerId, session).finally(() => {
           if (this._sessions.get(buyerPeerId) === session) {
@@ -236,6 +238,7 @@ export class SellerFreeUsageManager {
       recordsSinceFlush: 0,
       flushTimer: null,
       flushPromise: null,
+      closeRequested: false,
     };
     this._sessions.set(buyerPeerId, session);
 
@@ -386,7 +389,7 @@ export class SellerFreeUsageManager {
       if (session.flushPromise === promise) {
         session.flushPromise = null;
       }
-      if (session.pendingRecord) {
+      if (session.pendingRecord && !session.closeRequested) {
         this._scheduleRecordFlush(buyerPeerId, session, flushed ? {} : { retry: true });
       }
     })();
@@ -404,14 +407,36 @@ export class SellerFreeUsageManager {
     this._clearFlushTimer(session);
     try {
       await session.openPromise;
-      await this._client.record(
-        this._signer,
-        session.channelId,
-        record.sequence,
-        record.metadata,
-        record.deadline,
-        record.usageSig,
-      );
+      const closeRequested = session.closeRequested;
+      if (closeRequested) {
+        await this._client.close(
+          this._signer,
+          session.channelId,
+          record.sequence,
+          record.metadata,
+          record.deadline,
+          record.usageSig,
+        );
+      } else {
+        await this._client.record(
+          this._signer,
+          session.channelId,
+          record.sequence,
+          record.metadata,
+          record.deadline,
+          record.usageSig,
+        );
+      }
+      if (!closeRequested && session.closeRequested) {
+        await this._client.close(
+          this._signer,
+          session.channelId,
+          record.sequence,
+          record.metadata,
+          record.deadline,
+          record.usageSig,
+        );
+      }
       const pending = session.pendingRecord;
       if (!pending || pending.sequence <= record.sequence) {
         session.pendingRecord = null;
@@ -421,7 +446,7 @@ export class SellerFreeUsageManager {
         session.recordsSinceFlush = Number(delta > BigInt(Number.MAX_SAFE_INTEGER) ? BigInt(Number.MAX_SAFE_INTEGER) : delta);
       }
       debugLog(
-        `[SellerFreeUsage] Usage reported on-chain channel=${session.channelId.slice(0, 18)}... ` +
+        `[SellerFreeUsage] Usage ${session.closeRequested ? 'closed' : 'reported'} on-chain channel=${session.channelId.slice(0, 18)}... ` +
         `sequence=${record.sequence}`,
       );
       return true;

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -15,7 +15,7 @@ import {
 } from './evm/signatures.js';
 import { debugLog, debugWarn } from '../utils/debug.js';
 import { peerIdToAddress } from '../types/peer.js';
-import { ChannelStore, type StoredChannel } from './channel-store.js';
+import { ChannelStore, CHANNEL_ROLE, CHANNEL_STATUS, type StoredChannel } from './channel-store.js';
 import { classifyOnChainChannel, matchesChannelParties } from './channel-session-state.js';
 
 export interface SellerPaymentConfig {
@@ -167,7 +167,7 @@ export class SellerPaymentManager {
       : DEFAULT_MIN_SETTLE_DELTA;
 
     // Hydrate from persisted channels
-    const activeChannels = this._channelStore.getActiveChannels('seller');
+    const activeChannels = this._channelStore.getActiveChannels(CHANNEL_ROLE.SELLER);
     for (const channel of activeChannels) {
       this._activeBuyers.add(channel.peerId);
       this._hydratedChannelIds.add(channel.sessionId);
@@ -196,7 +196,7 @@ export class SellerPaymentManager {
    * Must be called after construction (async, cannot run in constructor).
    */
   async validateHydratedChannels(): Promise<void> {
-    const activeChannels = this._channelStore.getActiveChannels('seller');
+    const activeChannels = this._channelStore.getActiveChannels(CHANNEL_ROLE.SELLER);
     if (activeChannels.length === 0) return;
 
     const { seller: sellerEvmAddr } = await this._resolvedAddresses!;
@@ -247,7 +247,12 @@ export class SellerPaymentManager {
     }
   }
 
-  private _evictStaleChannel(channelId: string, peerId: string, reason: string, status: 'settled' | 'timeout' = 'settled'): void {
+  private _evictStaleChannel(
+    channelId: string,
+    peerId: string,
+    reason: string,
+    status: typeof CHANNEL_STATUS.SETTLED | typeof CHANNEL_STATUS.TIMEOUT = CHANNEL_STATUS.SETTLED,
+  ): void {
     this._channelStore.updateChannelStatus(channelId, status);
     this._acceptedCumulative.delete(channelId);
     this._spent.delete(channelId);
@@ -461,7 +466,7 @@ export class SellerPaymentManager {
         const session: StoredChannel = {
           sessionId: channelId,
           peerId: buyerPeerId,
-          role: 'seller',
+          role: CHANNEL_ROLE.SELLER,
           sellerEvmAddr,
           buyerEvmAddr,
           nonce: 0,
@@ -474,7 +479,7 @@ export class SellerPaymentManager {
           reservedAt: now,
           settledAt: null,
           settledAmount: null,
-          status: 'active',
+          status: CHANNEL_STATUS.ACTIVE,
           latestBuyerSig: payload.spendingAuthSig,
           latestSpendingAuthSig: payload.spendingAuthSig,
           latestMetadata: payload.metadata,
@@ -877,7 +882,7 @@ export class SellerPaymentManager {
     const session: StoredChannel = {
       sessionId: channelId,
       peerId: buyerPeerId,
-      role: 'seller',
+      role: CHANNEL_ROLE.SELLER,
       sellerEvmAddr,
       buyerEvmAddr,
       nonce: 0,
@@ -890,7 +895,7 @@ export class SellerPaymentManager {
       reservedAt: now,
       settledAt: null,
       settledAmount: onChain.settled > 0n ? onChain.settled.toString() : null,
-      status: 'active',
+      status: CHANNEL_STATUS.ACTIVE,
       latestBuyerSig: payload.spendingAuthSig,
       latestSpendingAuthSig: payload.spendingAuthSig,
       latestMetadata: payload.metadata,
@@ -944,7 +949,7 @@ export class SellerPaymentManager {
     auth: SpendingAuthPayload,
   ): Promise<boolean> {
     // Look up active session for this buyer
-    const session = this._channelStore.getActiveChannelByPeer(buyerPeerId, 'seller');
+    const session = this._channelStore.getActiveChannelByPeer(buyerPeerId, CHANNEL_ROLE.SELLER);
     if (!session) {
       debugWarn(`[SellerPayment] validateAndAcceptAuth: no active session for buyer ${buyerPeerId.slice(0, 12)}...`);
       return false;
@@ -1071,7 +1076,7 @@ export class SellerPaymentManager {
    *   for future requests. No cleanup is performed so the session can resume.
    */
   async settleSession(buyerPeerId: string, { cleanupOnFailure = false, settleOnly = false } = {}): Promise<void> {
-    const session = this._channelStore.getActiveChannelByPeer(buyerPeerId, 'seller');
+    const session = this._channelStore.getActiveChannelByPeer(buyerPeerId, CHANNEL_ROLE.SELLER);
     if (!session) {
       debugWarn(`[SellerPayment] settleSession: no active session for buyer ${buyerPeerId.slice(0, 12)}...`);
       return;
@@ -1101,7 +1106,7 @@ export class SellerPaymentManager {
         this._closingChannels.add(channelId);
         try {
           await this._channelsClient.close(this._signer, channelId, amount, metadata, sig);
-          this._channelStore.updateChannelStatus(channelId, 'settled', amount.toString());
+          this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.SETTLED, amount.toString());
           this._closeRetryCount.delete(channelId);
         } catch (err) {
           debugWarn(`[SellerPayment] Failed to close channel (attempt ${retries + 1}): ${err instanceof Error ? err.message : err}`);
@@ -1131,7 +1136,7 @@ export class SellerPaymentManager {
   // ── Disconnect handling ───────────────────────────────────────
 
   onBuyerDisconnect(buyerPeerId: string): void {
-    const session = this._channelStore.getActiveChannelByPeer(buyerPeerId, 'seller');
+    const session = this._channelStore.getActiveChannelByPeer(buyerPeerId, CHANNEL_ROLE.SELLER);
     if (!session) return;
 
     const settleOnDisconnect = this._config.settleOnDisconnect ?? true;
@@ -1167,7 +1172,7 @@ export class SellerPaymentManager {
    */
   async checkTimeouts(): Promise<void> {
     const nowSecs = Math.floor(Date.now() / 1000);
-    const activeChannels = this._channelStore.getActiveChannels('seller');
+    const activeChannels = this._channelStore.getActiveChannels(CHANNEL_ROLE.SELLER);
 
     for (const channel of activeChannels) {
       let accepted = this._acceptedCumulative.get(channel.sessionId) ?? 0n;
@@ -1204,7 +1209,12 @@ export class SellerPaymentManager {
           if (onChainState.status !== 'active') {
             // 'unknown' means the RPC returned partial data. Evict locally
             // rather than risking a close() against an ambiguous channel.
-            this._evictStaleChannel(channel.sessionId, channel.peerId, 'no auths, past deadline, on-chain status unknown', 'timeout');
+            this._evictStaleChannel(
+              channel.sessionId,
+              channel.peerId,
+              'no auths, past deadline, on-chain status unknown',
+              CHANNEL_STATUS.TIMEOUT,
+            );
             continue;
           }
           await this._closeWithoutAuth(channel.sessionId, channel.peerId, onChainState.channel.settled);
@@ -1230,7 +1240,7 @@ export class SellerPaymentManager {
     const retries = this._closeRetryCount.get(channelId) ?? 0;
     if (retries >= SellerPaymentManager.MAX_CLOSE_RETRIES) {
       debugWarn(`[SellerPayment] Zombie close failed ${retries} times for ${channelId.slice(0, 18)}... — falling back to local eviction`);
-      this._evictStaleChannel(channelId, peerId, 'no auths, past deadline, close retries exhausted', 'timeout');
+      this._evictStaleChannel(channelId, peerId, 'no auths, past deadline, close retries exhausted', CHANNEL_STATUS.TIMEOUT);
       return;
     }
 
@@ -1239,7 +1249,7 @@ export class SellerPaymentManager {
     try {
       await this._channelsClient.close(this._signer, channelId, onChainSettled, '0x', '0x');
       this._closeRetryCount.delete(channelId);
-      this._evictStaleChannel(channelId, peerId, 'zombie closed on-chain', 'settled');
+      this._evictStaleChannel(channelId, peerId, 'zombie closed on-chain', CHANNEL_STATUS.SETTLED);
     } catch (err) {
       this._closeRetryCount.set(channelId, retries + 1);
       debugWarn(`[SellerPayment] Zombie close failed (attempt ${retries + 1}): ${err instanceof Error ? err.message : err}`);
@@ -1256,7 +1266,7 @@ export class SellerPaymentManager {
 
   /** Get the active session for a buyer peer, or null. */
   getChannelByPeer(buyerPeerId: string): StoredChannel | null {
-    return this._channelStore.getActiveChannelByPeer(buyerPeerId, 'seller');
+    return this._channelStore.getActiveChannelByPeer(buyerPeerId, CHANNEL_ROLE.SELLER);
   }
 
   /** Get total USDC spent for a session (sum of recordSpend calls). */
@@ -1304,7 +1314,7 @@ export class SellerPaymentManager {
     let suggestedAmount = SellerPaymentManager.DEFAULT_SUGGESTED_AMOUNT;
     if (buyerPeerId) {
       const priorSession = this._channelStore.getLatestChannel(buyerPeerId, 'seller');
-      if (priorSession && priorSession.status === 'settled') {
+      if (priorSession && priorSession.status === CHANNEL_STATUS.SETTLED) {
         // Returning buyer with proven history — could use a different amount
         // For now, use the same default; config can override later
         suggestedAmount = SellerPaymentManager.DEFAULT_SUGGESTED_AMOUNT;
@@ -1336,7 +1346,7 @@ export class SellerPaymentManager {
       debugLog(`[SellerPayment] CloseRequested for channel ${channelId.slice(0, 18)}... — closing with cumulative=${amount}`);
       try {
         await this._channelsClient.close(this._signer, channelId, amount, metadata, sig);
-        this._channelStore.updateChannelStatus(channelId, 'settled', amount.toString());
+        this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.SETTLED, amount.toString());
         debugLog(`[SellerPayment] Channel ${channelId.slice(0, 18)}... closed successfully after CloseRequested`);
       } catch (err) {
         debugWarn(`[SellerPayment] Failed to close channel ${channelId.slice(0, 18)}... after CloseRequested: ${err instanceof Error ? err.message : err}`);
@@ -1346,7 +1356,7 @@ export class SellerPaymentManager {
       // No voucher — seller can't claim anything. Clean up locally;
       // buyer will withdraw after grace period.
       debugLog(`[SellerPayment] CloseRequested for channel ${channelId.slice(0, 18)}... — no SpendingAuth, cleaning up locally`);
-      this._channelStore.updateChannelStatus(channelId, 'timeout');
+      this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.TIMEOUT);
     }
 
     // Clean up in-memory state
@@ -1382,7 +1392,7 @@ export class SellerPaymentManager {
 
       for (const event of events) {
         // Only handle channels this seller is actively tracking
-        if (this._acceptedCumulative.has(event.channelId) || this._channelStore.getChannel(event.channelId)?.status === 'active') {
+        if (this._acceptedCumulative.has(event.channelId) || this._channelStore.getChannel(event.channelId)?.status === CHANNEL_STATUS.ACTIVE) {
           await this.handleCloseRequested(event.channelId);
         }
       }

--- a/packages/node/src/payments/types.ts
+++ b/packages/node/src/payments/types.ts
@@ -49,6 +49,8 @@ export interface CryptoPaymentConfig {
   depositsContractAddress: string;
   /** Deployed AntseedChannels contract address */
   channelsContractAddress: string;
+  /** Optional deployed AntseedFreeUsage contract address */
+  freeUsageContractAddress?: string;
   /** USDC token contract address */
   usdcAddress: string;
   /** Default lock amount for new sessions (USDC base units as string, e.g. "1000000" = 1 USDC) */

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -8,6 +8,7 @@ import type { PaymentMux } from './p2p/payment-mux.js';
 import type { Identity } from './p2p/identity.js';
 import type { ChannelsClient } from './payments/evm/channels-client.js';
 import type { SellerPaymentManager } from './payments/seller-payment-manager.js';
+import type { SellerFreeUsageManager } from './payments/seller-free-usage-manager.js';
 import { ProxyMux } from './proxy/proxy-mux.js';
 import type { PeerConnection } from './p2p/connection-manager.js';
 import type {
@@ -26,6 +27,7 @@ export interface SellerRequestHandlerDeps {
   identity: Identity;
   providers: Provider[];
   sellerPaymentManager: SellerPaymentManager | null;
+  sellerFreeUsageManager?: SellerFreeUsageManager | null;
   sessionTracker: SellerSessionTracker | null;
   channelsClient: ChannelsClient | null;
   announcer: PeerAnnouncer | null;
@@ -454,6 +456,13 @@ export class SellerRequestHandler {
               service: this._extractRequestedService(request) ?? undefined,
             }, buyerPeerId, 'post-response');
           }
+        } else if (isFreeService) {
+          this._deps.sellerFreeUsageManager?.reportUsageRequest(buyerPeerId, paymentMux, {
+            requestId: request.requestId,
+            inputTokens: responseUsage.inputTokens,
+            outputTokens: responseUsage.outputTokens,
+            service: this._extractRequestedService(request) ?? undefined,
+          });
         }
 
         const buyerSupportsResponseAuth = conn.hasRemoteCapability(CONNECTION_CAPABILITY_RESPONSE_AUTH_V1);

--- a/packages/node/src/storage/migrations/channels/004_add_channel_kind.ts
+++ b/packages/node/src/storage/migrations/channels/004_add_channel_kind.ts
@@ -1,0 +1,19 @@
+import type { Migration } from '../../migrate.js';
+
+export const migration: Migration = {
+  version: 4,
+  name: 'add_channel_kind',
+  up: (db) => {
+    const cols = db.pragma('table_info(payment_channels)') as Array<{ name: string }>;
+    const existing = new Set(cols.map((c) => c.name));
+
+    if (!existing.has('channel_kind')) {
+      db.exec("ALTER TABLE payment_channels ADD COLUMN channel_kind TEXT NOT NULL DEFAULT 'paid'");
+    }
+
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_channels_peer_role_kind_status
+        ON payment_channels(peer_id, role, channel_kind, status);
+    `);
+  },
+};

--- a/packages/node/src/storage/migrations/channels/index.ts
+++ b/packages/node/src/storage/migrations/channels/index.ts
@@ -2,5 +2,6 @@ import type { Migration } from '../../migrate.js';
 import { migration as m001 } from './001_create_tables.js';
 import { migration as m002 } from './002_add_auth_sig_columns.js';
 import { migration as m003 } from './003_create_service_totals.js';
+import { migration as m004 } from './004_add_channel_kind.js';
 
-export const channelMigrations: Migration[] = [m001, m002, m003];
+export const channelMigrations: Migration[] = [m001, m002, m003, m004];

--- a/packages/node/src/types/protocol.ts
+++ b/packages/node/src/types/protocol.ts
@@ -15,6 +15,10 @@ export enum MessageType {
   // --- Payment Protocol (0x50-0x5F) ---
   SpendingAuth = 0x50,
   AuthAck = 0x51,
+  FreeUsageOpen = 0x52,
+  FreeUsageAuth = 0x53,
+  FreeUsageAck = 0x54,
+  NeedFreeUsageAuth = 0x55,
   PaymentRequired = 0x56,
   NeedAuth = 0x58,
 
@@ -68,6 +72,53 @@ export interface SpendingAuthPayload {
  */
 export interface AuthAckPayload {
   channelId: string;
+}
+
+/**
+ * Buyer opens a zero-price usage channel. This does not require deposits.
+ */
+export interface FreeUsageOpenPayload {
+  channelId: string;
+  salt: string;
+  deadline: number;
+  openSig: string;
+}
+
+/**
+ * Buyer authorizes a cumulative zero-price usage record after the seller reports
+ * usage for a served request.
+ */
+export interface FreeUsageAuthPayload {
+  channelId: string;
+  cumulativeInputTokens: string;
+  cumulativeOutputTokens: string;
+  sequence: string;
+  metadataHash: string;
+  metadata: string;
+  deadline: number;
+  usageSig: string;
+}
+
+/**
+ * Seller acknowledges a free usage channel/open or record was accepted for
+ * on-chain reporting.
+ */
+export interface FreeUsageAckPayload {
+  channelId: string;
+  acceptedSequence?: string;
+}
+
+/**
+ * Seller asks the buyer to sign zero-price usage for a completed request.
+ */
+export interface NeedFreeUsageAuthPayload {
+  channelId: string;
+  requiredSequence: string;
+  currentAcceptedSequence: string;
+  requestId?: string;
+  inputTokens?: string;
+  outputTokens?: string;
+  service?: string;
 }
 
 /**

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { AbiCoder, id, Wallet } from 'ethers';
 import { BuyerPaymentManager, type BuyerPaymentConfig } from '../src/payments/buyer-payment-manager.js';
-import { ChannelStore } from '../src/payments/channel-store.js';
+import { ChannelStore, CHANNEL_ROLE } from '../src/payments/channel-store.js';
 import type { PaymentMux } from '../src/p2p/payment-mux.js';
 import type { Identity } from '../src/p2p/identity.js';
 import { bytesToHex } from '../src/utils/hex.js';
@@ -561,7 +561,7 @@ describe('BuyerPaymentManager', () => {
       cumulativeRequestCount: 1n,
     });
 
-    const channel = store.getActiveChannelByPeer(sellerPeerId, 'buyer');
+    const channel = store.getActiveChannelByPeer(sellerPeerId, CHANNEL_ROLE.BUYER);
     expect(channel).not.toBeNull();
     const storedServices = store.getServiceTotals(channel!.sessionId);
     expect(storedServices).toHaveLength(2);
@@ -1117,7 +1117,7 @@ describe('BuyerPaymentManager', () => {
     expect(totals.requests).toBe(2);
 
     // Persisted in channel store
-    const channel = store.getActiveChannelByPeer(sellerPeerId, 'buyer');
+    const channel = store.getActiveChannelByPeer(sellerPeerId, CHANNEL_ROLE.BUYER);
     expect(channel).not.toBeNull();
     expect(channel!.tokensDelivered).toBe('1500');
     expect(channel!.previousConsumption).toBe('350');
@@ -1144,7 +1144,7 @@ describe('BuyerPaymentManager', () => {
 
     // Reopen store and verify persisted data
     const store2 = new ChannelStore(tempDir);
-    const channel = store2.getActiveChannelByPeer(sellerPeerId, 'buyer');
+    const channel = store2.getActiveChannelByPeer(sellerPeerId, CHANNEL_ROLE.BUYER);
     expect(channel).not.toBeNull();
     expect(channel!.tokensDelivered).toBe('2000');
     expect(channel!.previousConsumption).toBe('800');
@@ -1193,7 +1193,7 @@ describe('BuyerPaymentManager', () => {
     expect(BigInt(extended.cumulativeAmount)).toBeGreaterThan(previousCumulative);
     expect(extended.metadata).toBe(previousMetadata);
 
-    const channel = store.getActiveChannelByPeer(sellerPeerId, 'buyer');
+    const channel = store.getActiveChannelByPeer(sellerPeerId, CHANNEL_ROLE.BUYER);
     expect(channel).not.toBeNull();
     expect(channel!.authMax).toBe(extended.cumulativeAmount);
   });
@@ -1354,7 +1354,7 @@ describe('BuyerPaymentManager', () => {
       requests: 2,
     });
 
-    const channel = store.getActiveChannelByPeer(sellerPeerId, 'buyer');
+    const channel = store.getActiveChannelByPeer(sellerPeerId, CHANNEL_ROLE.BUYER);
     expect(channel).not.toBeNull();
     expect(channel!.tokensDelivered).toBe('1500');
     expect(channel!.previousConsumption).toBe('350');

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -5,8 +5,7 @@ import type { SerializedHttpResponse, SerializedHttpRequest } from '../src/types
 import type { BuyerPaymentManager } from '../src/payments/buyer-payment-manager.js';
 import type { DepositsClient } from '../src/payments/evm/deposits-client.js';
 import type { ChannelsClient, ChannelInfo } from '../src/payments/evm/channels-client.js';
-import type { ChannelStore } from '../src/payments/channel-store.js';
-import type { StoredChannel } from '../src/payments/channel-store.js';
+import { CHANNEL_ROLE, CHANNEL_STATUS, type ChannelStore, type StoredChannel } from '../src/payments/channel-store.js';
 import type { Identity } from '../src/p2p/identity.js';
 import type { PeerConnection } from '../src/p2p/connection-manager.js';
 import type { PaymentRequiredPayload } from '../src/types/protocol.js';
@@ -305,7 +304,7 @@ describe('BuyerPaymentNegotiator', () => {
 
       const result = await negotiator.handle402(response, peer, conn, makeRequest());
 
-      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, 'ghost');
+      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, CHANNEL_STATUS.GHOST);
       // Critical: no futile signing on the dead channel.
       expect(bpm.extendCurrentSpendingAuth).not.toHaveBeenCalled();
       expect(bpm.resendCurrentSpendingAuth).not.toHaveBeenCalled();
@@ -341,7 +340,7 @@ describe('BuyerPaymentNegotiator', () => {
 
       const result = await negotiator.handle402(response, peer, conn, makeRequest());
 
-      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, 'ghost');
+      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, CHANNEL_STATUS.GHOST);
       expect(bpm.extendCurrentSpendingAuth).not.toHaveBeenCalled();
       expect(bpm.authorizeSpending).toHaveBeenCalled();
       expect(result.action).toBe('retry');
@@ -369,7 +368,7 @@ describe('BuyerPaymentNegotiator', () => {
       const result = await negotiator.handle402(make402Response(), peer, conn, makeRequest());
 
       expect(bpm.extendCurrentSpendingAuth).toHaveBeenCalled();
-      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, 'ghost');
+      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, CHANNEL_STATUS.GHOST);
       expect(bpm.authorizeSpending).toHaveBeenCalled();
       expect(result.action).toBe('retry');
     });
@@ -400,7 +399,7 @@ describe('BuyerPaymentNegotiator', () => {
 
       const result = await negotiator.handle402(make402Response(), peer, conn, makeRequest());
 
-      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, 'ghost');
+      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, CHANNEL_STATUS.GHOST);
       expect(bpm.authorizeSpending).toHaveBeenCalled();
       expect(result.action).toBe('retry');
     });
@@ -440,7 +439,7 @@ describe('BuyerPaymentNegotiator', () => {
 
       const result = await negotiator.handle402(make402Response(), peer, conn, makeRequest());
 
-      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, 'ghost');
+      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, CHANNEL_STATUS.GHOST);
       expect(bpm.authorizeSpending).toHaveBeenCalled();
       expect(result.action).toBe('retry');
     });
@@ -459,7 +458,7 @@ describe('BuyerPaymentNegotiator', () => {
 
       const result = await negotiator.handle402(make402Response(), peer, conn, makeRequest());
 
-      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, 'ghost');
+      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, CHANNEL_STATUS.GHOST);
       expect(bpm.authorizeSpending).toHaveBeenCalled();
       expect(result.action).toBe('retry');
     });
@@ -488,7 +487,7 @@ describe('BuyerPaymentNegotiator', () => {
 
       const result = await negotiator.handle402(make402Response(), peer, conn, makeRequest());
 
-      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, 'ghost');
+      expect(bpm.retireSession).toHaveBeenCalledWith(peer.peerId, CHANNEL_STATUS.GHOST);
       expect(bpm.authorizeSpending).toHaveBeenCalled();
       expect(result.action).toBe('retry');
     });
@@ -864,7 +863,7 @@ function makeActiveSession(peerId: string): StoredChannel {
   return {
     sessionId: '0x' + 'ab'.repeat(32),
     peerId,
-    role: 'buyer',
+    role: CHANNEL_ROLE.BUYER,
     sellerEvmAddr: '0x' + '22'.repeat(20),
     buyerEvmAddr: '0x' + '11'.repeat(20),
     nonce: 0,
@@ -877,7 +876,7 @@ function makeActiveSession(peerId: string): StoredChannel {
     reservedAt: now,
     settledAt: null,
     settledAmount: null,
-    status: 'active',
+    status: CHANNEL_STATUS.ACTIVE,
     latestBuyerSig: null,
     latestSpendingAuthSig: null,
     latestMetadata: null,

--- a/packages/node/tests/channel-store.test.ts
+++ b/packages/node/tests/channel-store.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { ChannelStore, type StoredChannel, type StoredReceipt } from '../src/payments/channel-store.js';
+import { ChannelStore, CHANNEL_KIND, CHANNEL_ROLE, CHANNEL_STATUS, type StoredChannel, type StoredReceipt } from '../src/payments/channel-store.js';
 
 function makeTempDir(): string {
   return mkdtempSync(join(tmpdir(), 'channel-store-test-'));
@@ -13,7 +13,7 @@ function makeChannel(overrides: Partial<StoredChannel> = {}): StoredChannel {
   return {
     sessionId: '0x' + 'aa'.repeat(32),
     peerId: 'peer-abc123',
-    role: 'buyer',
+    role: CHANNEL_ROLE.BUYER,
     sellerEvmAddr: '0x' + 'bb'.repeat(20),
     buyerEvmAddr: '0x' + 'cc'.repeat(20),
     nonce: 1,
@@ -26,7 +26,7 @@ function makeChannel(overrides: Partial<StoredChannel> = {}): StoredChannel {
     reservedAt: now,
     settledAt: null,
     settledAmount: null,
-    status: 'active',
+    status: CHANNEL_STATUS.ACTIVE,
     createdAt: now,
     updatedAt: now,
     ...overrides,
@@ -65,7 +65,7 @@ describe('ChannelStore', () => {
     expect(loaded!.previousConsumption).toBe(channel.previousConsumption);
     expect(loaded!.tokensDelivered).toBe(channel.tokensDelivered);
     expect(loaded!.requestCount).toBe(channel.requestCount);
-    expect(loaded!.status).toBe('active');
+    expect(loaded!.status).toBe(CHANNEL_STATUS.ACTIVE);
     expect(loaded!.settledAt).toBeNull();
     expect(loaded!.settledAmount).toBeNull();
   });
@@ -74,10 +74,10 @@ describe('ChannelStore', () => {
     const channel = makeChannel();
     store.upsertChannel(channel);
 
-    store.updateChannelStatus(channel.sessionId, 'settled', '500000');
+    store.updateChannelStatus(channel.sessionId, CHANNEL_STATUS.SETTLED, '500000');
 
     const loaded = store.getChannel(channel.sessionId);
-    expect(loaded!.status).toBe('settled');
+    expect(loaded!.status).toBe(CHANNEL_STATUS.SETTLED);
     expect(loaded!.settledAmount).toBe('500000');
     expect(loaded!.settledAt).toBeTypeOf('number');
   });
@@ -94,12 +94,12 @@ describe('ChannelStore', () => {
   });
 
   it('test_getActiveByPeer: returns correct active channel', () => {
-    const s1 = makeChannel({ sessionId: '0x' + '01'.repeat(32), status: 'settled', createdAt: Date.now() - 1000 });
-    const s2 = makeChannel({ sessionId: '0x' + '02'.repeat(32), status: 'active', createdAt: Date.now() });
+    const s1 = makeChannel({ sessionId: '0x' + '01'.repeat(32), status: CHANNEL_STATUS.SETTLED, createdAt: Date.now() - 1000 });
+    const s2 = makeChannel({ sessionId: '0x' + '02'.repeat(32), status: CHANNEL_STATUS.ACTIVE, createdAt: Date.now() });
     store.upsertChannel(s1);
     store.upsertChannel(s2);
 
-    const active = store.getActiveChannelByPeer('peer-abc123', 'buyer');
+    const active = store.getActiveChannelByPeer('peer-abc123', CHANNEL_ROLE.BUYER);
     expect(active).not.toBeNull();
     expect(active!.sessionId).toBe(s2.sessionId);
   });
@@ -107,41 +107,41 @@ describe('ChannelStore', () => {
   it('keeps active paid and free channels separate for the same peer', () => {
     const paid = makeChannel({
       sessionId: '0x' + '10'.repeat(32),
-      channelKind: 'paid',
+      channelKind: CHANNEL_KIND.PAID,
       createdAt: Date.now() - 1000,
     });
     const free = makeChannel({
       sessionId: '0x' + '20'.repeat(32),
-      channelKind: 'free',
+      channelKind: CHANNEL_KIND.FREE,
       authMax: '0',
       createdAt: Date.now(),
     });
     store.upsertChannel(paid);
     store.upsertChannel(free);
 
-    expect(store.getActiveChannelByPeer('peer-abc123', 'buyer')!.sessionId).toBe(paid.sessionId);
-    expect(store.getActiveChannelByPeer('peer-abc123', 'buyer', 'free')!.sessionId).toBe(free.sessionId);
+    expect(store.getActiveChannelByPeer('peer-abc123', CHANNEL_ROLE.BUYER)!.sessionId).toBe(paid.sessionId);
+    expect(store.getActiveChannelByPeer('peer-abc123', CHANNEL_ROLE.BUYER, CHANNEL_KIND.FREE)!.sessionId).toBe(free.sessionId);
     expect(store.listAllChannels()).toHaveLength(1);
-    expect(store.listAllChannels(100, 'free')).toHaveLength(1);
+    expect(store.listAllChannels(100, CHANNEL_KIND.FREE)).toHaveLength(1);
   });
 
   it('test_getActiveByPeer: returns null when no active channel', () => {
-    const s1 = makeChannel({ status: 'settled' });
+    const s1 = makeChannel({ status: CHANNEL_STATUS.SETTLED });
     store.upsertChannel(s1);
 
-    const active = store.getActiveChannelByPeer('peer-abc123', 'buyer');
+    const active = store.getActiveChannelByPeer('peer-abc123', CHANNEL_ROLE.BUYER);
     expect(active).toBeNull();
   });
 
   it('test_getLatestByPeer: returns most recent (any status)', () => {
-    const s1 = makeChannel({ sessionId: '0x' + '01'.repeat(32), status: 'settled', createdAt: Date.now() - 2000 });
-    const s2 = makeChannel({ sessionId: '0x' + '02'.repeat(32), status: 'settled', createdAt: Date.now() - 1000 });
-    const s3 = makeChannel({ sessionId: '0x' + '03'.repeat(32), status: 'active', createdAt: Date.now() });
+    const s1 = makeChannel({ sessionId: '0x' + '01'.repeat(32), status: CHANNEL_STATUS.SETTLED, createdAt: Date.now() - 2000 });
+    const s2 = makeChannel({ sessionId: '0x' + '02'.repeat(32), status: CHANNEL_STATUS.SETTLED, createdAt: Date.now() - 1000 });
+    const s3 = makeChannel({ sessionId: '0x' + '03'.repeat(32), status: CHANNEL_STATUS.ACTIVE, createdAt: Date.now() });
     store.upsertChannel(s1);
     store.upsertChannel(s2);
     store.upsertChannel(s3);
 
-    const latest = store.getLatestChannel('peer-abc123', 'buyer');
+    const latest = store.getLatestChannel('peer-abc123', CHANNEL_ROLE.BUYER);
     expect(latest).not.toBeNull();
     expect(latest!.sessionId).toBe(s3.sessionId);
   });

--- a/packages/node/tests/channel-store.test.ts
+++ b/packages/node/tests/channel-store.test.ts
@@ -104,6 +104,27 @@ describe('ChannelStore', () => {
     expect(active!.sessionId).toBe(s2.sessionId);
   });
 
+  it('keeps active paid and free channels separate for the same peer', () => {
+    const paid = makeChannel({
+      sessionId: '0x' + '10'.repeat(32),
+      channelKind: 'paid',
+      createdAt: Date.now() - 1000,
+    });
+    const free = makeChannel({
+      sessionId: '0x' + '20'.repeat(32),
+      channelKind: 'free',
+      authMax: '0',
+      createdAt: Date.now(),
+    });
+    store.upsertChannel(paid);
+    store.upsertChannel(free);
+
+    expect(store.getActiveChannelByPeer('peer-abc123', 'buyer')!.sessionId).toBe(paid.sessionId);
+    expect(store.getActiveChannelByPeer('peer-abc123', 'buyer', 'free')!.sessionId).toBe(free.sessionId);
+    expect(store.listAllChannels()).toHaveLength(1);
+    expect(store.listAllChannels(100, 'free')).toHaveLength(1);
+  });
+
   it('test_getActiveByPeer: returns null when no active channel', () => {
     const s1 = makeChannel({ status: 'settled' });
     store.upsertChannel(s1);

--- a/packages/node/tests/channel-usage-accounting.test.ts
+++ b/packages/node/tests/channel-usage-accounting.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { advanceUsageMetadata, CountedRequestTracker, RequestServiceTracker } from '../src/payments/channel-usage-accounting.js';
+import { getServiceMetadataId, ZERO_METADATA } from '../src/payments/evm/signatures.js';
+
+describe('channel usage accounting', () => {
+  it('advances aggregate and per-service metadata cumulatively', () => {
+    const first = advanceUsageMetadata(ZERO_METADATA, 'gpt-free', {
+      amount: 0n,
+      inputTokens: 10n,
+      cachedInputTokens: 2n,
+      outputTokens: 5n,
+      requests: 1n,
+    });
+    const second = advanceUsageMetadata(first, 'gpt-free', {
+      amount: 7n,
+      inputTokens: 3n,
+      cachedInputTokens: 1n,
+      outputTokens: 4n,
+      requests: 1n,
+    });
+
+    expect(second.cumulativeInputTokens).toBe(13n);
+    expect(second.cumulativeOutputTokens).toBe(9n);
+    expect(second.cumulativeRequestCount).toBe(2n);
+    expect(second.services).toEqual([
+      {
+        serviceId: getServiceMetadataId('gpt-free'),
+        cumulativeAmount: 7n,
+        cumulativeInputTokens: 13n,
+        cumulativeCachedInputTokens: 3n,
+        cumulativeOutputTokens: 9n,
+        cumulativeRequestCount: 2n,
+      },
+    ]);
+  });
+
+  it('can advance aggregate metadata without service attribution', () => {
+    const next = advanceUsageMetadata(ZERO_METADATA, undefined, {
+      amount: 99n,
+      inputTokens: 10n,
+      cachedInputTokens: 0n,
+      outputTokens: 5n,
+      requests: 1n,
+    });
+
+    expect(next).toEqual({
+      cumulativeInputTokens: 10n,
+      cumulativeOutputTokens: 5n,
+      cumulativeRequestCount: 1n,
+      services: [],
+    });
+  });
+
+  it('tracks request service attribution with bounded memory', () => {
+    const tracker = new RequestServiceTracker(2);
+    tracker.track('req-1', 'model-a');
+    tracker.track('req-2', 'model-b');
+    tracker.track('req-3', 'model-c');
+
+    expect(tracker.get('req-1')).toBeUndefined();
+    expect(tracker.take('req-2')).toBe('model-b');
+    expect(tracker.take('req-2')).toBeUndefined();
+    expect(tracker.get('req-3')).toBe('model-c');
+  });
+
+  it('dedupes counted requests with bounded memory', () => {
+    const tracker = new CountedRequestTracker(2);
+    tracker.mark('req-1');
+    tracker.mark('req-2');
+    tracker.mark('req-3');
+
+    expect(tracker.has('req-1')).toBe(false);
+    expect(tracker.has('req-2')).toBe(true);
+    expect(tracker.has('req-3')).toBe(true);
+    expect(tracker.has(undefined)).toBe(false);
+  });
+});

--- a/packages/node/tests/free-usage-lifecycle.test.ts
+++ b/packages/node/tests/free-usage-lifecycle.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { keccak256, verifyTypedData } from 'ethers';
 import { BuyerFreeUsageManager } from '../src/payments/buyer-free-usage-manager.js';
 import { SellerFreeUsageManager } from '../src/payments/seller-free-usage-manager.js';
-import { ChannelStore } from '../src/payments/channel-store.js';
+import { ChannelStore, CHANNEL_KIND, CHANNEL_ROLE } from '../src/payments/channel-store.js';
 import { PaymentMux } from '../src/p2p/payment-mux.js';
 import { decodeFrame } from '../src/p2p/message-protocol.js';
 import {
@@ -215,11 +215,11 @@ describe('FreeUsage P2P lifecycle', () => {
         service: 'gpt-free',
       }, buyerMux);
 
-      expect(store.getActiveChannelByPeer(seller.peerId, 'buyer')).toBeNull();
-      const freeChannel = store.getActiveChannelByPeer(seller.peerId, 'buyer', 'free');
+      expect(store.getActiveChannelByPeer(seller.peerId, CHANNEL_ROLE.BUYER)).toBeNull();
+      const freeChannel = store.getActiveChannelByPeer(seller.peerId, CHANNEL_ROLE.BUYER, CHANNEL_KIND.FREE);
       expect(freeChannel).toMatchObject({
         sessionId: openPayload.channelId,
-        channelKind: 'free',
+        channelKind: CHANNEL_KIND.FREE,
         authMax: '0',
         tokensDelivered: '12',
         previousConsumption: '7',
@@ -257,7 +257,7 @@ describe('FreeUsage P2P lifecycle', () => {
 
       const restartedAuth = decodeFreeUsageAuth(decodeSentFrame(restartedConn.frames[0]!).payload);
       expect(restartedAuth.sequence).toBe('2');
-      const updatedFreeChannel = store.getActiveChannelByPeer(seller.peerId, 'buyer', 'free')!;
+      const updatedFreeChannel = store.getActiveChannelByPeer(seller.peerId, CHANNEL_ROLE.BUYER, CHANNEL_KIND.FREE)!;
       expect(updatedFreeChannel.requestCount).toBe(2);
       expect(updatedFreeChannel.tokensDelivered).toBe('15');
       expect(updatedFreeChannel.previousConsumption).toBe('9');

--- a/packages/node/tests/free-usage-lifecycle.test.ts
+++ b/packages/node/tests/free-usage-lifecycle.test.ts
@@ -95,6 +95,7 @@ function installMockClient(manager: SellerFreeUsageManager) {
   const client = {
     open: vi.fn(async () => '0xopen'),
     record: vi.fn(async () => '0xrecord'),
+    close: vi.fn(async () => '0xclose'),
     getSession: vi.fn(async () => {
       throw new Error('missing session');
     }),
@@ -615,6 +616,59 @@ describe('FreeUsage P2P lifecycle', () => {
       BigInt(secondAuth.deadline),
       secondAuth.usageSig,
     );
+  });
+
+  it('seller closes the latest pending free usage record on disconnect', async () => {
+    const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
+    const sellerManager = new SellerFreeUsageManager(seller, sellerConfig({
+      recordBatchSize: 10,
+      recordFlushIntervalMs: 60_000,
+    }));
+    const client = installMockClient(sellerManager);
+    const sellerConn = makeConn();
+    const sellerMux = new PaymentMux(sellerConn.conn as any);
+    const buyerConn = makeConn();
+    const buyerMux = new PaymentMux(buyerConn.conn as any);
+    const openPayload = await prepareOpen(buyerManager);
+
+    await openSellerSession(sellerManager, openPayload, sellerMux);
+    buyerManager.handleAck(seller.peerId, {
+      channelId: openPayload.channelId,
+      acceptedSequence: '0',
+    });
+    sellerConn.frames.length = 0;
+
+    sellerManager.reportUsageRequest(buyer.peerId, sellerMux, {
+      requestId: 'req-free-close',
+      inputTokens: 12,
+      outputTokens: 7,
+      service: 'gpt-free',
+    });
+    buyerManager.trackRequestService('req-free-close', 'gpt-free');
+    await buyerManager.handleNeedAuth(
+      seller.peerId,
+      decodeNeedFreeUsageAuth(decodeSentFrame(sellerConn.frames[0]!).payload),
+      buyerMux,
+    );
+    const authPayload = decodeFreeUsageAuth(decodeSentFrame(buyerConn.frames[0]!).payload);
+    sellerManager.handleAuth(buyer.peerId, authPayload, sellerMux);
+    await flushAsync();
+
+    expect(client.record).not.toHaveBeenCalled();
+    sellerManager.onPeerDisconnect(buyer.peerId);
+
+    await vi.waitFor(() => {
+      expect(client.close).toHaveBeenCalledOnce();
+    });
+    expect(client.close).toHaveBeenCalledWith(
+      seller.wallet,
+      openPayload.channelId,
+      1n,
+      authPayload.metadata,
+      BigInt(authPayload.deadline),
+      authPayload.usageSig,
+    );
+    expect(client.record).not.toHaveBeenCalled();
   });
 
   it('seller rejects wrong channel, wrong signer, metadata mismatch, and stale sequences', async () => {

--- a/packages/node/tests/free-usage-lifecycle.test.ts
+++ b/packages/node/tests/free-usage-lifecycle.test.ts
@@ -277,6 +277,47 @@ describe('FreeUsage P2P lifecycle', () => {
     }
   });
 
+  it('does not advance buyer sequence state when sending usage auth fails', async () => {
+    const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
+    const openPayload = await prepareOpen(buyerManager);
+    buyerManager.handleAck(seller.peerId, {
+      channelId: openPayload.channelId,
+      acceptedSequence: '0',
+    });
+    buyerManager.trackRequestService('req-free-send-fails', 'gpt-free');
+
+    const failingMux = new PaymentMux({
+      send: vi.fn(() => {
+        throw new Error('datachannel closed');
+      }),
+    } as any);
+
+    await expect(buyerManager.handleNeedAuth(seller.peerId, {
+      channelId: openPayload.channelId,
+      requiredSequence: '1',
+      currentAcceptedSequence: '0',
+      requestId: 'req-free-send-fails',
+      inputTokens: '12',
+      outputTokens: '7',
+    }, failingMux)).rejects.toThrow('datachannel closed');
+
+    const retryConn = makeConn();
+    const retryMux = new PaymentMux(retryConn.conn as any);
+    await buyerManager.handleNeedAuth(seller.peerId, {
+      channelId: openPayload.channelId,
+      requiredSequence: '1',
+      currentAcceptedSequence: '0',
+      requestId: 'req-free-send-fails',
+      inputTokens: '12',
+      outputTokens: '7',
+    }, retryMux);
+
+    const authPayload = decodeFreeUsageAuth(decodeSentFrame(retryConn.frames[0]!).payload);
+    expect(authPayload.sequence).toBe('1');
+    expect(authPayload.cumulativeInputTokens).toBe('12');
+    expect(authPayload.cumulativeOutputTokens).toBe('7');
+  });
+
   it('seller verifies open, requests usage auth, and reports the buyer signature', async () => {
     const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
     const sellerManager = new SellerFreeUsageManager(seller, sellerConfig());
@@ -367,6 +408,13 @@ describe('FreeUsage P2P lifecycle', () => {
       channelId: openPayload.channelId,
       acceptedSequence: '0',
     });
+    sellerManager.reportUsageRequest(buyer.peerId, sellerMux, {
+      requestId: 'req-free-1',
+      inputTokens: 12,
+      outputTokens: 7,
+      service: 'gpt-free',
+    });
+    sellerConn.frames.length = 0;
 
     const buyerConn = makeConn();
     const buyerMux = new PaymentMux(buyerConn.conn as any);
@@ -433,6 +481,40 @@ describe('FreeUsage P2P lifecycle', () => {
     expect(client.record).not.toHaveBeenCalled();
     expect(sellerConn.frames).toHaveLength(0);
 
+    const mismatchedMetadata = encodeFreeUsageMetadata({
+      cumulativeInputTokens: 13n,
+      cumulativeOutputTokens: 7n,
+      cumulativeRequestCount: 1n,
+      services: [{
+        serviceId: getServiceMetadataId('gpt-free'),
+        cumulativeAmount: 0n,
+        cumulativeInputTokens: 13n,
+        cumulativeCachedInputTokens: 0n,
+        cumulativeOutputTokens: 7n,
+        cumulativeRequestCount: 1n,
+      }],
+    });
+    const mismatchedTotalsAuth: FreeUsageAuthPayload = {
+      ...validAuth,
+      cumulativeInputTokens: '13',
+      metadata: mismatchedMetadata,
+      metadataHash: keccak256(mismatchedMetadata),
+      usageSig: await signFreeUsageAuth(
+        buyer.wallet,
+        makeFreeUsageDomain(CHAIN_ID, FREE_USAGE_ADDRESS),
+        {
+          channelId: openPayload.channelId,
+          sequence: 1n,
+          metadataHash: keccak256(mismatchedMetadata),
+          deadline: BigInt(validAuth.deadline),
+        },
+      ),
+    };
+    sellerManager.handleAuth(buyer.peerId, mismatchedTotalsAuth, sellerMux);
+    await flushAsync();
+    expect(client.record).not.toHaveBeenCalled();
+    expect(sellerConn.frames).toHaveLength(0);
+
     sellerManager.handleAuth(buyer.peerId, validAuth, sellerMux);
     await vi.waitFor(() => {
       expect(client.record).toHaveBeenCalledOnce();
@@ -484,5 +566,26 @@ describe('FreeUsage P2P lifecycle', () => {
     await flushAsync();
     expect(client.open).not.toHaveBeenCalled();
     expect(sellerConn.frames).toHaveLength(0);
+  });
+
+  it('cleans up free usage sessions on peer disconnect', async () => {
+    const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
+    const sellerManager = new SellerFreeUsageManager(seller, sellerConfig());
+    installMockClient(sellerManager);
+    const sellerConn = makeConn();
+    const sellerMux = new PaymentMux(sellerConn.conn as any);
+    const openPayload = await prepareOpen(buyerManager);
+
+    await openSellerSession(sellerManager, openPayload, sellerMux);
+    expect((buyerManager as any)._sessions.size).toBe(1);
+    expect((sellerManager as any)._sessions.size).toBe(1);
+    expect((sellerManager as any)._buyerLocks.size).toBe(1);
+
+    buyerManager.onPeerDisconnect(seller.peerId);
+    sellerManager.onPeerDisconnect(buyer.peerId);
+
+    expect((buyerManager as any)._sessions.size).toBe(0);
+    expect((sellerManager as any)._sessions.size).toBe(0);
+    expect((sellerManager as any)._buyerLocks.size).toBe(0);
   });
 });

--- a/packages/node/tests/free-usage-lifecycle.test.ts
+++ b/packages/node/tests/free-usage-lifecycle.test.ts
@@ -56,11 +56,12 @@ function freeUsageConfig() {
   };
 }
 
-function sellerConfig() {
+function sellerConfig(overrides: Partial<ConstructorParameters<typeof SellerFreeUsageManager>[1]> = {}) {
   return {
     rpcUrl: 'http://127.0.0.1:8545',
     freeUsageContractAddress: FREE_USAGE_ADDRESS,
     chainId: CHAIN_ID,
+    ...overrides,
   };
 }
 
@@ -192,6 +193,30 @@ describe('FreeUsage P2P lifecycle', () => {
       },
       authPayload.usageSig,
     ).toLowerCase()).toBe(buyer.wallet.address.toLowerCase());
+  });
+
+  it('buyer waits for free usage open ack and clears unacked sessions on timeout', async () => {
+    const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
+    const buyerConn = makeConn();
+    const buyerMux = new PaymentMux(buyerConn.conn as any);
+
+    await buyerManager.prepareOpen(sellerPeer(), buyerMux);
+    const openPayload = decodeFreeUsageOpen(decodeSentFrame(buyerConn.frames[0]!).payload);
+
+    const waitForAck = buyerManager.waitForOpenAck(seller.peerId, 100);
+    buyerManager.handleAck(seller.peerId, {
+      channelId: openPayload.channelId,
+      acceptedSequence: '0',
+    });
+    await expect(waitForAck).resolves.toBeUndefined();
+
+    const timedOutManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
+    const timedOutConn = makeConn();
+    const timedOutMux = new PaymentMux(timedOutConn.conn as any);
+    await timedOutManager.prepareOpen(sellerPeer(), timedOutMux);
+
+    await expect(timedOutManager.waitForOpenAck(seller.peerId, 1)).rejects.toThrow(/timed out waiting/);
+    expect((timedOutManager as any)._sessions.size).toBe(0);
   });
 
   it('persists free usage accounting in the shared channel store', async () => {
@@ -381,7 +406,7 @@ describe('FreeUsage P2P lifecycle', () => {
 
   it('seller verifies open, requests usage auth, and reports the buyer signature', async () => {
     const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
-    const sellerManager = new SellerFreeUsageManager(seller, sellerConfig());
+    const sellerManager = new SellerFreeUsageManager(seller, sellerConfig({ recordBatchSize: 1 }));
     const client = installMockClient(sellerManager);
     const sellerConn = makeConn();
     const sellerMux = new PaymentMux(sellerConn.conn as any);
@@ -456,9 +481,81 @@ describe('FreeUsage P2P lifecycle', () => {
     });
   });
 
+  it('seller batches free usage records after local auth acceptance', async () => {
+    const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
+    const sellerManager = new SellerFreeUsageManager(seller, sellerConfig({
+      recordBatchSize: 2,
+      recordFlushIntervalMs: 60_000,
+    }));
+    const client = installMockClient(sellerManager);
+    const sellerConn = makeConn();
+    const sellerMux = new PaymentMux(sellerConn.conn as any);
+    const buyerConn = makeConn();
+    const buyerMux = new PaymentMux(buyerConn.conn as any);
+    const openPayload = await prepareOpen(buyerManager);
+
+    await openSellerSession(sellerManager, openPayload, sellerMux);
+    buyerManager.handleAck(seller.peerId, {
+      channelId: openPayload.channelId,
+      acceptedSequence: '0',
+    });
+    sellerConn.frames.length = 0;
+
+    sellerManager.reportUsageRequest(buyer.peerId, sellerMux, {
+      requestId: 'req-free-batch-1',
+      inputTokens: 12,
+      outputTokens: 7,
+      service: 'gpt-free',
+    });
+    buyerManager.trackRequestService('req-free-batch-1', 'gpt-free');
+    await buyerManager.handleNeedAuth(
+      seller.peerId,
+      decodeNeedFreeUsageAuth(decodeSentFrame(sellerConn.frames[0]!).payload),
+      buyerMux,
+    );
+    sellerConn.frames.length = 0;
+    sellerManager.handleAuth(buyer.peerId, decodeFreeUsageAuth(decodeSentFrame(buyerConn.frames[0]!).payload), sellerMux);
+    await flushAsync();
+
+    expect(client.record).not.toHaveBeenCalled();
+    expect(decodeFreeUsageAck(decodeSentFrame(sellerConn.frames[0]!).payload)).toEqual({
+      channelId: openPayload.channelId,
+      acceptedSequence: '1',
+    });
+
+    sellerConn.frames.length = 0;
+    buyerConn.frames.length = 0;
+    sellerManager.reportUsageRequest(buyer.peerId, sellerMux, {
+      requestId: 'req-free-batch-2',
+      inputTokens: 5,
+      outputTokens: 3,
+      service: 'gpt-free',
+    });
+    buyerManager.trackRequestService('req-free-batch-2', 'gpt-free');
+    await buyerManager.handleNeedAuth(
+      seller.peerId,
+      decodeNeedFreeUsageAuth(decodeSentFrame(sellerConn.frames[0]!).payload),
+      buyerMux,
+    );
+    const secondAuth = decodeFreeUsageAuth(decodeSentFrame(buyerConn.frames[0]!).payload);
+    sellerManager.handleAuth(buyer.peerId, secondAuth, sellerMux);
+
+    await vi.waitFor(() => {
+      expect(client.record).toHaveBeenCalledOnce();
+    });
+    expect(client.record).toHaveBeenCalledWith(
+      seller.wallet,
+      openPayload.channelId,
+      2n,
+      secondAuth.metadata,
+      BigInt(secondAuth.deadline),
+      secondAuth.usageSig,
+    );
+  });
+
   it('seller rejects wrong channel, wrong signer, metadata mismatch, and stale sequences', async () => {
     const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
-    const sellerManager = new SellerFreeUsageManager(seller, sellerConfig());
+    const sellerManager = new SellerFreeUsageManager(seller, sellerConfig({ recordBatchSize: 1 }));
     const client = installMockClient(sellerManager);
     const sellerConn = makeConn();
     const sellerMux = new PaymentMux(sellerConn.conn as any);
@@ -626,6 +723,24 @@ describe('FreeUsage P2P lifecycle', () => {
     }, sellerMux);
     await flushAsync();
     expect(client.open).not.toHaveBeenCalled();
+    expect(sellerConn.frames).toHaveLength(0);
+  });
+
+  it('seller clears provisional free usage sessions when open fails on-chain', async () => {
+    const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
+    const sellerManager = new SellerFreeUsageManager(seller, sellerConfig());
+    const client = installMockClient(sellerManager);
+    client.open.mockRejectedValueOnce(new Error('open reverted'));
+    const sellerConn = makeConn();
+    const sellerMux = new PaymentMux(sellerConn.conn as any);
+    const openPayload = await prepareOpen(buyerManager);
+
+    sellerManager.handleOpen(buyer.peerId, openPayload, sellerMux);
+
+    await vi.waitFor(() => {
+      expect(client.open).toHaveBeenCalledOnce();
+      expect((sellerManager as any)._sessions.size).toBe(0);
+    });
     expect(sellerConn.frames).toHaveLength(0);
   });
 

--- a/packages/node/tests/free-usage-lifecycle.test.ts
+++ b/packages/node/tests/free-usage-lifecycle.test.ts
@@ -1,0 +1,488 @@
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { keccak256, verifyTypedData } from 'ethers';
+import { BuyerFreeUsageManager } from '../src/payments/buyer-free-usage-manager.js';
+import { SellerFreeUsageManager } from '../src/payments/seller-free-usage-manager.js';
+import { ChannelStore } from '../src/payments/channel-store.js';
+import { PaymentMux } from '../src/p2p/payment-mux.js';
+import { decodeFrame } from '../src/p2p/message-protocol.js';
+import {
+  decodeFreeUsageAck,
+  decodeFreeUsageAuth,
+  decodeFreeUsageOpen,
+  decodeNeedFreeUsageAuth,
+} from '../src/p2p/payment-codec.js';
+import { identityFromPrivateKeyHex } from '../src/p2p/identity.js';
+import { MessageType, type FreeUsageAuthPayload, type FreeUsageOpenPayload } from '../src/types/protocol.js';
+import { peerIdToAddress, type PeerInfo } from '../src/types/peer.js';
+import {
+  FREE_USAGE_AUTH_TYPES,
+  FREE_USAGE_OPEN_TYPES,
+  computeFreeUsageChannelId,
+  computeFreeUsageMetadataHash,
+  encodeFreeUsageMetadata,
+  getServiceMetadataId,
+  makeFreeUsageDomain,
+  signFreeUsageAuth,
+} from '../src/payments/evm/signatures.js';
+
+const CHAIN_ID = 31337;
+const FREE_USAGE_ADDRESS = '0x0165878A594ca255338adfa4d48449f69242Eb8F';
+const AUTH_SECS = 3600;
+
+const buyer = identityFromPrivateKeyHex('22'.repeat(32));
+const seller = identityFromPrivateKeyHex('11'.repeat(32));
+const attacker = identityFromPrivateKeyHex('33'.repeat(32));
+
+function makeConn() {
+  const frames: Uint8Array[] = [];
+  return {
+    frames,
+    conn: {
+      send: vi.fn((frame: Uint8Array) => {
+        frames.push(frame);
+      }),
+    },
+  };
+}
+
+function freeUsageConfig() {
+  return {
+    chainId: CHAIN_ID,
+    freeUsageContractAddress: FREE_USAGE_ADDRESS,
+    defaultAuthDurationSecs: AUTH_SECS,
+  };
+}
+
+function sellerConfig() {
+  return {
+    rpcUrl: 'http://127.0.0.1:8545',
+    freeUsageContractAddress: FREE_USAGE_ADDRESS,
+    chainId: CHAIN_ID,
+  };
+}
+
+function sellerPeer(): PeerInfo {
+  return {
+    peerId: seller.peerId,
+    lastSeen: Date.now(),
+    providers: ['openai'],
+    providerPricing: {
+      openai: {
+        defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 1 },
+        services: {
+          'gpt-free': { inputUsdPerMillion: 0, outputUsdPerMillion: 0 },
+        },
+      },
+    },
+  };
+}
+
+function decodeSentFrame(frame: Uint8Array) {
+  const decoded = decodeFrame(frame);
+  if (!decoded) throw new Error('incomplete frame');
+  return decoded.message;
+}
+
+async function flushAsync(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function installMockClient(manager: SellerFreeUsageManager) {
+  const client = {
+    open: vi.fn(async () => '0xopen'),
+    record: vi.fn(async () => '0xrecord'),
+    getSession: vi.fn(async () => {
+      throw new Error('missing session');
+    }),
+  };
+  (manager as any)._client = client;
+  return client;
+}
+
+async function prepareOpen(buyerManager: BuyerFreeUsageManager): Promise<FreeUsageOpenPayload> {
+  const buyerConn = makeConn();
+  const buyerMux = new PaymentMux(buyerConn.conn as any);
+
+  await buyerManager.prepareOpen(sellerPeer(), buyerMux);
+
+  const openFrame = decodeSentFrame(buyerConn.frames[0]!);
+  expect(openFrame.type).toBe(MessageType.FreeUsageOpen);
+  return decodeFreeUsageOpen(openFrame.payload);
+}
+
+async function openSellerSession(
+  sellerManager: SellerFreeUsageManager,
+  openPayload: FreeUsageOpenPayload,
+  sellerMux: PaymentMux,
+) {
+  sellerManager.handleOpen(buyer.peerId, openPayload, sellerMux);
+  await vi.waitFor(() => {
+    expect(sellerManager.client.open).toHaveBeenCalledOnce();
+  });
+}
+
+describe('FreeUsage P2P lifecycle', () => {
+  it('buyer opens and signs free usage without deposits', async () => {
+    const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
+    const buyerConn = makeConn();
+    const buyerMux = new PaymentMux(buyerConn.conn as any);
+
+    await buyerManager.prepareOpen(sellerPeer(), buyerMux);
+
+    const openFrame = decodeSentFrame(buyerConn.frames[0]!);
+    expect(openFrame.type).toBe(MessageType.FreeUsageOpen);
+    const openPayload = decodeFreeUsageOpen(openFrame.payload);
+    const expectedChannelId = computeFreeUsageChannelId(
+      buyer.wallet.address,
+      seller.wallet.address,
+      openPayload.salt,
+    );
+    expect(openPayload.channelId).toBe(expectedChannelId);
+    expect(verifyTypedData(
+      makeFreeUsageDomain(CHAIN_ID, FREE_USAGE_ADDRESS),
+      FREE_USAGE_OPEN_TYPES,
+      { channelId: openPayload.channelId, deadline: BigInt(openPayload.deadline) },
+      openPayload.openSig,
+    ).toLowerCase()).toBe(buyer.wallet.address.toLowerCase());
+
+    buyerManager.handleAck(seller.peerId, {
+      channelId: openPayload.channelId,
+      acceptedSequence: '0',
+    });
+    buyerManager.trackRequestService('req-free-1', 'gpt-free');
+
+    await buyerManager.handleNeedAuth(seller.peerId, {
+      channelId: openPayload.channelId,
+      requiredSequence: '1',
+      currentAcceptedSequence: '0',
+      requestId: 'req-free-1',
+      inputTokens: '12',
+      outputTokens: '7',
+    }, buyerMux);
+
+    const authFrame = decodeSentFrame(buyerConn.frames[1]!);
+    expect(authFrame.type).toBe(MessageType.FreeUsageAuth);
+    const authPayload = decodeFreeUsageAuth(authFrame.payload);
+    const expectedMetadata = {
+      cumulativeInputTokens: 12n,
+      cumulativeOutputTokens: 7n,
+      cumulativeRequestCount: 1n,
+      services: [{
+        serviceId: getServiceMetadataId('gpt-free'),
+        cumulativeAmount: 0n,
+        cumulativeInputTokens: 12n,
+        cumulativeCachedInputTokens: 0n,
+        cumulativeOutputTokens: 7n,
+        cumulativeRequestCount: 1n,
+      }],
+    };
+    expect(authPayload.metadata).toBe(encodeFreeUsageMetadata(expectedMetadata));
+    expect(authPayload.metadataHash).toBe(computeFreeUsageMetadataHash(expectedMetadata));
+    expect(verifyTypedData(
+      makeFreeUsageDomain(CHAIN_ID, FREE_USAGE_ADDRESS),
+      FREE_USAGE_AUTH_TYPES,
+      {
+        channelId: authPayload.channelId,
+        sequence: 1n,
+        metadataHash: authPayload.metadataHash,
+        deadline: BigInt(authPayload.deadline),
+      },
+      authPayload.usageSig,
+    ).toLowerCase()).toBe(buyer.wallet.address.toLowerCase());
+  });
+
+  it('persists free usage accounting in the shared channel store', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'free-usage-channel-store-'));
+    const store = new ChannelStore(dir);
+    try {
+      const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig(), undefined, store);
+      const buyerConn = makeConn();
+      const buyerMux = new PaymentMux(buyerConn.conn as any);
+
+      await buyerManager.prepareOpen(sellerPeer(), buyerMux);
+      const openPayload = decodeFreeUsageOpen(decodeSentFrame(buyerConn.frames[0]!).payload);
+
+      await buyerManager.handleNeedAuth(seller.peerId, {
+        channelId: openPayload.channelId,
+        requiredSequence: '1',
+        currentAcceptedSequence: '0',
+        requestId: 'req-free-store',
+        inputTokens: '12',
+        outputTokens: '7',
+        service: 'gpt-free',
+      }, buyerMux);
+
+      expect(store.getActiveChannelByPeer(seller.peerId, 'buyer')).toBeNull();
+      const freeChannel = store.getActiveChannelByPeer(seller.peerId, 'buyer', 'free');
+      expect(freeChannel).toMatchObject({
+        sessionId: openPayload.channelId,
+        channelKind: 'free',
+        authMax: '0',
+        tokensDelivered: '12',
+        previousConsumption: '7',
+        requestCount: 1,
+      });
+      expect(freeChannel!.latestMetadata).toBe(decodeFreeUsageAuth(decodeSentFrame(buyerConn.frames[1]!).payload).metadata);
+
+      const serviceTotals = store.getServiceTotals(openPayload.channelId);
+      expect(serviceTotals).toEqual([
+        expect.objectContaining({
+          serviceId: getServiceMetadataId('gpt-free'),
+          cumulativeAmount: '0',
+          cumulativeInputTokens: '12',
+          cumulativeCachedInputTokens: '0',
+          cumulativeOutputTokens: '7',
+          cumulativeRequestCount: '1',
+        }),
+      ]);
+
+      const restartedManager = new BuyerFreeUsageManager(buyer, freeUsageConfig(), undefined, store);
+      const restartedConn = makeConn();
+      const restartedMux = new PaymentMux(restartedConn.conn as any);
+      await restartedManager.prepareOpen(sellerPeer(), restartedMux);
+      expect(restartedConn.frames).toHaveLength(0);
+
+      restartedManager.trackRequestService('req-free-store-2', 'gpt-free');
+      await restartedManager.handleNeedAuth(seller.peerId, {
+        channelId: openPayload.channelId,
+        requiredSequence: '2',
+        currentAcceptedSequence: '1',
+        requestId: 'req-free-store-2',
+        inputTokens: '3',
+        outputTokens: '2',
+      }, restartedMux);
+
+      const restartedAuth = decodeFreeUsageAuth(decodeSentFrame(restartedConn.frames[0]!).payload);
+      expect(restartedAuth.sequence).toBe('2');
+      const updatedFreeChannel = store.getActiveChannelByPeer(seller.peerId, 'buyer', 'free')!;
+      expect(updatedFreeChannel.requestCount).toBe(2);
+      expect(updatedFreeChannel.tokensDelivered).toBe('15');
+      expect(updatedFreeChannel.previousConsumption).toBe('9');
+      expect(store.getServiceTotals(openPayload.channelId)).toEqual([
+        expect.objectContaining({
+          serviceId: getServiceMetadataId('gpt-free'),
+          cumulativeAmount: '0',
+          cumulativeInputTokens: '15',
+          cumulativeCachedInputTokens: '0',
+          cumulativeOutputTokens: '9',
+          cumulativeRequestCount: '2',
+        }),
+      ]);
+    } finally {
+      store.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('seller verifies open, requests usage auth, and reports the buyer signature', async () => {
+    const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
+    const sellerManager = new SellerFreeUsageManager(seller, sellerConfig());
+    const client = installMockClient(sellerManager);
+    const sellerConn = makeConn();
+    const sellerMux = new PaymentMux(sellerConn.conn as any);
+    const openPayload = await prepareOpen(buyerManager);
+
+    await openSellerSession(sellerManager, openPayload, sellerMux);
+
+    expect(client.open).toHaveBeenCalledWith(
+      seller.wallet,
+      peerIdToAddress(buyer.peerId),
+      openPayload.salt,
+      BigInt(openPayload.deadline),
+      openPayload.openSig,
+    );
+    const openAckFrame = decodeSentFrame(sellerConn.frames[0]!);
+    expect(openAckFrame.type).toBe(MessageType.FreeUsageAck);
+    expect(decodeFreeUsageAck(openAckFrame.payload)).toEqual({
+      channelId: openPayload.channelId,
+      acceptedSequence: '0',
+    });
+
+    buyerManager.handleAck(seller.peerId, {
+      channelId: openPayload.channelId,
+      acceptedSequence: '0',
+    });
+    buyerManager.trackRequestService('req-free-1', 'gpt-free');
+    sellerConn.frames.length = 0;
+
+    sellerManager.reportUsageRequest(buyer.peerId, sellerMux, {
+      requestId: 'req-free-1',
+      inputTokens: 12,
+      outputTokens: 7,
+      service: 'gpt-free',
+    });
+
+    const needFrame = decodeSentFrame(sellerConn.frames[0]!);
+    expect(needFrame.type).toBe(MessageType.NeedFreeUsageAuth);
+    const needPayload = decodeNeedFreeUsageAuth(needFrame.payload);
+    expect(needPayload).toMatchObject({
+      channelId: openPayload.channelId,
+      requiredSequence: '1',
+      currentAcceptedSequence: '0',
+      requestId: 'req-free-1',
+      inputTokens: '12',
+      outputTokens: '7',
+      service: 'gpt-free',
+    });
+
+    const buyerConn = makeConn();
+    const buyerMux = new PaymentMux(buyerConn.conn as any);
+    await buyerManager.handleNeedAuth(seller.peerId, needPayload, buyerMux);
+    const authPayload = decodeFreeUsageAuth(decodeSentFrame(buyerConn.frames[0]!).payload);
+
+    sellerConn.frames.length = 0;
+    sellerManager.handleAuth(buyer.peerId, authPayload, sellerMux);
+    await vi.waitFor(() => {
+      expect(client.record).toHaveBeenCalledOnce();
+    });
+
+    expect(client.record).toHaveBeenCalledWith(
+      seller.wallet,
+      openPayload.channelId,
+      1n,
+      authPayload.metadata,
+      BigInt(authPayload.deadline),
+      authPayload.usageSig,
+    );
+    const recordAck = decodeFreeUsageAck(decodeSentFrame(sellerConn.frames[0]!).payload);
+    expect(recordAck).toEqual({
+      channelId: openPayload.channelId,
+      acceptedSequence: '1',
+    });
+  });
+
+  it('seller rejects wrong channel, wrong signer, metadata mismatch, and stale sequences', async () => {
+    const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
+    const sellerManager = new SellerFreeUsageManager(seller, sellerConfig());
+    const client = installMockClient(sellerManager);
+    const sellerConn = makeConn();
+    const sellerMux = new PaymentMux(sellerConn.conn as any);
+    const openPayload = await prepareOpen(buyerManager);
+
+    await openSellerSession(sellerManager, openPayload, sellerMux);
+    buyerManager.handleAck(seller.peerId, {
+      channelId: openPayload.channelId,
+      acceptedSequence: '0',
+    });
+
+    const buyerConn = makeConn();
+    const buyerMux = new PaymentMux(buyerConn.conn as any);
+    buyerManager.trackRequestService('req-free-1', 'gpt-free');
+    await buyerManager.handleNeedAuth(seller.peerId, {
+      channelId: openPayload.channelId,
+      requiredSequence: '1',
+      currentAcceptedSequence: '0',
+      requestId: 'req-free-1',
+      inputTokens: '12',
+      outputTokens: '7',
+    }, buyerMux);
+    const validAuth = decodeFreeUsageAuth(decodeSentFrame(buyerConn.frames[0]!).payload);
+
+    client.record.mockClear();
+    sellerConn.frames.length = 0;
+    sellerManager.handleAuth(buyer.peerId, {
+      ...validAuth,
+      channelId: '0x' + '44'.repeat(32),
+    }, sellerMux);
+    await flushAsync();
+    expect(client.record).not.toHaveBeenCalled();
+    expect(sellerConn.frames).toHaveLength(0);
+
+    const metadataHashMismatch: FreeUsageAuthPayload = {
+      ...validAuth,
+      metadataHash: '0x' + '99'.repeat(32),
+    };
+    sellerManager.handleAuth(buyer.peerId, metadataHashMismatch, sellerMux);
+    await flushAsync();
+    expect(client.record).not.toHaveBeenCalled();
+    expect(sellerConn.frames).toHaveLength(0);
+
+    const metadata = encodeFreeUsageMetadata({
+      cumulativeInputTokens: 12n,
+      cumulativeOutputTokens: 7n,
+      cumulativeRequestCount: 1n,
+      services: [{
+        serviceId: getServiceMetadataId('gpt-free'),
+        cumulativeAmount: 0n,
+        cumulativeInputTokens: 12n,
+        cumulativeCachedInputTokens: 0n,
+        cumulativeOutputTokens: 7n,
+        cumulativeRequestCount: 1n,
+      }],
+    });
+    const wrongSignerAuth: FreeUsageAuthPayload = {
+      ...validAuth,
+      metadata,
+      metadataHash: keccak256(metadata),
+      usageSig: await signFreeUsageAuth(
+        attacker.wallet,
+        makeFreeUsageDomain(CHAIN_ID, FREE_USAGE_ADDRESS),
+        {
+          channelId: openPayload.channelId,
+          sequence: 1n,
+          metadataHash: keccak256(metadata),
+          deadline: BigInt(validAuth.deadline),
+        },
+      ),
+    };
+    sellerManager.handleAuth(buyer.peerId, wrongSignerAuth, sellerMux);
+    await flushAsync();
+    expect(client.record).not.toHaveBeenCalled();
+    expect(sellerConn.frames).toHaveLength(0);
+
+    sellerManager.handleAuth(buyer.peerId, validAuth, sellerMux);
+    await vi.waitFor(() => {
+      expect(client.record).toHaveBeenCalledOnce();
+    });
+
+    client.record.mockClear();
+    sellerConn.frames.length = 0;
+    sellerManager.handleAuth(buyer.peerId, validAuth, sellerMux);
+    await flushAsync();
+
+    expect(client.record).not.toHaveBeenCalled();
+    expect(decodeFreeUsageAck(decodeSentFrame(sellerConn.frames[0]!).payload)).toEqual({
+      channelId: openPayload.channelId,
+      acceptedSequence: '1',
+    });
+  });
+
+  it('seller rejects FreeUsageOpen with a mismatched channel id or signer', async () => {
+    const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
+    const sellerManager = new SellerFreeUsageManager(seller, sellerConfig());
+    const client = installMockClient(sellerManager);
+    const sellerConn = makeConn();
+    const sellerMux = new PaymentMux(sellerConn.conn as any);
+    const openPayload = await prepareOpen(buyerManager);
+
+    sellerManager.handleOpen(buyer.peerId, {
+      ...openPayload,
+      channelId: '0x' + '55'.repeat(32),
+    }, sellerMux);
+    await flushAsync();
+    expect(client.open).not.toHaveBeenCalled();
+    expect(sellerConn.frames).toHaveLength(0);
+
+    const attackerChannelId = computeFreeUsageChannelId(
+      attacker.wallet.address,
+      seller.wallet.address,
+      openPayload.salt,
+    );
+    const attackerOpenSig = await attacker.wallet.signTypedData(
+      makeFreeUsageDomain(CHAIN_ID, FREE_USAGE_ADDRESS),
+      FREE_USAGE_OPEN_TYPES,
+      { channelId: attackerChannelId, deadline: BigInt(openPayload.deadline) },
+    );
+
+    sellerManager.handleOpen(buyer.peerId, {
+      ...openPayload,
+      openSig: attackerOpenSig,
+    }, sellerMux);
+    await flushAsync();
+    expect(client.open).not.toHaveBeenCalled();
+    expect(sellerConn.frames).toHaveLength(0);
+  });
+});

--- a/packages/node/tests/free-usage-lifecycle.test.ts
+++ b/packages/node/tests/free-usage-lifecycle.test.ts
@@ -318,6 +318,67 @@ describe('FreeUsage P2P lifecycle', () => {
     expect(authPayload.cumulativeOutputTokens).toBe('7');
   });
 
+  it('serializes concurrent buyer free usage auth requests per seller', async () => {
+    const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
+    const openPayload = await prepareOpen(buyerManager);
+    buyerManager.handleAck(seller.peerId, {
+      channelId: openPayload.channelId,
+      acceptedSequence: '0',
+    });
+    buyerManager.trackRequestService('req-free-concurrent-1', 'gpt-free');
+    buyerManager.trackRequestService('req-free-concurrent-2', 'gpt-free');
+
+    const buyerConn = makeConn();
+    const buyerMux = new PaymentMux(buyerConn.conn as any);
+
+    await Promise.all([
+      buyerManager.handleNeedAuth(seller.peerId, {
+        channelId: openPayload.channelId,
+        requiredSequence: '1',
+        currentAcceptedSequence: '0',
+        requestId: 'req-free-concurrent-1',
+        inputTokens: '12',
+        outputTokens: '7',
+      }, buyerMux),
+      buyerManager.handleNeedAuth(seller.peerId, {
+        channelId: openPayload.channelId,
+        requiredSequence: '2',
+        currentAcceptedSequence: '0',
+        requestId: 'req-free-concurrent-2',
+        inputTokens: '7',
+        outputTokens: '3',
+      }, buyerMux),
+    ]);
+
+    const authPayloads = buyerConn.frames
+      .map((frame) => decodeFreeUsageAuth(decodeSentFrame(frame).payload))
+      .sort((a, b) => Number(BigInt(a.sequence) - BigInt(b.sequence)));
+    expect(authPayloads).toHaveLength(2);
+    expect(authPayloads[0]).toMatchObject({
+      sequence: '1',
+      cumulativeInputTokens: '12',
+      cumulativeOutputTokens: '7',
+    });
+    expect(authPayloads[1]).toMatchObject({
+      sequence: '2',
+      cumulativeInputTokens: '19',
+      cumulativeOutputTokens: '10',
+    });
+    expect(authPayloads[1]!.metadata).toBe(encodeFreeUsageMetadata({
+      cumulativeInputTokens: 19n,
+      cumulativeOutputTokens: 10n,
+      cumulativeRequestCount: 2n,
+      services: [{
+        serviceId: getServiceMetadataId('gpt-free'),
+        cumulativeAmount: 0n,
+        cumulativeInputTokens: 19n,
+        cumulativeCachedInputTokens: 0n,
+        cumulativeOutputTokens: 10n,
+        cumulativeRequestCount: 2n,
+      }],
+    }));
+  });
+
   it('seller verifies open, requests usage auth, and reports the buyer signature', async () => {
     const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig());
     const sellerManager = new SellerFreeUsageManager(seller, sellerConfig());

--- a/packages/node/tests/free-usage-lifecycle.test.ts
+++ b/packages/node/tests/free-usage-lifecycle.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { keccak256, verifyTypedData } from 'ethers';
 import { BuyerFreeUsageManager } from '../src/payments/buyer-free-usage-manager.js';
 import { SellerFreeUsageManager } from '../src/payments/seller-free-usage-manager.js';
-import { ChannelStore, CHANNEL_KIND, CHANNEL_ROLE } from '../src/payments/channel-store.js';
+import { ChannelStore, CHANNEL_KIND, CHANNEL_ROLE, CHANNEL_STATUS } from '../src/payments/channel-store.js';
 import { PaymentMux } from '../src/p2p/payment-mux.js';
 import { decodeFrame } from '../src/p2p/message-protocol.js';
 import {
@@ -217,6 +217,70 @@ describe('FreeUsage P2P lifecycle', () => {
 
     await expect(timedOutManager.waitForOpenAck(seller.peerId, 1)).rejects.toThrow(/timed out waiting/);
     expect((timedOutManager as any)._sessions.size).toBe(0);
+  });
+
+  it('does not wedge buyer state when sending FreeUsageOpen fails', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'free-usage-open-send-fails-'));
+    const store = new ChannelStore(dir);
+    try {
+      const buyerManager = new BuyerFreeUsageManager(buyer, freeUsageConfig(), undefined, store);
+      const failingMux = new PaymentMux({
+        send: vi.fn(() => {
+          throw new Error('datachannel closed');
+        }),
+      } as any);
+
+      await expect(buyerManager.prepareOpen(sellerPeer(), failingMux)).rejects.toThrow('datachannel closed');
+      expect((buyerManager as any)._sessions.size).toBe(0);
+      expect(store.getActiveChannelByPeer(seller.peerId, CHANNEL_ROLE.BUYER, CHANNEL_KIND.FREE)).toBeNull();
+
+      const retryConn = makeConn();
+      const retryMux = new PaymentMux(retryConn.conn as any);
+      await buyerManager.prepareOpen(sellerPeer(), retryMux);
+
+      expect(decodeSentFrame(retryConn.frames[0]!).type).toBe(MessageType.FreeUsageOpen);
+    } finally {
+      store.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('hydrates the newest free usage channel after rotation', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'free-usage-rotation-'));
+    const store = new ChannelStore(dir);
+    try {
+      const buyerManager = new BuyerFreeUsageManager(
+        buyer,
+        { ...freeUsageConfig(), defaultAuthDurationSecs: 20 },
+        undefined,
+        store,
+      );
+      const buyerConn = makeConn();
+      const buyerMux = new PaymentMux(buyerConn.conn as any);
+
+      await buyerManager.prepareOpen(sellerPeer(), buyerMux);
+      const firstOpen = decodeFreeUsageOpen(decodeSentFrame(buyerConn.frames[0]!).payload);
+      buyerManager.handleAck(seller.peerId, {
+        channelId: firstOpen.channelId,
+        acceptedSequence: '0',
+      });
+
+      await buyerManager.prepareOpen(sellerPeer(), buyerMux);
+      const secondOpen = decodeFreeUsageOpen(decodeSentFrame(buyerConn.frames[1]!).payload);
+      buyerManager.handleAck(seller.peerId, {
+        channelId: secondOpen.channelId,
+        acceptedSequence: '0',
+      });
+
+      expect(store.getChannel(firstOpen.channelId)?.status).toBe(CHANNEL_STATUS.GHOST);
+      expect(store.getChannel(secondOpen.channelId)?.status).toBe(CHANNEL_STATUS.ACTIVE);
+
+      const restartedManager = new BuyerFreeUsageManager(buyer, freeUsageConfig(), undefined, store);
+      expect((restartedManager as any)._sessions.get(seller.peerId).channelId).toBe(secondOpen.channelId);
+    } finally {
+      store.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('persists free usage accounting in the shared channel store', async () => {

--- a/packages/node/tests/free-usage-signatures.test.ts
+++ b/packages/node/tests/free-usage-signatures.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { AbiCoder, keccak256, toUtf8Bytes, verifyTypedData } from 'ethers';
+import {
+  FREE_USAGE_AUTH_TYPES,
+  FREE_USAGE_OPEN_TYPES,
+  computeChannelId,
+  computeFreeUsageChannelId,
+  computeFreeUsageMetadataHash,
+  encodeFreeUsageMetadata,
+  getServiceMetadataId,
+  makeFreeUsageDomain,
+  signFreeUsageAuth,
+  signFreeUsageOpen,
+  type FreeUsageAuthMessage,
+  type FreeUsageOpenMessage,
+} from '../src/payments/evm/signatures.js';
+import { loadOrCreateIdentity } from '../src/p2p/identity.js';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('FreeUsage EIP-712 helpers', () => {
+  it('typehashes match AntseedFreeUsage contract strings', () => {
+    const openType = `FreeUsageOpen(${FREE_USAGE_OPEN_TYPES.FreeUsageOpen.map((f) => `${f.type} ${f.name}`).join(',')})`;
+    expect(keccak256(toUtf8Bytes(openType))).toBe(
+      keccak256(toUtf8Bytes('FreeUsageOpen(bytes32 channelId,uint256 deadline)')),
+    );
+
+    const authType = `FreeUsageAuth(${FREE_USAGE_AUTH_TYPES.FreeUsageAuth.map((f) => `${f.type} ${f.name}`).join(',')})`;
+    expect(keccak256(toUtf8Bytes(authType))).toBe(
+      keccak256(toUtf8Bytes('FreeUsageAuth(bytes32 channelId,uint256 sequence,bytes32 metadataHash,uint256 deadline)')),
+    );
+  });
+
+  it('encodes metadata with services and zero prices in contract layout', () => {
+    const serviceId = getServiceMetadataId('gpt-free');
+    const metadata = {
+      cumulativeInputTokens: 100n,
+      cumulativeOutputTokens: 40n,
+      cumulativeRequestCount: 2n,
+      services: [{
+        serviceId,
+        cumulativeAmount: 0n,
+        cumulativeInputTokens: 100n,
+        cumulativeCachedInputTokens: 0n,
+        cumulativeOutputTokens: 40n,
+        cumulativeRequestCount: 2n,
+      }],
+    };
+
+    const encoded = encodeFreeUsageMetadata(metadata);
+    const coder = AbiCoder.defaultAbiCoder();
+    const decoded = coder.decode(
+      [
+        'uint256',
+        'uint256',
+        'uint256',
+        'uint256',
+        'tuple(bytes32 serviceId,uint256 cumulativeAmount,uint256 cumulativeInputTokens,uint256 cumulativeCachedInputTokens,uint256 cumulativeOutputTokens,uint256 cumulativeRequestCount)[]',
+      ],
+      encoded,
+    );
+
+    expect(decoded[0]).toBe(1n);
+    expect(decoded[1]).toBe(100n);
+    expect(decoded[2]).toBe(40n);
+    expect(decoded[3]).toBe(2n);
+    expect(decoded[4]).toEqual([[
+      serviceId,
+      0n,
+      100n,
+      0n,
+      40n,
+      2n,
+    ]]);
+    expect(computeFreeUsageMetadataHash(metadata)).toBe(keccak256(encoded));
+  });
+
+  it('signs and recovers free usage open and usage auth', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'free-usage-eip712-'));
+    try {
+      const identity = await loadOrCreateIdentity(dir);
+      const domain = makeFreeUsageDomain(31337, '0x0165878A594ca255338adfa4d48449f69242Eb8F');
+      const channelId = computeChannelId(
+        identity.wallet.address,
+        '0x00000000000000000000000000000000000000b0',
+        '0x' + '01'.repeat(32),
+      );
+
+      const openMsg: FreeUsageOpenMessage = {
+        channelId,
+        deadline: 1234n,
+      };
+      const openSig = await signFreeUsageOpen(identity.wallet, domain, openMsg);
+      expect(verifyTypedData(domain, FREE_USAGE_OPEN_TYPES, openMsg, openSig).toLowerCase())
+        .toBe(identity.wallet.address.toLowerCase());
+
+      const metadataHash = computeFreeUsageMetadataHash({
+        cumulativeInputTokens: 10n,
+        cumulativeOutputTokens: 5n,
+        cumulativeRequestCount: 1n,
+        services: [{
+          serviceId: getServiceMetadataId('gpt-free'),
+          cumulativeAmount: 0n,
+          cumulativeInputTokens: 10n,
+          cumulativeCachedInputTokens: 0n,
+          cumulativeOutputTokens: 5n,
+          cumulativeRequestCount: 1n,
+        }],
+      });
+      const usageMsg: FreeUsageAuthMessage = {
+        channelId,
+        sequence: 1n,
+        metadataHash,
+        deadline: 1234n,
+      };
+      const usageSig = await signFreeUsageAuth(identity.wallet, domain, usageMsg);
+      expect(verifyTypedData(domain, FREE_USAGE_AUTH_TYPES, usageMsg, usageSig).toLowerCase())
+        .toBe(identity.wallet.address.toLowerCase());
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('free usage channel IDs are domain-separated from paid channel IDs', () => {
+    const buyer = '0x00000000000000000000000000000000000000a1';
+    const seller = '0x00000000000000000000000000000000000000b0';
+    const salt = '0x' + '01'.repeat(32);
+
+    expect(computeFreeUsageChannelId(buyer, seller, salt))
+      .not.toBe(computeChannelId(buyer, seller, salt));
+  });
+});

--- a/packages/node/tests/node-payment-mux-wiring.test.ts
+++ b/packages/node/tests/node-payment-mux-wiring.test.ts
@@ -80,6 +80,80 @@ describe('BuyerRequestHandler payment mux wiring', () => {
     ).toBeLessThan(sendProxyRequest.mock.invocationCallOrder[0]);
   });
 
+  it('opens free usage and skips paid cost tracking for advertised zero-price services', async () => {
+    const peer = {
+      peerId: 'b'.repeat(40),
+      providerPricing: {
+        openai: {
+          defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 1 },
+          services: {
+            'gpt-free': { inputUsdPerMillion: 0, outputUsdPerMillion: 0 },
+          },
+        },
+      },
+    } as PeerInfo;
+    const request: SerializedHttpRequest = {
+      requestId: 'req-free-usage',
+      method: 'POST',
+      path: '/v1/chat/completions',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ model: 'gpt-free' })),
+    };
+
+    const conn = { state: 'open' };
+    const sendProxyRequest = vi.fn((
+      _: SerializedHttpRequest,
+      onResponse: (response: SerializedHttpResponse, metadata: { streamingStart: boolean }) => void,
+    ) => {
+      onResponse({
+        requestId: request.requestId,
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' },
+        body: new TextEncoder().encode(JSON.stringify({
+          usage: { prompt_tokens: 12, completion_tokens: 7 },
+        })),
+      }, { streamingStart: false });
+    });
+
+    const trackRequestService = vi.fn();
+    const trackFreeUsageRequestService = vi.fn();
+    const prepareFreeUsageOpen = vi.fn(async () => {});
+    const estimateCostFromResponse = vi.fn();
+    const handler = new BuyerRequestHandler(
+      {},
+      {
+        localPeerId: 'a'.repeat(40) as PeerId,
+        negotiator: {
+          bpm: { trackRequestService },
+          getOrCreatePaymentMux: vi.fn().mockReturnValue({}),
+          prepareFreeUsageOpen,
+          trackFreeUsageRequestService,
+          preparePreRequestAuth: vi.fn(),
+          sendPostResponseAuth: vi.fn(),
+          estimateCostFromResponse,
+          parseCostHeaders: vi.fn(),
+          recordResponseContent: vi.fn(),
+        } as any,
+        verificationStorage: null,
+        verificationSampler: null,
+        getConnection: vi.fn(async () => conn) as any,
+        getMux: vi.fn(() => ({
+          sendProxyRequest,
+          cancelProxyRequest: vi.fn(),
+        })) as any,
+        getVerificationMux: vi.fn(() => createNoopVerificationMux()) as any,
+        registerPaymentMux: vi.fn(),
+      },
+    );
+
+    await handler.sendRequest(peer, request);
+
+    expect(trackFreeUsageRequestService).toHaveBeenCalledWith('req-free-usage', 'gpt-free');
+    expect(prepareFreeUsageOpen).toHaveBeenCalledWith(peer, conn);
+    expect(trackRequestService).not.toHaveBeenCalled();
+    expect(estimateCostFromResponse).not.toHaveBeenCalled();
+  });
+
   it('re-negotiates on 402 even when the peer was already locked', async () => {
     const peer = { peerId: 'b'.repeat(40) } as PeerInfo;
     const request: SerializedHttpRequest = {

--- a/packages/node/tests/node-payment-mux-wiring.test.ts
+++ b/packages/node/tests/node-payment-mux-wiring.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { BuyerRequestHandler } from '../src/buyer-request-handler.js';
+import { PaymentMux } from '../src/p2p/payment-mux.js';
 import type { SerializedHttpRequest } from '../src/types/http.js';
 import type { SerializedHttpResponse } from '../src/types/http.js';
 import type { PeerInfo, PeerId } from '../src/types/peer.js';
@@ -220,6 +221,71 @@ describe('BuyerRequestHandler payment mux wiring', () => {
 
     expect(response.statusCode).toBe(200);
     expect(prepareFreeUsageOpen).toHaveBeenCalledWith(peer, conn);
+    expect(sendProxyRequest).toHaveBeenCalledOnce();
+  });
+
+  it('opens free usage for zero-price services without a paid negotiator', async () => {
+    const peer = {
+      peerId: 'b'.repeat(40),
+      providerPricing: {
+        openai: {
+          defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 1 },
+          services: {
+            'gpt-free': { inputUsdPerMillion: 0, outputUsdPerMillion: 0 },
+          },
+        },
+      },
+    } as PeerInfo;
+    const request: SerializedHttpRequest = {
+      requestId: 'req-free-only',
+      method: 'POST',
+      path: '/v1/chat/completions',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ model: 'gpt-free' })),
+    };
+
+    const conn = { state: 'open' };
+    const sendProxyRequest = vi.fn((
+      _: SerializedHttpRequest,
+      onResponse: (response: SerializedHttpResponse, metadata: { streamingStart: boolean }) => void,
+    ) => {
+      onResponse({
+        requestId: request.requestId,
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' },
+        body: new Uint8Array(0),
+      }, { streamingStart: false });
+    });
+    const freeUsageManager = {
+      trackRequestService: vi.fn(),
+      prepareOpen: vi.fn(async () => {}),
+      waitForOpenAck: vi.fn(async () => {}),
+      handleAck: vi.fn(),
+      handleNeedAuth: vi.fn(async () => {}),
+    };
+    const handler = new BuyerRequestHandler(
+      {},
+      {
+        localPeerId: 'a'.repeat(40) as PeerId,
+        negotiator: null,
+        freeUsageManager: freeUsageManager as any,
+        verificationStorage: null,
+        verificationSampler: null,
+        getConnection: vi.fn(async () => conn) as any,
+        getMux: vi.fn(() => ({
+          sendProxyRequest,
+          cancelProxyRequest: vi.fn(),
+        })) as any,
+        getVerificationMux: vi.fn(() => createNoopVerificationMux()) as any,
+        registerPaymentMux: vi.fn(),
+      },
+    );
+
+    const response = await handler.sendRequest(peer, request);
+
+    expect(response.statusCode).toBe(200);
+    expect(freeUsageManager.trackRequestService).toHaveBeenCalledWith('req-free-only', 'gpt-free');
+    expect(freeUsageManager.prepareOpen).toHaveBeenCalledWith(peer, expect.any(PaymentMux));
     expect(sendProxyRequest).toHaveBeenCalledOnce();
   });
 

--- a/packages/node/tests/node-payment-mux-wiring.test.ts
+++ b/packages/node/tests/node-payment-mux-wiring.test.ts
@@ -154,6 +154,75 @@ describe('BuyerRequestHandler payment mux wiring', () => {
     expect(estimateCostFromResponse).not.toHaveBeenCalled();
   });
 
+  it('continues zero-price requests when free usage setup is unavailable', async () => {
+    const peer = {
+      peerId: 'b'.repeat(40),
+      providerPricing: {
+        openai: {
+          defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 1 },
+          services: {
+            'gpt-free': { inputUsdPerMillion: 0, outputUsdPerMillion: 0 },
+          },
+        },
+      },
+    } as PeerInfo;
+    const request: SerializedHttpRequest = {
+      requestId: 'req-free-legacy',
+      method: 'POST',
+      path: '/v1/chat/completions',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ model: 'gpt-free' })),
+    };
+
+    const conn = { state: 'open' };
+    const sendProxyRequest = vi.fn((
+      _: SerializedHttpRequest,
+      onResponse: (response: SerializedHttpResponse, metadata: { streamingStart: boolean }) => void,
+    ) => {
+      onResponse({
+        requestId: request.requestId,
+        statusCode: 200,
+        headers: { 'content-type': 'application/json' },
+        body: new Uint8Array(0),
+      }, { streamingStart: false });
+    });
+    const prepareFreeUsageOpen = vi.fn(async () => {
+      throw new Error('free usage unsupported');
+    });
+    const handler = new BuyerRequestHandler(
+      {},
+      {
+        localPeerId: 'a'.repeat(40) as PeerId,
+        negotiator: {
+          bpm: { trackRequestService: vi.fn() },
+          getOrCreatePaymentMux: vi.fn().mockReturnValue({}),
+          prepareFreeUsageOpen,
+          trackFreeUsageRequestService: vi.fn(),
+          preparePreRequestAuth: vi.fn(),
+          sendPostResponseAuth: vi.fn(),
+          estimateCostFromResponse: vi.fn(),
+          parseCostHeaders: vi.fn(),
+          recordResponseContent: vi.fn(),
+        } as any,
+        verificationStorage: null,
+        verificationSampler: null,
+        getConnection: vi.fn(async () => conn) as any,
+        getMux: vi.fn(() => ({
+          sendProxyRequest,
+          cancelProxyRequest: vi.fn(),
+        })) as any,
+        getVerificationMux: vi.fn(() => createNoopVerificationMux()) as any,
+        registerPaymentMux: vi.fn(),
+      },
+    );
+
+    const response = await handler.sendRequest(peer, request);
+
+    expect(response.statusCode).toBe(200);
+    expect(prepareFreeUsageOpen).toHaveBeenCalledWith(peer, conn);
+    expect(sendProxyRequest).toHaveBeenCalledOnce();
+  });
+
   it('re-negotiates on 402 even when the peer was already locked', async () => {
     const peer = { peerId: 'b'.repeat(40) } as PeerInfo;
     const request: SerializedHttpRequest = {

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -201,9 +201,11 @@ describe('SellerRequestHandler payment pricing selection', () => {
 
     const sendNeedAuth = vi.fn();
     const recordSpend = vi.fn();
+    const reportUsageRequest = vi.fn();
     const handler = new SellerRequestHandler({
       providers: [provider],
       sellerPaymentManager: makeSpmMock({ recordSpend, getPaymentRequirements: () => ({ minBudgetPerRequest: '0', suggestedAmount: '0' }) }),
+      sellerFreeUsageManager: { reportUsageRequest } as any,
       sessionTracker: null,
       channelsClient: {} as any,
       announcer: null,
@@ -221,6 +223,13 @@ describe('SellerRequestHandler payment pricing selection', () => {
     expect(sentFrames.length).toBeGreaterThan(0);
     expect(recordSpend).not.toHaveBeenCalled();
     expect(sendNeedAuth).not.toHaveBeenCalled();
+    expect(reportUsageRequest).toHaveBeenCalledOnce();
+    expect(reportUsageRequest).toHaveBeenCalledWith('b'.repeat(40), paymentMux, {
+      requestId: 'req-zero-cost',
+      inputTokens: 0,
+      outputTokens: 0,
+      service: 'local-test',
+    });
   });
 
   it('uses cumulative spend as NeedAuth required amount without double-counting the latest request', async () => {

--- a/packages/node/tests/payment-codec.test.ts
+++ b/packages/node/tests/payment-codec.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   encodeSpendingAuth, decodeSpendingAuth,
   encodeAuthAck, decodeAuthAck,
+  encodeFreeUsageOpen, decodeFreeUsageOpen,
+  encodeFreeUsageAuth, decodeFreeUsageAuth,
+  encodeFreeUsageAck, decodeFreeUsageAck,
+  encodeNeedFreeUsageAuth, decodeNeedFreeUsageAuth,
   encodePaymentRequired, decodePaymentRequired,
   encodeNeedAuth, decodeNeedAuth,
 } from '../src/p2p/payment-codec.js';
@@ -23,6 +27,51 @@ describe('payment codec round-trips', () => {
   it('AuthAck', () => {
     const payload = { channelId: '0x' + 'aa'.repeat(32) };
     expect(decodeAuthAck(encodeAuthAck(payload))).toEqual(payload);
+  });
+
+  it('FreeUsageOpen', () => {
+    const payload = {
+      channelId: '0x' + 'ab'.repeat(32),
+      salt: '0x' + '01'.repeat(32),
+      deadline: 123456,
+      openSig: '0x' + 'ef'.repeat(65),
+    };
+    expect(decodeFreeUsageOpen(encodeFreeUsageOpen(payload))).toEqual(payload);
+  });
+
+  it('FreeUsageAuth', () => {
+    const payload = {
+      channelId: '0x' + 'ab'.repeat(32),
+      cumulativeInputTokens: '100',
+      cumulativeOutputTokens: '40',
+      sequence: '2',
+      metadataHash: '0x' + 'cd'.repeat(32),
+      metadata: '0x' + '12'.repeat(128),
+      deadline: 123456,
+      usageSig: '0x' + 'ef'.repeat(65),
+    };
+    expect(decodeFreeUsageAuth(encodeFreeUsageAuth(payload))).toEqual(payload);
+  });
+
+  it('FreeUsageAck', () => {
+    const payload = {
+      channelId: '0x' + 'ab'.repeat(32),
+      acceptedSequence: '2',
+    };
+    expect(decodeFreeUsageAck(encodeFreeUsageAck(payload))).toEqual(payload);
+  });
+
+  it('NeedFreeUsageAuth', () => {
+    const payload = {
+      channelId: '0x' + 'ab'.repeat(32),
+      requiredSequence: '3',
+      currentAcceptedSequence: '2',
+      requestId: 'req-free',
+      inputTokens: '100',
+      outputTokens: '40',
+      service: 'gpt-free',
+    };
+    expect(decodeNeedFreeUsageAuth(encodeNeedFreeUsageAuth(payload))).toEqual(payload);
   });
 
   it('PaymentRequired', () => {

--- a/packages/node/tests/payment-codec.test.ts
+++ b/packages/node/tests/payment-codec.test.ts
@@ -39,6 +39,16 @@ describe('payment codec round-trips', () => {
     expect(decodeFreeUsageOpen(encodeFreeUsageOpen(payload))).toEqual(payload);
   });
 
+  it('rejects FreeUsageOpen with a non-finite deadline', () => {
+    const encoded = new TextEncoder().encode(JSON.stringify({
+      channelId: '0x' + 'ab'.repeat(32),
+      salt: '0x' + '01'.repeat(32),
+      deadline: 'NaN',
+      openSig: '0x' + 'ef'.repeat(65),
+    }));
+    expect(() => decodeFreeUsageOpen(encoded)).toThrow(/finite number/);
+  });
+
   it('FreeUsageAuth', () => {
     const payload = {
       channelId: '0x' + 'ab'.repeat(32),
@@ -51,6 +61,20 @@ describe('payment codec round-trips', () => {
       usageSig: '0x' + 'ef'.repeat(65),
     };
     expect(decodeFreeUsageAuth(encodeFreeUsageAuth(payload))).toEqual(payload);
+  });
+
+  it('rejects FreeUsageAuth with a non-finite deadline', () => {
+    const encoded = new TextEncoder().encode(JSON.stringify({
+      channelId: '0x' + 'ab'.repeat(32),
+      cumulativeInputTokens: '100',
+      cumulativeOutputTokens: '40',
+      sequence: '2',
+      metadataHash: '0x' + 'cd'.repeat(32),
+      metadata: '0x' + '12'.repeat(128),
+      deadline: 'NaN',
+      usageSig: '0x' + 'ef'.repeat(65),
+    }));
+    expect(() => decodeFreeUsageAuth(encoded)).toThrow(/finite number/);
   });
 
   it('FreeUsageAck', () => {

--- a/packages/node/tests/payment-negotiation.test.ts
+++ b/packages/node/tests/payment-negotiation.test.ts
@@ -11,7 +11,7 @@ import type { SerializedHttpRequest, SerializedHttpResponse } from '../src/types
 import { SellerPaymentManager, type SellerPaymentConfig } from '../src/payments/seller-payment-manager.js';
 import { BuyerPaymentManager } from '../src/payments/buyer-payment-manager.js';
 import { BuyerPaymentNegotiator } from '../src/payments/buyer-payment-negotiator.js';
-import { ChannelStore } from '../src/payments/channel-store.js';
+import { ChannelStore, CHANNEL_ROLE, CHANNEL_STATUS } from '../src/payments/channel-store.js';
 import type { Identity } from '../src/p2p/identity.js';
 import { bytesToHex } from '../src/utils/hex.js';
 import { toPeerId } from '../src/types/peer.js';
@@ -279,7 +279,7 @@ describe('SellerPaymentManager suggested amount', () => {
     store.upsertChannel({
       sessionId: '0x' + 'aa'.repeat(32),
       peerId: 'returning-buyer',
-      role: 'seller',
+      role: CHANNEL_ROLE.SELLER,
       sellerEvmAddr: sellerIdentity.wallet.address,
       buyerEvmAddr: '0x' + 'bb'.repeat(20),
       nonce: 1,
@@ -292,7 +292,7 @@ describe('SellerPaymentManager suggested amount', () => {
       reservedAt: Date.now(),
       settledAt: null,
       settledAmount: null,
-      status: 'settled',
+      status: CHANNEL_STATUS.SETTLED,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     });

--- a/packages/node/tests/proof-chain-integration.test.ts
+++ b/packages/node/tests/proof-chain-integration.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { Wallet, AbiCoder } from 'ethers';
 import { BuyerPaymentManager, type BuyerPaymentConfig } from '../src/payments/buyer-payment-manager.js';
-import { ChannelStore } from '../src/payments/channel-store.js';
+import { ChannelStore, CHANNEL_STATUS } from '../src/payments/channel-store.js';
 import type { PaymentMux } from '../src/p2p/payment-mux.js';
 import type {
   SpendingAuthPayload,
@@ -244,7 +244,7 @@ describe('Cumulative SpendingAuth Integration', () => {
 
     const session = newStore.getChannel(channelId);
     expect(session).not.toBeNull();
-    expect(session!.status).toBe('active');
+    expect(session!.status).toBe(CHANNEL_STATUS.ACTIVE);
     expect(BigInt(session!.tokensDelivered)).toBeGreaterThan(0n);
 
     buyerStore = newStore;

--- a/packages/node/tests/seller-close-requested.test.ts
+++ b/packages/node/tests/seller-close-requested.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { SellerPaymentManager, type SellerPaymentConfig } from '../src/payments/seller-payment-manager.js';
-import { ChannelStore } from '../src/payments/channel-store.js';
+import { ChannelStore, CHANNEL_STATUS } from '../src/payments/channel-store.js';
 import type { PaymentMux } from '../src/p2p/payment-mux.js';
 import type { Identity } from '../src/p2p/identity.js';
 import type { SpendingAuthPayload } from '../src/types/protocol.js';
@@ -167,7 +167,7 @@ describe('SellerPaymentManager — CloseRequested handling', () => {
 
     // Channel should be settled
     const session = store.getChannel(channelId);
-    expect(session!.status).toBe('settled');
+    expect(session!.status).toBe(CHANNEL_STATUS.SETTLED);
 
     // In-memory state cleaned up
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
@@ -191,7 +191,7 @@ describe('SellerPaymentManager — CloseRequested handling', () => {
 
     // Channel should be marked as timeout
     const session = store.getChannel(channelId);
-    expect(session!.status).toBe('timeout');
+    expect(session!.status).toBe(CHANNEL_STATUS.TIMEOUT);
 
     // In-memory state cleaned up
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { SellerPaymentManager, type SellerPaymentConfig } from '../src/payments/seller-payment-manager.js';
-import { ChannelStore } from '../src/payments/channel-store.js';
+import { ChannelStore, CHANNEL_ROLE, CHANNEL_STATUS } from '../src/payments/channel-store.js';
 import type { PaymentMux } from '../src/p2p/payment-mux.js';
 import type { Identity } from '../src/p2p/identity.js';
 import type { SpendingAuthPayload } from '../src/types/protocol.js';
@@ -173,7 +173,7 @@ describe('SellerPaymentManager', () => {
     const session = store.getChannel(channelId);
     expect(session).not.toBeNull();
     expect(session!.role).toBe('seller');
-    expect(session!.status).toBe('active');
+    expect(session!.status).toBe(CHANNEL_STATUS.ACTIVE);
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
   });
 
@@ -327,7 +327,7 @@ describe('SellerPaymentManager', () => {
     expect(manager.hasPendingTopUp(channelId)).toBe(false);
     expect(manager.isChannelBlocked(channelId)).toBe(false);
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
-    expect(store.getChannel(channelId)!.status).toBe('settled');
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
   });
 
   it('blocks the channel if permanent top-up failure cannot close immediately', async () => {
@@ -360,7 +360,7 @@ describe('SellerPaymentManager', () => {
     expect(manager.hasPendingTopUp(channelId)).toBe(false);
     expect(manager.isChannelBlocked(channelId)).toBe(true);
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
-    expect(store.getChannel(channelId)!.status).toBe('active');
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
   });
 
   it('closes the channel if a deferred top-up retry fails permanently', async () => {
@@ -410,7 +410,7 @@ describe('SellerPaymentManager', () => {
     expect(manager.hasPendingTopUp(channelId)).toBe(false);
     expect(manager.isChannelBlocked(channelId)).toBe(false);
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
-    expect(store.getChannel(channelId)!.status).toBe('settled');
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
   });
 
   it('serializes a burst of concurrent SpendingAuth updates and ends at the latest cumulative amount', async () => {
@@ -520,7 +520,7 @@ describe('SellerPaymentManager', () => {
 
     const session = store.getChannel(channelId);
     expect(session).not.toBeNull();
-    expect(session!.status).toBe('active');
+    expect(session!.status).toBe(CHANNEL_STATUS.ACTIVE);
     expect(session!.previousConsumption).toBe('1000000');
     expect(session!.tokensDelivered).toBe('50000');
   });
@@ -641,7 +641,7 @@ describe('SellerPaymentManager', () => {
 
     const session = store.getChannel(channelId);
     expect(session).not.toBeNull();
-    expect(session!.status).toBe('active');
+    expect(session!.status).toBe(CHANNEL_STATUS.ACTIVE);
     expect(manager2.channelsClient.close).not.toHaveBeenCalled();
   });
 
@@ -800,7 +800,7 @@ describe('SellerPaymentManager', () => {
     }
     await new Promise<void>((r) => setImmediate(r));
 
-    expect(store.getChannel(channelId)!.status).toBe('active');
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
     expect(manager.getAcceptedCumulative(channelId)).toBe(0n);
 
@@ -820,7 +820,7 @@ describe('SellerPaymentManager', () => {
     expect(retryArgs[2]).toBe(300_000n);
     expect(retryArgs[3]).toBe(auth.metadata);
     expect(retryArgs[4]).toBe(auth.spendingAuthSig);
-    expect(store.getChannel(channelId)!.status).toBe('settled');
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
     expect(store.getChannel(channelId)!.settledAmount).toBe('300000');
   });
 
@@ -850,7 +850,7 @@ describe('SellerPaymentManager', () => {
     expect(closeArgs[2]).toBe(0n);
     expect(closeArgs[3]).toBe('0x');
     expect(closeArgs[4]).toBe('0x');
-    expect(store.getChannel(channelId)!.status).toBe('settled');
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
   });
 
@@ -886,7 +886,7 @@ describe('SellerPaymentManager', () => {
     const closeArgs = (restarted.channelsClient.close as ReturnType<typeof vi.fn>).mock.calls[0]!;
     expect(closeArgs[1]).toBe(channelId);
     expect(closeArgs[2]).toBe(0n);
-    expect(store.getChannel(channelId)!.status).toBe('settled');
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
     expect(restarted.hasSession(buyerIdentity.peerId)).toBe(false);
   });
 
@@ -912,7 +912,7 @@ describe('SellerPaymentManager', () => {
     await manager.checkTimeouts();
 
     expect(manager.channelsClient.close).toHaveBeenCalledOnce();
-    expect(store.getChannel(channelId)!.status).toBe('active');
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
   });
 
@@ -941,7 +941,7 @@ describe('SellerPaymentManager', () => {
     await manager.checkTimeouts();
 
     expect(manager.channelsClient.close).toHaveBeenCalledTimes(3);
-    expect(store.getChannel(channelId)!.status).toBe('timeout');
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.TIMEOUT);
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
   });
 
@@ -1018,7 +1018,7 @@ describe('SellerPaymentManager', () => {
       const channel: StoredChannel = {
         sessionId: channelId,
         peerId: buyer.peerId,
-        role: 'seller',
+        role: CHANNEL_ROLE.SELLER,
         sellerEvmAddr: seller.wallet.address,
         buyerEvmAddr: buyer.wallet.address,
         nonce: 0,
@@ -1031,7 +1031,7 @@ describe('SellerPaymentManager', () => {
         reservedAt: now,
         settledAt: null,
         settledAmount: null,
-        status: 'active',
+        status: CHANNEL_STATUS.ACTIVE,
         latestBuyerSig: '0xdead',
         latestSpendingAuthSig: '0xdead',
         latestMetadata: null,
@@ -1077,7 +1077,7 @@ describe('SellerPaymentManager', () => {
       await mgr.validateHydratedChannels();
 
       expect(mgr.hasSession(buyerIdentity.peerId)).toBe(false);
-      expect(store.getChannel(channelId)!.status).toBe('settled');
+      expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
     });
 
     it('evicts channel with settled on-chain status', async () => {
@@ -1092,7 +1092,7 @@ describe('SellerPaymentManager', () => {
       await mgr.validateHydratedChannels();
 
       expect(mgr.hasSession(buyerIdentity.peerId)).toBe(false);
-      expect(store.getChannel(channelId)!.status).toBe('settled');
+      expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
     });
 
     it('keeps channel and reconciles when active on-chain with higher settled', async () => {
@@ -1190,7 +1190,7 @@ describe('SellerPaymentManager', () => {
       await mgr.validateHydratedChannels();
 
       expect(mgr.hasSession(buyerIdentity.peerId)).toBe(true);
-      expect(store.getChannel(channelId)!.status).toBe('active');
+      expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
     });
 
     it('evicts channel with mismatched parties', async () => {
@@ -1206,7 +1206,7 @@ describe('SellerPaymentManager', () => {
       await mgr.validateHydratedChannels();
 
       expect(mgr.hasSession(buyerIdentity.peerId)).toBe(false);
-      expect(store.getChannel(channelId)!.status).toBe('settled');
+      expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
     });
 
     it('keeps channel with unknown on-chain status', async () => {


### PR DESCRIPTION
## Description

Adds zero-price free usage authorization across contracts, node P2P negotiation, and CLI chain configuration. Buyers can sign FreeUsageOpen and FreeUsageAuth records without deposits, while sellers can report those buyer signatures on-chain through AntseedFreeUsage.

## Release Notes

- Added free usage authorization for advertised zero-price services
- Added AntseedFreeUsage contract deployment/configuration support
- Added P2P FreeUsageOpen, NeedFreeUsageAuth, FreeUsageAuth, and FreeUsageAck exchange

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
