### PR TITLE
fix(desktop): stop treating chat URLs as sensitive artifacts

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/ChatBubble.module.scss
@@ -379,14 +379,6 @@
       color: inherit;
     }
 
-    .chat-external-link-gated .chat-sensitive-action {
-      color: var(--accent-blue);
-    }
-
-    .chat-external-link-gated .chat-sensitive-action:hover {
-      background: color-mix(in srgb, var(--accent-blue) 12%, transparent);
-    }
-
     .chat-payment-link-hidden {
       font-weight: 600;
     }

--- a/apps/desktop/src/renderer/ui/components/chat/chat-safety.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-safety.ts
@@ -1,5 +1,4 @@
 export type SensitiveChatArtifact =
-  | { type: 'url'; value: string; scheme: string; display: string }
   | { type: 'wallet-address'; value: string; chainHint: string };
 
 export type ChatTextSegment =
@@ -14,7 +13,6 @@ type MatchCandidate = {
 };
 
 const ZERO_WIDTH_CHARS = /[\u200B-\u200D\uFEFF]/g;
-const URL_OR_PAYMENT_URI_PATTERN = /\b(?:(?:https?:\/\/|www\.)[^\s<>{}|\\^`"']+|(?:ethereum|bitcoin|solana|wc):[^\s<>{}|\\^`"']+)/giu;
 const EVM_ADDRESS_PATTERN = /\b0x[a-fA-F0-9]{40}\b/g;
 const BITCOIN_ADDRESS_PATTERN = /\b(?:bc1[ac-hj-np-z02-9]{25,87}|[13][a-km-zA-HJ-NP-Z1-9]{25,34})\b/gi;
 const COSMOS_ADDRESS_PATTERN = /\b[a-z]{2,16}1[0-9a-z]{38,58}\b/gi;
@@ -24,7 +22,6 @@ const COSMOS_ADDRESS_PATTERN = /\b[a-z]{2,16}1[0-9a-z]{38,58}\b/gi;
 // still trigger the safety gate; recall matters more than precision here.
 const SOLANA_ADDRESS_PATTERN = /\b(?=[1-9A-HJ-NP-Za-km-z]{32,44}\b)(?=[1-9A-HJ-NP-Za-km-z]*\d)[1-9A-HJ-NP-Za-km-z]{32,44}\b/g;
 
-const TRAILING_URL_PUNCTUATION = /[),.;:!?]+$/;
 const PAYMENT_INTENT_PATTERN = /\b(?:send|transfer|deposit|top\s*up|fund|funds|pay|payment|required|billing|balance|insufficient|add\s+credits?|add\s+funds?|connect\s+(?:your\s+)?wallet|approve\s+(?:the\s+)?(?:transaction|token|spend|allowance)|claim\s+(?:refund|airdrop|reward)|verify\s+(?:your\s+)?wallet|wallet\s+verification)\b/i;
 
 function stripZeroWidthChars(text: string): string {
@@ -40,42 +37,6 @@ function normalizeForDetection(text: string): string {
     .trim();
 }
 
-function trimUrlPunctuation(value: string): string {
-  let next = value;
-  while (TRAILING_URL_PUNCTUATION.test(next)) {
-    const candidate = next.replace(TRAILING_URL_PUNCTUATION, '');
-    if (candidate.length === next.length || candidate.length === 0) break;
-    next = candidate;
-  }
-  return next;
-}
-
-function urlArtifact(rawValue: string): SensitiveChatArtifact | null {
-  const trimmed = trimUrlPunctuation(rawValue.trim());
-  if (!trimmed) return null;
-  const withProtocol = trimmed.toLowerCase().startsWith('www.') ? `https://${trimmed}` : trimmed;
-
-  try {
-    const parsed = new URL(withProtocol);
-    const scheme = parsed.protocol.replace(/:$/, '').toLowerCase();
-    if (!scheme) return null;
-
-    let display = scheme;
-    if (scheme === 'http' || scheme === 'https') {
-      display = parsed.hostname.replace(/^www\./i, '') || 'external link';
-    } else if (scheme === 'mailto') {
-      display = 'email link';
-    } else if (scheme === 'wc') {
-      display = 'WalletConnect link';
-    } else if (scheme === 'ethereum' || scheme === 'bitcoin' || scheme === 'solana') {
-      display = `${scheme} payment link`;
-    }
-
-    return { type: 'url', value: withProtocol, scheme, display };
-  } catch {
-    return null;
-  }
-}
 
 function pushRegexMatches(
   candidates: MatchCandidate[],
@@ -99,20 +60,6 @@ function pushRegexMatches(
 
 function collectSensitiveArtifacts(text: string): MatchCandidate[] {
   const candidates: MatchCandidate[] = [];
-
-  URL_OR_PAYMENT_URI_PATTERN.lastIndex = 0;
-  for (const match of text.matchAll(URL_OR_PAYMENT_URI_PATTERN)) {
-    const raw = match[0];
-    if (!raw || match.index === undefined) continue;
-    const artifact = urlArtifact(raw);
-    if (!artifact) continue;
-    candidates.push({
-      start: match.index,
-      end: match.index + trimUrlPunctuation(raw).length,
-      artifact,
-      priority: 10,
-    });
-  }
 
   pushRegexMatches(candidates, text, EVM_ADDRESS_PATTERN, 'EVM', 5);
   pushRegexMatches(candidates, text, BITCOIN_ADDRESS_PATTERN, 'Bitcoin', 4);
@@ -166,12 +113,5 @@ export function isLikelyUnsafePaymentInstruction(text: string): boolean {
 }
 
 export function formatArtifactLabel(artifact: SensitiveChatArtifact): string {
-  if (artifact.type === 'wallet-address') {
-    return `${artifact.chainHint} address hidden`;
-  }
-  if (artifact.scheme === 'wc') return 'WalletConnect link hidden';
-  if (artifact.scheme === 'ethereum' || artifact.scheme === 'bitcoin' || artifact.scheme === 'solana') {
-    return `${artifact.scheme} payment link hidden`;
-  }
-  return `External link: ${artifact.display}`;
+  return `${artifact.chainHint} address hidden`;
 }

--- a/apps/desktop/src/renderer/ui/components/chat/chat-utils.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/chat-utils.tsx
@@ -104,8 +104,16 @@ function splitHighlightedText(text: string, query: string | undefined, keyPrefix
   return <>{parts}</>;
 }
 
-function safeOpenExternalUrl(url: string): void {
-  window.open(url, '_blank', 'noopener,noreferrer');
+function isSafeHref(rawHref: string): boolean {
+  const trimmed = rawHref.trim();
+  if (!trimmed) return false;
+  try {
+    const parsed = new URL(trimmed, 'https://antseed.invalid');
+    const protocol = parsed.protocol.toLowerCase();
+    return protocol === 'http:' || protocol === 'https:' || protocol === 'mailto:';
+  } catch {
+    return false;
+  }
 }
 
 function firstArtifactFromText(value: string): SensitiveChatArtifact | null {
@@ -146,23 +154,9 @@ function HiddenWalletAddress({ artifact }: { artifact: SensitiveChatArtifact }) 
   return <code className="chat-wallet-revealed-text">{value}</code>;
 }
 
-function SafeExternalLink({ artifact }: { artifact: SensitiveChatArtifact }) {
-  const label = formatArtifactLabel(artifact);
-  const isPaymentLink = artifact.type === 'url' && ['ethereum', 'bitcoin', 'solana', 'wc'].includes(artifact.scheme);
 
-  return (
-    <span className={`chat-sensitive-artifact${isPaymentLink ? ' chat-payment-link-hidden' : ' chat-external-link-gated'}`}>
-      <span className="chat-sensitive-label">{label}</span>
-      <button type="button" className="chat-sensitive-action" onClick={() => safeOpenExternalUrl(artifact.value)}>
-        {isPaymentLink ? 'Open' : 'Open'}
-      </button>
-    </span>
-  );
-}
-
-function SafeArtifact({ artifact }: { artifact: SensitiveChatArtifact; children?: ReactNode }) {
-  if (artifact.type === 'wallet-address') return <HiddenWalletAddress artifact={artifact} />;
-  return <SafeExternalLink artifact={artifact} />;
+function SafeArtifact({ artifact }: { artifact: SensitiveChatArtifact }) {
+  return <HiddenWalletAddress artifact={artifact} />;
 }
 
 function splitSafeHighlightedText(text: string, query: string | undefined, keyPrefix: string, activeHighlight = false): ReactNode {
@@ -241,35 +235,41 @@ function renderInlineToken(token: MarkdownToken, key: string, highlightQuery?: s
     case 'link': {
       const href = normalizeText(token.href);
       const content = renderInlineTokens(token.tokens, key, highlightQuery, activeHighlight);
-      const artifact = firstArtifactFromText(href);
-      if (!artifact || artifact.type !== 'url') {
+
+      if (!isSafeHref(href)) {
         return (
           <span key={key} className="chat-inline-link-invalid">
             {content}
           </span>
         );
       }
-      return <SafeArtifact key={key} artifact={artifact}>{content}</SafeArtifact>;
+
+      return (
+        <a
+          key={key}
+          href={href}
+          style={{ color: 'var(--accent-blue)', textDecoration: 'underline' }}
+          target="_blank"
+          rel="noopener noreferrer"
+          title={token.title ?? undefined}
+        >
+          {content}
+        </a>
+      );
     }
     case 'image': {
       const href = normalizeText(token.href);
       const alt = flattenPlainText(token.tokens) || normalizeText(token.text) || 'Image';
-      const artifact = firstArtifactFromText(href);
-      if (!artifact || artifact.type !== 'url') {
+
+      if (!isSafeHref(href)) {
         return (
           <span key={key} className="chat-inline-link-invalid">
             {alt}
           </span>
         );
       }
-      return (
-        <span key={key} className="chat-sensitive-artifact chat-external-image-hidden">
-          <span className="chat-sensitive-label">External image hidden: {artifact.display}</span>
-          <button type="button" className="chat-sensitive-action" onClick={() => safeOpenExternalUrl(artifact.value)}>
-            Open
-          </button>
-        </span>
-      );
+
+      return <img key={key} src={href} alt={alt} className="chat-inline-image" />;
     }
     default:
       if (Array.isArray(token.tokens) && token.tokens.length > 0) {


### PR DESCRIPTION
## Summary
- remove normal URL and payment-URI matching from chat sensitive-artifact detection
- let Markdown render regular links and images normally again
- keep wallet address redaction in place

## Context
This is a follow-up to the unsafe payment chat rendering work. The intended safety behavior is to hide wallet addresses inline; regular links should be handled by the Markdown renderer and should not be replaced with custom `External link` / `Open` pills.

## Verification
- `pnpm --filter=@antseed/desktop run typecheck:renderer`
- `pnpm --filter=@antseed/desktop run build:renderer`
- manual Electron check with Markdown links, plain URLs, and wallet-address redaction