### PR TITLE
feat(desktop): Add macOS tray icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- Added a macOS menu bar icon for Desktop with quick actions to show or quit AntSeed.
 - Added Desktop peer favicons from verified domains, showing fetched site icons in Discover and chat peer avatars when available.
 - Added zero-price free usage authorization for advertised free services, including buyer-signed P2P usage records, seller on-chain reporting through `AntseedFreeUsage`, and CLI configuration for the deployed free usage contract address.
 - Added a buyer-side metadata v2 service attribution opt-out for CLI and Desktop. Buyers can disable per-service attribution while preserving aggregate usage metadata in paid SpendingAuth and free-usage records.

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -52,6 +52,7 @@ import {
   type DashboardNetworkPeer,
 } from './peer-cache.js';
 import { createWindow, createApplicationMenu, getMainWindow } from './window.js';
+import { createDesktopTray } from './tray.js';
 import { ensureConfig, readConfig, mergeConfig, readNodeStatus } from './config-io.js';
 import { registerAttachmentScheme, installAttachmentProtocol } from './attachment-protocol.js';
 import { resolveAttachmentPath } from './attachment-store.js';
@@ -117,7 +118,23 @@ function resolveAppIconPath(): string | undefined {
   return undefined;
 }
 
+function resolveTrayIconPath(): string | undefined {
+  const candidates = [
+    path.resolve(__dirname, '../../assets/antseed-mark.png'),
+    path.resolve(process.cwd(), 'assets/antseed-mark.png'),
+    path.resolve(__dirname, '../../assets/antseed-dock-icon.png'),
+    path.resolve(process.cwd(), 'assets/antseed-dock-icon.png'),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
 const APP_ICON_PATH = resolveAppIconPath();
+const TRAY_ICON_PATH = resolveTrayIconPath();
 
 // Set app name as early as possible; on macOS dev runs may still show "Electron"
 // in some surfaces because the underlying bundle is Electron.app.
@@ -1006,7 +1023,18 @@ app.whenReady().then(async () => {
   // buyer runtime which needs config.json to find the router plugin.
   await ensureConfig(ACTIVE_CONFIG_PATH).catch(() => {});
 
-  createWindow({ appName: APP_NAME, appIconPath: APP_ICON_PATH, isDev, rendererUrl });
+  const showMainWindow = () => {
+    const existingWindow = getMainWindow();
+    if (existingWindow) {
+      existingWindow.show();
+      existingWindow.focus();
+      return;
+    }
+    createWindow({ appName: APP_NAME, appIconPath: APP_ICON_PATH, isDev, rendererUrl });
+  };
+
+  showMainWindow();
+  createDesktopTray({ appName: APP_NAME, iconPath: TRAY_ICON_PATH, onShow: showMainWindow });
 
   // Pre-load identity from encrypted store so it's ready before the first CLI spawn.
   void ensureSecureIdentity().catch(() => {
@@ -1116,7 +1144,7 @@ app.whenReady().then(async () => {
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
-      createWindow({ appName: APP_NAME, appIconPath: APP_ICON_PATH, isDev, rendererUrl });
+      showMainWindow();
     }
   });
 });

--- a/apps/desktop/src/main/tray.ts
+++ b/apps/desktop/src/main/tray.ts
@@ -1,0 +1,32 @@
+import { Menu, nativeImage, Tray } from 'electron';
+
+let tray: Tray | null = null;
+
+export type DesktopTrayOptions = {
+  appName: string;
+  iconPath: string | undefined;
+  onShow: () => void;
+};
+
+export function createDesktopTray({ appName, iconPath, onShow }: DesktopTrayOptions): void {
+  if (process.platform !== 'darwin' || tray || !iconPath) {
+    return;
+  }
+
+  const sourceImage = nativeImage.createFromPath(iconPath);
+  if (sourceImage.isEmpty()) {
+    return;
+  }
+
+  const image = sourceImage.resize({ width: 18, height: 18 });
+  image.setTemplateImage(true);
+
+  tray = new Tray(image);
+  tray.setToolTip(appName);
+  tray.setContextMenu(Menu.buildFromTemplate([
+    { label: `Show ${appName}`, click: onShow },
+    { type: 'separator' },
+    { role: 'quit', label: `Quit ${appName}` },
+  ]));
+  tray.on('click', onShow);
+}


### PR DESCRIPTION
## Description

Adds a macOS menu bar icon for AntSeed Desktop using the existing desktop mark as a template tray image. The menu bar item can restore/focus the Desktop window and exposes the standard Quit action.

## Release Notes

- Added a macOS menu bar icon for Desktop with quick actions to show or quit AntSeed.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Verification

- `pnpm -C packages/api-adapter run build`
- `pnpm -C packages/node run build`
- `pnpm -C apps/payments run build:server`
- `pnpm -C apps/desktop run build:main`
- `pnpm -C apps/desktop run typecheck:renderer`
