### PR TITLE
feat(cli): withdraw buyer channel reserves

### DIFF
--- a/apps/cli/src/cli/commands/buyer/channel-withdraw.test.ts
+++ b/apps/cli/src/cli/commands/buyer/channel-withdraw.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { StoredChannel } from '@antseed/node';
+import {
+  CHANNEL_CLOSE_GRACE_PERIOD_SECONDS,
+  resolveBuyerChannelById,
+  secondsUntilChannelWithdrawReady,
+} from './channel-withdraw.js';
+
+function channel(sessionId: string): StoredChannel {
+  return {
+    sessionId,
+    peerId: 'peer',
+    role: 'buyer',
+    sellerEvmAddr: '0x' + '11'.repeat(20),
+    buyerEvmAddr: '0x' + '22'.repeat(20),
+    nonce: 0,
+    authMax: '1000000',
+    previousConsumption: '0',
+    tokensDelivered: '0',
+    deadline: 0,
+    previousSessionId: '',
+    requestCount: 0,
+    reservedAt: 0,
+    settledAt: null,
+    settledAmount: null,
+    status: 'active',
+    latestBuyerSig: null,
+    latestSpendingAuthSig: null,
+    latestMetadata: null,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+test('resolveBuyerChannelById accepts exact ids and unique prefixes', () => {
+  const first = channel('0x' + 'aa'.repeat(32));
+  const second = channel('0x' + 'bb'.repeat(32));
+
+  assert.equal(resolveBuyerChannelById([first, second], first.sessionId), first);
+  assert.equal(resolveBuyerChannelById([first, second], '0xaaaa'), first);
+});
+
+test('resolveBuyerChannelById rejects ambiguous prefixes', () => {
+  const first = channel('0xaaaa' + '11'.repeat(30));
+  const second = channel('0xaaaa' + '22'.repeat(30));
+
+  assert.throws(
+    () => resolveBuyerChannelById([first, second], '0xaaaa'),
+    /ambiguous/i,
+  );
+});
+
+test('secondsUntilChannelWithdrawReady tracks 15 minute timeout grace period', () => {
+  assert.equal(
+    secondsUntilChannelWithdrawReady(100n, 100 + CHANNEL_CLOSE_GRACE_PERIOD_SECONDS - 1),
+    1,
+  );
+  assert.equal(
+    secondsUntilChannelWithdrawReady(100n, 100 + CHANNEL_CLOSE_GRACE_PERIOD_SECONDS),
+    0,
+  );
+});

--- a/apps/cli/src/cli/commands/buyer/channel-withdraw.test.ts
+++ b/apps/cli/src/cli/commands/buyer/channel-withdraw.test.ts
@@ -53,6 +53,10 @@ test('resolveBuyerChannelById rejects ambiguous prefixes', () => {
 
 test('secondsUntilChannelWithdrawReady tracks 15 minute timeout grace period', () => {
   assert.equal(
+    secondsUntilChannelWithdrawReady(0n, 100),
+    CHANNEL_CLOSE_GRACE_PERIOD_SECONDS,
+  );
+  assert.equal(
     secondsUntilChannelWithdrawReady(100n, 100 + CHANNEL_CLOSE_GRACE_PERIOD_SECONDS - 1),
     1,
   );

--- a/apps/cli/src/cli/commands/buyer/channel-withdraw.ts
+++ b/apps/cli/src/cli/commands/buyer/channel-withdraw.ts
@@ -1,0 +1,205 @@
+import type { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import type { StoredChannel } from '@antseed/node';
+import { CHANNEL_STATUS } from '@antseed/node/payments';
+import { getGlobalOptions } from '../types.js';
+import { loadConfig } from '../../../config/loader.js';
+import {
+  createChannelsClient,
+  formatUsdc,
+  loadCryptoContext,
+  openChannelStore,
+} from '../../payment-utils.js';
+
+export const CHANNEL_CLOSE_GRACE_PERIOD_SECONDS = 15 * 60;
+
+const CHANNEL_STATUS_LABELS: Record<number, string> = {
+  0: 'none',
+  1: 'active',
+  2: 'settled',
+  3: 'timed out',
+};
+
+function normalizeChannelId(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function short(value: string, len = 18): string {
+  return value.length > len ? `${value.slice(0, len)}...` : value;
+}
+
+export function resolveBuyerChannelById(
+  channels: StoredChannel[],
+  channelIdOrPrefix: string,
+): StoredChannel {
+  const query = normalizeChannelId(channelIdOrPrefix);
+  const matches = channels.filter((channel) => normalizeChannelId(channel.sessionId).startsWith(query));
+
+  if (matches.length === 0) {
+    throw new Error(`No local buyer channel found for ${channelIdOrPrefix}. Run \`antseed buyer channels\` to list channels.`);
+  }
+  if (matches.length > 1) {
+    const examples = matches.slice(0, 5).map((channel) => channel.sessionId).join(', ');
+    throw new Error(`Channel id prefix is ambiguous. Matches: ${examples}`);
+  }
+  return matches[0]!;
+}
+
+export function secondsUntilChannelWithdrawReady(
+  closeRequestedAtSeconds: bigint,
+  nowSeconds: number,
+  gracePeriodSeconds = CHANNEL_CLOSE_GRACE_PERIOD_SECONDS,
+): number {
+  if (closeRequestedAtSeconds <= 0n) return gracePeriodSeconds;
+  const readyAt = Number(closeRequestedAtSeconds) + gracePeriodSeconds;
+  return Math.max(0, readyAt - nowSeconds);
+}
+
+function formatWait(seconds: number): string {
+  const minutes = Math.ceil(seconds / 60);
+  if (minutes <= 1) return 'about 1 minute';
+  return `about ${minutes} minutes`;
+}
+
+export function registerBuyerChannelWithdrawCommands(channelsCmd: Command, buyerCmd: Command): void {
+  channelsCmd
+    .command('request-close <channelId>')
+    .description('Request timeout close for an active buyer payment channel so reserved funds can be withdrawn after the grace period')
+    .option('--json', 'output as JSON', false)
+    .action(async (channelId: string, options) => {
+      const globalOpts = getGlobalOptions(buyerCmd);
+      const config = await loadConfig(globalOpts.config);
+      const { wallet, address } = await loadCryptoContext(globalOpts.dataDir);
+      const channelsClient = createChannelsClient(config);
+
+      let localChannel: StoredChannel;
+      const store = openChannelStore(globalOpts.dataDir);
+      try {
+        localChannel = resolveBuyerChannelById(
+          store.getAllChannelsByBuyer('buyer', address),
+          channelId,
+        );
+      } finally {
+        store.close();
+      }
+
+      if (localChannel.status !== CHANNEL_STATUS.ACTIVE) {
+        console.error(chalk.red(`Error: Local channel ${short(localChannel.sessionId)} is ${localChannel.status}, not active.`));
+        console.error(chalk.dim('Only active channels can be timeout closed.'));
+        process.exit(1);
+      }
+
+      const spinner = ora(`Requesting timeout close for channel ${short(localChannel.sessionId)}...`).start();
+      try {
+        const onChain = await channelsClient.getSession(localChannel.sessionId);
+        if (onChain.buyer.toLowerCase() !== address.toLowerCase()) {
+          throw new Error(`Configured wallet ${address} is not the on-chain buyer for this channel.`);
+        }
+        if (onChain.status !== 1) {
+          throw new Error(`On-chain channel is ${CHANNEL_STATUS_LABELS[onChain.status] ?? `status ${onChain.status}`}, not active.`);
+        }
+        if (onChain.closeRequestedAt > 0n) {
+          const waitSeconds = secondsUntilChannelWithdrawReady(
+            onChain.closeRequestedAt,
+            Math.floor(Date.now() / 1000),
+          );
+          spinner.stop();
+          if (options.json) {
+            console.log(JSON.stringify({
+              channelId: localChannel.sessionId,
+              alreadyRequested: true,
+              closeRequestedAt: onChain.closeRequestedAt.toString(),
+              withdrawReady: waitSeconds === 0,
+              waitSeconds,
+            }, null, 2));
+            return;
+          }
+          console.log(chalk.yellow(`Close was already requested for ${short(localChannel.sessionId)}.`));
+          console.log(waitSeconds === 0
+            ? chalk.green('It is ready to withdraw now: antseed buyer channels withdraw ' + localChannel.sessionId)
+            : chalk.dim(`Withdraw should be available in ${formatWait(waitSeconds)}.`));
+          return;
+        }
+
+        const txHash = await channelsClient.requestClose(wallet, localChannel.sessionId);
+        spinner.succeed(chalk.green(`Requested timeout close for ${short(localChannel.sessionId)}`));
+        if (options.json) {
+          console.log(JSON.stringify({
+            channelId: localChannel.sessionId,
+            transaction: txHash,
+            withdrawAfterSeconds: CHANNEL_CLOSE_GRACE_PERIOD_SECONDS,
+          }, null, 2));
+          return;
+        }
+        console.log(chalk.dim(`Transaction: ${txHash}`));
+        console.log(chalk.dim(`Withdraw reserved funds after ${formatWait(CHANNEL_CLOSE_GRACE_PERIOD_SECONDS)}:`));
+        console.log(chalk.cyan(`  antseed buyer channels withdraw ${localChannel.sessionId}`));
+      } catch (err) {
+        spinner.fail(chalk.red(`Close request failed: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+
+  channelsCmd
+    .command('withdraw <channelId>')
+    .description('Withdraw/release reserved buyer funds after a channel timeout close grace period has elapsed')
+    .option('--json', 'output as JSON', false)
+    .action(async (channelId: string, options) => {
+      const globalOpts = getGlobalOptions(buyerCmd);
+      const config = await loadConfig(globalOpts.config);
+      const { wallet, address } = await loadCryptoContext(globalOpts.dataDir);
+      const channelsClient = createChannelsClient(config);
+
+      let localChannel: StoredChannel;
+      const store = openChannelStore(globalOpts.dataDir);
+      try {
+        localChannel = resolveBuyerChannelById(
+          store.getAllChannelsByBuyer('buyer', address),
+          channelId,
+        );
+      } finally {
+        store.close();
+      }
+
+      const spinner = ora(`Withdrawing reserved funds for channel ${short(localChannel.sessionId)}...`).start();
+      try {
+        const onChain = await channelsClient.getSession(localChannel.sessionId);
+        if (onChain.buyer.toLowerCase() !== address.toLowerCase()) {
+          throw new Error(`Configured wallet ${address} is not the on-chain buyer for this channel.`);
+        }
+        if (onChain.status !== 1) {
+          throw new Error(`On-chain channel is ${CHANNEL_STATUS_LABELS[onChain.status] ?? `status ${onChain.status}`}; nothing active remains to withdraw.`);
+        }
+        const waitSeconds = secondsUntilChannelWithdrawReady(
+          onChain.closeRequestedAt,
+          Math.floor(Date.now() / 1000),
+        );
+        if (onChain.closeRequestedAt <= 0n) {
+          throw new Error(`Close has not been requested yet. Run \`antseed buyer channels request-close ${localChannel.sessionId}\` first.`);
+        }
+        if (waitSeconds > 0) {
+          throw new Error(`Close grace period is not over yet. Try again in ${formatWait(waitSeconds)}.`);
+        }
+
+        const refund = onChain.deposit > onChain.settled ? onChain.deposit - onChain.settled : 0n;
+        const txHash = await channelsClient.withdraw(wallet, localChannel.sessionId);
+        spinner.succeed(chalk.green(`Withdrew reserved funds for ${short(localChannel.sessionId)}`));
+        if (options.json) {
+          console.log(JSON.stringify({
+            channelId: localChannel.sessionId,
+            transaction: txHash,
+            deposit: onChain.deposit.toString(),
+            settled: onChain.settled.toString(),
+            estimatedRefund: refund.toString(),
+          }, null, 2));
+          return;
+        }
+        console.log(chalk.dim(`Transaction: ${txHash}`));
+        console.log(chalk.dim(`Estimated released reserve: ${formatUsdc(refund)} USDC`));
+      } catch (err) {
+        spinner.fail(chalk.red(`Withdraw failed: ${(err as Error).message}`));
+        process.exit(1);
+      }
+    });
+}

--- a/apps/cli/src/cli/commands/buyer/channel-withdraw.ts
+++ b/apps/cli/src/cli/commands/buyer/channel-withdraw.ts
@@ -10,9 +10,12 @@ import {
   formatUsdc,
   loadCryptoContext,
   openChannelStore,
+  shortId,
 } from '../../payment-utils.js';
 
 export const CHANNEL_CLOSE_GRACE_PERIOD_SECONDS = 15 * 60;
+// Contract channel status is a uint8; 1 maps to the on-chain Active enum value.
+const ON_CHAIN_STATUS_ACTIVE = 1;
 
 const CHANNEL_STATUS_LABELS: Record<number, string> = {
   0: 'none',
@@ -23,10 +26,6 @@ const CHANNEL_STATUS_LABELS: Record<number, string> = {
 
 function normalizeChannelId(value: string): string {
   return value.trim().toLowerCase();
-}
-
-function short(value: string, len = 18): string {
-  return value.length > len ? `${value.slice(0, len)}...` : value;
 }
 
 export function resolveBuyerChannelById(
@@ -62,6 +61,16 @@ function formatWait(seconds: number): string {
   return `about ${minutes} minutes`;
 }
 
+function openChannelStoreOrExit(dataDir: string): ReturnType<typeof openChannelStore> {
+  try {
+    return openChannelStore(dataDir);
+  } catch (err) {
+    console.error(chalk.red(`Failed to open channel store: ${(err as Error).message}`));
+    console.error(chalk.dim('Have you connected to the network yet? Channels are stored locally after first use.'));
+    process.exit(1);
+  }
+}
+
 export function registerBuyerChannelWithdrawCommands(channelsCmd: Command, buyerCmd: Command): void {
   channelsCmd
     .command('request-close <channelId>')
@@ -74,7 +83,7 @@ export function registerBuyerChannelWithdrawCommands(channelsCmd: Command, buyer
       const channelsClient = createChannelsClient(config);
 
       let localChannel: StoredChannel;
-      const store = openChannelStore(globalOpts.dataDir);
+      const store = openChannelStoreOrExit(globalOpts.dataDir);
       try {
         localChannel = resolveBuyerChannelById(
           store.getAllChannelsByBuyer('buyer', address),
@@ -85,18 +94,18 @@ export function registerBuyerChannelWithdrawCommands(channelsCmd: Command, buyer
       }
 
       if (localChannel.status !== CHANNEL_STATUS.ACTIVE) {
-        console.error(chalk.red(`Error: Local channel ${short(localChannel.sessionId)} is ${localChannel.status}, not active.`));
+        console.error(chalk.red(`Error: Local channel ${shortId(localChannel.sessionId, 18)} is ${localChannel.status}, not active.`));
         console.error(chalk.dim('Only active channels can be timeout closed.'));
         process.exit(1);
       }
 
-      const spinner = ora(`Requesting timeout close for channel ${short(localChannel.sessionId)}...`).start();
+      const spinner = ora(`Requesting timeout close for channel ${shortId(localChannel.sessionId, 18)}...`).start();
       try {
         const onChain = await channelsClient.getSession(localChannel.sessionId);
         if (onChain.buyer.toLowerCase() !== address.toLowerCase()) {
           throw new Error(`Configured wallet ${address} is not the on-chain buyer for this channel.`);
         }
-        if (onChain.status !== 1) {
+        if (onChain.status !== ON_CHAIN_STATUS_ACTIVE) {
           throw new Error(`On-chain channel is ${CHANNEL_STATUS_LABELS[onChain.status] ?? `status ${onChain.status}`}, not active.`);
         }
         if (onChain.closeRequestedAt > 0n) {
@@ -115,7 +124,7 @@ export function registerBuyerChannelWithdrawCommands(channelsCmd: Command, buyer
             }, null, 2));
             return;
           }
-          console.log(chalk.yellow(`Close was already requested for ${short(localChannel.sessionId)}.`));
+          console.log(chalk.yellow(`Close was already requested for ${shortId(localChannel.sessionId, 18)}.`));
           console.log(waitSeconds === 0
             ? chalk.green('It is ready to withdraw now: antseed buyer channels withdraw ' + localChannel.sessionId)
             : chalk.dim(`Withdraw should be available in ${formatWait(waitSeconds)}.`));
@@ -123,7 +132,7 @@ export function registerBuyerChannelWithdrawCommands(channelsCmd: Command, buyer
         }
 
         const txHash = await channelsClient.requestClose(wallet, localChannel.sessionId);
-        spinner.succeed(chalk.green(`Requested timeout close for ${short(localChannel.sessionId)}`));
+        spinner.succeed(chalk.green(`Requested timeout close for ${shortId(localChannel.sessionId, 18)}`));
         if (options.json) {
           console.log(JSON.stringify({
             channelId: localChannel.sessionId,
@@ -152,7 +161,7 @@ export function registerBuyerChannelWithdrawCommands(channelsCmd: Command, buyer
       const channelsClient = createChannelsClient(config);
 
       let localChannel: StoredChannel;
-      const store = openChannelStore(globalOpts.dataDir);
+      const store = openChannelStoreOrExit(globalOpts.dataDir);
       try {
         localChannel = resolveBuyerChannelById(
           store.getAllChannelsByBuyer('buyer', address),
@@ -162,29 +171,29 @@ export function registerBuyerChannelWithdrawCommands(channelsCmd: Command, buyer
         store.close();
       }
 
-      const spinner = ora(`Withdrawing reserved funds for channel ${short(localChannel.sessionId)}...`).start();
+      const spinner = ora(`Withdrawing reserved funds for channel ${shortId(localChannel.sessionId, 18)}...`).start();
       try {
         const onChain = await channelsClient.getSession(localChannel.sessionId);
         if (onChain.buyer.toLowerCase() !== address.toLowerCase()) {
           throw new Error(`Configured wallet ${address} is not the on-chain buyer for this channel.`);
         }
-        if (onChain.status !== 1) {
+        if (onChain.status !== ON_CHAIN_STATUS_ACTIVE) {
           throw new Error(`On-chain channel is ${CHANNEL_STATUS_LABELS[onChain.status] ?? `status ${onChain.status}`}; nothing active remains to withdraw.`);
+        }
+        if (onChain.closeRequestedAt <= 0n) {
+          throw new Error(`Close has not been requested yet. Run \`antseed buyer channels request-close ${localChannel.sessionId}\` first.`);
         }
         const waitSeconds = secondsUntilChannelWithdrawReady(
           onChain.closeRequestedAt,
           Math.floor(Date.now() / 1000),
         );
-        if (onChain.closeRequestedAt <= 0n) {
-          throw new Error(`Close has not been requested yet. Run \`antseed buyer channels request-close ${localChannel.sessionId}\` first.`);
-        }
         if (waitSeconds > 0) {
           throw new Error(`Close grace period is not over yet. Try again in ${formatWait(waitSeconds)}.`);
         }
 
         const refund = onChain.deposit > onChain.settled ? onChain.deposit - onChain.settled : 0n;
         const txHash = await channelsClient.withdraw(wallet, localChannel.sessionId);
-        spinner.succeed(chalk.green(`Withdrew reserved funds for ${short(localChannel.sessionId)}`));
+        spinner.succeed(chalk.green(`Withdrew reserved funds for ${shortId(localChannel.sessionId, 18)}`));
         if (options.json) {
           console.log(JSON.stringify({
             channelId: localChannel.sessionId,

--- a/apps/cli/src/cli/commands/buyer/channels.ts
+++ b/apps/cli/src/cli/commands/buyer/channels.ts
@@ -2,12 +2,8 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import { loadOrCreateIdentity } from '@antseed/node';
 import { getGlobalOptions } from '../types.js';
-import { formatUsdc, openChannelStore } from '../../payment-utils.js';
+import { formatUsdc, openChannelStore, shortId } from '../../payment-utils.js';
 import { registerBuyerChannelWithdrawCommands } from './channel-withdraw.js';
-
-function short(id: string, len = 10): string {
-  return id.length > len ? id.slice(0, len) + '...' : id;
-}
 
 function statusColor(status: string): string {
   switch (status) {
@@ -66,9 +62,9 @@ async function listBuyerChannels(buyerCmd: Command, options: { status?: string; 
 
     console.log(chalk.bold(`Payment Channels (${limited.length} of ${filtered.length}):\n`));
     for (const session of limited) {
-      console.log(`  ${chalk.bold(short(session.sessionId, 16))}  ${statusColor(session.status)}  ${chalk.dim(session.role)}`);
+      console.log(`  ${chalk.bold(shortId(session.sessionId, 16))}  ${statusColor(session.status)}  ${chalk.dim(session.role)}`);
       const unsettled = subtractBigintFloor(session.authMax, session.settledAmount);
-      console.log(`    Peer: ${chalk.dim(short(session.peerId, 16))}  Requests: ${session.requestCount}  Tokens: ${session.tokensDelivered}`);
+      console.log(`    Peer: ${chalk.dim(shortId(session.peerId, 16))}  Requests: ${session.requestCount}  Tokens: ${session.tokensDelivered}`);
       console.log(`    Deposit: ${chalk.green(usdc(session.authMax))}  Settled: ${chalk.cyan(usdc(session.settledAmount))}  Unsettled: ${chalk.yellow(usdc(unsettled))}`);
       console.log(`    Created: ${chalk.dim(new Date(session.createdAt).toISOString())}`);
       if (session.settledAt) {

--- a/apps/cli/src/cli/commands/buyer/channels.ts
+++ b/apps/cli/src/cli/commands/buyer/channels.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import { loadOrCreateIdentity } from '@antseed/node';
 import { getGlobalOptions } from '../types.js';
 import { formatUsdc, openChannelStore } from '../../payment-utils.js';
+import { registerBuyerChannelWithdrawCommands } from './channel-withdraw.js';
 
 function short(id: string, len = 10): string {
   return id.length > len ? id.slice(0, len) + '...' : id;
@@ -27,63 +28,77 @@ function subtractBigintFloor(left: string | null | undefined, right: string | nu
   return result > 0n ? result.toString() : '0';
 }
 
+async function listBuyerChannels(buyerCmd: Command, options: { status?: string; limit?: string; json?: boolean }): Promise<void> {
+  const globalOpts = getGlobalOptions(buyerCmd);
+
+  const identity = await loadOrCreateIdentity(globalOpts.dataDir);
+  const buyerAddress = identity.wallet.address;
+
+  let store;
+  try {
+    store = openChannelStore(globalOpts.dataDir);
+  } catch (err) {
+    console.error(chalk.red(`Failed to open channel store: ${(err as Error).message}`));
+    console.error(chalk.dim('Have you connected to the network yet? Channels are stored locally after first use.'));
+    process.exit(1);
+  }
+
+  try {
+    const limit = parseInt(options.limit as string, 10) || 20;
+    const statusFilter = options.status as string | undefined;
+
+    const allSessions = store.getAllChannelsByBuyer('buyer', buyerAddress);
+    let filtered = allSessions;
+    if (statusFilter) filtered = filtered.filter((session) => session.status === statusFilter);
+
+    filtered.sort((a, b) => b.updatedAt - a.updatedAt);
+    const limited = filtered.slice(0, limit);
+
+    if (options.json) {
+      console.log(JSON.stringify(limited, null, 2));
+      return;
+    }
+
+    if (limited.length === 0) {
+      console.log(chalk.yellow('No channels found.'));
+      return;
+    }
+
+    console.log(chalk.bold(`Payment Channels (${limited.length} of ${filtered.length}):\n`));
+    for (const session of limited) {
+      console.log(`  ${chalk.bold(short(session.sessionId, 16))}  ${statusColor(session.status)}  ${chalk.dim(session.role)}`);
+      const unsettled = subtractBigintFloor(session.authMax, session.settledAmount);
+      console.log(`    Peer: ${chalk.dim(short(session.peerId, 16))}  Requests: ${session.requestCount}  Tokens: ${session.tokensDelivered}`);
+      console.log(`    Deposit: ${chalk.green(usdc(session.authMax))}  Settled: ${chalk.cyan(usdc(session.settledAmount))}  Unsettled: ${chalk.yellow(usdc(unsettled))}`);
+      console.log(`    Created: ${chalk.dim(new Date(session.createdAt).toISOString())}`);
+      if (session.settledAt) {
+        console.log(`    Settled: ${chalk.dim(new Date(session.settledAt).toISOString())}`);
+      }
+      console.log('');
+    }
+  } finally {
+    store.close();
+  }
+}
+
 export function registerBuyerChannelsCommand(buyerCmd: Command): void {
-  buyerCmd
+  const channelsCmd = buyerCmd
     .command('channels')
+    .description('List, request-close, and withdraw buyer payment channels');
+
+  channelsCmd
+    .command('list')
     .description('List payment channels from local store')
     .option('--status <status>', 'filter by status: active, settled, timeout, ghost')
     .option('--limit <number>', 'max number of channels to show', '20')
     .option('--json', 'output as JSON', false)
-    .action(async (options) => {
-      const globalOpts = getGlobalOptions(buyerCmd);
+    .action(async (options) => listBuyerChannels(buyerCmd, options));
 
-      const identity = await loadOrCreateIdentity(globalOpts.dataDir);
-      const buyerAddress = identity.wallet.address;
+  channelsCmd
+    .option('--status <status>', 'filter by status: active, settled, timeout, ghost')
+    .option('--limit <number>', 'max number of channels to show', '20')
+    .option('--json', 'output as JSON', false)
+    .action(async (options) => listBuyerChannels(buyerCmd, options));
 
-      let store;
-      try {
-        store = openChannelStore(globalOpts.dataDir);
-      } catch (err) {
-        console.error(chalk.red(`Failed to open channel store: ${(err as Error).message}`));
-        console.error(chalk.dim('Have you connected to the network yet? Channels are stored locally after first use.'));
-        process.exit(1);
-      }
-
-      try {
-        const limit = parseInt(options.limit as string, 10) || 20;
-        const statusFilter = options.status as string | undefined;
-
-        const allSessions = store.getAllChannelsByBuyer('buyer', buyerAddress);
-        let filtered = allSessions;
-        if (statusFilter) filtered = filtered.filter((session) => session.status === statusFilter);
-
-        filtered.sort((a, b) => b.updatedAt - a.updatedAt);
-        const limited = filtered.slice(0, limit);
-
-        if (options.json) {
-          console.log(JSON.stringify(limited, null, 2));
-          return;
-        }
-
-        if (limited.length === 0) {
-          console.log(chalk.yellow('No channels found.'));
-          return;
-        }
-
-        console.log(chalk.bold(`Payment Channels (${limited.length} of ${filtered.length}):\n`));
-        for (const session of limited) {
-          console.log(`  ${chalk.bold(short(session.sessionId, 16))}  ${statusColor(session.status)}  ${chalk.dim(session.role)}`);
-          const unsettled = subtractBigintFloor(session.authMax, session.settledAmount);
-          console.log(`    Peer: ${chalk.dim(short(session.peerId, 16))}  Requests: ${session.requestCount}  Tokens: ${session.tokensDelivered}`);
-          console.log(`    Deposit: ${chalk.green(usdc(session.authMax))}  Settled: ${chalk.cyan(usdc(session.settledAmount))}  Unsettled: ${chalk.yellow(usdc(unsettled))}`);
-          console.log(`    Created: ${chalk.dim(new Date(session.createdAt).toISOString())}`);
-          if (session.settledAt) {
-            console.log(`    Settled: ${chalk.dim(new Date(session.settledAt).toISOString())}`);
-          }
-          console.log('');
-        }
-      } finally {
-        store.close();
-      }
-    });
+  registerBuyerChannelWithdrawCommands(channelsCmd, buyerCmd);
 }

--- a/apps/cli/src/cli/payment-utils.ts
+++ b/apps/cli/src/cli/payment-utils.ts
@@ -78,6 +78,10 @@ export function formatUsdc(baseUnits: bigint): string {
   return `${whole}.${fracStr}`;
 }
 
+export function shortId(value: string, len = 10): string {
+  return value.length > len ? `${value.slice(0, len)}...` : value;
+}
+
 /** Parse human-readable USDC to base units (6 decimals). */
 export function parseUsdcToBaseUnits(amount: string): bigint {
   const amountFloat = parseFloat(amount);


### PR DESCRIPTION
Closes #633.

## Summary
- add `antseed buyer channels request-close <channelId>` to call the channel contract `requestClose` flow for active buyer channels
- add `antseed buyer channels withdraw <channelId>` to call the channel contract `withdraw` flow after the grace period
- keep existing `antseed buyer channels` list behavior and add explicit `channels list` subcommand
- add unit coverage for local channel id resolution and timeout grace-period timing

## Validation
- `corepack pnpm --filter=@antseed/cli run typecheck`
- `corepack pnpm --filter=@antseed/cli run build`
- `node --test apps/cli/dist/cli/commands/buyer/channel-withdraw.test.js`