### PR TITLE
fix(node): Delay free usage flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project uses selective package publishing. Each release entry lists the pub
 ### Changed
 
 - Reduced the default buyer response-auth evidence sample rate from 20% to 0.5% to limit local `verification_samples` growth during high-request sessions.
+- Increased the default free-usage on-chain record flush interval from 10 seconds to 5 minutes to reduce background transaction frequency while preserving batch, disconnect, and shutdown flushes.
 
 ### Fixed
 

--- a/packages/node/src/payments/seller-free-usage-manager.ts
+++ b/packages/node/src/payments/seller-free-usage-manager.ts
@@ -67,7 +67,7 @@ const FREE_USAGE_METADATA_ABI = [
 ] as const;
 
 const DEFAULT_RECORD_BATCH_SIZE = 16;
-const DEFAULT_RECORD_FLUSH_INTERVAL_MS = 10_000;
+const DEFAULT_RECORD_FLUSH_INTERVAL_MS = 5 * 60_000;
 
 function normalizeTokenCount(value: number): bigint {
   if (!Number.isFinite(value) || value <= 0) return 0n;


### PR DESCRIPTION
## Description

Increases the default seller free-usage on-chain record flush interval from 10 seconds to 5 minutes. Batch, disconnect, and shutdown flushes are unchanged, so sellers still record accepted free-usage auths without creating frequent background transactions during active sessions.

## Release Notes

- Increased the default free-usage on-chain record flush interval from 10 seconds to 5 minutes.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Validation:
- pnpm --filter @antseed/node test -- free-usage-lifecycle.test.ts free-usage-signatures.test.ts
- pnpm --filter @antseed/node typecheck