### PR TITLE
fix(desktop): Surface updater failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed Desktop auto-update failures so download and install errors appear in the title bar with copyable details, and fixed macOS Quit so the first menu action exits after cleanup instead of requiring a second click.
 - Fixed buyer response-auth timeout warnings for non-inference probes and sellers that do not advertise response-auth support.
 - Fixed buyer discovery so temporarily unreachable metadata endpoints are probed for recovery before the full exponential cooldown expires, allowing recovered peers to reappear in buyer peer lists sooner.
 - Fixed Desktop chats for peers that disappear from discovery so the header reports that the peer was not found and disables the composer instead of showing stale peer identifiers.

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1206,7 +1206,7 @@ app.whenReady().then(async () => {
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
-    void processManager.stopAll().finally(() => app.quit());
+    app.quit();
   }
 });
 
@@ -1218,17 +1218,15 @@ app.on('before-quit', (event) => {
   event.preventDefault();
   isQuitting = true;
 
-  void processManager.stopAll()
-    .then(() => stopPaymentsPortal())
-    .finally(() => {
-      app.quit();
-    });
+  void stopDesktopServices().finally(() => {
+    app.exit(0);
+  });
 });
 
 // Ensure child processes are cleaned up if the main process receives SIGTERM
 // (e.g. dev runner Ctrl+C kills Electron before before-quit fires).
 process.on('SIGTERM', () => {
-  void Promise.all([processManager.stopAll(), stopPaymentsPortal()]).finally(() => process.exit(0));
+  void stopDesktopServices().finally(() => process.exit(0));
 });
 
 // Suppress EPIPE errors from console.error/console.warn when the dev terminal

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -78,6 +78,16 @@ const DESKTOP_DEBUG_ENV = 'ANTSEED_DESKTOP_DEBUG';
 const DESKTOP_DEBUG_FLAGS = new Set(['--debug-runtime', '--desktop-debug']);
 const DEFAULT_BUYER_PROXY_PORT = 8377;
 
+type UpdateStatus =
+  | { status: 'downloading'; version: string; percent: number }
+  | { status: 'ready'; version: string }
+  | { status: 'installing'; version: string | null }
+  | { status: 'error'; version: string | null; message: string; details: string; hint?: string };
+
+type InstallUpdateResult =
+  | { ok: true }
+  | { ok: false; error: string; details: string; hint?: string };
+
 function isTruthyEnv(value: string | undefined): boolean {
   if (!value) {
     return false;
@@ -95,7 +105,43 @@ function hasDesktopDebugFlag(argv: string[]): boolean {
   return false;
 }
 
+function errorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === 'string' && error.trim()) return error.trim();
+  return 'Unknown updater error';
+}
+
+function errorDetails(error: unknown): string {
+  if (error instanceof Error) {
+    return error.stack || error.message || String(error);
+  }
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+function getMacUpdateInstallHint(): string | undefined {
+  if (process.platform !== 'darwin') return undefined;
+
+  const executablePath = process.execPath;
+  if (executablePath.includes('/AppTranslocation/')) {
+    return 'Quit AntSeed, move it to Applications, reopen, and try again.';
+  }
+  if (executablePath.startsWith('/Volumes/')) {
+    return 'Quit AntSeed, move it from the disk image to Applications, reopen, and try again.';
+  }
+  if (executablePath.includes('.app/') && !executablePath.startsWith('/Applications/')) {
+    return 'Quit AntSeed, move it to Applications, reopen, and try again.';
+  }
+  return undefined;
+}
+
 let desktopDebugEnabled = isTruthyEnv(process.env[DESKTOP_DEBUG_ENV]) || hasDesktopDebugFlag(process.argv);
+let isQuitting = false;
+let isInstallingUpdate = false;
 
 // The `antseed-attachment://` scheme must be registered as privileged
 // *before* `app.whenReady()` fires. The actual request handler is wired
@@ -330,6 +376,10 @@ async function stopPaymentsPortal(): Promise<void> {
     // Already closed
   }
   paymentsServer = null;
+}
+
+async function stopDesktopServices(): Promise<void> {
+  await Promise.all([processManager.stopAll(), stopPaymentsPortal()]);
 }
 
 ipcMain.handle('payments:open-portal', async (_event, tab?: string) => {
@@ -1042,6 +1092,11 @@ app.whenReady().then(async () => {
   let downloadStallInterval: ReturnType<typeof setInterval> | null = null;
   let lastDownloadProgressAt: number | null = null;
   let lastDownloadPercent = 0;
+  let updateVersion: string | null = null;
+
+  const sendUpdateStatus = (status: UpdateStatus) => {
+    getMainWindow()?.webContents.send('app:update-status', status);
+  };
 
   const clearStallWatchdog = () => {
     if (downloadStallInterval) {
@@ -1052,11 +1107,27 @@ app.whenReady().then(async () => {
     lastDownloadPercent = 0;
   };
 
+  const reportUpdateError = (error: unknown, context: string): InstallUpdateResult => {
+    const message = errorMessage(error);
+    const details = errorDetails(error);
+    const hint = getMacUpdateInstallHint();
+    console.error(`[auto-update] ${context}:`, details);
+    appendLog('connect', 'system', `Auto-update ${context}: ${message}`);
+    clearStallWatchdog();
+    if (isInstallingUpdate) {
+      isQuitting = false;
+    }
+    isInstallingUpdate = false;
+    sendUpdateStatus({ status: 'error', version: updateVersion, message, details, hint });
+    updateVersion = null;
+    return { ok: false, error: message, details, hint };
+  };
+
   const startStallWatchdog = () => {
     clearStallWatchdog();
     lastDownloadProgressAt = Date.now();
     downloadStallInterval = setInterval(() => {
-      if (!pendingUpdateVersion || lastDownloadProgressAt === null) return;
+      if (!updateVersion || lastDownloadProgressAt === null) return;
       // Once bytes are done electron-updater still spends time verifying the
       // file (sha512 / code-sign) and emits no progress — don't treat that as
       // a stall, just wait for update-downloaded.
@@ -1065,43 +1136,40 @@ app.whenReady().then(async () => {
       if (idleMs < DOWNLOAD_STALL_TIMEOUT_MS) return;
       console.warn(`[auto-update] download stalled (${Math.round(idleMs / 1000)}s with no progress) — retrying`);
       clearStallWatchdog();
-      pendingUpdateVersion = null;
+      updateVersion = null;
       void autoUpdater.checkForUpdates().catch((err) => {
-        console.error('[auto-update] stall-retry failed:', err?.message ?? err);
+        reportUpdateError(err, 'stall-retry failed');
       });
     }, DOWNLOAD_STALL_POLL_MS);
   };
 
-  let pendingUpdateVersion: string | null = null;
   autoUpdater.on('update-available', (info) => {
-    pendingUpdateVersion = info.version;
+    updateVersion = info.version;
     startStallWatchdog();
-    getMainWindow()?.webContents.send('app:update-status', { status: 'downloading', version: info.version, percent: 0 });
+    sendUpdateStatus({ status: 'downloading', version: info.version, percent: 0 });
   });
   autoUpdater.on('download-progress', (progress) => {
-    if (!pendingUpdateVersion) return;
+    if (!updateVersion) return;
     lastDownloadProgressAt = Date.now();
     const percent = Math.max(0, Math.min(100, Math.round(progress.percent ?? 0)));
     lastDownloadPercent = percent;
-    getMainWindow()?.webContents.send('app:update-status', {
+    sendUpdateStatus({
       status: 'downloading',
-      version: pendingUpdateVersion,
+      version: updateVersion,
       percent,
     });
   });
   autoUpdater.on('update-downloaded', (info) => {
-    pendingUpdateVersion = null;
+    updateVersion = info.version;
     clearStallWatchdog();
-    getMainWindow()?.webContents.send('app:update-status', { status: 'ready', version: info.version });
+    sendUpdateStatus({ status: 'ready', version: info.version });
     if (updateCheckInterval) {
       clearInterval(updateCheckInterval);
       updateCheckInterval = null;
     }
   });
   autoUpdater.on('error', (err) => {
-    console.error('[auto-update] error:', err?.message ?? err);
-    clearStallWatchdog();
-    pendingUpdateVersion = null;
+    reportUpdateError(err, 'error');
   });
 
   void autoUpdater.checkForUpdates().catch(() => {});
@@ -1110,8 +1178,23 @@ app.whenReady().then(async () => {
     void autoUpdater.checkForUpdates().catch(() => {});
   }, UPDATE_CHECK_INTERVAL_MS);
 
-  ipcMain.handle('app:install-update', () => {
-    autoUpdater.quitAndInstall(false, true);
+  ipcMain.handle('app:install-update', async (): Promise<InstallUpdateResult> => {
+    if (isInstallingUpdate) {
+      return { ok: true };
+    }
+
+    isInstallingUpdate = true;
+    sendUpdateStatus({ status: 'installing', version: updateVersion });
+
+    try {
+      await stopDesktopServices();
+      isQuitting = true;
+      autoUpdater.quitAndInstall(false, true);
+      return { ok: true };
+    } catch (err) {
+      isQuitting = false;
+      return reportUpdateError(err, 'install failed');
+    }
   });
 
   app.on('activate', () => {
@@ -1126,8 +1209,6 @@ app.on('window-all-closed', () => {
     void processManager.stopAll().finally(() => app.quit());
   }
 });
-
-let isQuitting = false;
 
 app.on('before-quit', (event) => {
   if (isQuitting) {

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -111,6 +111,16 @@ type PluginInstallResult = {
   error: string | null;
 };
 
+type UpdateStatus =
+  | { status: 'downloading'; version: string; percent: number }
+  | { status: 'ready'; version: string }
+  | { status: 'installing'; version: string | null }
+  | { status: 'error'; version: string | null; message: string; details: string; hint?: string };
+
+type InstallUpdateResult =
+  | { ok: true }
+  | { ok: false; error: string; details: string; hint?: string };
+
 type ChatPermissionMode = 'manual' | 'full';
 type ToolApprovalDecision = 'allow_once' | 'always_allow_peer' | 'deny';
 type ToolApprovalRequest = {
@@ -431,13 +441,13 @@ const api = {
   },
 
   // Auto-update
-  onUpdateStatus(handler: (data: { status: string; version: string }) => void): () => void {
-    const listener = (_: unknown, data: { status: string; version: string }) => handler(data);
+  onUpdateStatus(handler: (data: UpdateStatus) => void): () => void {
+    const listener = (_: unknown, data: UpdateStatus) => handler(data);
     ipcRenderer.on('app:update-status', listener);
     return () => ipcRenderer.off('app:update-status', listener);
   },
-  installUpdate(): Promise<void> {
-    return ipcRenderer.invoke('app:install-update') as Promise<void>;
+  installUpdate(): Promise<InstallUpdateResult> {
+    return ipcRenderer.invoke('app:install-update') as Promise<InstallUpdateResult>;
   },
   setDebugLogs(enabled: boolean): Promise<{ ok: true }> {
     return ipcRenderer.invoke('desktop:set-debug-logs', enabled) as Promise<{ ok: true }>;

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -73,6 +73,16 @@ export type PluginInstallResult = {
   error: string | null;
 };
 
+export type UpdateStatus =
+  | { status: 'downloading'; version: string; percent: number }
+  | { status: 'ready'; version: string }
+  | { status: 'installing'; version: string | null }
+  | { status: 'error'; version: string | null; message: string; details: string; hint?: string };
+
+export type InstallUpdateResult =
+  | { ok: true }
+  | { ok: false; error: string; details: string; hint?: string };
+
 export type ChatWorkspaceGitStatus = {
   available: boolean;
   rootPath: string | null;
@@ -236,6 +246,8 @@ export type DesktopBridge = {
   getAppSetupStatus?: () => Promise<{ needed: boolean; complete: boolean }>;
   onAppSetupStep?: (handler: (data: { step: string; label: string }) => void) => () => void;
   onAppSetupComplete?: (handler: () => void) => () => void;
+  onUpdateStatus?: (handler: (data: UpdateStatus) => void) => () => void;
+  installUpdate?: () => Promise<InstallUpdateResult>;
   setDebugLogs?: (enabled: boolean) => Promise<{ ok: true }>;
   creditsGetInfo?: () => Promise<{ ok: boolean; data: { evmAddress: string | null; operatorAddress: string | null; balanceUsdc: string; reservedUsdc: string; availableUsdc: string; creditLimitUsdc: string } | null; error: string | null }>;
 

--- a/apps/desktop/src/renderer/ui/components/TitleBar.module.scss
+++ b/apps/desktop/src/renderer/ui/components/TitleBar.module.scss
@@ -113,6 +113,108 @@
   }
 }
 
+.title-bar-update-badge-error {
+  background: rgba(var(--danger-rgb), 0.1);
+  border: 1px solid rgba(var(--danger-rgb), 0.35);
+  color: var(--danger);
+  cursor: pointer;
+
+  .title-bar-update-dot {
+    background: var(--danger);
+  }
+
+  &:hover {
+    background: rgba(var(--danger-rgb), 0.16);
+  }
+}
+
+.title-bar-update-error-wrap {
+  position: relative;
+}
+
+.title-bar-update-error-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 50%;
+  width: min(360px, calc(100vw - 32px));
+  transform: translateX(-50%);
+  padding: 12px;
+  background: var(--bg-primary);
+  border: 1px solid rgba(var(--danger-rgb), 0.28);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.16);
+  color: var(--text-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  white-space: normal;
+  text-align: left;
+  z-index: 220;
+
+  :global(body.dark-theme) & {
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
+  }
+
+  p {
+    margin: 0;
+    color: var(--text-secondary);
+    font-size: 12px;
+    line-height: 1.4;
+  }
+
+  pre {
+    margin: 0;
+    max-height: 120px;
+    overflow: auto;
+    padding: 8px;
+    border-radius: 6px;
+    background: var(--bg-hover);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    font-size: 11px;
+    line-height: 1.35;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+}
+
+.title-bar-update-error-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.title-bar-update-error-message {
+  color: var(--danger);
+  font-size: 12px;
+  line-height: 1.35;
+  word-break: break-word;
+}
+
+.title-bar-update-error-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+
+  button {
+    height: 26px;
+    padding: 0 9px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    background: var(--bg-primary);
+    color: var(--text-secondary);
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+
+    &:hover {
+      border-color: var(--border-strong);
+      color: var(--text-primary);
+      background: var(--bg-hover);
+    }
+  }
+}
+
 .title-bar-update-fill {
   position: absolute;
   top: 0;
@@ -311,4 +413,3 @@
     opacity: 0.85;
   }
 }
-

--- a/apps/desktop/src/renderer/ui/components/TitleBar.tsx
+++ b/apps/desktop/src/renderer/ui/components/TitleBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, type ReactNode } from 'react';
+import { useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Sun02Icon } from '@hugeicons/core-free-icons';
 import { Moon02Icon } from '@hugeicons/core-free-icons';
@@ -29,6 +29,8 @@ export function TitleBar() {
   >(null);
   const [errorDetailsOpen, setErrorDetailsOpen] = useState(false);
   const [detailsCopied, setDetailsCopied] = useState(false);
+  const updateErrorFromEventRef = useRef(false);
+  const updateErrorWrapRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (isDark) {
@@ -44,10 +46,12 @@ export function TitleBar() {
     if (!bridge?.onUpdateStatus) return;
     return bridge.onUpdateStatus((data) => {
       if (data.status === 'error') {
+        updateErrorFromEventRef.current = true;
         setErrorDetailsOpen(true);
         setUpdateState(data);
         return;
       }
+      updateErrorFromEventRef.current = false;
       setErrorDetailsOpen(false);
       setDetailsCopied(false);
       if (data.status === 'downloading') {
@@ -87,6 +91,10 @@ export function TitleBar() {
     try {
       const result = await bridge.installUpdate();
       if (!result.ok) {
+        if (updateErrorFromEventRef.current) {
+          updateErrorFromEventRef.current = false;
+          return;
+        }
         showUpdateError(result.error, result.details, result.hint);
       }
     } catch (err) {
@@ -150,6 +158,19 @@ export function TitleBar() {
     return () => document.removeEventListener('mousedown', handler);
   }, [creditsDropdownOpen]);
 
+  useEffect(() => {
+    if (!errorDetailsOpen || updateState?.status !== 'error') return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target;
+      if (!(target instanceof Node)) return;
+      if (!updateErrorWrapRef.current?.contains(target)) {
+        setErrorDetailsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [errorDetailsOpen, updateState?.status]);
+
   let updateControl: ReactNode = null;
   if (updateState?.status === 'ready') {
     updateControl = (
@@ -194,7 +215,7 @@ export function TitleBar() {
     );
   } else if (updateState?.status === 'error') {
     updateControl = (
-      <div className={styles.titleBarUpdateErrorWrap}>
+      <div className={styles.titleBarUpdateErrorWrap} ref={updateErrorWrapRef}>
         <button
           className={`${styles.titleBarUpdateBadge} ${styles.titleBarUpdateBadgeError}`}
           onClick={() => setErrorDetailsOpen((prev) => !prev)}

--- a/apps/desktop/src/renderer/ui/components/TitleBar.tsx
+++ b/apps/desktop/src/renderer/ui/components/TitleBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, type ReactNode } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import { Sun02Icon } from '@hugeicons/core-free-icons';
 import { Moon02Icon } from '@hugeicons/core-free-icons';
@@ -6,9 +6,11 @@ import { Button } from '@antseed/ui';
 import { AntStationLogo } from './AntStationLogo';
 import { useUiSnapshot } from '../hooks/useUiSnapshot';
 import { useActions } from '../hooks/useActions';
+import type { UpdateStatus } from '../../types/bridge';
 import styles from './TitleBar.module.scss';
 
 const THEME_STORAGE_KEY = 'antseed:theme';
+const DEFAULT_UPDATE_INSTALL_HINT = 'Quit AntSeed, reopen, and try again.';
 
 const CHAIN_LABELS: Record<string, string> = {
   'base-sepolia': 'Base Sepolia',
@@ -23,10 +25,10 @@ export function TitleBar() {
     return document.body.classList.contains('dark-theme');
   });
   const [updateState, setUpdateState] = useState<
-    | { status: 'downloading'; version: string; percent: number }
-    | { status: 'ready'; version: string }
-    | null
+    UpdateStatus | null
   >(null);
+  const [errorDetailsOpen, setErrorDetailsOpen] = useState(false);
+  const [detailsCopied, setDetailsCopied] = useState(false);
 
   useEffect(() => {
     if (isDark) {
@@ -38,25 +40,76 @@ export function TitleBar() {
   }, [isDark]);
 
   useEffect(() => {
-    const bridge = (window as unknown as { antseedDesktop?: { onUpdateStatus?: (h: (d: { status: string; version: string; percent?: number }) => void) => () => void } }).antseedDesktop;
+    const bridge = window.antseedDesktop;
     if (!bridge?.onUpdateStatus) return;
     return bridge.onUpdateStatus((data) => {
-      if (data.status === 'ready') {
-        setUpdateState({ status: 'ready', version: data.version });
-      } else if (data.status === 'downloading') {
-        const percent = typeof data.percent === 'number' ? data.percent : 0;
+      if (data.status === 'error') {
+        setErrorDetailsOpen(true);
+        setUpdateState(data);
+        return;
+      }
+      setErrorDetailsOpen(false);
+      setDetailsCopied(false);
+      if (data.status === 'downloading') {
         setUpdateState((prev) => {
           if (prev?.status === 'ready') return prev;
-          return { status: 'downloading', version: data.version, percent };
+          return data;
         });
+        return;
       }
+      setUpdateState(data);
     });
   }, []);
 
-  const handleUpdate = useCallback(() => {
-    const bridge = (window as unknown as { antseedDesktop?: { installUpdate?: () => Promise<void> } }).antseedDesktop;
-    void bridge?.installUpdate?.();
+  const showUpdateError = useCallback((message: string, details: string, hint?: string) => {
+    setUpdateState((prev) => ({
+      status: 'error',
+      version: prev?.version ?? null,
+      message,
+      details,
+      hint: hint ?? DEFAULT_UPDATE_INSTALL_HINT,
+    }));
+    setErrorDetailsOpen(true);
   }, []);
+
+  const handleUpdate = useCallback(async () => {
+    const bridge = window.antseedDesktop;
+    if (!bridge?.installUpdate) {
+      showUpdateError('Desktop updater is unavailable.', 'window.antseedDesktop.installUpdate is not available.');
+      return;
+    }
+
+    setUpdateState((prev) => {
+      if (prev?.status !== 'ready') return prev;
+      return { status: 'installing', version: prev.version };
+    });
+
+    try {
+      const result = await bridge.installUpdate();
+      if (!result.ok) {
+        showUpdateError(result.error, result.details, result.hint);
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Update failed to install.';
+      const details = err instanceof Error ? (err.stack || err.message) : String(err);
+      showUpdateError(message, details);
+    }
+  }, [showUpdateError]);
+
+  const handleCopyUpdateDetails = useCallback(() => {
+    if (updateState?.status !== 'error') return;
+    const detailText = [
+      `Message: ${updateState.message}`,
+      updateState.hint ? `Hint: ${updateState.hint}` : null,
+      `Details: ${updateState.details}`,
+    ].filter(Boolean).join('\n');
+    void navigator.clipboard.writeText(detailText).then(() => {
+      setDetailsCopied(true);
+      window.setTimeout(() => setDetailsCopied(false), 1500);
+    }).catch(() => {
+      setDetailsCopied(false);
+    });
+  }, [updateState]);
 
   const {
     creditsAvailableUsdc,
@@ -97,38 +150,90 @@ export function TitleBar() {
     return () => document.removeEventListener('mousedown', handler);
   }, [creditsDropdownOpen]);
 
+  let updateControl: ReactNode = null;
+  if (updateState?.status === 'ready') {
+    updateControl = (
+      <button
+        className={`${styles.titleBarUpdateBadge} ${styles.titleBarUpdateBadgeReady}`}
+        onClick={handleUpdate}
+        aria-label={`Install v${updateState.version} and restart`}
+        title={`Click to install v${updateState.version} and restart`}
+      >
+        <span className={styles.titleBarUpdateDot} />
+        Update to v{updateState.version}
+      </button>
+    );
+  } else if (updateState?.status === 'downloading') {
+    updateControl = (
+      <button
+        className={`${styles.titleBarUpdateBadge} ${styles.titleBarUpdateBadgeDownloading}`}
+        disabled
+        aria-label={`Downloading v${updateState.version} ${updateState.percent}%`}
+        title={`Downloading v${updateState.version} - ${updateState.percent}%`}
+      >
+        <span className={styles.titleBarUpdateFill} style={{ width: `${updateState.percent}%` }} aria-hidden="true" />
+        <span className={styles.titleBarUpdateLabel}>
+          <span className={styles.titleBarUpdateDot} />
+          Downloading v{updateState.version} · {updateState.percent}%
+        </span>
+      </button>
+    );
+  } else if (updateState?.status === 'installing') {
+    updateControl = (
+      <button
+        className={`${styles.titleBarUpdateBadge} ${styles.titleBarUpdateBadgeDownloading}`}
+        disabled
+        aria-label="Installing update and restarting"
+        title="Installing update and restarting"
+      >
+        <span className={styles.titleBarUpdateLabel}>
+          <span className={styles.titleBarUpdateDot} />
+          Installing update
+        </span>
+      </button>
+    );
+  } else if (updateState?.status === 'error') {
+    updateControl = (
+      <div className={styles.titleBarUpdateErrorWrap}>
+        <button
+          className={`${styles.titleBarUpdateBadge} ${styles.titleBarUpdateBadgeError}`}
+          onClick={() => setErrorDetailsOpen((prev) => !prev)}
+          aria-expanded={errorDetailsOpen}
+          aria-label="Update failed. Show details"
+          title={updateState.message}
+        >
+          <span className={styles.titleBarUpdateDot} />
+          Update failed
+        </button>
+        {errorDetailsOpen && (
+          <div className={styles.titleBarUpdateErrorPanel} role="alert">
+            <div className={styles.titleBarUpdateErrorTitle}>Update failed to install</div>
+            <p>{updateState.hint ?? DEFAULT_UPDATE_INSTALL_HINT}</p>
+            <div className={styles.titleBarUpdateErrorMessage}>{updateState.message}</div>
+            <pre>{updateState.details}</pre>
+            <div className={styles.titleBarUpdateErrorActions}>
+              <button type="button" onClick={handleCopyUpdateDetails}>
+                {detailsCopied ? 'Copied' : 'Copy details'}
+              </button>
+              <button type="button" onClick={() => setErrorDetailsOpen(false)}>
+                Dismiss
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <header className={styles.titleBar}>
       <div className={styles.titleBarLeft}>
         <AntStationLogo height={20} className={styles.titleBarLogo} />
       </div>
       <div className={styles.titleBarRight}>
-        {updateState && (
+        {updateControl && (
           <div className={styles.titleBarCenter}>
-            {updateState.status === 'ready' ? (
-              <button
-                className={`${styles.titleBarUpdateBadge} ${styles.titleBarUpdateBadgeReady}`}
-                onClick={handleUpdate}
-                aria-label={`Install v${updateState.version} and restart`}
-                title={`Click to install v${updateState.version} and restart`}
-              >
-                <span className={styles.titleBarUpdateDot} />
-                Update to v{updateState.version}
-              </button>
-            ) : (
-              <button
-                className={`${styles.titleBarUpdateBadge} ${styles.titleBarUpdateBadgeDownloading}`}
-                disabled
-                aria-label={`Downloading v${updateState.version} ${updateState.percent}%`}
-                title={`Downloading v${updateState.version} — ${updateState.percent}%`}
-              >
-                <span className={styles.titleBarUpdateFill} style={{ width: `${updateState.percent}%` }} aria-hidden="true" />
-                <span className={styles.titleBarUpdateLabel}>
-                  <span className={styles.titleBarUpdateDot} />
-                  Downloading v{updateState.version} · {updateState.percent}%
-                </span>
-              </button>
-            )}
+            {updateControl}
           </div>
         )}
         <div className={styles.titleBarCreditsWrapper}>


### PR DESCRIPTION
## Description

Surfaces Desktop auto-updater failures in the renderer instead of only logging them in the main process. Also fixes the macOS Quit menu flow so the first quit action exits after runtime cleanup instead of requiring a second click.

Fixes #604.

## Release Notes

- Fixed Desktop auto-update failures so download and install errors appear in the title bar with copyable details.
- Fixed macOS Quit so the first menu action exits after child process cleanup instead of requiring a second click.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Verification

- `pnpm -C apps/desktop run build:main`
- `pnpm -C apps/desktop run typecheck:renderer`
