### PR TITLE
feat(desktop): Show verified domain peer icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ This project uses selective package publishing. Each release entry lists the pub
 - `@antseed/cli`
 - `@antseed/node`
 
+### Desktop
+
+- `@antseed/desktop`
+
 ### Added
 
+- Added Desktop peer favicons from verified domains, showing fetched site icons in Discover and chat peer avatars when available.
 - Added zero-price free usage authorization for advertised free services, including buyer-signed P2P usage records, seller on-chain reporting through `AntseedFreeUsage`, and CLI configuration for the deployed free usage contract address.
 
 ### Removed

--- a/apps/desktop/src/main/domain-site-metadata.test.ts
+++ b/apps/desktop/src/main/domain-site-metadata.test.ts
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { enrichDomainVerificationLinks } from './domain-site-metadata.js';
+
+test('enrichDomainVerificationLinks adds desktop-only domain page metadata', async () => {
+  const calls: string[] = [];
+  const fetchImpl: typeof fetch = async (input) => {
+    calls.push(String(input));
+    return new Response(`
+      <!doctype html>
+      <html>
+        <head>
+          <title>Example &amp; Co</title>
+          <meta name="description" content="A verified example domain.">
+          <link rel="icon" href="/assets/icon.png">
+        </head>
+      </html>
+    `, {
+      status: 200,
+      headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+  };
+
+  const links = await enrichDomainVerificationLinks([
+    { kind: 'domain', label: 'example.com', href: 'https://example.com' },
+    { kind: 'github', label: '@antseed/test', href: 'https://github.com/antseed/test' },
+  ], { fetch: fetchImpl, nowMs: 1000 });
+
+  assert.deepEqual(calls, ['https://example.com/']);
+  assert.deepEqual(links, [
+    {
+      kind: 'domain',
+      label: 'example.com',
+      href: 'https://example.com',
+      title: 'Example & Co',
+      description: 'A verified example domain.',
+      faviconUrl: 'https://example.com/assets/icon.png',
+    },
+    { kind: 'github', label: '@antseed/test', href: 'https://github.com/antseed/test' },
+  ]);
+});
+
+test('enrichDomainVerificationLinks caches duplicate domain metadata', async () => {
+  let callCount = 0;
+  const fetchImpl: typeof fetch = async () => {
+    callCount += 1;
+    return new Response('<title>Cached Site</title>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+  };
+
+  const links = await enrichDomainVerificationLinks([
+    { kind: 'domain', label: 'cache.example', href: 'https://cache.example' },
+    { kind: 'domain', label: 'cache.example', href: 'https://cache.example/about' },
+  ], { fetch: fetchImpl, nowMs: 2000 });
+
+  assert.equal(callCount, 1);
+  assert.equal(links[0]?.title, 'Cached Site');
+  assert.equal(links[1]?.title, 'Cached Site');
+});
+
+test('enrichDomainVerificationLinks ignores non-html responses', async () => {
+  const fetchImpl: typeof fetch = async () => new Response('{"ok":true}', {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
+  const links = await enrichDomainVerificationLinks([
+    { kind: 'domain', label: 'json.example', href: 'https://json.example' },
+  ], { fetch: fetchImpl, nowMs: 3000 });
+
+  assert.deepEqual(links, [
+    { kind: 'domain', label: 'json.example', href: 'https://json.example' },
+  ]);
+});

--- a/apps/desktop/src/main/domain-site-metadata.ts
+++ b/apps/desktop/src/main/domain-site-metadata.ts
@@ -1,0 +1,254 @@
+import type { PeerVerificationLink } from '@antseed/node/discovery';
+
+export type DomainSiteMetadata = {
+  title?: string;
+  description?: string;
+  faviconUrl?: string;
+};
+
+export type DesktopVerificationLink = PeerVerificationLink & DomainSiteMetadata;
+
+type CacheEntry = {
+  fetchedAtMs: number;
+  metadata: DomainSiteMetadata | null;
+};
+
+type EnrichOptions = {
+  fetch?: typeof fetch;
+  nowMs?: number;
+  timeoutMs?: number;
+  successTtlMs?: number;
+  failureTtlMs?: number;
+};
+
+const MAX_DOMAIN_SITE_METADATA_BYTES = 2 * 1024 * 1024;
+const MAX_SITE_TITLE_LENGTH = 120;
+const MAX_SITE_DESCRIPTION_LENGTH = 280;
+const DEFAULT_TIMEOUT_MS = 2_500;
+const DEFAULT_SUCCESS_TTL_MS = 6 * 60 * 60 * 1000;
+const DEFAULT_FAILURE_TTL_MS = 10 * 60 * 1000;
+
+const metadataCache = new Map<string, CacheEntry>();
+const metadataInFlight = new Map<string, Promise<DomainSiteMetadata | null>>();
+
+function withTimeoutSignal(timeoutMs: number): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error('domain metadata request timed out')), timeoutMs);
+  return {
+    signal: controller.signal,
+    cleanup: () => clearTimeout(timer),
+  };
+}
+
+async function readBodyWithLimit(response: Response, maxBytes: number): Promise<string> {
+  const contentLength = Number(response.headers.get('content-length') ?? '');
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new Error(`Domain metadata body exceeds ${maxBytes} bytes`);
+  }
+  if (!response.body) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > maxBytes) {
+      throw new Error(`Domain metadata body exceeds ${maxBytes} bytes`);
+    }
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel().catch(() => {});
+      throw new Error(`Domain metadata body exceeds ${maxBytes} bytes`);
+    }
+    chunks.push(value);
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(merged);
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (match, entity: string) => {
+    const normalized = entity.toLowerCase();
+    if (normalized.startsWith('#x')) {
+      const parsed = Number.parseInt(normalized.slice(2), 16);
+      return Number.isFinite(parsed) ? String.fromCodePoint(parsed) : match;
+    }
+    if (normalized.startsWith('#')) {
+      const parsed = Number.parseInt(normalized.slice(1), 10);
+      return Number.isFinite(parsed) ? String.fromCodePoint(parsed) : match;
+    }
+    switch (normalized) {
+      case 'amp': return '&';
+      case 'lt': return '<';
+      case 'gt': return '>';
+      case 'quot': return '"';
+      case 'apos': return "'";
+      case 'nbsp': return ' ';
+      default: return match;
+    }
+  });
+}
+
+function cleanSiteText(value: string, maxLength: number): string | undefined {
+  const cleaned = decodeHtmlEntities(value)
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/[\u0000-\u001f\u007f]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!cleaned) return undefined;
+  return cleaned.length > maxLength ? `${cleaned.slice(0, maxLength - 3).trimEnd()}...` : cleaned;
+}
+
+function parseTagAttributes(raw: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const attrRe = /([^\s"'=<>`]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+  for (;;) {
+    const match = attrRe.exec(raw);
+    if (!match) break;
+    const name = match[1]?.toLowerCase();
+    if (!name) continue;
+    attrs[name] = decodeHtmlEntities(match[2] ?? match[3] ?? match[4] ?? '');
+  }
+  return attrs;
+}
+
+function findMetaContent(html: string, names: string[]): string | undefined {
+  const wanted = new Set(names.map((name) => name.toLowerCase()));
+  const metaRe = /<meta\s+([^>]*?)>/gi;
+  for (;;) {
+    const match = metaRe.exec(html);
+    if (!match?.[1]) break;
+    const attrs = parseTagAttributes(match[1]);
+    const key = (attrs.name ?? attrs.property ?? '').trim().toLowerCase();
+    if (wanted.has(key) && attrs.content) {
+      return attrs.content;
+    }
+  }
+  return undefined;
+}
+
+function findFaviconUrl(html: string, baseUrl: string): string | undefined {
+  const linkRe = /<link\s+([^>]*?)>/gi;
+  for (;;) {
+    const match = linkRe.exec(html);
+    if (!match?.[1]) break;
+    const attrs = parseTagAttributes(match[1]);
+    const rel = (attrs.rel ?? '').toLowerCase().split(/\s+/);
+    if (!attrs.href || !rel.some((part) => part === 'icon' || part === 'apple-touch-icon' || part === 'shortcut')) {
+      continue;
+    }
+    try {
+      const url = new URL(attrs.href, baseUrl);
+      if (url.protocol === 'https:') {
+        return url.toString();
+      }
+    } catch {
+      // Ignore malformed favicon URLs.
+    }
+  }
+  return undefined;
+}
+
+function parseSiteMetadata(html: string, baseUrl: string): DomainSiteMetadata | null {
+  const titleMatch = /<title(?:\s[^>]*)?>([\s\S]*?)<\/title>/i.exec(html);
+  const title = titleMatch?.[1] ? cleanSiteText(titleMatch[1], MAX_SITE_TITLE_LENGTH) : undefined;
+  const description = cleanSiteText(
+    findMetaContent(html, ['og:description', 'twitter:description', 'description']) ?? '',
+    MAX_SITE_DESCRIPTION_LENGTH,
+  );
+  const faviconUrl = findFaviconUrl(html, baseUrl) ?? new URL('/favicon.ico', baseUrl).toString();
+  const metadata: DomainSiteMetadata = {
+    ...(title ? { title } : {}),
+    ...(description ? { description } : {}),
+    ...(faviconUrl.startsWith('https://') ? { faviconUrl } : {}),
+  };
+  return Object.keys(metadata).length > 0 ? metadata : null;
+}
+
+function domainFromVerificationLink(link: PeerVerificationLink): string | null {
+  if (link.kind !== 'domain') return null;
+  try {
+    const url = new URL(link.href);
+    if (url.protocol !== 'https:') return null;
+    return url.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchDomainSiteMetadata(domain: string, options: EnrichOptions): Promise<DomainSiteMetadata | null> {
+  const fetchImpl = options.fetch ?? fetch;
+  const { signal, cleanup } = withTimeoutSignal(options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(`https://${domain}/`, {
+      headers: { accept: 'text/html,application/xhtml+xml' },
+      signal,
+    });
+    if (!response.ok) return null;
+    const contentType = response.headers.get('content-type') ?? '';
+    if (contentType && !/\b(?:text\/html|application\/xhtml\+xml)\b/i.test(contentType)) {
+      return null;
+    }
+    const baseUrl = response.url && response.url.startsWith('https://') ? response.url : `https://${domain}/`;
+    return parseSiteMetadata(await readBodyWithLimit(response, MAX_DOMAIN_SITE_METADATA_BYTES), baseUrl);
+  } catch {
+    return null;
+  } finally {
+    cleanup();
+  }
+}
+
+async function getDomainSiteMetadata(domain: string, options: EnrichOptions): Promise<DomainSiteMetadata | null> {
+  const nowMs = options.nowMs ?? Date.now();
+  const successTtlMs = options.successTtlMs ?? DEFAULT_SUCCESS_TTL_MS;
+  const failureTtlMs = options.failureTtlMs ?? DEFAULT_FAILURE_TTL_MS;
+  const cached = metadataCache.get(domain);
+  if (cached) {
+    const ttlMs = cached.metadata ? successTtlMs : failureTtlMs;
+    if (nowMs - cached.fetchedAtMs < ttlMs) {
+      return cached.metadata;
+    }
+  }
+
+  const existing = metadataInFlight.get(domain);
+  if (existing) return existing;
+
+  const promise = fetchDomainSiteMetadata(domain, options)
+    .then((metadata) => {
+      metadataCache.set(domain, { fetchedAtMs: options.nowMs ?? Date.now(), metadata });
+      return metadata;
+    })
+    .finally(() => {
+      metadataInFlight.delete(domain);
+    });
+  metadataInFlight.set(domain, promise);
+  return promise;
+}
+
+export async function enrichDomainVerificationLinks(
+  links: PeerVerificationLink[],
+  options: EnrichOptions = {},
+): Promise<DesktopVerificationLink[]> {
+  return Promise.all(links.map(async (link) => {
+    const domain = domainFromVerificationLink(link);
+    if (!domain) return link;
+    const metadata = await getDomainSiteMetadata(domain, options);
+    return {
+      ...link,
+      ...(metadata ?? {}),
+    };
+  }));
+}

--- a/apps/desktop/src/main/pi-chat-engine.ts
+++ b/apps/desktop/src/main/pi-chat-engine.ts
@@ -71,8 +71,9 @@ import {
   type ChatServiceProtocol,
   type NetworkPeerAddress,
 } from './chat-service-catalog.js';
+import { enrichDomainVerificationLinks, type DesktopVerificationLink } from './domain-site-metadata.js';
 import { resolveChainConfig } from '@antseed/node';
-import { collectPeerVerificationLinks, type PeerVerificationLink } from '@antseed/node/discovery';
+import { collectPeerVerificationLinks } from '@antseed/node/discovery';
 import {
   AuthStorage,
   createAgentSession,
@@ -272,6 +273,7 @@ type DiscoverRowEntry = {
   sellerEvmAddress: string;
   sellerContract: string | null;
   verificationLinks: DiscoverVerificationLink[];
+  peerIconUrl: string | null;
   peerDisplayName: string | null;
   peerLabel: string;
   inputUsdPerMillion: number | null;
@@ -300,7 +302,7 @@ type DiscoverRowEntry = {
   selectionValue: string;
 };
 
-type DiscoverVerificationLink = PeerVerificationLink;
+type DiscoverVerificationLink = DesktopVerificationLink;
 
 const CHAT_SESSIONS_DIR = path.join(CHAT_DATA_DIR, 'sessions');
 const CHAT_AGENT_DIR = path.join(CHAT_DATA_DIR, 'pi-agent');
@@ -620,6 +622,7 @@ type BuyerStateDiscoveredPeer = {
   onChainSybilFlags: string[];
   sellerContract?: string;
   verificationLinks: DiscoverVerificationLink[];
+  peerIconUrl: string | null;
   providerPricing?: Record<string, { services?: Record<string, { cachedInputUsdPerMillion?: number }> }>;
 };
 
@@ -685,6 +688,7 @@ async function buildDiscoverRows(
       sellerEvmAddress,
       sellerContract: /^[0-9a-f]{40}$/.test(sellerHex) ? `0x${sellerHex}` : null,
       verificationLinks: peerBlob?.verificationLinks ?? [],
+      peerIconUrl: peerBlob?.peerIconUrl ?? null,
       peerDisplayName: entry.peerLabel?.split(' (')[0] ?? null,
       peerLabel: entry.peerLabel ?? peerId.slice(0, 12) + '...',
       inputUsdPerMillion: entry.inputUsdPerMillion ?? null,
@@ -2713,11 +2717,12 @@ export function registerPiChatHandlers({
         const raw = await readFile(DEFAULT_BUYER_STATE_PATH, 'utf-8');
         const parsed = JSON.parse(raw) as Record<string, unknown>;
         const arr = Array.isArray(parsed.discoveredPeers) ? parsed.discoveredPeers : [];
+        const enrichmentTasks: Array<Promise<void>> = [];
         for (const p of arr) {
           if (p && typeof p === 'object' && typeof (p as { peerId?: unknown }).peerId === 'string') {
             const rec = p as Record<string, unknown>;
             const peerId = rec.peerId as string;
-            discoveredPeersMap[peerId] = {
+            const peerRecord: BuyerStateDiscoveredPeer = {
               onChainAgentId: typeof rec.onChainAgentId === 'number' ? rec.onChainAgentId : null,
               onChainStakeUsdcMicros: typeof rec.onChainStakeUsdcMicros === 'number' ? rec.onChainStakeUsdcMicros : null,
               onChainChannelCount: typeof rec.onChainChannelCount === 'number' ? rec.onChainChannelCount : null,
@@ -2732,12 +2737,21 @@ export function registerPiChatHandlers({
                 : [],
               sellerContract: typeof rec.sellerContract === 'string' ? rec.sellerContract : undefined,
               verificationLinks: collectPeerVerificationLinks({ verificationResults: rec.verificationResults }),
+              peerIconUrl: null,
               providerPricing: rec.providerPricing as Record<string, {
                 services?: Record<string, { cachedInputUsdPerMillion?: number }>
               }> | undefined,
             };
+            discoveredPeersMap[peerId] = peerRecord;
+            enrichmentTasks.push(
+              enrichDomainVerificationLinks(peerRecord.verificationLinks).then((links) => {
+                peerRecord.verificationLinks = links;
+                peerRecord.peerIconUrl = links.find((link) => link.kind === 'domain' && link.faviconUrl)?.faviconUrl ?? null;
+              }),
+            );
           }
         }
+        await Promise.all(enrichmentTasks);
       } catch {
         // No state file yet
       }

--- a/apps/desktop/src/renderer/core/state.ts
+++ b/apps/desktop/src/renderer/core/state.ts
@@ -64,6 +64,7 @@ export type ChatServiceOptionEntry = {
   peerId: string;
   peerDisplayName: string | null;
   peerLabel: string;
+  peerIconUrl: string | null;
   inputUsdPerMillion: number | null;
   outputUsdPerMillion: number | null;
   cachedInputUsdPerMillion?: number | null;
@@ -75,6 +76,9 @@ export type DiscoverVerificationLink = {
   kind: 'domain' | 'github';
   label: string;
   href: string;
+  title?: string;
+  description?: string;
+  faviconUrl?: string;
 };
 
 export type DiscoverRow = {
@@ -99,6 +103,7 @@ export type DiscoverRow = {
    */
   sellerContract: string | null;
   verificationLinks: DiscoverVerificationLink[];
+  peerIconUrl: string | null;
   peerDisplayName: string | null;
   peerLabel: string;
 

--- a/apps/desktop/src/renderer/modules/chat.discover-rows.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.discover-rows.test.ts
@@ -19,6 +19,7 @@ test('normalizeDiscoverRow populates all numeric defaults to 0 / null', () => {
   assert.equal(row!.lifetimeSessions, 0);
   assert.equal(row!.stakeUsdc, '0');
   assert.equal(row!.cachedInputUsdPerMillion, null);
+  assert.equal(row!.peerIconUrl, null);
   assert.equal(row!.onChainReputationScore, null);
   assert.equal(row!.onChainSybilRisk, null);
   assert.deepEqual(row!.onChainSybilFlags, []);
@@ -42,24 +43,42 @@ test('normalizeDiscoverRow preserves safe verified external links only', () => {
   const row = normalizeDiscoverRow({
     peerId: 'abc123',
     serviceId: 'gpt-5',
+    peerIconUrl: 'https://example.com/favicon.ico',
     verificationLinks: [
-      { kind: 'domain', label: 'example.com', href: 'https://example.com' },
+      {
+        kind: 'domain',
+        label: 'example.com',
+        href: 'https://example.com',
+        title: ' Example Site ',
+        description: ' A verified domain. ',
+        faviconUrl: 'https://example.com/favicon.ico',
+      },
       { kind: 'github', label: '@antseed/test', href: 'https://github.com/antseed/test' },
+      { kind: 'domain', label: 'bad-icon', href: 'https://bad-icon.example', faviconUrl: 'http://bad-icon.example/favicon.ico' },
       { kind: 'domain', label: 'bad', href: 'http://example.com' },
       { kind: 'x', label: 'bad', href: 'https://example.com' },
     ],
   });
   assert.ok(row);
   assert.deepEqual(row!.verificationLinks, [
-    { kind: 'domain', label: 'example.com', href: 'https://example.com/' },
+    {
+      kind: 'domain',
+      label: 'example.com',
+      href: 'https://example.com/',
+      title: 'Example Site',
+      description: 'A verified domain.',
+      faviconUrl: 'https://example.com/favicon.ico',
+    },
     { kind: 'github', label: '@antseed/test', href: 'https://github.com/antseed/test' },
+    { kind: 'domain', label: 'bad-icon', href: 'https://bad-icon.example/' },
   ]);
+  assert.equal(row!.peerIconUrl, 'https://example.com/favicon.ico');
 });
 
 test('projectRowsToChatServiceOptions dedupes by (provider, service, peer)', () => {
   const rows = [
-    { rowKey: 'p1:s1', serviceId: 's1', serviceLabel: 's1', categories: [], provider: 'openai', protocol: 'openai-chat-completions', peerId: 'p1', peerEvmAddress: '', sellerContract: null, verificationLinks: [], peerDisplayName: null, peerLabel: '', inputUsdPerMillion: 1, outputUsdPerMillion: 2, cachedInputUsdPerMillion: null, lifetimeSessions: 0, lifetimeRequests: 0, lifetimeInputTokens: 0, lifetimeOutputTokens: 0, lifetimeFirstSessionAt: null, lifetimeLastSessionAt: null, onChainChannelCount: null, agentId: 1, stakeUsdc: '0', onChainActiveChannelCount: 0, onChainGhostCount: 0, onChainTotalVolumeUsdc: '0', onChainLastSettledAt: 0, onChainReputationScore: null, selectionValue: 'openai\u0001s1\u0001p1' },
-    { rowKey: 'p1:s1', serviceId: 's1', serviceLabel: 's1', categories: [], provider: 'openai', protocol: 'openai-chat-completions', peerId: 'p1', peerEvmAddress: '', sellerContract: null, verificationLinks: [], peerDisplayName: null, peerLabel: '', inputUsdPerMillion: 1, outputUsdPerMillion: 2, cachedInputUsdPerMillion: null, lifetimeSessions: 0, lifetimeRequests: 0, lifetimeInputTokens: 0, lifetimeOutputTokens: 0, lifetimeFirstSessionAt: null, lifetimeLastSessionAt: null, onChainChannelCount: null, agentId: 1, stakeUsdc: '0', onChainActiveChannelCount: 0, onChainGhostCount: 0, onChainTotalVolumeUsdc: '0', onChainLastSettledAt: 0, onChainReputationScore: null, selectionValue: 'openai\u0001s1\u0001p1' },
+    { rowKey: 'p1:s1', serviceId: 's1', serviceLabel: 's1', categories: [], provider: 'openai', protocol: 'openai-chat-completions', peerId: 'p1', peerEvmAddress: '', sellerContract: null, verificationLinks: [], peerIconUrl: null, peerDisplayName: null, peerLabel: '', inputUsdPerMillion: 1, outputUsdPerMillion: 2, cachedInputUsdPerMillion: null, lifetimeSessions: 0, lifetimeRequests: 0, lifetimeInputTokens: 0, lifetimeOutputTokens: 0, lifetimeFirstSessionAt: null, lifetimeLastSessionAt: null, onChainChannelCount: null, agentId: 1, stakeUsdc: '0', onChainActiveChannelCount: 0, onChainGhostCount: 0, onChainTotalVolumeUsdc: '0', onChainLastSettledAt: 0, onChainReputationScore: null, selectionValue: 'openai\u0001s1\u0001p1' },
+    { rowKey: 'p1:s1', serviceId: 's1', serviceLabel: 's1', categories: [], provider: 'openai', protocol: 'openai-chat-completions', peerId: 'p1', peerEvmAddress: '', sellerContract: null, verificationLinks: [], peerIconUrl: null, peerDisplayName: null, peerLabel: '', inputUsdPerMillion: 1, outputUsdPerMillion: 2, cachedInputUsdPerMillion: null, lifetimeSessions: 0, lifetimeRequests: 0, lifetimeInputTokens: 0, lifetimeOutputTokens: 0, lifetimeFirstSessionAt: null, lifetimeLastSessionAt: null, onChainChannelCount: null, agentId: 1, stakeUsdc: '0', onChainActiveChannelCount: 0, onChainGhostCount: 0, onChainTotalVolumeUsdc: '0', onChainLastSettledAt: 0, onChainReputationScore: null, selectionValue: 'openai\u0001s1\u0001p1' },
   ];
   const options = projectRowsToChatServiceOptions(rows);
   assert.equal(options.length, 1);
@@ -79,5 +98,6 @@ test('projectRowsToChatServiceOptions preserves peer display name and cached inp
   const [option] = projectRowsToChatServiceOptions([row!]);
   assert.equal(option.peerDisplayName, 'Friendly Peer');
   assert.equal(option.peerLabel, '0xabc123...');
+  assert.equal(option.peerIconUrl, null);
   assert.equal(option.cachedInputUsdPerMillion, 0.5);
 });

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1242,6 +1242,7 @@ export function initChatModule({
       peerId: entry.peerId,
       peerDisplayName: entry.peerDisplayName,
       peerLabel: entry.peerLabel,
+      peerIconUrl: null,
       inputUsdPerMillion: entry.inputUsdPerMillion,
       outputUsdPerMillion: entry.outputUsdPerMillion,
       categories: entry.categories,

--- a/apps/desktop/src/renderer/modules/discover-rows.ts
+++ b/apps/desktop/src/renderer/modules/discover-rows.ts
@@ -21,7 +21,35 @@ function normalizeVerificationLink(raw: unknown): DiscoverVerificationLink | nul
   try {
     const url = new URL(href);
     if (url.protocol !== 'https:') return null;
-    return { kind, label, href: url.toString() };
+    const title = typeof r.title === 'string' ? r.title.replace(/\s+/g, ' ').trim().slice(0, 120) : '';
+    const description = typeof r.description === 'string' ? r.description.replace(/\s+/g, ' ').trim().slice(0, 280) : '';
+    let faviconUrl = '';
+    if (typeof r.faviconUrl === 'string' && r.faviconUrl.trim().length > 0) {
+      try {
+        const iconUrl = new URL(r.faviconUrl.trim());
+        faviconUrl = iconUrl.protocol === 'https:' ? iconUrl.toString() : '';
+      } catch {
+        faviconUrl = '';
+      }
+    }
+    return {
+      kind,
+      label,
+      href: url.toString(),
+      ...(title ? { title } : {}),
+      ...(description ? { description } : {}),
+      ...(faviconUrl ? { faviconUrl } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function normalizeHttpsUrl(value: unknown): string | null {
+  if (typeof value !== 'string' || value.trim().length === 0) return null;
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === 'https:' ? url.toString() : null;
   } catch {
     return null;
   }
@@ -48,6 +76,7 @@ export function normalizeDiscoverRow(raw: unknown): DiscoverRow | null {
         .map(normalizeVerificationLink)
         .filter((link): link is DiscoverVerificationLink => link !== null)
       : [],
+    peerIconUrl: normalizeHttpsUrl(r.peerIconUrl),
     peerDisplayName: typeof r.peerDisplayName === 'string' ? r.peerDisplayName : null,
     peerLabel: String(r.peerLabel ?? ''),
     inputUsdPerMillion: typeof r.inputUsdPerMillion === 'number' ? r.inputUsdPerMillion : null,
@@ -100,6 +129,7 @@ export function projectRowsToChatServiceOptions(rows: DiscoverRow[]): ChatServic
       peerId: row.peerId,
       peerDisplayName: row.peerDisplayName,
       peerLabel: row.peerLabel,
+      peerIconUrl: row.peerIconUrl,
       inputUsdPerMillion: row.inputUsdPerMillion,
       outputUsdPerMillion: row.outputUsdPerMillion,
       cachedInputUsdPerMillion: row.cachedInputUsdPerMillion,

--- a/apps/desktop/src/renderer/ui/components/Sidebar.module.scss
+++ b/apps/desktop/src/renderer/ui/components/Sidebar.module.scss
@@ -435,6 +435,21 @@ $collapsed-nav-height: 45px;
   font-size: 8px;
   font-weight: 700;
   line-height: 1;
+  overflow: hidden;
+}
+
+.recent-session-avatar-icon {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+}
+
+.recent-session-avatar-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .recent-session-peer {

--- a/apps/desktop/src/renderer/ui/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/ui/components/Sidebar.tsx
@@ -244,6 +244,7 @@ function ConversationListRow({
   approvalConvIds,
   chatActiveChannels,
   peerDisplayNameById,
+  peerIconUrlById,
   onSelectConv,
   onCloseChannel,
   menuOpenId,
@@ -256,6 +257,7 @@ function ConversationListRow({
   approvalConvIds: ReadonlySet<string>;
   chatActiveChannels: Map<string, { reservedUsdc: string; peerName: string }>;
   peerDisplayNameById: ReadonlyMap<string, string>;
+  peerIconUrlById: ReadonlyMap<string, string>;
   onSelectConv: (id: string) => void;
   onCloseChannel: () => void;
   menuOpenId: string | null;
@@ -282,6 +284,9 @@ function ConversationListRow({
   const avatarGradient = convPeerId
     ? getPeerGradient(convPeerId)
     : 'linear-gradient(180deg, #9a9a96, #6b6b68)';
+  const avatarIconUrl = convPeerId ? peerIconUrlById.get(convPeerId) ?? null : null;
+  const [avatarIconFailed, setAvatarIconFailed] = useState(false);
+  const showAvatarIcon = Boolean(avatarIconUrl) && !avatarIconFailed;
 
   return (
     <div
@@ -312,8 +317,20 @@ function ConversationListRow({
         </div>
       </div>
       <div className={styles.recentSessionMeta}>
-        <span className={styles.recentSessionAvatar} style={{ background: avatarGradient }}>
-          {avatarLetter}
+        <span
+          className={`${styles.recentSessionAvatar}${showAvatarIcon ? ` ${styles.recentSessionAvatarIcon}` : ''}`}
+          style={showAvatarIcon ? undefined : { background: avatarGradient }}
+        >
+          {showAvatarIcon ? (
+            <img
+              className={styles.recentSessionAvatarImage}
+              src={avatarIconUrl ?? undefined}
+              alt=""
+              loading="lazy"
+              referrerPolicy="no-referrer"
+              onError={() => setAvatarIconFailed(true)}
+            />
+          ) : avatarLetter}
         </span>
         <span className={styles.recentSessionPeer}>{peerName}</span>
         {costLabel && <span className={`${styles.chatConvCost} ${styles.recentSessionCost}`}>{costLabel}</span>}
@@ -355,6 +372,7 @@ function ChatListSection({
   approvalConvIds,
   chatActiveChannels,
   peerDisplayNameById,
+  peerIconUrlById,
   onSelectConv,
   onCloseChannel,
   onOpenChatSearch,
@@ -371,6 +389,7 @@ function ChatListSection({
   approvalConvIds: ReadonlySet<string>;
   chatActiveChannels: Map<string, { reservedUsdc: string; peerName: string }>;
   peerDisplayNameById: ReadonlyMap<string, string>;
+  peerIconUrlById: ReadonlyMap<string, string>;
   onSelectConv: (id: string) => void;
   onCloseChannel: () => void;
   onOpenChatSearch: () => void;
@@ -426,6 +445,7 @@ function ChatListSection({
               approvalConvIds={approvalConvIds}
               chatActiveChannels={chatActiveChannels}
               peerDisplayNameById={peerDisplayNameById}
+              peerIconUrlById={peerIconUrlById}
               onSelectConv={onSelectConv}
               onCloseChannel={onCloseChannel}
               menuOpenId={menuOpenId}
@@ -627,6 +647,17 @@ function ChatSidebar({ onSelectView }: { onSelectView: (view: ViewName) => void 
     return map;
   }, [allConversations, discoverRows]);
 
+  const peerIconUrlById = useMemo(() => {
+    const map = new Map<string, string>();
+    const rows = Array.isArray(discoverRows) ? discoverRows : [];
+    for (const row of rows) {
+      const peerId = String(row.peerId || '').trim();
+      if (!peerId || map.has(peerId) || !row.peerIconUrl) continue;
+      map.set(peerId, row.peerIconUrl);
+    }
+    return map;
+  }, [discoverRows]);
+
   // Sort the full list — the row itself is scrollable, so we render every
   // conversation rather than slicing. "Recent" (touched in the last 24 h)
   // still floats to the top so the active workstream stays one glance away;
@@ -700,6 +731,7 @@ function ChatSidebar({ onSelectView }: { onSelectView: (view: ViewName) => void 
         approvalConvIds={approvalConvIds}
         chatActiveChannels={chatActiveChannels}
         peerDisplayNameById={peerDisplayNameById}
+        peerIconUrlById={peerIconUrlById}
         onSelectConv={handleSelectConv}
         onCloseChannel={handleCloseChannel}
         onOpenChatSearch={() => setChatSearchOpen(true)}

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.module.scss
@@ -191,6 +191,23 @@
   font-weight: 700;
   color: #fff;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.04);
+}
+
+.peer-avatar-icon {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  text-shadow: none;
+  padding: 0;
+}
+
+.peer-avatar-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .peer-label {

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverFilters.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { ContractsIcon } from '@hugeicons/core-free-icons';
 import type { DiscoverFilterState } from '../../hooks/useDiscoverFilters';
@@ -15,6 +15,28 @@ import styles from './DiscoverFilters.module.scss';
 type Props = {
   filters: DiscoverFilterState;
 };
+
+function PeerAvatar({ letter, gradient, iconUrl }: { letter: string; gradient: string; iconUrl: string | null }) {
+  const [iconFailed, setIconFailed] = useState(false);
+  const showIcon = Boolean(iconUrl) && !iconFailed;
+  return (
+    <span
+      className={`${styles.peerAvatar}${showIcon ? ` ${styles.peerAvatarIcon}` : ''}`}
+      style={showIcon ? undefined : { background: gradient }}
+    >
+      {showIcon ? (
+        <img
+          className={styles.peerAvatarImage}
+          src={iconUrl ?? undefined}
+          alt=""
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          onError={() => setIconFailed(true)}
+        />
+      ) : letter}
+    </span>
+  );
+}
 
 function formatPriceLabel(value: number, max: number): string {
   if (value >= max) return 'Any';
@@ -46,9 +68,7 @@ export const DiscoverFilters = memo(function DiscoverFilters({ filters }: Props)
                   aria-pressed={active}
                   title={p.peerId}
                 >
-                  <span className={styles.peerAvatar} style={{ background: p.gradient }}>
-                    {p.letter}
-                  </span>
+                  <PeerAvatar letter={p.letter} gradient={p.gradient} iconUrl={p.iconUrl} />
                   <span className={styles.peerLabel}>{p.label}</span>
                   {p.knownProxy && (
                     /* Icon-only identifier: this peer routes settlement through a

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
@@ -588,6 +588,23 @@
   font-weight: 700;
   color: #fff;
   line-height: 1;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.04);
+}
+
+.provider-avatar-icon {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  color: inherit;
+  padding: 0;
+}
+
+.provider-avatar-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .card-provider-name {
@@ -706,6 +723,12 @@
   &:focus-visible {
     color: var(--accent);
   }
+}
+
+.verification-description {
+  max-width: 240px;
+  color: var(--text-secondary);
+  line-height: 1.35;
 }
 
 /* ── Loading / empty states ─────────────────────────────────────────── */

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -55,6 +55,7 @@ type CardItem = {
   displayName: string;
   peerLabel: string;
   peerId: string;
+  peerIconUrl: string | null;
   value: string;
   provider: string;
   providerCount: number;
@@ -143,6 +144,7 @@ function buildCards(options: ChatServiceOptionEntry[]): CardItem[] {
       displayName: normalizeServiceName(rawName),
       peerLabel: opt.peerLabel || '',
       peerId: opt.peerId || '',
+      peerIconUrl: opt.peerIconUrl ?? null,
       value: opt.value,
       provider: opt.provider,
       providerCount: opt.count,
@@ -207,6 +209,7 @@ function buildCardsFromRows(rows: DiscoverRow[]): CardItem[] {
       displayName: normalizeServiceName(rawName),
       peerLabel,
       peerId: row.peerId,
+      peerIconUrl: row.peerIconUrl,
       value: row.selectionValue,
       provider: row.provider,
       providerCount: 1,
@@ -300,11 +303,25 @@ function SkeletonCard() {
 
 /* ── Provider avatar ─────────────────────────────────────────────────── */
 
-function ProviderAvatar({ name, gradient }: { name: string; gradient: string }) {
+function ProviderAvatar({ name, gradient, iconUrl }: { name: string; gradient: string; iconUrl?: string | null }) {
+  const [iconFailed, setIconFailed] = useState(false);
   const letter = (name || '?').charAt(0).toUpperCase();
+  const showIcon = Boolean(iconUrl) && !iconFailed;
   return (
-    <span className={styles.providerAvatar} style={{ background: gradient }}>
-      {letter}
+    <span
+      className={`${styles.providerAvatar}${showIcon ? ` ${styles.providerAvatarIcon}` : ''}`}
+      style={showIcon ? undefined : { background: gradient }}
+    >
+      {showIcon ? (
+        <img
+          className={styles.providerAvatarImage}
+          src={iconUrl ?? undefined}
+          alt=""
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          onError={() => setIconFailed(true)}
+        />
+      ) : letter}
     </span>
   );
 }
@@ -317,12 +334,16 @@ function verificationTitle(link: DiscoverVerificationLink): string {
 
 function VerificationLinkBadge({ link }: { link: DiscoverVerificationLink }) {
   const title = verificationTitle(link);
+  const hasDomainPreview = link.kind === 'domain' && (link.title || link.description);
   return (
     <InfoTooltip
       align="left"
       content={(
         <>
-          <strong>{title}</strong>
+          <strong>{hasDomainPreview ? (link.title ?? title) : title}</strong>
+          {link.kind === 'domain' && link.description && (
+            <span className={styles.verificationDescription}>{link.description}</span>
+          )}
           <span>{link.href}</span>
         </>
       )}
@@ -820,7 +841,7 @@ function Card({
       <div className={styles.cardFooter}>
         <div className={styles.cardFooterTop}>
           <div className={styles.cardProvider}>
-            <ProviderAvatar name={providerName} gradient={item.gradient} />
+            <ProviderAvatar name={providerName} gradient={item.gradient} iconUrl={item.peerIconUrl} />
             <span className={styles.cardProviderName}>{providerName}</span>
             <CardBadges item={item} />
           </div>

--- a/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.ts
+++ b/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.ts
@@ -14,6 +14,7 @@ export type DiscoverPeerOption = {
   label: string;
   letter: string;
   gradient: string;
+  iconUrl: string | null;
   /**
    * Metadata for a recognised on-chain seller-proxy contract (e.g. the DIEM
    * Staking Pool). Surfaced as a tiny contract icon next to the peer name in
@@ -105,7 +106,7 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
       const gradient = getPeerGradient(r.peerId || r.peerLabel || r.provider || r.serviceId);
       const letter = (label || '?').charAt(0).toUpperCase();
       seen.set(r.peerId, {
-        opt: { peerId: r.peerId, label, letter, gradient, knownProxy: getKnownProxy(r.sellerContract) },
+        opt: { peerId: r.peerId, label, letter, gradient, iconUrl: r.peerIconUrl, knownProxy: getKnownProxy(r.sellerContract) },
         score: rowReputationScore(r),
         label,
       });


### PR DESCRIPTION
## Description

Adds desktop-only metadata enrichment for verified peer domains so the app can fetch site titles, descriptions, and favicons without changing core discovery semantics. Discover cards, peer filters, and recent chat peer avatars now use verified-domain favicons when available, with existing generated avatars as fallback.

## Release Notes

- Desktop now shows verified domain favicons as peer icons in Discover and chat surfaces when available.
- Verified domain tooltips can include fetched site title and description metadata.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Validation

- `pnpm -C apps/desktop run build:main`
- `pnpm -C apps/desktop run typecheck:renderer`
- `pnpm -C apps/desktop run build:renderer`
- `node --test apps/desktop/dist/main/domain-site-metadata.test.js`
- `pnpm exec tsx --test apps/desktop/src/renderer/modules/chat.discover-rows.test.ts apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.test.ts`