### PR TITLE
fix(app): Show missing peer state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ This project uses selective package publishing. Each release entry lists the pub
 - `@antseed/cli`
 - `@antseed/node`
 
+### Desktop
+
+- `@antseed/desktop`
+
 ### Added
 
 - Added zero-price free usage authorization for advertised free services, including buyer-signed P2P usage records, seller on-chain reporting through `AntseedFreeUsage`, and CLI configuration for the deployed free usage contract address.
@@ -28,6 +32,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 - Fixed buyer response-auth timeout warnings for non-inference probes and sellers that do not advertise response-auth support.
 - Fixed buyer discovery so temporarily unreachable metadata endpoints are probed for recovery before the full exponential cooldown expires, allowing recovered peers to reappear in buyer peer lists sooner.
+- Fixed Desktop chats for peers that disappear from discovery so the header reports that the peer was not found and disables the composer instead of showing stale peer identifiers.
 
 ## 2026-06-15 — Buyer peer failure accounting and desktop stream responsiveness
 

--- a/apps/desktop/src/renderer/core/state.ts
+++ b/apps/desktop/src/renderer/core/state.ts
@@ -245,6 +245,7 @@ export type RendererUiState = {
 
   // --- Chat display ---
   chatActiveConversation: string | null;
+  chatOpeningConversationId: string | null;
   chatConversationTitle: string;
   chatConversations: unknown[];
   chatConversationsLoaded: boolean;
@@ -268,6 +269,7 @@ export type RendererUiState = {
   chatLifetimeSessions: string;
   chatServiceOptions: ChatServiceOptionEntry[];
   discoverRows: DiscoverRow[];
+  chatDiscoverRowsLoaded: boolean;
   chatSelectedServiceValue: string;
   chatSelectedPeerId: string;
   chatServiceStatus: BadgeState;
@@ -394,6 +396,7 @@ export function createInitialUiState(): RendererUiState {
 
     // Chat
     chatActiveConversation: null,
+    chatOpeningConversationId: null,
     chatConversationTitle: 'Conversation',
     chatConversations: [],
     chatConversationsLoaded: false,
@@ -416,6 +419,7 @@ export function createInitialUiState(): RendererUiState {
     chatLifetimeSessions: '',
     chatServiceOptions: [],
     discoverRows: [],
+    chatDiscoverRowsLoaded: false,
     chatSelectedServiceValue: '',
     chatSelectedPeerId: '',
     chatServiceStatus: { tone: 'idle', label: 'Services idle' },

--- a/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
@@ -67,6 +67,110 @@ type Conversation = {
   usage: { inputTokens: number; outputTokens: number };
 };
 
+test('discover rows are marked loaded only after a successful catalog response', async () => {
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  const catalog = createDeferred<{ ok: true; data: unknown[] }>();
+  const bridge: DesktopBridge = {
+    chatAiListDiscoverRows: async () => catalog.promise,
+  };
+
+  initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+
+  await waitFor(() => uiState.chatServiceSelectDisabled);
+  assert.equal(uiState.chatDiscoverRowsLoaded, false);
+
+  catalog.resolve({
+    ok: true,
+    data: [
+      {
+        peerId: 'peer-a',
+        serviceId: 'model-a',
+      },
+    ],
+  });
+
+  await waitFor(() => uiState.chatDiscoverRowsLoaded && !uiState.chatServiceSelectDisabled);
+  assert.equal(uiState.discoverRows[0]?.peerId, 'peer-a');
+});
+
+test('empty successful discover response still settles catalog loading', async () => {
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  const bridge: DesktopBridge = {
+    chatAiListDiscoverRows: async () => ({ ok: true, data: [] }),
+  };
+
+  initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+
+  await waitFor(() => uiState.chatDiscoverRowsLoaded && !uiState.chatServiceSelectDisabled);
+  assert.equal(uiState.discoverRows.length, 0);
+  assert.equal(uiState.chatServiceStatus.label, 'No services available');
+});
+
+test('failed discover response does not mark catalog loaded', async () => {
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  const bridge: DesktopBridge = {
+    chatAiListDiscoverRows: async () => ({ ok: false, error: 'offline' }),
+  };
+
+  initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+
+  await waitFor(() => !uiState.chatServiceSelectDisabled && uiState.chatServiceStatus.label === 'offline');
+  assert.equal(uiState.chatDiscoverRowsLoaded, false);
+});
+
+test('opening a conversation tracks the loading gap before peer binding is restored', async () => {
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  uiState.chatConversations = [
+    {
+      id: 'conv-a',
+      title: 'Conversation A',
+      service: 'model-a',
+      provider: 'openai',
+      peerId: 'peer-a',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+  ];
+
+  const conversation: Conversation = {
+    id: 'conv-a',
+    title: 'Conversation A',
+    service: 'model-a',
+    provider: 'openai',
+    peerId: 'peer-a',
+    messages: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    usage: { inputTokens: 0, outputTokens: 0 },
+  };
+  const conversationLoad = createDeferred<{ ok: true; data: Conversation }>();
+  const bridge: DesktopBridge = {
+    chatAiGetConversation: async () => conversationLoad.promise,
+  };
+
+  const api = initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+  const openPromise = api.openConversation('conv-a');
+
+  await waitFor(() => uiState.chatOpeningConversationId === 'conv-a');
+  assert.equal(uiState.chatActiveConversation, 'conv-a');
+  assert.equal(uiState.chatSelectedPeerId, '');
+
+  conversationLoad.resolve({ ok: true, data: conversation });
+  await openPromise;
+
+  assert.equal(uiState.chatOpeningConversationId, null);
+  assert.equal(uiState.chatSelectedPeerId, 'peer-a');
+});
+
 test('new chat created while previous response is pending sends to its own peer', async () => {
   installDomTimers();
 

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1314,6 +1314,7 @@ export function initChatModule({
     const fallback = fallbackChatServices.map((entry) => ({ ...entry }));
 
     if (!bridge?.chatAiListDiscoverRows) {
+      uiState.chatDiscoverRowsLoaded = false;
       updateChatServiceOptions(fallback);
       setServiceCatalogStatus('warn', 'Services unavailable');
       setRuntimeActivity('warn', 'Service catalog unavailable (bridge missing).');
@@ -1329,6 +1330,7 @@ export function initChatModule({
       if (refreshToken !== serviceRefreshToken) return;
 
       if (!result.ok || !Array.isArray(result.data)) {
+        uiState.chatDiscoverRowsLoaded = false;
         updateChatServiceOptions(fallback);
         setServiceCatalogStatus('warn', result.error || 'Services unavailable');
         setRuntimeActivity('warn', result.error || 'Service catalog unavailable.');
@@ -1340,6 +1342,7 @@ export function initChatModule({
         .map((raw) => normalizeDiscoverRow(raw))
         .filter((row): row is DiscoverRow => row !== null);
       uiState.discoverRows = rows;
+      uiState.chatDiscoverRowsLoaded = true;
       const optionsToRender = rows.length > 0 ? projectRowsToChatServiceOptions(rows) : fallback;
       updateChatServiceOptions(optionsToRender);
       setServiceCatalogStatus(
@@ -1356,6 +1359,7 @@ export function initChatModule({
       );
     } catch (error) {
       if (refreshToken !== serviceRefreshToken) return;
+      uiState.chatDiscoverRowsLoaded = false;
       updateChatServiceOptions(fallback);
       const message = toErrorMessage(error, 'Failed to load services');
       setServiceCatalogStatus('warn', message);
@@ -1603,6 +1607,7 @@ export function initChatModule({
     const workspacePathAtOpen = uiState.chatWorkspacePath;
 
     uiState.chatActiveConversation = convId;
+    uiState.chatOpeningConversationId = convId;
     uiState.chatRoutedPeerId = '';
     uiState.chatSelectedPeerId = '';
     uiState.chatSessionStarted = '';
@@ -1660,6 +1665,7 @@ export function initChatModule({
         setLocalConversationMessages(convId, uiState.chatMessages as ChatMessage[]);
         updateThreadMeta(activeConversation);
         clearTransientChatNotices();
+        uiState.chatOpeningConversationId = null;
         void refreshChatPermissionModeForPeer(resolveConversationPeerId(activeConversation));
         notifyUiStateChanged();
 
@@ -1675,9 +1681,11 @@ export function initChatModule({
         const peerId = resolveConversationPeerId(activeConversation);
         if (peerId) debouncedFetchMeteringStats(peerId);
       } else {
+        uiState.chatOpeningConversationId = null;
         reportChatError(result.error, 'Failed to open conversation');
       }
     } catch (err) {
+      uiState.chatOpeningConversationId = null;
       reportChatError(err, 'Failed to open conversation');
     }
   }
@@ -1685,6 +1693,7 @@ export function initChatModule({
   function startNewChat(): void {
     newChatDraftVersion += 1;
     uiState.chatActiveConversation = null;
+    uiState.chatOpeningConversationId = null;
     uiState.chatMessages = [];
     setStreamingMessage(null);
     activeConversation = null;

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -34,6 +34,7 @@ import { BrowserPreview } from '../BrowserPreview';
 import type { ChatMessage } from '../chat/chat-shared';
 import { buildDisplayMessages } from '../chat/chat-shared';
 import type { ChatPermissionMode, ChatWorkspaceGitStatus, RawChatAttachment } from '../../../types/bridge';
+import { getPeerDisplayName } from '../../../core/peer-utils';
 import { AntStationStackedLogo } from '../AntStationLogo';
 import { cancelVoiceRecording, startVoiceRecording, stopVoiceRecording } from '../../lib/voice-recorder';
 
@@ -459,6 +460,78 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     return () => observer.disconnect();
   }, [visibleMessages, snap.chatStreamingMessage, snap.chatSending, scrollChatToBottom]);
 
+  const activeConversationSummary = useMemo(() => {
+    const activeConversationId = snap.chatActiveConversation;
+    if (!activeConversationId || !Array.isArray(snap.chatConversations)) return null;
+    return snap.chatConversations.find((conv) => (
+      conv
+      && typeof conv === 'object'
+      && String((conv as { id?: unknown }).id || '') === activeConversationId
+    )) as Record<string, unknown> | null;
+  }, [snap.chatActiveConversation, snap.chatConversations]);
+  const activeConversationPeerId =
+    typeof activeConversationSummary?.peerId === 'string'
+      ? activeConversationSummary.peerId.trim()
+      : '';
+  const activeConversationServiceId =
+    typeof activeConversationSummary?.service === 'string'
+      ? activeConversationSummary.service.trim()
+      : '';
+  const activeConversationPeerLabel =
+    typeof activeConversationSummary?.peerLabel === 'string'
+      ? activeConversationSummary.peerLabel.trim()
+      : '';
+  const activeConversationPeerName =
+    getPeerDisplayName(activeConversationPeerLabel)
+    || activeConversationPeerLabel
+    || (activeConversationPeerId ? activeConversationPeerId.slice(0, 8) : '');
+  const openingActiveConversation = Boolean(
+    snap.chatOpeningConversationId
+    && snap.chatOpeningConversationId === snap.chatActiveConversation,
+  );
+
+  // Services filtered to the currently-routed peer — lets the user switch
+  // between services offered by the same peer without going back to Discover.
+  const currentPeerId = snap.chatRoutedPeerId || snap.chatSelectedPeerId || activeConversationPeerId || '';
+  const [headerCopied, setHeaderCopied] = useState(false);
+  const peerServiceOptions = useMemo(
+    () =>
+      currentPeerId
+        ? snap.chatServiceOptions.filter((o) => o.peerId === currentPeerId)
+        : [],
+    [snap.chatServiceOptions, currentPeerId],
+  );
+  const currentServiceOption = useMemo(
+    () => snap.chatServiceOptions.find((o) => o.value === snap.chatSelectedServiceValue),
+    [snap.chatServiceOptions, snap.chatSelectedServiceValue],
+  );
+  const currentPeerNotFound = Boolean(
+    snap.chatActiveConversation
+    && currentPeerId
+    && !openingActiveConversation
+    && snap.chatDiscoverRowsLoaded
+    && !snap.chatServiceSelectDisabled
+    && !snap.discoverRows.some((row) => row.peerId === currentPeerId)
+    && !snap.chatServiceOptions.some((option) => option.peerId === currentPeerId),
+  );
+  const currentServiceKey = currentServiceOption?.id || '';
+  const currentServiceLabel = openingActiveConversation
+    ? activeConversationServiceId || currentServiceOption?.label || 'Loading chat...'
+    : currentServiceOption?.label || activeConversationServiceId || 'No peer selected';
+  const supportsMultimodal = currentServiceOption?.categories?.includes('multimodal') ?? false;
+  const hasAttachedImages = useMemo(
+    () => attachedFiles.some((file) => isImageAttachmentLike(file.name, file.mimeType)),
+    [attachedFiles],
+  );
+  const peerDisplayName =
+    currentPeerNotFound
+      ? ''
+      : openingActiveConversation
+        ? activeConversationPeerName
+        : snap.chatRoutedPeer || currentServiceOption?.peerDisplayName || currentServiceOption?.peerLabel || '';
+
+  const headerCopyValue = currentPeerNotFound ? '' : `${currentPeerId} ${currentServiceKey}`.trim();
+
   const activePendingQueue = useMemo(
     () => pendingQueue.filter((item) => item.conversationId === snap.chatActiveConversation),
     [pendingQueue, snap.chatActiveConversation],
@@ -470,7 +543,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   // in so switching chats while a response streams cannot send the draft in the
   // newly-opened chat.
   useEffect(() => {
-    if (snap.chatInputDisabled) return;
+    if (snap.chatInputDisabled || currentPeerNotFound) return;
     if (inputRef.current) inputRef.current.focus();
     if (activePendingQueue.length === 0) return;
     const head = activePendingQueue[0];
@@ -481,7 +554,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     } else {
       actions.sendMessage(head.text, head.attachments);
     }
-  }, [snap.chatInputDisabled, activePendingQueue, actions]);
+  }, [snap.chatInputDisabled, activePendingQueue, actions, currentPeerNotFound]);
 
   // --- Divider drag (pointer capture — no orphaned listeners) ---
   const handleDividerPointerDown = useCallback((e: React.PointerEvent) => {
@@ -531,32 +604,6 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, [permissionMenuOpen]);
-
-  // Services filtered to the currently-routed peer — lets the user switch
-  // between services offered by the same peer without going back to Discover.
-  const currentPeerId = snap.chatRoutedPeerId || snap.chatSelectedPeerId || '';
-  const [headerCopied, setHeaderCopied] = useState(false);
-  const peerServiceOptions = useMemo(
-    () =>
-      currentPeerId
-        ? snap.chatServiceOptions.filter((o) => o.peerId === currentPeerId)
-        : [],
-    [snap.chatServiceOptions, currentPeerId],
-  );
-  const currentServiceOption = useMemo(
-    () => snap.chatServiceOptions.find((o) => o.value === snap.chatSelectedServiceValue),
-    [snap.chatServiceOptions, snap.chatSelectedServiceValue],
-  );
-  const currentServiceKey = currentServiceOption?.id || '';
-  const supportsMultimodal = currentServiceOption?.categories?.includes('multimodal') ?? false;
-  const hasAttachedImages = useMemo(
-    () => attachedFiles.some((file) => isImageAttachmentLike(file.name, file.mimeType)),
-    [attachedFiles],
-  );
-  const peerDisplayName =
-    snap.chatRoutedPeer || currentServiceOption?.peerDisplayName || currentServiceOption?.peerLabel || '';
-
-  const headerCopyValue = `${currentPeerId} ${currentServiceKey}`.trim();
 
   useEffect(() => {
     if (!headerCopied) return undefined;
@@ -692,6 +739,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   const handleSend = useCallback(() => {
     const text = inputValue.trim();
     if (!text && attachedFiles.length === 0) return;
+    if (currentPeerNotFound) return;
     // If the current turn is still streaming, park the draft as a pending
     // card above the composer and clear the input so the user can keep
     // typing the next one. The disabled→enabled effect flushes the queue
@@ -723,7 +771,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     resetComposer();
     actions.sendMessage(text, filesToSend);
     scrollChatToBottom('smooth');
-  }, [inputValue, attachedFiles, actions, snap.chatInputDisabled, snap.chatActiveConversation, resetComposer, lowReputationPeer, visibleMessages.length]);
+  }, [inputValue, attachedFiles, actions, snap.chatInputDisabled, snap.chatActiveConversation, resetComposer, lowReputationPeer, visibleMessages.length, currentPeerNotFound]);
 
   const handleLowReputationContinue = useCallback(() => {
     if (lowReputationPeer) {
@@ -858,23 +906,26 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   }, [attachFiles]);
 
   const handleFileDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    if (currentPeerNotFound) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'copy';
     setIsDragOver(true);
-  }, []);
+  }, [currentPeerNotFound]);
 
   const handleFileDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    if (currentPeerNotFound) return;
     e.preventDefault();
     if (!e.currentTarget.contains(e.relatedTarget as Node)) {
       setIsDragOver(false);
     }
-  }, []);
+  }, [currentPeerNotFound]);
 
   const handleFileDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     setIsDragOver(false);
+    if (currentPeerNotFound) return;
     if (e.dataTransfer.files.length > 0) void attachFiles(e.dataTransfer.files);
-  }, [attachFiles]);
+  }, [attachFiles, currentPeerNotFound]);
 
 
   const handleInput = useCallback(() => {
@@ -887,6 +938,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   }, []);
 
   const handleVoiceRecord = useCallback(async () => {
+    if (currentPeerNotFound) return;
     setVoiceError(null);
     try {
       if (voiceState === 'idle') {
@@ -918,7 +970,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
       setVoiceState('idle');
       setVoiceError(error instanceof Error ? error.message : String(error));
     }
-  }, [handleInput, voiceState]);
+  }, [currentPeerNotFound, handleInput, voiceState]);
 
   useEffect(() => {
     if (voiceState !== 'recording') return undefined;
@@ -992,6 +1044,8 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
     snap.chatSendingConversationId === snap.chatActiveConversation ||
     activeConversationIsSending
   );
+  const chatComposerDisabled = currentPeerNotFound;
+  const chatSendDisabled = currentPeerNotFound || (snap.chatSendDisabled && attachedFiles.length === 0);
 
   const workspacePath = snap.chatWorkspacePath || snap.chatWorkspaceDefaultPath;
   const workspaceLabel = getPathEnding(workspacePath);
@@ -1013,7 +1067,11 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
               <span className={styles.peerName}>{peerDisplayName}</span>
             </span>
           )}
-          {peerServiceOptions.length > 0 ? (
+          {currentPeerNotFound ? (
+            <span className={styles.headerLabelGroup}>
+              <span className={styles.serviceLabel}>Peer was not found</span>
+            </span>
+          ) : peerServiceOptions.length > 0 ? (
             <div className={styles.serviceSwitcherAnchor}>
               <ServiceDropdown
                 options={peerServiceOptions}
@@ -1042,7 +1100,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
           ) : (
             <span className={styles.headerLabelGroup}>
               <span className={styles.serviceLabel}>
-                {currentServiceOption?.label || 'No peer selected'}
+                {currentServiceLabel}
               </span>
               {headerCopyValue && (
                 <button
@@ -1380,12 +1438,15 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                 multiple
                 style={{ display: 'none' }}
                 onChange={handleFileAttach}
+                disabled={chatComposerDisabled}
               />
               <textarea
                 ref={inputRef}
                 className={styles.chatTextInput}
                 placeholder={
-                  voiceState === 'recording'
+                  currentPeerNotFound
+                    ? 'Peer was not found. Choose another service from Discover to continue.'
+                    : voiceState === 'recording'
                     ? 'Recording… click the mic again to transcribe, or press Esc to cancel'
                     : voiceState === 'transcribing'
                       ? 'Transcribing locally…'
@@ -1399,6 +1460,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                 onInput={handleInput}
                 onKeyDown={handleKeyDown}
                 onPaste={handlePaste}
+                disabled={chatComposerDisabled}
               />
               <div className={styles.chatInputBottom}>
                 <div className={styles.chatInputActionsLeft}>
@@ -1406,6 +1468,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                     className={`${styles.chatAttachBtn} ${supportsMultimodal ? '' : styles.chatAttachBtnLimited}`}
                     title={supportsMultimodal ? 'Attach files' : "Attach files (images unavailable for selected model)"}
                     onClick={() => fileInputRef.current?.click()}
+                    disabled={chatComposerDisabled}
                     type="button"
                   >
                     <HugeiconsIcon icon={Add01Icon} size={18} strokeWidth={2} />
@@ -1414,7 +1477,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                     className={`${styles.chatVoiceBtn} ${voiceState === 'recording' ? styles.chatVoiceBtnRecording : ''}`}
                     title={voiceState === 'recording' ? 'Stop recording and transcribe' : voiceState === 'transcribing' ? 'Transcribing locally…' : 'Record voice message'}
                     onClick={() => void handleVoiceRecord()}
-                    disabled={voiceState === 'transcribing'}
+                    disabled={chatComposerDisabled || voiceState === 'transcribing'}
                     type="button"
                   >
                     {voiceState === 'transcribing' ? '…' : <HugeiconsIcon icon={Mic01Icon} size={18} strokeWidth={2} />}
@@ -1428,7 +1491,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
                     Stop
                   </button>
                 ) : (
-                  <button className={styles.chatSendBtn} disabled={snap.chatSendDisabled && attachedFiles.length === 0} onClick={handleSend}>
+                  <button className={styles.chatSendBtn} disabled={chatSendDisabled} onClick={handleSend}>
                     <HugeiconsIcon icon={ArrowUp02Icon} size={18} strokeWidth={2.5} />
                   </button>
                 )}


### PR DESCRIPTION
## Description

Fixes Desktop chat behavior when an active conversation is pinned to a peer that no longer appears in discovery. The chat header now reports that the peer was not found only after service discovery has settled, and the composer is disabled so messages cannot be sent to a missing peer.

## Release Notes

- Fixed Desktop chats for peers that disappear from discovery so the header shows that the peer was not found and disables the composer instead of showing stale peer identifiers.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
