### PR TITLE
feat(buyer): Add metadata v2 opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@ This project uses selective package publishing. Each release entry lists the pub
 - `@antseed/cli`
 - `@antseed/node`
 
+### Desktop
+
+- `@antseed/desktop`
+
 ### Added
 
 - Added zero-price free usage authorization for advertised free services, including buyer-signed P2P usage records, seller on-chain reporting through `AntseedFreeUsage`, and CLI configuration for the deployed free usage contract address.
+- Added a buyer-side metadata v2 service attribution opt-out for CLI and Desktop. Buyers can disable per-service attribution while preserving aggregate usage metadata in paid SpendingAuth and free-usage records.
 
 ### Removed
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -174,7 +174,8 @@ Pricing is configured in USD per 1M tokens with role-specific defaults and optio
     },
     "proxyPort": 8377,
     "peerRefreshIntervalMs": 300000,
-    "metadataFetchTimeoutMs": 1500
+    "metadataFetchTimeoutMs": 1500,
+    "metadataV2ServicesEnabled": true
   }
 }
 ```
@@ -233,6 +234,7 @@ antseed config buyer set maxPricing.defaults.cachedInputUsdPerMillion 12
 antseed config buyer set maxPricing.defaults.outputUsdPerMillion 75
 antseed config buyer set peerRefreshIntervalMs 300000
 antseed config buyer set metadataFetchTimeoutMs 1500
+antseed config buyer set metadataV2ServicesEnabled false
 ```
 
 Runtime-only overrides (do not write your config file):
@@ -242,6 +244,7 @@ antseed seller start --provider anthropic --input-usd-per-million 10 --cached-in
 antseed seller start --base-rpc-url https://base-mainnet.infura.io/v3/<key>
 antseed buyer start --max-input-usd-per-million 20 --max-cached-input-usd-per-million 10 --max-output-usd-per-million 60
 antseed buyer start --metadata-fetch-timeout-ms 1500
+antseed buyer start --disable-metadata-v2-services
 ```
 
 For production sellers, prefer a dedicated Base JSON-RPC endpoint over public defaults. You can set it durably with `payments.crypto.rpcUrl`, at runtime with `ANTSEED_BASE_RPC_URL`, or for one run with `antseed seller start --base-rpc-url <url>`.
@@ -331,6 +334,7 @@ Use `base-sepolia` for testing with MockUSDC.
 
 - `ANTSEED_BASE_RPC_URL=<url>` — custom Base JSON-RPC endpoint for seller on-chain operations (recommended for production)
 - `ANTSEED_BUYER_METADATA_FETCH_TIMEOUT_MS=<ms>` — runtime override for buyer peer-discovery metadata fetch timeout
+- `ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED=false` — suppress buyer per-service metadata v2 attribution while keeping aggregate usage totals
 - `ANTSEED_SETTLEMENT_IDLE_MS=600000` — idle time before settling a session (default: 10 minutes)
 - `ANTSEED_DEFAULT_DEPOSIT_USDC=1` — default lock amount per session
 - `ANTSEED_IDENTITY_HEX=<hex>` — inject identity via env (supports 0x prefix)

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -175,7 +175,7 @@ Pricing is configured in USD per 1M tokens with role-specific defaults and optio
     "proxyPort": 8377,
     "peerRefreshIntervalMs": 300000,
     "metadataFetchTimeoutMs": 1500,
-    "metadataV2ServicesEnabled": true
+    "disableMetadataV2Services": false
   }
 }
 ```
@@ -234,7 +234,7 @@ antseed config buyer set maxPricing.defaults.cachedInputUsdPerMillion 12
 antseed config buyer set maxPricing.defaults.outputUsdPerMillion 75
 antseed config buyer set peerRefreshIntervalMs 300000
 antseed config buyer set metadataFetchTimeoutMs 1500
-antseed config buyer set metadataV2ServicesEnabled false
+antseed config buyer set disableMetadataV2Services true
 ```
 
 Runtime-only overrides (do not write your config file):
@@ -334,7 +334,7 @@ Use `base-sepolia` for testing with MockUSDC.
 
 - `ANTSEED_BASE_RPC_URL=<url>` — custom Base JSON-RPC endpoint for seller on-chain operations (recommended for production)
 - `ANTSEED_BUYER_METADATA_FETCH_TIMEOUT_MS=<ms>` — runtime override for buyer peer-discovery metadata fetch timeout
-- `ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED=false` — suppress buyer per-service metadata v2 attribution while keeping aggregate usage totals
+- `ANTSEED_BUYER_DISABLE_METADATA_V2_SERVICES=true` — suppress buyer per-service metadata v2 attribution while keeping aggregate usage totals
 - `ANTSEED_SETTLEMENT_IDLE_MS=600000` — idle time before settling a session (default: 10 minutes)
 - `ANTSEED_DEFAULT_DEPOSIT_USDC=1` — default lock amount per session
 - `ANTSEED_IDENTITY_HEX=<hex>` — inject identity via env (supports 0x prefix)

--- a/apps/cli/src/cli/commands/buyer/start.test.ts
+++ b/apps/cli/src/cli/commands/buyer/start.test.ts
@@ -28,6 +28,7 @@ test('buyer start runtime overrides are runtime-only and win over env/config', (
     maxInputUsdPerMillion: 90,
     maxOutputUsdPerMillion: 95,
     metadataFetchTimeoutMs: 2500,
+    disableMetadataV2Services: true,
   });
 
   const effective = resolveEffectiveBuyerConfig({
@@ -40,6 +41,7 @@ test('buyer start runtime overrides are runtime-only and win over env/config', (
   assert.equal(effective.maxPricing.defaults.inputUsdPerMillion, 90);
   assert.equal(effective.maxPricing.defaults.outputUsdPerMillion, 95);
   assert.equal(effective.metadataFetchTimeoutMs, 2500);
+  assert.equal(effective.metadataV2ServicesEnabled, false);
   assert.deepEqual(config, beforeResolution);
 });
 

--- a/apps/cli/src/cli/commands/buyer/start.test.ts
+++ b/apps/cli/src/cli/commands/buyer/start.test.ts
@@ -41,7 +41,7 @@ test('buyer start runtime overrides are runtime-only and win over env/config', (
   assert.equal(effective.maxPricing.defaults.inputUsdPerMillion, 90);
   assert.equal(effective.maxPricing.defaults.outputUsdPerMillion, 95);
   assert.equal(effective.metadataFetchTimeoutMs, 2500);
-  assert.equal(effective.metadataV2ServicesEnabled, false);
+  assert.equal(effective.disableMetadataV2Services, true);
   assert.deepEqual(config, beforeResolution);
 });
 

--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -38,7 +38,7 @@ export function buildBuyerRuntimeOverridesFromFlags(options: {
   if (options.maxInputUsdPerMillion !== undefined) overrides.maxInputUsdPerMillion = options.maxInputUsdPerMillion
   if (options.maxOutputUsdPerMillion !== undefined) overrides.maxOutputUsdPerMillion = options.maxOutputUsdPerMillion
   if (options.metadataFetchTimeoutMs !== undefined) overrides.metadataFetchTimeoutMs = options.metadataFetchTimeoutMs
-  if (options.disableMetadataV2Services === true) overrides.metadataV2ServicesEnabled = false
+  if (options.disableMetadataV2Services === true) overrides.disableMetadataV2Services = true
   return overrides
 }
 
@@ -325,7 +325,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
           // seller can extract via an inflated 402 target (per 402 round trip).
           maxPerRequestUsdc: config.payments?.maxPerRequestUsdc ?? '300000',
           maxReserveAmountUsdc: config.payments?.maxReserveAmountUsdc ?? '1000000',
-          metadataV2ServicesEnabled: effectiveBuyerConfig.metadataV2ServicesEnabled,
+          disableMetadataV2Services: effectiveBuyerConfig.disableMetadataV2Services,
         }
       }
 
@@ -345,7 +345,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
       console.log(chalk.dim(`  min peer reputation: ${effectiveBuyerConfig.minPeerReputation}`))
       console.log(chalk.dim(`  peer refresh interval: ${effectiveBuyerConfig.peerRefreshIntervalMs}ms`))
       console.log(chalk.dim(`  metadata fetch timeout: ${effectiveBuyerConfig.metadataFetchTimeoutMs}ms`))
-      console.log(chalk.dim(`  metadata v2 service attribution: ${effectiveBuyerConfig.metadataV2ServicesEnabled ? 'enabled' : 'disabled'}`))
+      console.log(chalk.dim(`  metadata v2 service opt-out: ${effectiveBuyerConfig.disableMetadataV2Services ? 'enabled' : 'disabled'}`))
       console.log(chalk.dim(`  proxy port: ${effectiveBuyerConfig.proxyPort}`))
       if (pinnedPeerId) {
         console.log(chalk.yellow(`  pinned peer: ${pinnedPeerId} (router bypassed)`))

--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -30,6 +30,7 @@ export function buildBuyerRuntimeOverridesFromFlags(options: {
   maxInputUsdPerMillion?: number
   maxOutputUsdPerMillion?: number
   metadataFetchTimeoutMs?: number
+  disableMetadataV2Services?: boolean
 }): BuyerRuntimeOverrides {
   const overrides: BuyerRuntimeOverrides = {}
   if (options.port !== undefined) overrides.proxyPort = options.port
@@ -37,6 +38,7 @@ export function buildBuyerRuntimeOverridesFromFlags(options: {
   if (options.maxInputUsdPerMillion !== undefined) overrides.maxInputUsdPerMillion = options.maxInputUsdPerMillion
   if (options.maxOutputUsdPerMillion !== undefined) overrides.maxOutputUsdPerMillion = options.maxOutputUsdPerMillion
   if (options.metadataFetchTimeoutMs !== undefined) overrides.metadataFetchTimeoutMs = options.metadataFetchTimeoutMs
+  if (options.disableMetadataV2Services === true) overrides.metadataV2ServicesEnabled = false
   return overrides
 }
 
@@ -193,6 +195,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
     .option('--max-input-usd-per-million <number>', 'runtime-only max input pricing override in USD per 1M tokens', parseFloat)
     .option('--max-output-usd-per-million <number>', 'runtime-only max output pricing override in USD per 1M tokens', parseFloat)
     .option('--metadata-fetch-timeout-ms <number>', 'runtime-only timeout for each peer metadata HTTP fetch during discovery', Number)
+    .option('--disable-metadata-v2-services', 'runtime-only opt-out from per-service buyer metadata v2 attribution')
     .option('--peer <peerId>', 'pin all requests to a specific peer ID (40-char hex EVM address), bypassing the router')
     .action(async (options) => {
       const globalOpts = getGlobalOptions(buyerCmd)
@@ -209,6 +212,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
         maxInputUsdPerMillion: options.maxInputUsdPerMillion as number | undefined,
         maxOutputUsdPerMillion: options.maxOutputUsdPerMillion as number | undefined,
         metadataFetchTimeoutMs: options.metadataFetchTimeoutMs as number | undefined,
+        disableMetadataV2Services: options.disableMetadataV2Services as boolean | undefined,
       })
       const effectiveBuyerConfig = resolveEffectiveBuyerConfig({
         config,
@@ -321,6 +325,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
           // seller can extract via an inflated 402 target (per 402 round trip).
           maxPerRequestUsdc: config.payments?.maxPerRequestUsdc ?? '300000',
           maxReserveAmountUsdc: config.payments?.maxReserveAmountUsdc ?? '1000000',
+          metadataV2ServicesEnabled: effectiveBuyerConfig.metadataV2ServicesEnabled,
         }
       }
 
@@ -340,6 +345,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
       console.log(chalk.dim(`  min peer reputation: ${effectiveBuyerConfig.minPeerReputation}`))
       console.log(chalk.dim(`  peer refresh interval: ${effectiveBuyerConfig.peerRefreshIntervalMs}ms`))
       console.log(chalk.dim(`  metadata fetch timeout: ${effectiveBuyerConfig.metadataFetchTimeoutMs}ms`))
+      console.log(chalk.dim(`  metadata v2 service attribution: ${effectiveBuyerConfig.metadataV2ServicesEnabled ? 'enabled' : 'disabled'}`))
       console.log(chalk.dim(`  proxy port: ${effectiveBuyerConfig.proxyPort}`))
       if (pinnedPeerId) {
         console.log(chalk.yellow(`  pinned peer: ${pinnedPeerId} (router bypassed)`))

--- a/apps/cli/src/config/defaults.ts
+++ b/apps/cli/src/config/defaults.ts
@@ -30,6 +30,7 @@ export function createDefaultConfig(): AntseedConfig {
       proxyPort: 8377,
       peerRefreshIntervalMs: DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS,
       metadataFetchTimeoutMs: DEFAULT_BUYER_METADATA_FETCH_TIMEOUT_MS,
+      metadataV2ServicesEnabled: true,
     },
     payments: {
       preferredMethod: 'crypto',

--- a/apps/cli/src/config/defaults.ts
+++ b/apps/cli/src/config/defaults.ts
@@ -30,7 +30,7 @@ export function createDefaultConfig(): AntseedConfig {
       proxyPort: 8377,
       peerRefreshIntervalMs: DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS,
       metadataFetchTimeoutMs: DEFAULT_BUYER_METADATA_FETCH_TIMEOUT_MS,
-      metadataV2ServicesEnabled: true,
+      disableMetadataV2Services: false,
     },
     payments: {
       preferredMethod: 'crypto',

--- a/apps/cli/src/config/effective.test.ts
+++ b/apps/cli/src/config/effective.test.ts
@@ -46,7 +46,7 @@ test('effective buyer config precedence is flags > env > config > defaults', () 
   config.buyer.minPeerReputation = 25;
   config.buyer.peerRefreshIntervalMs = 120_000;
   config.buyer.metadataFetchTimeoutMs = 1_200;
-  config.buyer.metadataV2ServicesEnabled = true;
+  config.buyer.disableMetadataV2Services = false;
   config.buyer.maxPricing.defaults.inputUsdPerMillion = 70;
   config.buyer.maxPricing.defaults.outputUsdPerMillion = 80;
 
@@ -55,7 +55,7 @@ test('effective buyer config precedence is flags > env > config > defaults', () 
     ANTSEED_BUYER_MAX_INPUT_USD_PER_MILLION: '90',
     ANTSEED_BUYER_MAX_OUTPUT_USD_PER_MILLION: '95',
     ANTSEED_BUYER_METADATA_FETCH_TIMEOUT_MS: '2200',
-    ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED: 'false',
+    ANTSEED_BUYER_DISABLE_METADATA_V2_SERVICES: 'true',
   } as NodeJS.ProcessEnv;
 
   const effective = resolveEffectiveBuyerConfig({
@@ -70,20 +70,20 @@ test('effective buyer config precedence is flags > env > config > defaults', () 
   assert.equal(effective.minPeerReputation, 55);
   assert.equal(effective.peerRefreshIntervalMs, 120_000);
   assert.equal(effective.metadataFetchTimeoutMs, 2200);
-  assert.equal(effective.metadataV2ServicesEnabled, false);
+  assert.equal(effective.disableMetadataV2Services, true);
   assert.equal(effective.maxPricing.defaults.inputUsdPerMillion, 90);
   assert.equal(effective.maxPricing.defaults.outputUsdPerMillion, 99);
 });
 
-test('effective buyer config rejects invalid metadata v2 services env overrides', () => {
+test('effective buyer config rejects invalid metadata v2 opt-out env overrides', () => {
   const config = createDefaultConfig();
 
   assert.throws(
     () => resolveEffectiveBuyerConfig({
       config,
-      env: { ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED: 'maybe' } as NodeJS.ProcessEnv,
+      env: { ANTSEED_BUYER_DISABLE_METADATA_V2_SERVICES: 'maybe' } as NodeJS.ProcessEnv,
     }),
-    /ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED must be a boolean/,
+    /ANTSEED_BUYER_DISABLE_METADATA_V2_SERVICES must be a boolean/,
   );
 });
 

--- a/apps/cli/src/config/effective.test.ts
+++ b/apps/cli/src/config/effective.test.ts
@@ -46,6 +46,7 @@ test('effective buyer config precedence is flags > env > config > defaults', () 
   config.buyer.minPeerReputation = 25;
   config.buyer.peerRefreshIntervalMs = 120_000;
   config.buyer.metadataFetchTimeoutMs = 1_200;
+  config.buyer.metadataV2ServicesEnabled = true;
   config.buyer.maxPricing.defaults.inputUsdPerMillion = 70;
   config.buyer.maxPricing.defaults.outputUsdPerMillion = 80;
 
@@ -54,6 +55,7 @@ test('effective buyer config precedence is flags > env > config > defaults', () 
     ANTSEED_BUYER_MAX_INPUT_USD_PER_MILLION: '90',
     ANTSEED_BUYER_MAX_OUTPUT_USD_PER_MILLION: '95',
     ANTSEED_BUYER_METADATA_FETCH_TIMEOUT_MS: '2200',
+    ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED: 'false',
   } as NodeJS.ProcessEnv;
 
   const effective = resolveEffectiveBuyerConfig({
@@ -68,8 +70,21 @@ test('effective buyer config precedence is flags > env > config > defaults', () 
   assert.equal(effective.minPeerReputation, 55);
   assert.equal(effective.peerRefreshIntervalMs, 120_000);
   assert.equal(effective.metadataFetchTimeoutMs, 2200);
+  assert.equal(effective.metadataV2ServicesEnabled, false);
   assert.equal(effective.maxPricing.defaults.inputUsdPerMillion, 90);
   assert.equal(effective.maxPricing.defaults.outputUsdPerMillion, 99);
+});
+
+test('effective buyer config rejects invalid metadata v2 services env overrides', () => {
+  const config = createDefaultConfig();
+
+  assert.throws(
+    () => resolveEffectiveBuyerConfig({
+      config,
+      env: { ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED: 'maybe' } as NodeJS.ProcessEnv,
+    }),
+    /ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED must be a boolean/,
+  );
 });
 
 test('effective buyer config rejects invalid metadata fetch timeout env overrides', () => {

--- a/apps/cli/src/config/effective.ts
+++ b/apps/cli/src/config/effective.ts
@@ -13,7 +13,7 @@ export interface BuyerRuntimeOverrides {
   maxInputUsdPerMillion?: number;
   maxOutputUsdPerMillion?: number;
   metadataFetchTimeoutMs?: number;
-  metadataV2ServicesEnabled?: boolean;
+  disableMetadataV2Services?: boolean;
 }
 
 export interface ResolveEffectiveConfigInput {
@@ -110,7 +110,7 @@ export function resolveEffectiveBuyerConfig(input: ResolveEffectiveConfigInput):
   if (env[envMetadataFetchTimeoutKey] !== undefined && envMetadataFetchTimeoutMs === undefined) {
     throw new Error(`${envMetadataFetchTimeoutKey} must be a finite number`);
   }
-  const envMetadataV2ServicesEnabled = parseEnvBoolean(env, 'ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED');
+  const envDisableMetadataV2Services = parseEnvBoolean(env, 'ANTSEED_BUYER_DISABLE_METADATA_V2_SERVICES');
 
   if (envMinReputation !== undefined) {
     buyer.minPeerReputation = envMinReputation;
@@ -124,8 +124,8 @@ export function resolveEffectiveBuyerConfig(input: ResolveEffectiveConfigInput):
   if (envMetadataFetchTimeoutMs !== undefined) {
     buyer.metadataFetchTimeoutMs = envMetadataFetchTimeoutMs;
   }
-  if (envMetadataV2ServicesEnabled !== undefined) {
-    buyer.metadataV2ServicesEnabled = envMetadataV2ServicesEnabled;
+  if (envDisableMetadataV2Services !== undefined) {
+    buyer.disableMetadataV2Services = envDisableMetadataV2Services;
   }
 
   const overrides = input.buyerOverrides;
@@ -144,8 +144,8 @@ export function resolveEffectiveBuyerConfig(input: ResolveEffectiveConfigInput):
   if (overrides?.metadataFetchTimeoutMs !== undefined) {
     buyer.metadataFetchTimeoutMs = overrides.metadataFetchTimeoutMs;
   }
-  if (overrides?.metadataV2ServicesEnabled !== undefined) {
-    buyer.metadataV2ServicesEnabled = overrides.metadataV2ServicesEnabled;
+  if (overrides?.disableMetadataV2Services !== undefined) {
+    buyer.disableMetadataV2Services = overrides.disableMetadataV2Services;
   }
 
   assertValidMetadataFetchTimeoutMs(buyer.metadataFetchTimeoutMs, 'buyer.metadataFetchTimeoutMs');

--- a/apps/cli/src/config/effective.ts
+++ b/apps/cli/src/config/effective.ts
@@ -13,6 +13,7 @@ export interface BuyerRuntimeOverrides {
   maxInputUsdPerMillion?: number;
   maxOutputUsdPerMillion?: number;
   metadataFetchTimeoutMs?: number;
+  metadataV2ServicesEnabled?: boolean;
 }
 
 export interface ResolveEffectiveConfigInput {
@@ -27,6 +28,15 @@ function parseEnvNumber(env: NodeJS.ProcessEnv, key: string): number | undefined
   if (raw === undefined) return undefined;
   const parsed = Number(raw);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseEnvBoolean(env: NodeJS.ProcessEnv, key: string): boolean | undefined {
+  const raw = env[key];
+  if (raw === undefined) return undefined;
+  const normalized = raw.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  throw new Error(`${key} must be a boolean`);
 }
 
 function assertValidMetadataFetchTimeoutMs(value: number, sourceLabel: string): void {
@@ -100,6 +110,7 @@ export function resolveEffectiveBuyerConfig(input: ResolveEffectiveConfigInput):
   if (env[envMetadataFetchTimeoutKey] !== undefined && envMetadataFetchTimeoutMs === undefined) {
     throw new Error(`${envMetadataFetchTimeoutKey} must be a finite number`);
   }
+  const envMetadataV2ServicesEnabled = parseEnvBoolean(env, 'ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED');
 
   if (envMinReputation !== undefined) {
     buyer.minPeerReputation = envMinReputation;
@@ -112,6 +123,9 @@ export function resolveEffectiveBuyerConfig(input: ResolveEffectiveConfigInput):
   }
   if (envMetadataFetchTimeoutMs !== undefined) {
     buyer.metadataFetchTimeoutMs = envMetadataFetchTimeoutMs;
+  }
+  if (envMetadataV2ServicesEnabled !== undefined) {
+    buyer.metadataV2ServicesEnabled = envMetadataV2ServicesEnabled;
   }
 
   const overrides = input.buyerOverrides;
@@ -129,6 +143,9 @@ export function resolveEffectiveBuyerConfig(input: ResolveEffectiveConfigInput):
   }
   if (overrides?.metadataFetchTimeoutMs !== undefined) {
     buyer.metadataFetchTimeoutMs = overrides.metadataFetchTimeoutMs;
+  }
+  if (overrides?.metadataV2ServicesEnabled !== undefined) {
+    buyer.metadataV2ServicesEnabled = overrides.metadataV2ServicesEnabled;
   }
 
   assertValidMetadataFetchTimeoutMs(buyer.metadataFetchTimeoutMs, 'buyer.metadataFetchTimeoutMs');

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -120,7 +120,7 @@ test('loadConfig preserves explicit buyer peerRefreshIntervalMs and metadataFetc
   );
 });
 
-test('loadConfig defaults and preserves buyer metadata v2 service attribution setting', async () => {
+test('loadConfig defaults and preserves buyer metadata v2 service opt-out setting', async () => {
   await withTempConfig(
     JSON.stringify({
       buyer: {
@@ -129,34 +129,34 @@ test('loadConfig defaults and preserves buyer metadata v2 service attribution se
     }),
     async (configPath) => {
       const config = await loadConfig(configPath);
-      assert.equal(config.buyer.metadataV2ServicesEnabled, true);
+      assert.equal(config.buyer.disableMetadataV2Services, false);
     }
   );
 
   await withTempConfig(
     JSON.stringify({
       buyer: {
-        metadataV2ServicesEnabled: false,
+        disableMetadataV2Services: true,
       },
     }),
     async (configPath) => {
       const config = await loadConfig(configPath);
-      assert.equal(config.buyer.metadataV2ServicesEnabled, false);
+      assert.equal(config.buyer.disableMetadataV2Services, true);
     }
   );
 });
 
-test('loadConfig rejects invalid buyer metadataV2ServicesEnabled', async () => {
+test('loadConfig rejects invalid buyer disableMetadataV2Services', async () => {
   await withTempConfig(
     JSON.stringify({
       buyer: {
-        metadataV2ServicesEnabled: 'false',
+        disableMetadataV2Services: 'false',
       },
     }),
     async (configPath) => {
       await assert.rejects(
         async () => loadConfig(configPath),
-        /buyer\.metadataV2ServicesEnabled/
+        /buyer\.disableMetadataV2Services/
       );
     }
   );

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -120,6 +120,48 @@ test('loadConfig preserves explicit buyer peerRefreshIntervalMs and metadataFetc
   );
 });
 
+test('loadConfig defaults and preserves buyer metadata v2 service attribution setting', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      buyer: {
+        proxyPort: 9123,
+      },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.equal(config.buyer.metadataV2ServicesEnabled, true);
+    }
+  );
+
+  await withTempConfig(
+    JSON.stringify({
+      buyer: {
+        metadataV2ServicesEnabled: false,
+      },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.equal(config.buyer.metadataV2ServicesEnabled, false);
+    }
+  );
+});
+
+test('loadConfig rejects invalid buyer metadataV2ServicesEnabled', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      buyer: {
+        metadataV2ServicesEnabled: 'false',
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        async () => loadConfig(configPath),
+        /buyer\.metadataV2ServicesEnabled/
+      );
+    }
+  );
+});
+
 test('loadConfig preserves buyer verification sampling settings', async () => {
   await withTempConfig(
     JSON.stringify({

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -364,11 +364,19 @@ function mergeBuyerConfig(
     metadataFetchTimeoutMs: typeof value['metadataFetchTimeoutMs'] === 'number'
       ? value['metadataFetchTimeoutMs']
       : defaults.metadataFetchTimeoutMs,
-    disableMetadataV2Services: value['disableMetadataV2Services'] !== undefined
-      ? value['disableMetadataV2Services'] as boolean
-      : defaults.disableMetadataV2Services,
+    disableMetadataV2Services: normalizeBooleanConfigValue(
+      value['disableMetadataV2Services'],
+      defaults.disableMetadataV2Services,
+      'buyer.disableMetadataV2Services',
+    ),
     ...(normalizeBuyerVerification(value['verification'], defaults.verification)),
   };
+}
+
+function normalizeBooleanConfigValue(value: unknown, defaultValue: boolean, path: string): boolean {
+  if (value === undefined) return defaultValue;
+  if (typeof value === 'boolean') return value;
+  throw new Error(`${path} must be a boolean`);
 }
 
 /**

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -348,6 +348,7 @@ function mergeBuyerConfig(
       proxyPort: defaults.proxyPort,
       peerRefreshIntervalMs: defaults.peerRefreshIntervalMs,
       metadataFetchTimeoutMs: defaults.metadataFetchTimeoutMs,
+      metadataV2ServicesEnabled: defaults.metadataV2ServicesEnabled,
       ...(normalizeBuyerVerification(undefined, defaults.verification)),
     };
   }
@@ -363,6 +364,9 @@ function mergeBuyerConfig(
     metadataFetchTimeoutMs: typeof value['metadataFetchTimeoutMs'] === 'number'
       ? value['metadataFetchTimeoutMs']
       : defaults.metadataFetchTimeoutMs,
+    metadataV2ServicesEnabled: value['metadataV2ServicesEnabled'] !== undefined
+      ? value['metadataV2ServicesEnabled'] as boolean
+      : defaults.metadataV2ServicesEnabled,
     ...(normalizeBuyerVerification(value['verification'], defaults.verification)),
   };
 }

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -348,7 +348,7 @@ function mergeBuyerConfig(
       proxyPort: defaults.proxyPort,
       peerRefreshIntervalMs: defaults.peerRefreshIntervalMs,
       metadataFetchTimeoutMs: defaults.metadataFetchTimeoutMs,
-      metadataV2ServicesEnabled: defaults.metadataV2ServicesEnabled,
+      disableMetadataV2Services: defaults.disableMetadataV2Services,
       ...(normalizeBuyerVerification(undefined, defaults.verification)),
     };
   }
@@ -364,9 +364,9 @@ function mergeBuyerConfig(
     metadataFetchTimeoutMs: typeof value['metadataFetchTimeoutMs'] === 'number'
       ? value['metadataFetchTimeoutMs']
       : defaults.metadataFetchTimeoutMs,
-    metadataV2ServicesEnabled: value['metadataV2ServicesEnabled'] !== undefined
-      ? value['metadataV2ServicesEnabled'] as boolean
-      : defaults.metadataV2ServicesEnabled,
+    disableMetadataV2Services: value['disableMetadataV2Services'] !== undefined
+      ? value['disableMetadataV2Services'] as boolean
+      : defaults.disableMetadataV2Services,
     ...(normalizeBuyerVerification(value['verification'], defaults.verification)),
   };
 }

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -141,11 +141,8 @@ export interface BuyerCLIConfig {
   peerRefreshIntervalMs: number;
   /** Timeout in ms for each HTTP metadata fetch during peer discovery */
   metadataFetchTimeoutMs: number;
-  /**
-   * Include per-service attribution in buyer-signed metadata v2. Disable to
-   * keep aggregate usage metadata while avoiding service-intent disclosure.
-   */
-  metadataV2ServicesEnabled: boolean;
+  /** Disable per-service attribution in buyer-signed metadata v2. */
+  disableMetadataV2Services: boolean;
   /** Buyer-side response-auth evidence sampling settings. */
   verification?: BuyerVerificationConfig;
 }

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -141,6 +141,11 @@ export interface BuyerCLIConfig {
   peerRefreshIntervalMs: number;
   /** Timeout in ms for each HTTP metadata fetch during peer discovery */
   metadataFetchTimeoutMs: number;
+  /**
+   * Include per-service attribution in buyer-signed metadata v2. Disable to
+   * keep aggregate usage metadata while avoiding service-intent disclosure.
+   */
+  metadataV2ServicesEnabled: boolean;
   /** Buyer-side response-auth evidence sampling settings. */
   verification?: BuyerVerificationConfig;
 }

--- a/apps/cli/src/config/validation.ts
+++ b/apps/cli/src/config/validation.ts
@@ -319,6 +319,10 @@ export function validateConfig(config: AntseedConfig): string[] {
     errors.push('buyer.metadataFetchTimeoutMs must be an integer >= 100');
   }
 
+  if (typeof config.buyer.metadataV2ServicesEnabled !== 'boolean') {
+    errors.push('buyer.metadataV2ServicesEnabled must be a boolean');
+  }
+
   validateBuyerVerification('buyer.verification', config.buyer.verification, errors);
 
   if (!Number.isInteger(config.seller.maxConcurrentBuyers) || config.seller.maxConcurrentBuyers < 1) {

--- a/apps/cli/src/config/validation.ts
+++ b/apps/cli/src/config/validation.ts
@@ -319,8 +319,8 @@ export function validateConfig(config: AntseedConfig): string[] {
     errors.push('buyer.metadataFetchTimeoutMs must be an integer >= 100');
   }
 
-  if (typeof config.buyer.metadataV2ServicesEnabled !== 'boolean') {
-    errors.push('buyer.metadataV2ServicesEnabled must be a boolean');
+  if (typeof config.buyer.disableMetadataV2Services !== 'boolean') {
+    errors.push('buyer.disableMetadataV2Services must be a boolean');
   }
 
   validateBuyerVerification('buyer.verification', config.buyer.verification, errors);

--- a/apps/desktop/src/main/config-io.test.ts
+++ b/apps/desktop/src/main/config-io.test.ts
@@ -41,7 +41,7 @@ test('ensureConfig creates config with desktop buyer max pricing defaults', asyn
   assert.equal((config.buyer as { minPeerReputation?: number }).minPeerReputation, DESKTOP_DEFAULT_MIN_PEER_REPUTATION);
   assert.equal((config.buyer as { peerRefreshIntervalMs?: number }).peerRefreshIntervalMs, DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS);
   assert.equal((config.buyer as { metadataFetchTimeoutMs?: number }).metadataFetchTimeoutMs, DESKTOP_DEFAULT_METADATA_FETCH_TIMEOUT_MS);
-  assert.equal((config.buyer as { metadataV2ServicesEnabled?: boolean }).metadataV2ServicesEnabled, true);
+  assert.equal((config.buyer as { disableMetadataV2Services?: boolean }).disableMetadataV2Services, false);
 });
 
 test('ensureConfig clamps buyer max pricing above desktop defaults', async (t) => {
@@ -117,7 +117,7 @@ test('ensureConfig fills missing buyer max pricing defaults for existing configs
   assert.equal((config.buyer as { proxyPort?: number }).proxyPort, 9123);
   assert.equal((config.buyer as { minPeerReputation?: number }).minPeerReputation, 42);
   assert.equal((config.buyer as { peerRefreshIntervalMs?: number }).peerRefreshIntervalMs, DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS);
-  assert.equal((config.buyer as { metadataV2ServicesEnabled?: boolean }).metadataV2ServicesEnabled, true);
+  assert.equal((config.buyer as { disableMetadataV2Services?: boolean }).disableMetadataV2Services, false);
 });
 
 test('ensureConfig preserves valid buyer peer refresh interval and metadata v2 setting', async (t) => {
@@ -128,7 +128,7 @@ test('ensureConfig preserves valid buyer peer refresh interval and metadata v2 s
     buyer: {
       peerRefreshIntervalMs: 30_000,
       metadataFetchTimeoutMs: 2_000,
-      metadataV2ServicesEnabled: false,
+      disableMetadataV2Services: true,
       maxPricing: {
         defaults: {
           inputUsdPerMillion: 4,
@@ -143,7 +143,7 @@ test('ensureConfig preserves valid buyer peer refresh interval and metadata v2 s
   const config = await readConfig(configPath);
   assert.equal((config.buyer as { peerRefreshIntervalMs?: number }).peerRefreshIntervalMs, 30_000);
   assert.equal((config.buyer as { metadataFetchTimeoutMs?: number }).metadataFetchTimeoutMs, 2_000);
-  assert.equal((config.buyer as { metadataV2ServicesEnabled?: boolean }).metadataV2ServicesEnabled, false);
+  assert.equal((config.buyer as { disableMetadataV2Services?: boolean }).disableMetadataV2Services, true);
 });
 
 test('ensureConfig preserves buyer max pricing at or below desktop defaults', async (t) => {

--- a/apps/desktop/src/main/config-io.test.ts
+++ b/apps/desktop/src/main/config-io.test.ts
@@ -41,6 +41,7 @@ test('ensureConfig creates config with desktop buyer max pricing defaults', asyn
   assert.equal((config.buyer as { minPeerReputation?: number }).minPeerReputation, DESKTOP_DEFAULT_MIN_PEER_REPUTATION);
   assert.equal((config.buyer as { peerRefreshIntervalMs?: number }).peerRefreshIntervalMs, DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS);
   assert.equal((config.buyer as { metadataFetchTimeoutMs?: number }).metadataFetchTimeoutMs, DESKTOP_DEFAULT_METADATA_FETCH_TIMEOUT_MS);
+  assert.equal((config.buyer as { metadataV2ServicesEnabled?: boolean }).metadataV2ServicesEnabled, true);
 });
 
 test('ensureConfig clamps buyer max pricing above desktop defaults', async (t) => {
@@ -116,9 +117,10 @@ test('ensureConfig fills missing buyer max pricing defaults for existing configs
   assert.equal((config.buyer as { proxyPort?: number }).proxyPort, 9123);
   assert.equal((config.buyer as { minPeerReputation?: number }).minPeerReputation, 42);
   assert.equal((config.buyer as { peerRefreshIntervalMs?: number }).peerRefreshIntervalMs, DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS);
+  assert.equal((config.buyer as { metadataV2ServicesEnabled?: boolean }).metadataV2ServicesEnabled, true);
 });
 
-test('ensureConfig preserves valid buyer peer refresh interval', async (t) => {
+test('ensureConfig preserves valid buyer peer refresh interval and metadata v2 setting', async (t) => {
   const { dir, configPath } = await makeTempConfigPath();
   t.after(() => rm(dir, { recursive: true, force: true }));
 
@@ -126,6 +128,7 @@ test('ensureConfig preserves valid buyer peer refresh interval', async (t) => {
     buyer: {
       peerRefreshIntervalMs: 30_000,
       metadataFetchTimeoutMs: 2_000,
+      metadataV2ServicesEnabled: false,
       maxPricing: {
         defaults: {
           inputUsdPerMillion: 4,
@@ -140,6 +143,7 @@ test('ensureConfig preserves valid buyer peer refresh interval', async (t) => {
   const config = await readConfig(configPath);
   assert.equal((config.buyer as { peerRefreshIntervalMs?: number }).peerRefreshIntervalMs, 30_000);
   assert.equal((config.buyer as { metadataFetchTimeoutMs?: number }).metadataFetchTimeoutMs, 2_000);
+  assert.equal((config.buyer as { metadataV2ServicesEnabled?: boolean }).metadataV2ServicesEnabled, false);
 });
 
 test('ensureConfig preserves buyer max pricing at or below desktop defaults', async (t) => {

--- a/apps/desktop/src/main/config-io.ts
+++ b/apps/desktop/src/main/config-io.ts
@@ -30,6 +30,7 @@ const DEFAULT_CONFIG: Record<string, unknown> = {
     proxyPort: 8377,
     peerRefreshIntervalMs: DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS,
     metadataFetchTimeoutMs: DESKTOP_DEFAULT_METADATA_FETCH_TIMEOUT_MS,
+    metadataV2ServicesEnabled: true,
   },
   network: { bootstrapNodes: [] },
   payments: { preferredMethod: 'crypto', platformFeeRate: 0.05 },
@@ -65,6 +66,7 @@ function migrateDesktopBuyerDefaults(config: Record<string, unknown>): {
   const minPeerReputation = buyer.minPeerReputation;
   const peerRefreshIntervalMs = buyer.peerRefreshIntervalMs;
   const metadataFetchTimeoutMs = buyer.metadataFetchTimeoutMs;
+  const metadataV2ServicesEnabled = buyer.metadataV2ServicesEnabled;
   const nextDefaults = { ...defaults };
   let migrated = false;
   let nextBuyer = buyer;
@@ -119,6 +121,14 @@ function migrateDesktopBuyerDefaults(config: Record<string, unknown>): {
     nextBuyer = {
       ...nextBuyer,
       metadataFetchTimeoutMs: DESKTOP_DEFAULT_METADATA_FETCH_TIMEOUT_MS,
+    };
+    migrated = true;
+  }
+
+  if (typeof metadataV2ServicesEnabled !== 'boolean') {
+    nextBuyer = {
+      ...nextBuyer,
+      metadataV2ServicesEnabled: true,
     };
     migrated = true;
   }

--- a/apps/desktop/src/main/config-io.ts
+++ b/apps/desktop/src/main/config-io.ts
@@ -30,7 +30,7 @@ const DEFAULT_CONFIG: Record<string, unknown> = {
     proxyPort: 8377,
     peerRefreshIntervalMs: DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS,
     metadataFetchTimeoutMs: DESKTOP_DEFAULT_METADATA_FETCH_TIMEOUT_MS,
-    metadataV2ServicesEnabled: true,
+    disableMetadataV2Services: false,
   },
   network: { bootstrapNodes: [] },
   payments: { preferredMethod: 'crypto', platformFeeRate: 0.05 },
@@ -66,7 +66,7 @@ function migrateDesktopBuyerDefaults(config: Record<string, unknown>): {
   const minPeerReputation = buyer.minPeerReputation;
   const peerRefreshIntervalMs = buyer.peerRefreshIntervalMs;
   const metadataFetchTimeoutMs = buyer.metadataFetchTimeoutMs;
-  const metadataV2ServicesEnabled = buyer.metadataV2ServicesEnabled;
+  const disableMetadataV2Services = buyer.disableMetadataV2Services;
   const nextDefaults = { ...defaults };
   let migrated = false;
   let nextBuyer = buyer;
@@ -125,10 +125,10 @@ function migrateDesktopBuyerDefaults(config: Record<string, unknown>): {
     migrated = true;
   }
 
-  if (typeof metadataV2ServicesEnabled !== 'boolean') {
+  if (typeof disableMetadataV2Services !== 'boolean') {
     nextBuyer = {
       ...nextBuyer,
-      metadataV2ServicesEnabled: true,
+      disableMetadataV2Services: false,
     };
     migrated = true;
   }

--- a/apps/desktop/src/renderer/core/state.ts
+++ b/apps/desktop/src/renderer/core/state.ts
@@ -49,7 +49,7 @@ export type ConfigFormData = {
   maxInputUsdPerMillion: number;
   maxOutputUsdPerMillion: number;
   minRep: number;
-  metadataV2ServicesEnabled: boolean;
+  disableMetadataV2Services: boolean;
   paymentMethod: string;
   devMode: boolean;
   cryptoChainId: string;

--- a/apps/desktop/src/renderer/core/state.ts
+++ b/apps/desktop/src/renderer/core/state.ts
@@ -49,6 +49,7 @@ export type ConfigFormData = {
   maxInputUsdPerMillion: number;
   maxOutputUsdPerMillion: number;
   minRep: number;
+  metadataV2ServicesEnabled: boolean;
   paymentMethod: string;
   devMode: boolean;
   cryptoChainId: string;

--- a/apps/desktop/src/renderer/modules/settings.ts
+++ b/apps/desktop/src/renderer/modules/settings.ts
@@ -18,6 +18,10 @@ function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
 }
 
+function safeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
 const DESKTOP_DEV_MODE_KEY = 'antseed.desktop.devMode';
 const DESKTOP_DEFAULT_MAX_INPUT_USD_PER_MILLION = 5;
 const DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION = 30;
@@ -78,6 +82,7 @@ export function initSettingsModule({
         DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION,
       ),
       minRep: safeNumber(buyer.minPeerReputation, 0),
+      metadataV2ServicesEnabled: safeBoolean(buyer.metadataV2ServicesEnabled, true),
       paymentMethod: safeString(payments.preferredMethod, 'crypto'),
       devMode: uiState.devMode,
       cryptoChainId: safeString(crypto.chainId, 'base-mainnet'),
@@ -115,6 +120,7 @@ export function initSettingsModule({
             },
           },
           minPeerReputation: formData.minRep,
+          metadataV2ServicesEnabled: formData.metadataV2ServicesEnabled,
         },
         payments: {
           ...asRecord(currentConfig.payments),

--- a/apps/desktop/src/renderer/modules/settings.ts
+++ b/apps/desktop/src/renderer/modules/settings.ts
@@ -82,7 +82,7 @@ export function initSettingsModule({
         DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION,
       ),
       minRep: safeNumber(buyer.minPeerReputation, 0),
-      metadataV2ServicesEnabled: safeBoolean(buyer.metadataV2ServicesEnabled, true),
+      disableMetadataV2Services: safeBoolean(buyer.disableMetadataV2Services, false),
       paymentMethod: safeString(payments.preferredMethod, 'crypto'),
       devMode: uiState.devMode,
       cryptoChainId: safeString(crypto.chainId, 'base-mainnet'),
@@ -120,7 +120,7 @@ export function initSettingsModule({
             },
           },
           minPeerReputation: formData.minRep,
-          metadataV2ServicesEnabled: formData.metadataV2ServicesEnabled,
+          disableMetadataV2Services: formData.disableMetadataV2Services,
         },
         payments: {
           ...asRecord(currentConfig.payments),

--- a/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
@@ -27,7 +27,7 @@ export function ConfigView({ active }: ConfigViewProps) {
   const [proxyPort, setProxyPort] = useState('8377');
   const [minRep, setMinRep] = useState('0');
   const [chainId, setChainId] = useState('base-mainnet');
-  const [metadataV2ServicesEnabled, setMetadataV2ServicesEnabled] = useState(true);
+  const [disableMetadataV2Services, setDisableMetadataV2Services] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [voiceStatus, setVoiceStatus] = useState<VoiceModelStatus | null>(null);
   const [voiceInstalling, setVoiceInstalling] = useState(false);
@@ -40,7 +40,7 @@ export function ConfigView({ active }: ConfigViewProps) {
       setProxyPort(String(configFormData.proxyPort));
       setMinRep(String(configFormData.minRep));
       setChainId(configFormData.cryptoChainId || 'base-mainnet');
-      setMetadataV2ServicesEnabled(configFormData.metadataV2ServicesEnabled);
+      setDisableMetadataV2Services(configFormData.disableMetadataV2Services);
       setInitialized(true);
     }
   }, [configFormData, initialized]);
@@ -95,7 +95,7 @@ export function ConfigView({ active }: ConfigViewProps) {
       proxyPort: parseInt(proxyPort, 10) || 8377,
       peerRefreshIntervalMs: configFormData.peerRefreshIntervalMs,
       minRep: parseInt(minRep, 10) || 0,
-      metadataV2ServicesEnabled,
+      disableMetadataV2Services,
       cryptoChainId: chainId,
     });
     setDirty(false);
@@ -148,15 +148,15 @@ export function ConfigView({ active }: ConfigViewProps) {
             </label>
             <div className="settings-item">
               <div className="settings-copy">
-                <h4>Service Metadata Attribution</h4>
-                <p>Include per-service usage details in signed payment metadata.</p>
+                <h4>Disable Service Metadata Attribution</h4>
+                <p>Omit per-service usage details from paid and free usage metadata.</p>
               </div>
               <button
                 type="button"
-                className={`settings-switch${metadataV2ServicesEnabled ? ' is-on' : ''}`}
-                aria-pressed={metadataV2ServicesEnabled}
+                className={`settings-switch${disableMetadataV2Services ? ' is-on' : ''}`}
+                aria-pressed={disableMetadataV2Services}
                 onClick={() => {
-                  setMetadataV2ServicesEnabled((value) => !value);
+                  setDisableMetadataV2Services((value) => !value);
                   markDirty();
                 }}
                 disabled={configSaving}
@@ -164,7 +164,7 @@ export function ConfigView({ active }: ConfigViewProps) {
                 <span className="settings-switch-track">
                   <span className="settings-switch-thumb" />
                 </span>
-                <span className="settings-switch-label">{metadataV2ServicesEnabled ? 'On' : 'Off'}</span>
+                <span className="settings-switch-label">{disableMetadataV2Services ? 'On' : 'Off'}</span>
               </button>
             </div>
           </div>

--- a/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
@@ -164,7 +164,7 @@ export function ConfigView({ active }: ConfigViewProps) {
                 <span className="settings-switch-track">
                   <span className="settings-switch-thumb" />
                 </span>
-                <span className="settings-switch-label">{disableMetadataV2Services ? 'On' : 'Off'}</span>
+                <span className="settings-switch-label">{disableMetadataV2Services ? 'Enabled' : 'Disabled'}</span>
               </button>
             </div>
           </div>

--- a/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
@@ -27,6 +27,7 @@ export function ConfigView({ active }: ConfigViewProps) {
   const [proxyPort, setProxyPort] = useState('8377');
   const [minRep, setMinRep] = useState('0');
   const [chainId, setChainId] = useState('base-mainnet');
+  const [metadataV2ServicesEnabled, setMetadataV2ServicesEnabled] = useState(true);
   const [dirty, setDirty] = useState(false);
   const [voiceStatus, setVoiceStatus] = useState<VoiceModelStatus | null>(null);
   const [voiceInstalling, setVoiceInstalling] = useState(false);
@@ -39,6 +40,7 @@ export function ConfigView({ active }: ConfigViewProps) {
       setProxyPort(String(configFormData.proxyPort));
       setMinRep(String(configFormData.minRep));
       setChainId(configFormData.cryptoChainId || 'base-mainnet');
+      setMetadataV2ServicesEnabled(configFormData.metadataV2ServicesEnabled);
       setInitialized(true);
     }
   }, [configFormData, initialized]);
@@ -93,6 +95,7 @@ export function ConfigView({ active }: ConfigViewProps) {
       proxyPort: parseInt(proxyPort, 10) || 8377,
       peerRefreshIntervalMs: configFormData.peerRefreshIntervalMs,
       minRep: parseInt(minRep, 10) || 0,
+      metadataV2ServicesEnabled,
       cryptoChainId: chainId,
     });
     setDirty(false);
@@ -143,6 +146,27 @@ export function ConfigView({ active }: ConfigViewProps) {
                 onChange={(e) => { setMinRep(e.target.value); markDirty(); }}
               />
             </label>
+            <div className="settings-item">
+              <div className="settings-copy">
+                <h4>Service Metadata Attribution</h4>
+                <p>Include per-service usage details in signed payment metadata.</p>
+              </div>
+              <button
+                type="button"
+                className={`settings-switch${metadataV2ServicesEnabled ? ' is-on' : ''}`}
+                aria-pressed={metadataV2ServicesEnabled}
+                onClick={() => {
+                  setMetadataV2ServicesEnabled((value) => !value);
+                  markDirty();
+                }}
+                disabled={configSaving}
+              >
+                <span className="settings-switch-track">
+                  <span className="settings-switch-thumb" />
+                </span>
+                <span className="settings-switch-label">{metadataV2ServicesEnabled ? 'On' : 'Off'}</span>
+              </button>
+            </div>
           </div>
 
         <div className="settings-footer" />

--- a/apps/website/docs/getting-started/configuration.md
+++ b/apps/website/docs/getting-started/configuration.md
@@ -282,9 +282,9 @@ ANTSEED_BUYER_METADATA_FETCH_TIMEOUT_MS=1500 antseed buyer start
 Buyer SpendingAuth and free-usage metadata v2 include aggregate usage totals by default. They also include per-service attribution unless disabled. Privacy-sensitive buyers can keep aggregate accounting while suppressing service IDs and per-service totals:
 
 ```bash
-antseed config buyer set metadataV2ServicesEnabled false
+antseed config buyer set disableMetadataV2Services true
 antseed buyer start --disable-metadata-v2-services
-ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED=false antseed buyer start
+ANTSEED_BUYER_DISABLE_METADATA_V2_SERVICES=true antseed buyer start
 ```
 
 ## Identity and Metadata
@@ -467,7 +467,7 @@ Only secrets, global toggles, and deployment-specific runtime overrides are set 
 | `ANTSEED_IDENTITY_HEX` | Identity private key (64 hex chars, optional 0x prefix) |
 | `ANTSEED_BASE_RPC_URL` | Runtime Base JSON-RPC endpoint override for seller on-chain operations |
 | `ANTSEED_BUYER_METADATA_FETCH_TIMEOUT_MS` | Runtime buyer peer-discovery metadata fetch timeout in milliseconds |
-| `ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED` | Runtime toggle for buyer per-service metadata v2 attribution (`false` opts out) |
+| `ANTSEED_BUYER_DISABLE_METADATA_V2_SERVICES` | Runtime opt-out for buyer per-service metadata v2 attribution (`true` opts out) |
 | `ANTHROPIC_API_KEY` | Upstream Anthropic API key (used by the `anthropic` provider plugin) |
 | `OPENAI_API_KEY` | Upstream OpenAI-compatible API key (used by the `openai` provider plugin) |
 | `ANTSEED_SETTLEMENT_IDLE_MS` | Idle time before settling a session (default: 600000 / 10 min) |

--- a/apps/website/docs/getting-started/configuration.md
+++ b/apps/website/docs/getting-started/configuration.md
@@ -279,6 +279,14 @@ antseed buyer start --metadata-fetch-timeout-ms 1500
 ANTSEED_BUYER_METADATA_FETCH_TIMEOUT_MS=1500 antseed buyer start
 ```
 
+Buyer SpendingAuth and free-usage metadata v2 include aggregate usage totals by default. They also include per-service attribution unless disabled. Privacy-sensitive buyers can keep aggregate accounting while suppressing service IDs and per-service totals:
+
+```bash
+antseed config buyer set metadataV2ServicesEnabled false
+antseed buyer start --disable-metadata-v2-services
+ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED=false antseed buyer start
+```
+
 ## Identity and Metadata
 
 ```bash
@@ -459,6 +467,7 @@ Only secrets, global toggles, and deployment-specific runtime overrides are set 
 | `ANTSEED_IDENTITY_HEX` | Identity private key (64 hex chars, optional 0x prefix) |
 | `ANTSEED_BASE_RPC_URL` | Runtime Base JSON-RPC endpoint override for seller on-chain operations |
 | `ANTSEED_BUYER_METADATA_FETCH_TIMEOUT_MS` | Runtime buyer peer-discovery metadata fetch timeout in milliseconds |
+| `ANTSEED_BUYER_METADATA_V2_SERVICES_ENABLED` | Runtime toggle for buyer per-service metadata v2 attribution (`false` opts out) |
 | `ANTHROPIC_API_KEY` | Upstream Anthropic API key (used by the `anthropic` provider plugin) |
 | `OPENAI_API_KEY` | Upstream OpenAI-compatible API key (used by the `openai` provider plugin) |
 | `ANTSEED_SETTLEMENT_IDLE_MS` | Idle time before settling a session (default: 600000 / 10 min) |

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -153,6 +153,8 @@ export interface NodePaymentsConfig {
   maxPerRequestUsdc?: string;
   /** Maximum total USDC the buyer will reserve in a single SpendingAuth (base units). Default: "10000000" ($10.00). */
   maxReserveAmountUsdc?: string;
+  /** Include per-service buyer attribution in metadata v2. Default: true. */
+  metadataV2ServicesEnabled?: boolean;
 }
 
 export interface NodeVerificationConfig {
@@ -1489,6 +1491,7 @@ export class AntseedNode extends EventEmitter {
           defaultAuthDurationSecs: payments.defaultAuthDurationSecs ?? 900, // 15 min — seller must call reserve() promptly
           maxPerRequestUsdc: BigInt(payments.maxPerRequestUsdc ?? "500000"),  // $0.50 default — covers most LLM requests
           maxReserveAmountUsdc: BigInt(payments.maxReserveAmountUsdc ?? "1000000"),  // $1.00 default per session (matches FIRST_SIGN_CAP)
+          metadataV2ServicesEnabled: payments.metadataV2ServicesEnabled ?? true,
           dataDir: paymentsDir,
         };
         this._buyerPaymentManager = new BuyerPaymentManager(identity, buyerPaymentConfig, this._channelStore, this._sellerAddressResolver ?? undefined);
@@ -1673,6 +1676,7 @@ export class AntseedNode extends EventEmitter {
             chainId: freeUsageConfig.chainId,
             freeUsageContractAddress: freeUsageConfig.freeUsageContractAddress,
             defaultAuthDurationSecs: payments.defaultAuthDurationSecs ?? 900,
+            metadataV2ServicesEnabled: payments.metadataV2ServicesEnabled ?? true,
           },
           this._sellerAddressResolver ?? undefined,
           this._channelStore ?? undefined,

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -153,8 +153,8 @@ export interface NodePaymentsConfig {
   maxPerRequestUsdc?: string;
   /** Maximum total USDC the buyer will reserve in a single SpendingAuth (base units). Default: "10000000" ($10.00). */
   maxReserveAmountUsdc?: string;
-  /** Include per-service buyer attribution in metadata v2. Default: true. */
-  metadataV2ServicesEnabled?: boolean;
+  /** Disable per-service buyer attribution in metadata v2. Default: false. */
+  disableMetadataV2Services?: boolean;
 }
 
 export interface NodeVerificationConfig {
@@ -1491,7 +1491,7 @@ export class AntseedNode extends EventEmitter {
           defaultAuthDurationSecs: payments.defaultAuthDurationSecs ?? 900, // 15 min — seller must call reserve() promptly
           maxPerRequestUsdc: BigInt(payments.maxPerRequestUsdc ?? "500000"),  // $0.50 default — covers most LLM requests
           maxReserveAmountUsdc: BigInt(payments.maxReserveAmountUsdc ?? "1000000"),  // $1.00 default per session (matches FIRST_SIGN_CAP)
-          metadataV2ServicesEnabled: payments.metadataV2ServicesEnabled ?? true,
+          disableMetadataV2Services: payments.disableMetadataV2Services ?? false,
           dataDir: paymentsDir,
         };
         this._buyerPaymentManager = new BuyerPaymentManager(identity, buyerPaymentConfig, this._channelStore, this._sellerAddressResolver ?? undefined);
@@ -1676,7 +1676,7 @@ export class AntseedNode extends EventEmitter {
             chainId: freeUsageConfig.chainId,
             freeUsageContractAddress: freeUsageConfig.freeUsageContractAddress,
             defaultAuthDurationSecs: payments.defaultAuthDurationSecs ?? 900,
-            metadataV2ServicesEnabled: payments.metadataV2ServicesEnabled ?? true,
+            disableMetadataV2Services: payments.disableMetadataV2Services ?? false,
           },
           this._sellerAddressResolver ?? undefined,
           this._channelStore ?? undefined,

--- a/packages/node/src/payments/buyer-free-usage-manager.ts
+++ b/packages/node/src/payments/buyer-free-usage-manager.ts
@@ -23,8 +23,8 @@ export interface BuyerFreeUsageConfig {
   freeUsageContractAddress: string;
   defaultAuthDurationSecs: number;
   openAckTimeoutMs?: number;
-  /** Include per-service attribution in free-usage metadata. Default: true. */
-  metadataV2ServicesEnabled?: boolean;
+  /** Disable per-service attribution in free-usage metadata. Default: false. */
+  disableMetadataV2Services?: boolean;
 }
 
 interface FreeUsageSession {
@@ -76,12 +76,12 @@ export class BuyerFreeUsageManager {
     this._hydrateFromStore();
   }
 
-  private get _metadataV2ServicesEnabled(): boolean {
-    return this._config.metadataV2ServicesEnabled !== false;
+  private get _disableMetadataV2Services(): boolean {
+    return this._config.disableMetadataV2Services === true;
   }
 
   private _sanitizeMetadata(metadata: FreeUsageMetadata): FreeUsageMetadata {
-    if (this._metadataV2ServicesEnabled) return metadata;
+    if (!this._disableMetadataV2Services) return metadata;
     return {
       cumulativeInputTokens: metadata.cumulativeInputTokens,
       cumulativeOutputTokens: metadata.cumulativeOutputTokens,
@@ -97,7 +97,7 @@ export class BuyerFreeUsageManager {
   ): FreeUsageMetadata {
     return advanceUsageMetadata(
       this._sanitizeMetadata(previous),
-      this._metadataV2ServicesEnabled ? service : undefined,
+      this._disableMetadataV2Services ? undefined : service,
       delta,
     );
   }
@@ -108,7 +108,7 @@ export class BuyerFreeUsageManager {
     for (const channel of activeChannels) {
       if (this._sessions.has(channel.peerId)) continue;
       const metadata = this._sanitizeMetadata(this._channelStore.getChannelMetadata(channel));
-      if (!this._metadataV2ServicesEnabled) {
+      if (!this._disableMetadataV2Services) {
         this._channelStore.replaceMetadataServiceTotals(channel.sessionId, metadata.services);
       }
       this._sessions.set(channel.peerId, {

--- a/packages/node/src/payments/buyer-free-usage-manager.ts
+++ b/packages/node/src/payments/buyer-free-usage-manager.ts
@@ -23,6 +23,8 @@ export interface BuyerFreeUsageConfig {
   freeUsageContractAddress: string;
   defaultAuthDurationSecs: number;
   openAckTimeoutMs?: number;
+  /** Include per-service attribution in free-usage metadata. Default: true. */
+  metadataV2ServicesEnabled?: boolean;
 }
 
 interface FreeUsageSession {
@@ -74,12 +76,41 @@ export class BuyerFreeUsageManager {
     this._hydrateFromStore();
   }
 
+  private get _metadataV2ServicesEnabled(): boolean {
+    return this._config.metadataV2ServicesEnabled !== false;
+  }
+
+  private _sanitizeMetadata(metadata: FreeUsageMetadata): FreeUsageMetadata {
+    if (this._metadataV2ServicesEnabled) return metadata;
+    return {
+      cumulativeInputTokens: metadata.cumulativeInputTokens,
+      cumulativeOutputTokens: metadata.cumulativeOutputTokens,
+      cumulativeRequestCount: metadata.cumulativeRequestCount,
+      services: [],
+    };
+  }
+
+  private _advanceUsageMetadata(
+    previous: FreeUsageMetadata,
+    service: string | undefined,
+    delta: Parameters<typeof advanceUsageMetadata>[2],
+  ): FreeUsageMetadata {
+    return advanceUsageMetadata(
+      this._sanitizeMetadata(previous),
+      this._metadataV2ServicesEnabled ? service : undefined,
+      delta,
+    );
+  }
+
   private _hydrateFromStore(): void {
     if (!this._channelStore) return;
     const activeChannels = this._channelStore.getActiveChannelsByBuyer(CHANNEL_ROLE.BUYER, this._identity.wallet.address, CHANNEL_KIND.FREE);
     for (const channel of activeChannels) {
       if (this._sessions.has(channel.peerId)) continue;
-      const metadata = this._channelStore.getChannelMetadata(channel);
+      const metadata = this._sanitizeMetadata(this._channelStore.getChannelMetadata(channel));
+      if (!this._metadataV2ServicesEnabled) {
+        this._channelStore.replaceMetadataServiceTotals(channel.sessionId, metadata.services);
+      }
       this._sessions.set(channel.peerId, {
         channelId: channel.sessionId,
         // Salt is only needed to create a fresh open signature; hydrated
@@ -232,7 +263,7 @@ export class BuyerFreeUsageManager {
     const outputTokens = BigInt(payload.outputTokens ?? '0');
     const attributedService = this._requestService.get(payload.requestId) ?? payload.service;
 
-    const metadata = advanceUsageMetadata(session.latestMetadata, attributedService, {
+    const metadata = this._advanceUsageMetadata(session.latestMetadata, attributedService, {
       amount: 0n,
       inputTokens,
       cachedInputTokens: 0n,
@@ -352,6 +383,6 @@ export class BuyerFreeUsageManager {
       createdAt: existing?.createdAt ?? now,
       updatedAt: now,
     });
-    this._channelStore.replaceMetadataServiceTotals(session.channelId, session.services);
+    this._channelStore.replaceMetadataServiceTotals(session.channelId, this._sanitizeMetadata(session.latestMetadata).services);
   }
 }

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -54,8 +54,8 @@ export interface BuyerPaymentConfig {
   maxReserveAmountUsdc: bigint;
   /** Max ratio of seller-claimed cost to buyer's bytes/4 estimate. Default: 1.4. */
   costToleranceMultiplier?: number;
-  /** Include per-service attribution in metadata v2. Default: true. */
-  metadataV2ServicesEnabled?: boolean;
+  /** Disable per-service attribution in metadata v2. Default: false. */
+  disableMetadataV2Services?: boolean;
   dataDir: string;
 }
 
@@ -139,7 +139,7 @@ export class BuyerPaymentManager {
       this._cumulativeAmount.set(peerId, persistedCumulative);
       const metadata = this._sanitizeMetadata(this._channelStore.getChannelMetadata(channel));
       this._metadata.set(peerId, metadata);
-      if (!this._metadataV2ServicesEnabled) {
+      if (!this._disableMetadataV2Services) {
         this._persistServiceMetadata(channel.sessionId, metadata);
       }
       // Hydrate verifiedCost to authMax so _maxSignable can grow beyond maxPerRequestUsdc.
@@ -170,13 +170,13 @@ export class BuyerPaymentManager {
     return this._config.costToleranceMultiplier ?? DEFAULT_COST_TOLERANCE;
   }
 
-  private get _metadataV2ServicesEnabled(): boolean {
-    return this._config.metadataV2ServicesEnabled !== false;
+  private get _disableMetadataV2Services(): boolean {
+    return this._config.disableMetadataV2Services === true;
   }
 
   private _sanitizeMetadata(metadata: SpendingAuthMetadata | undefined): SpendingAuthMetadata {
     const current = metadata ?? ZERO_METADATA;
-    if (this._metadataV2ServicesEnabled) return current;
+    if (!this._disableMetadataV2Services) return current;
     return {
       cumulativeInputTokens: current.cumulativeInputTokens,
       cumulativeOutputTokens: current.cumulativeOutputTokens,
@@ -192,7 +192,7 @@ export class BuyerPaymentManager {
   ): SpendingAuthMetadata {
     return advanceUsageMetadata(
       this._sanitizeMetadata(previous),
-      this._metadataV2ServicesEnabled ? service : undefined,
+      this._disableMetadataV2Services ? undefined : service,
       delta,
     );
   }

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -54,6 +54,8 @@ export interface BuyerPaymentConfig {
   maxReserveAmountUsdc: bigint;
   /** Max ratio of seller-claimed cost to buyer's bytes/4 estimate. Default: 1.4. */
   costToleranceMultiplier?: number;
+  /** Include per-service attribution in metadata v2. Default: true. */
+  metadataV2ServicesEnabled?: boolean;
   dataDir: string;
 }
 
@@ -135,7 +137,11 @@ export class BuyerPaymentManager {
       const peerId = channel.peerId;
       const persistedCumulative = BigInt(channel.authMax);
       this._cumulativeAmount.set(peerId, persistedCumulative);
-      this._metadata.set(peerId, this._channelStore.getChannelMetadata(channel));
+      const metadata = this._sanitizeMetadata(this._channelStore.getChannelMetadata(channel));
+      this._metadata.set(peerId, metadata);
+      if (!this._metadataV2ServicesEnabled) {
+        this._persistServiceMetadata(channel.sessionId, metadata);
+      }
       // Hydrate verifiedCost to authMax so _maxSignable can grow beyond maxPerRequestUsdc.
       // Without this, maxSignable = 0 + maxPerRequestUsdc after restart, permanently capping
       // the cumulative and causing non-monotonic SpendingAuth rejections on the seller.
@@ -162,6 +168,33 @@ export class BuyerPaymentManager {
 
   private get _costTolerance(): number {
     return this._config.costToleranceMultiplier ?? DEFAULT_COST_TOLERANCE;
+  }
+
+  private get _metadataV2ServicesEnabled(): boolean {
+    return this._config.metadataV2ServicesEnabled !== false;
+  }
+
+  private _sanitizeMetadata(metadata: SpendingAuthMetadata | undefined): SpendingAuthMetadata {
+    const current = metadata ?? ZERO_METADATA;
+    if (this._metadataV2ServicesEnabled) return current;
+    return {
+      cumulativeInputTokens: current.cumulativeInputTokens,
+      cumulativeOutputTokens: current.cumulativeOutputTokens,
+      cumulativeRequestCount: current.cumulativeRequestCount,
+      services: [],
+    };
+  }
+
+  private _advanceUsageMetadata(
+    previous: SpendingAuthMetadata | undefined,
+    service: string | undefined,
+    delta: Parameters<typeof advanceUsageMetadata>[2],
+  ): SpendingAuthMetadata {
+    return advanceUsageMetadata(
+      this._sanitizeMetadata(previous),
+      this._metadataV2ServicesEnabled ? service : undefined,
+      delta,
+    );
   }
 
   private _getCeiling(sellerPeerId: string): bigint {
@@ -220,7 +253,7 @@ export class BuyerPaymentManager {
     }
 
     const cumulativeAmount = this._cumulativeAmount.get(sellerPeerId) ?? BigInt(session.authMax);
-    const currentMeta = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
+    const currentMeta = this._sanitizeMetadata(this._metadata.get(sellerPeerId));
     const metadataHashHex = computeMetadataHash(currentMeta);
     const encodedMetadata = encodeMetadata(currentMeta);
 
@@ -280,7 +313,7 @@ export class BuyerPaymentManager {
       return session.sessionId;
     }
 
-    const currentMeta = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
+    const currentMeta = this._sanitizeMetadata(this._metadata.get(sellerPeerId));
     await this._sendUpdatedSpendingAuth(session, sellerPeerId, nextCumulative, currentMeta, paymentMux);
 
     // Send topUp AFTER the SpendingAuth so the seller processes the higher
@@ -318,7 +351,7 @@ export class BuyerPaymentManager {
       channelId: session.sessionId,
       cumulativeAmount: session.authMax,
       metadataHash: ZERO_METADATA_HASH,
-      metadata: encodeMetadata(this._metadata.get(sellerPeerId) ?? ZERO_METADATA),
+      metadata: encodeMetadata(this._sanitizeMetadata(this._metadata.get(sellerPeerId))),
       spendingAuthSig: reserveAuthSig,
       reserveSalt: salt,
       reserveMaxAmount: maxAmount.toString(),
@@ -376,7 +409,7 @@ export class BuyerPaymentManager {
   private readonly _serviceTokensCounted = new CountedRequestTracker();
 
   private _persistServiceMetadata(sessionId: string, metadata: SpendingAuthMetadata): void {
-    this._channelStore.replaceMetadataServiceTotals(sessionId, metadata.services);
+    this._channelStore.replaceMetadataServiceTotals(sessionId, this._sanitizeMetadata(metadata).services);
   }
 
   private async _sendUpdatedSpendingAuth(
@@ -386,8 +419,9 @@ export class BuyerPaymentManager {
     metadata: SpendingAuthMetadata,
     paymentMux: PaymentMux,
   ): Promise<void> {
-    const metadataHashHex = computeMetadataHash(metadata);
-    const encodedMetadata = encodeMetadata(metadata);
+    const sanitizedMetadata = this._sanitizeMetadata(metadata);
+    const metadataHashHex = computeMetadataHash(sanitizedMetadata);
+    const encodedMetadata = encodeMetadata(sanitizedMetadata);
     const metadataMsg: SpendingAuthMessage = {
       channelId: session.sessionId,
       cumulativeAmount,
@@ -396,7 +430,7 @@ export class BuyerPaymentManager {
     const spendingAuthSig = await signSpendingAuth(this._signer, this._channelsDomain, metadataMsg);
 
     this._cumulativeAmount.set(sellerPeerId, cumulativeAmount);
-    this._persistServiceMetadata(session.sessionId, metadata);
+    this._persistServiceMetadata(session.sessionId, sanitizedMetadata);
     this._channelStore.upsertChannel({
       ...session,
       authMax: cumulativeAmount.toString(),
@@ -505,7 +539,7 @@ export class BuyerPaymentManager {
     // The first real SpendingAuth will be sent by handleNeedAuth after the seller serves
     // the first request and reports its cost.
     this._cumulativeAmount.set(sellerPeerId, 0n);
-    this._metadata.set(sellerPeerId, { ...ZERO_METADATA });
+    this._metadata.set(sellerPeerId, this._sanitizeMetadata({ ...ZERO_METADATA }));
     this._verifiedCost.set(sellerPeerId, 0n);
     this._currentReserveCeiling.set(sellerPeerId, maxAmount);
     this._reserveSalt.set(sellerPeerId, salt);
@@ -779,7 +813,7 @@ export class BuyerPaymentManager {
     // raced ahead), skip service attribution entirely: service totals are
     // documented as lower bounds, so undercounting beats double-counting.
     const alreadyCounted = this._serviceTokensCounted.has(responseStats.requestId);
-    const newMeta = advanceUsageMetadata(
+    const newMeta = this._advanceUsageMetadata(
       this._metadata.get(sellerPeerId),
       alreadyCounted ? undefined : responseStats.service,
       {
@@ -968,7 +1002,7 @@ export class BuyerPaymentManager {
     // service attribution entirely: service totals are documented as lower
     // bounds, so undercounting beats double-counting.
     const alreadyCounted = this._serviceTokensCounted.has(payload.requestId);
-    const newMeta = advanceUsageMetadata(
+    const newMeta = this._advanceUsageMetadata(
       this._metadata.get(sellerPeerId),
       alreadyCounted ? undefined : buyerService,
       {
@@ -1052,7 +1086,7 @@ export class BuyerPaymentManager {
     const reserveAuthSig = await signReserveAuth(this._signer, channelsDomain, reserveMsg);
 
     const currentCumulative = this._cumulativeAmount.get(sellerPeerId) ?? 0n;
-    const currentMeta = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
+    const currentMeta = this._sanitizeMetadata(this._metadata.get(sellerPeerId));
     const metadataHashHex = computeMetadataHash(currentMeta);
     const encodedMetadata = encodeMetadata(currentMeta);
 
@@ -1108,7 +1142,7 @@ export class BuyerPaymentManager {
 
   /** Live cumulative token counts for a seller (in-memory, always up-to-date). */
   getCumulativeTokens(sellerPeerId: string): { inputTokens: bigint; outputTokens: bigint } {
-    const meta = this._metadata.get(sellerPeerId) ?? ZERO_METADATA;
+    const meta = this._sanitizeMetadata(this._metadata.get(sellerPeerId));
     return { inputTokens: meta.cumulativeInputTokens, outputTokens: meta.cumulativeOutputTokens };
   }
 

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -577,7 +577,7 @@ describe('BuyerPaymentManager', () => {
 
   it('signPerRequestAuth suppresses per-service metadata when disabled', async () => {
     manager = new BuyerPaymentManager(identity, makeConfig(tempDir, {
-      metadataV2ServicesEnabled: false,
+      disableMetadataV2Services: true,
     }), store);
     manager.setSigner(Wallet.createRandom());
 

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -711,6 +711,41 @@ describe('BuyerPaymentManager', () => {
     }]);
   });
 
+  it('handleNeedAuth suppresses per-service metadata when disabled', async () => {
+    manager = new BuyerPaymentManager(identity, makeConfig(tempDir, {
+      disableMetadataV2Services: true,
+    }), store);
+    manager.setSigner(Wallet.createRandom());
+
+    const sellerPeerId = fakePeerId('seller-needauth-no-service-meta');
+    const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);
+    manager.trackRequestService('req-sensitive-needauth', 'sensitive-model');
+    mux.sentSpendingAuths.length = 0;
+
+    await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requestId: 'req-sensitive-needauth',
+      requiredCumulativeAmount: '50000',
+      currentAcceptedCumulative: '0',
+      deposit: '1000000',
+      lastRequestCost: '100',
+      inputTokens: '1000',
+      cachedInputTokens: '200',
+      outputTokens: '50',
+    }, mux);
+
+    expect(mux.sentSpendingAuths.length).toBe(1);
+    const sent = mux.sentSpendingAuths[0] as Record<string, string>;
+    const meta = decodeMetadataTokens(sent.metadata);
+    expect(meta.inputTokens).toBe(1000n);
+    expect(meta.outputTokens).toBe(50n);
+    expect(decodeMetadataServices(sent.metadata)).toEqual([]);
+
+    const channel = store.getActiveChannelByPeer(sellerPeerId, CHANNEL_ROLE.BUYER);
+    expect(channel).not.toBeNull();
+    expect(store.getServiceTotals(channel!.sessionId)).toEqual([]);
+  });
+
   it('handleNeedAuth does not double-count service totals for a request already counted by signPerRequestAuth', async () => {
     const sellerPeerId = fakePeerId('seller-service-dedup');
     const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -575,6 +575,38 @@ describe('BuyerPaymentManager', () => {
     }));
   });
 
+  it('signPerRequestAuth suppresses per-service metadata when disabled', async () => {
+    manager = new BuyerPaymentManager(identity, makeConfig(tempDir, {
+      metadataV2ServicesEnabled: false,
+    }), store);
+    manager.setSigner(Wallet.createRandom());
+
+    const sellerPeerId = fakePeerId('seller-no-service-meta');
+    await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);
+
+    const { payload } = await manager.signPerRequestAuth(
+      sellerPeerId,
+      {
+        inputBytes: SAMPLE_INPUT,
+        outputBytes: SAMPLE_OUTPUT,
+        sellerClaimedCost: 100n,
+        reportedInputTokens: 1000n,
+        reportedCachedInputTokens: 200n,
+        reportedOutputTokens: 50n,
+        service: 'sensitive-model',
+      },
+    );
+
+    const meta = decodeMetadataTokens(payload.metadata);
+    expect(meta.inputTokens).toBe(1000n);
+    expect(meta.outputTokens).toBe(50n);
+    expect(decodeMetadataServices(payload.metadata)).toEqual([]);
+
+    const channel = store.getActiveChannelByPeer(sellerPeerId, CHANNEL_ROLE.BUYER);
+    expect(channel).not.toBeNull();
+    expect(store.getServiceTotals(channel!.sessionId)).toEqual([]);
+  });
+
   it('signPerRequestAuth hydrates cumulative service metadata after restart', async () => {
     const sellerPeerId = fakePeerId('seller-service-restart');
     await manager.authorizeSpending(sellerPeerId, mux, 10_000n, TEST_PRICING);

--- a/packages/node/tests/free-usage-lifecycle.test.ts
+++ b/packages/node/tests/free-usage-lifecycle.test.ts
@@ -203,7 +203,7 @@ describe('FreeUsage P2P lifecycle', () => {
     try {
       const buyerManager = new BuyerFreeUsageManager(
         buyer,
-        freeUsageConfig({ metadataV2ServicesEnabled: false }),
+        freeUsageConfig({ disableMetadataV2Services: true }),
         undefined,
         store,
       );

--- a/packages/node/tests/free-usage-lifecycle.test.ts
+++ b/packages/node/tests/free-usage-lifecycle.test.ts
@@ -48,11 +48,12 @@ function makeConn() {
   };
 }
 
-function freeUsageConfig() {
+function freeUsageConfig(overrides: Partial<ConstructorParameters<typeof BuyerFreeUsageManager>[1]> = {}) {
   return {
     chainId: CHAIN_ID,
     freeUsageContractAddress: FREE_USAGE_ADDRESS,
     defaultAuthDurationSecs: AUTH_SECS,
+    ...overrides,
   };
 }
 
@@ -194,6 +195,52 @@ describe('FreeUsage P2P lifecycle', () => {
       },
       authPayload.usageSig,
     ).toLowerCase()).toBe(buyer.wallet.address.toLowerCase());
+  });
+
+  it('buyer can suppress per-service free usage metadata', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'free-usage-no-service-meta-'));
+    const store = new ChannelStore(dir);
+    try {
+      const buyerManager = new BuyerFreeUsageManager(
+        buyer,
+        freeUsageConfig({ metadataV2ServicesEnabled: false }),
+        undefined,
+        store,
+      );
+      const buyerConn = makeConn();
+      const buyerMux = new PaymentMux(buyerConn.conn as any);
+
+      await buyerManager.prepareOpen(sellerPeer(), buyerMux);
+      const openPayload = decodeFreeUsageOpen(decodeSentFrame(buyerConn.frames[0]!).payload);
+      buyerManager.handleAck(seller.peerId, {
+        channelId: openPayload.channelId,
+        acceptedSequence: '0',
+      });
+      buyerManager.trackRequestService('req-free-private', 'sensitive-free-model');
+
+      await buyerManager.handleNeedAuth(seller.peerId, {
+        channelId: openPayload.channelId,
+        requiredSequence: '1',
+        currentAcceptedSequence: '0',
+        requestId: 'req-free-private',
+        inputTokens: '12',
+        outputTokens: '7',
+      }, buyerMux);
+
+      const authPayload = decodeFreeUsageAuth(decodeSentFrame(buyerConn.frames[1]!).payload);
+      const expectedMetadata = {
+        cumulativeInputTokens: 12n,
+        cumulativeOutputTokens: 7n,
+        cumulativeRequestCount: 1n,
+        services: [],
+      };
+      expect(authPayload.metadata).toBe(encodeFreeUsageMetadata(expectedMetadata));
+      expect(authPayload.metadataHash).toBe(computeFreeUsageMetadataHash(expectedMetadata));
+      expect(store.getServiceTotals(openPayload.channelId)).toEqual([]);
+    } finally {
+      store.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('buyer waits for free usage open ack and clears unacked sessions on timeout', async () => {


### PR DESCRIPTION
## Description

Adds a buyer-side opt-out for per-service metadata v2 attribution. When disabled, paid SpendingAuth and free-usage auth metadata keep aggregate token/request totals but omit service IDs and per-service totals.

The option is available in config, env, CLI startup, and Desktop Settings. Closes #656.

## Release Notes

- Added a buyer privacy setting to disable per-service metadata v2 attribution while preserving aggregate usage accounting.
- Added CLI, environment, and Desktop Settings controls for the metadata v2 service attribution opt-out.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes