### PR TITLE
fix(desktop): Show overflow tag tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project uses selective package publishing. Each release entry lists the pub
 - Fixed buyer response-auth timeout warnings for non-inference probes and sellers that do not advertise response-auth support.
 - Fixed buyer discovery so temporarily unreachable metadata endpoints are probed for recovery before the full exponential cooldown expires, allowing recovered peers to reappear in buyer peer lists sooner.
 - Fixed Desktop chats for peers that disappear from discovery so the header reports that the peer was not found and disables the composer instead of showing stale peer identifiers.
+- Fixed Desktop Discover overflow tag tooltips so the `+N` category indicator works on service cards in the first row.
 - Fixed `antseed seller emissions claim` so it only checks and claims seller rewards, leaving buyer rewards to the buyer command.
 
 ## 2026-06-15 — Buyer peer failure accounting and desktop stream responsiveness

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.module.scss
@@ -810,43 +810,7 @@
 }
 
 .tagMore {
-  position: relative;
   cursor: default;
-}
-
-.tagMoreTooltip {
-  position: absolute;
-  bottom: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
-  background: var(--bg-card);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  padding: 6px 10px;
-  opacity: 0;
-  pointer-events: none;
-  white-space: normal;
-  max-width: 220px;
-  transition: opacity 0.15s;
-  z-index: 10;
-  border: 1px solid var(--border-subtle, rgba(0, 0, 0, 0.08));
-  border-radius: 10px;
-  background: var(--bg-card);
-  color: var(--text-secondary);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
-  
-  :global(.dark-theme) {
-    .tooltip {
-      border-color: rgba(255, 255, 255, 0.08);
-      box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
-    }
-  }
-  
-}
-
-.tagMore:hover .tagMoreTooltip,
-.tagMore:focus-within .tagMoreTooltip {
-  opacity: 1;
 }
 
 @keyframes discover-drawer-in {

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -752,6 +752,8 @@ function Card({
     && (!hasCachedInput || item.cachedInputUsdPerMillion === 0);
   const lowReputation = isLowReputation(item.reputationScore);
   const reputationTooltip = formatReputationTooltip(item);
+  const hiddenTags = item.tags.slice(MAX_VISIBLE_CARD_TAGS);
+  const hiddenTagLabels = hiddenTags.map(formatCategoryLabel).join(', ');
 
   useEffect(() => {
     if (!copied) return undefined;
@@ -786,20 +788,26 @@ function Card({
           {item.tags.slice(0, MAX_VISIBLE_CARD_TAGS).map((t) => (
             <span key={t} className={styles.tag} style={getTagTint(t)}>{formatCategoryLabel(t)}</span>
           ))}
-          {item.tags.length > MAX_VISIBLE_CARD_TAGS && (
-            <span
-              className={`${styles.tag} ${styles.tagMore}`}
-              tabIndex={0}
-              aria-label={`${item.tags.length - MAX_VISIBLE_CARD_TAGS} more categories: `
-                + item.tags.slice(MAX_VISIBLE_CARD_TAGS).map(formatCategoryLabel).join(', ')}
-              onClick={(e) => e.stopPropagation()}
-              onKeyDown={(e) => e.stopPropagation()}
+          {hiddenTags.length > 0 && (
+            <InfoTooltip
+              align="left"
+              content={(
+                <>
+                  <strong>More categories</strong>
+                  <span>{hiddenTagLabels}</span>
+                </>
+              )}
             >
-              +{item.tags.length - MAX_VISIBLE_CARD_TAGS}
-              <span role="tooltip" className={styles.tagMoreTooltip}>
-                {item.tags.slice(MAX_VISIBLE_CARD_TAGS).map(formatCategoryLabel).join(', ')}
+              <span
+                className={`${styles.tag} ${styles.tagMore}`}
+                tabIndex={0}
+                aria-label={`${hiddenTags.length} more categories: ${hiddenTagLabels}`}
+                onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => e.stopPropagation()}
+              >
+                +{hiddenTags.length}
               </span>
-            </span>
+            </InfoTooltip>
           )}
         </div>
         <div className={styles.cardNameRow}>


### PR DESCRIPTION
## Description

Fixes the Discover service-card overflow tag popover so the `+N` indicator uses the shared fixed-position tooltip. This lets the hidden category list render consistently for cards in the first grid row as well as lower rows.

Closes #610.

## Release Notes

- Fixed Desktop Discover overflow tag tooltips so the `+N` category indicator works on service cards in the first row.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Verification:
- `pnpm --filter=@antseed/desktop run typecheck:renderer`
- `pnpm --filter=@antseed/desktop run build:renderer`