### PR TITLE
perf(desktop): Lazy-load renderer views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Changed
 
+- Changed Desktop renderer navigation to load only the active view, preload likely next views, and show a lightweight loading state while lazily loaded pages resolve.
 - Reduced the default buyer response-auth evidence sample rate from 20% to 0.5% to limit local `verification_samples` growth during high-request sessions.
 - Increased the default free-usage on-chain record flush interval from 10 seconds to 5 minutes to reduce background transaction frequency while preserving batch, disconnect, and shutdown flushes.
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,8 @@
     "build": "npm run build:main && npm run build:renderer",
     "build:main": "tsc -p tsconfig.main.json",
     "build:renderer": "vite build",
-    "test": "npm run build:main && node --test dist/main",
+    "test": "pnpm run build:main && node --test dist/main/*.test.js && pnpm run test:renderer",
+    "test:renderer": "vitest run --dir src/renderer",
     "typecheck:renderer": "tsc -p tsconfig.renderer.json --noEmit",
     "dev": "concurrently -k \"npm:dev:renderer\" \"npm:dev:main\" \"npm:dev:electron\"",
     "dev:debug": "concurrently -k \"npm:dev:renderer\" \"npm:dev:main\" \"npm:dev:electron:debug\"",
@@ -85,6 +86,7 @@
     "sass": "^1.97.3",
     "typescript": "^5.6.0",
     "vite": "^6.0.0",
+    "vitest": "^2.1.9",
     "wait-on": "^8.0.1"
   }
 }

--- a/apps/desktop/scripts/brand-electron-dev.mjs
+++ b/apps/desktop/scripts/brand-electron-dev.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 
 import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { existsSync, renameSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 const APP_NAME = 'AntSeed Desktop';
 const APP_BUNDLE_ID = 'com.antseed.desktop-dev';
+const require = createRequire(import.meta.url);
 
 function runPlistBuddy(plistPath, command) {
   execFileSync('/usr/libexec/PlistBuddy', ['-c', command, plistPath], {
@@ -30,7 +32,15 @@ function main() {
     process.exit(0);
   }
 
-  const distDir = path.resolve(process.cwd(), 'node_modules', 'electron', 'dist');
+  let electronPackageJson;
+  try {
+    electronPackageJson = require.resolve('electron/package.json', { paths: [process.cwd()] });
+  } catch {
+    process.exit(0);
+  }
+
+  const electronPackageDir = path.dirname(electronPackageJson);
+  const distDir = path.join(electronPackageDir, 'dist');
   const originalApp = path.join(distDir, 'Electron.app');
   const brandedApp = path.join(distDir, `${APP_NAME}.app`);
 
@@ -52,7 +62,7 @@ function main() {
   }
 
   // Update electron's path.txt so the `electron` CLI can find the renamed binary
-  const pathTxt = path.resolve(process.cwd(), 'node_modules', 'electron', 'path.txt');
+  const pathTxt = path.join(electronPackageDir, 'path.txt');
   writeFileSync(pathTxt, `${APP_NAME}.app/Contents/MacOS/Electron`, 'utf-8');
 }
 

--- a/apps/desktop/src/renderer/core/store.ts
+++ b/apps/desktop/src/renderer/core/store.ts
@@ -63,6 +63,10 @@ function getStateRef(): RendererUiState {
   return stateRef;
 }
 
+export function getUiStateRef(): RendererUiState {
+  return getStateRef();
+}
+
 export function getUiSnapshot(): RendererUiState {
   if (cachedSnapshot && cachedSnapshotVersion === version) {
     return cachedSnapshot;

--- a/apps/desktop/src/renderer/global.scss
+++ b/apps/desktop/src/renderer/global.scss
@@ -179,6 +179,27 @@ textarea {
   display: block;
 }
 
+.route-loading {
+  display: grid;
+  place-items: center;
+  background: var(--bg-primary);
+}
+
+.route-loading-spinner {
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--border-strong);
+  border-top-color: var(--accent-green);
+  border-radius: 50%;
+  animation: route-loading-spin 0.75s linear infinite;
+}
+
+@keyframes route-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .view-desktop.view {
   overflow: hidden;
 }

--- a/apps/desktop/src/renderer/modules/chat.discover-rows.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.discover-rows.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import { normalizeDiscoverRow, projectRowsToChatServiceOptions } from './discover-rows.js';
 

--- a/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
+++ b/apps/desktop/src/renderer/modules/chat.peer-routing.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 
 import { createInitialUiState } from '../core/state.js';
@@ -169,6 +169,82 @@ test('opening a conversation tracks the loading gap before peer binding is resto
 
   assert.equal(uiState.chatOpeningConversationId, null);
   assert.equal(uiState.chatSelectedPeerId, 'peer-a');
+});
+
+test('deleting a conversation removes it from the list before IPC settles', async () => {
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  uiState.chatConversations = [
+    {
+      id: 'conv-a',
+      title: 'Conversation A',
+      service: 'model-a',
+      provider: 'openai',
+      peerId: 'peer-a',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+    {
+      id: 'conv-b',
+      title: 'Conversation B',
+      service: 'model-b',
+      provider: 'openai',
+      peerId: 'peer-b',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      usage: { inputTokens: 0, outputTokens: 0 },
+    },
+  ];
+
+  const deletion = createDeferred<{ ok: boolean }>();
+  const bridge: DesktopBridge = {
+    chatAiDeleteConversation: async () => deletion.promise,
+    chatAiListConversations: async () => ({ ok: true, data: [uiState.chatConversations[0]] }),
+  };
+
+  const api = initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+  const deletePromise = api.deleteConversation('conv-b');
+
+  assert.deepEqual(
+    uiState.chatConversations.map((conv) => (conv as Conversation).id),
+    ['conv-a'],
+  );
+
+  deletion.resolve({ ok: true });
+  await deletePromise;
+});
+
+test('aborting a chat clears sending state before IPC settles', async () => {
+  installDomTimers();
+
+  const uiState = createInitialUiState();
+  uiState.chatActiveConversation = 'conv-a';
+  uiState.chatSending = true;
+  uiState.chatSendingConversationId = 'conv-a';
+  uiState.chatSendingConversationIds = ['conv-a'];
+  uiState.chatInputDisabled = true;
+  uiState.chatSendDisabled = true;
+  uiState.chatAbortVisible = true;
+
+  const abort = createDeferred<void>();
+  const bridge: DesktopBridge = {
+    chatAiAbort: async () => abort.promise,
+  };
+
+  const api = initChatModule({ bridge, uiState, appendSystemLog: () => undefined });
+  const abortPromise = api.abortChat();
+
+  assert.equal(uiState.chatSending, false);
+  assert.equal(uiState.chatSendingConversationId, null);
+  assert.deepEqual(uiState.chatSendingConversationIds, []);
+  assert.equal(uiState.chatInputDisabled, false);
+  assert.equal(uiState.chatSendDisabled, false);
+  assert.equal(uiState.chatAbortVisible, false);
+
+  abort.resolve();
+  await abortPromise;
 });
 
 test('new chat created while previous response is pending sends to its own peer', async () => {

--- a/apps/desktop/src/renderer/modules/chat.ts
+++ b/apps/desktop/src/renderer/modules/chat.ts
@@ -1937,26 +1937,41 @@ export function initChatModule({
     const convId = targetId || uiState.chatActiveConversation;
     if (!convId || !bridge || !bridge.chatAiDeleteConversation) return;
 
+    const previousConversations = Array.isArray(uiState.chatConversations)
+      ? [...uiState.chatConversations]
+      : [];
+    const nextConversations = previousConversations.filter((conv) => {
+      const candidate = conv as ChatConversationSummary;
+      return candidate.id !== convId;
+    });
+    if (nextConversations.length !== previousConversations.length) {
+      uiState.chatConversations = nextConversations;
+    }
+    localConversationMessages.delete(convId);
+    streamingMessagesByConversation.delete(convId);
+    sendingConversationIds.delete(convId);
+    streamTurnsByConversation.delete(convId);
+    streamStartedAtByConversation.delete(convId);
+    // Publish the updated sending set (and resync active-conv UI) before we
+    // potentially reset to new-chat state. This covers both the active and
+    // non-active delete paths.
+    syncActiveConversationSendingState();
+
+    // If we deleted the active conversation, reset to new-chat state immediately
+    // so the UI does not wait on IPC, storage, or attachment cleanup.
+    if (convId === uiState.chatActiveConversation) {
+      startNewChat();
+    } else {
+      notifyUiStateChanged();
+    }
+
     try {
       await bridge.chatAiDeleteConversation(convId);
-      localConversationMessages.delete(convId);
-      streamingMessagesByConversation.delete(convId);
-      sendingConversationIds.delete(convId);
-      streamTurnsByConversation.delete(convId);
-      streamStartedAtByConversation.delete(convId);
-      // Publish the updated sending set (and resync active-conv UI) before we
-      // potentially reset to new-chat state. This covers both the active and
-      // non-active delete paths.
-      syncActiveConversationSendingState();
-
-      // If we deleted the active conversation, reset to new-chat state
-      if (convId === uiState.chatActiveConversation) {
-        startNewChat();
-      }
-
-      notifyUiStateChanged();
       await refreshChatConversations();
     } catch (err) {
+      uiState.chatConversations = previousConversations;
+      notifyUiStateChanged();
+      void refreshChatConversations();
       reportChatError(err, 'Failed to delete conversation');
     }
   }
@@ -2339,13 +2354,13 @@ export function initChatModule({
 
   async function abortChat(): Promise<void> {
     const convId = uiState.chatActiveConversation;
-    if (bridge && bridge.chatAiAbort) {
-      await bridge.chatAiAbort(convId ?? undefined);
-    }
     if (convId) {
       setConversationSending(convId, false);
     } else {
       setChatSending(false);
+    }
+    if (bridge && bridge.chatAiAbort) {
+      await bridge.chatAiAbort(convId ?? undefined);
     }
   }
 

--- a/apps/desktop/src/renderer/ui/AppShell.tsx
+++ b/apps/desktop/src/renderer/ui/AppShell.tsx
@@ -1,23 +1,43 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState } from 'react';
 import { Sidebar } from './components/Sidebar';
 import { StreamingIndicator } from './components/StreamingIndicator';
 import { TitleBar } from './components/TitleBar';
 import { ViewHost } from './components/ViewHost';
-import { DiscoverWelcome } from './components/chat/DiscoverWelcome';
 import { SetupScreen } from './components/SetupScreen';
-import { useUiSnapshot } from './hooks/useUiSnapshot';
-import { useActions } from './hooks/useActions';
+import { preloadViews } from './components/viewRegistry';
+import { shallowEqual, useUiSelector } from './hooks/useUiSelector';
 import type { ViewName } from './types';
 
+type IdleCallbackHandle = ReturnType<typeof setTimeout> | number;
+
+function scheduleRoutePreload(callback: () => void): () => void {
+  const win = window as unknown as {
+    requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number;
+    cancelIdleCallback?: (handle: number) => void;
+  };
+
+  if (win.requestIdleCallback) {
+    const handle = win.requestIdleCallback(callback, { timeout: 1_500 });
+    return () => win.cancelIdleCallback?.(handle);
+  }
+
+  const handle: IdleCallbackHandle = window.setTimeout(callback, 250);
+  return () => window.clearTimeout(handle);
+}
+
 export function AppShell() {
-  const snap = useUiSnapshot();
-  const actions = useActions();
+  const snap = useUiSelector((state) => ({
+    appSetupStatusKnown: state.appSetupStatusKnown,
+    appSetupNeeded: state.appSetupNeeded,
+    appSetupComplete: state.appSetupComplete,
+    chatServiceCount: state.chatServiceOptions.length,
+    devMode: state.devMode,
+  }), shallowEqual);
   const [activeView, setActiveView] = useState<ViewName>('discover');
-  const [onboardingDismissed, setOnboardingDismissed] = useState(false);
   const [setupVisible, setSetupVisible] = useState(false);
   const [setupDismissed, setSetupDismissed] = useState(false);
 
-  const hasServices = snap.chatServiceOptions.length > 0;
+  const hasServices = snap.chatServiceCount > 0;
 
   // Show setup during first-run plugin/runtime bootstrapping, but never re-open it
   // just because the service catalog is temporarily empty. Service discovery is
@@ -62,55 +82,25 @@ export function AppShell() {
 
   const showSetup = setupVisible;
 
-  const hasConversations = Array.isArray(snap.chatConversations) && snap.chatConversations.length > 0;
-  const showOnboarding =
-    !onboardingDismissed &&
-    !hasConversations &&
-    !snap.chatActiveConversation &&
-    !snap.chatStreamingMessage &&
-    !snap.chatSending;
-
   useEffect(() => {
     if (!snap.devMode && (activeView === 'connection' || activeView === 'peers' || activeView === 'desktop')) {
       setActiveView('overview');
     }
   }, [activeView, snap.devMode]);
 
-  // Re-show onboarding if user deletes all conversations
   useEffect(() => {
-    if (hasConversations) setOnboardingDismissed(false);
-  }, [hasConversations]);
+    if (showSetup) return undefined;
 
-  const handleStartChatting = useCallback(
-    (serviceValue: string, peerId?: string) => {
-      actions.startNewChat();
-      actions.handleServiceChange(serviceValue, peerId);
-      setOnboardingDismissed(true);
-      setActiveView('chat');
-    },
-    [actions],
-  );
+    void preloadViews(['discover', 'chat']);
+
+    return scheduleRoutePreload(() => {
+      void preloadViews(['external-clients', 'config']);
+    });
+  }, [showSetup]);
 
   if (showSetup) {
     return <SetupScreen />;
   }
-
-  /* if (showOnboarding) {
-    return (
-      <>
-        <TitleBar />
-        <div className="app-container">
-          <main className="main-content">
-            <DiscoverWelcome
-              serviceOptions={snap.chatServiceOptions}
-              onStartChatting={handleStartChatting}
-            />
-          </main>
-        </div>
-        <StreamingIndicator />
-      </>
-    );
-  } */
 
   return (
     <>

--- a/apps/desktop/src/renderer/ui/components/SetupScreen.tsx
+++ b/apps/desktop/src/renderer/ui/components/SetupScreen.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import { AntStationStackedLogo } from './AntStationLogo';
 import { TitleBar } from './TitleBar';
-import { useUiSnapshot } from '../hooks/useUiSnapshot';
+import { shallowEqual, useUiSelector } from '../hooks/useUiSelector';
 import styles from './SetupScreen.module.scss';
 
 function CheckIcon() {
@@ -45,11 +45,16 @@ function StepRow({ label, done, active }: StepRowProps) {
 type ProgressLevel = 0 | 1 | 2 | 3;
 
 export function SetupScreen() {
-  const snap = useUiSnapshot();
+  const snap = useUiSelector((state) => ({
+    appSetupComplete: state.appSetupComplete,
+    appSetupStep: state.appSetupStep,
+    chatServiceCount: state.chatServiceOptions.length,
+    runtimeActivityMessage: state.runtimeActivity.message,
+  }), shallowEqual);
   const [level, setLevel] = useState<ProgressLevel>(0);
 
-  const hasServices = snap.chatServiceOptions.length > 0;
-  const msg = snap.runtimeActivity.message;
+  const hasServices = snap.chatServiceCount > 0;
+  const msg = snap.runtimeActivityMessage;
 
   // Advance progress level monotonically inside useEffect so mutations
   // only happen during the commit phase (safe in concurrent/strict mode).

--- a/apps/desktop/src/renderer/ui/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/ui/components/Sidebar.tsx
@@ -21,7 +21,8 @@ import { ComputerTerminal01Icon } from '@hugeicons/core-free-icons';
 import { DiscoverCircleIcon } from '@hugeicons/core-free-icons';
 import { getPeerGradient, getPeerDisplayName, formatCompactTokens } from '../../core/peer-utils';
 import type { ViewName } from '../types';
-import { useUiSnapshot } from '../hooks/useUiSnapshot';
+import { preloadView } from './viewRegistry';
+import { shallowEqual, useUiSelector } from '../hooks/useUiSelector';
 import { useActions } from '../hooks/useActions';
 import styles from './Sidebar.module.scss';
 
@@ -61,7 +62,7 @@ const RECENT_SESSION_WINDOW_MS = 24 * 60 * 60 * 1000;
 const RECENT_SESSION_CLOCK_MS = 60 * 1000;
 
 const SidebarWarning = memo(function SidebarWarning() {
-  const { connectWarning } = useUiSnapshot();
+  const connectWarning = useUiSelector((state) => state.connectWarning);
   if (!connectWarning) return null;
   return <p className={styles.sidebarWarning}>{connectWarning}</p>;
 });
@@ -600,7 +601,18 @@ function ChatSidebar({ onSelectView }: { onSelectView: (view: ViewName) => void 
     chatServiceOptions,
     chatSelectedServiceValue,
     chatSelectedPeerId,
-  } = useUiSnapshot();
+  } = useUiSelector((state) => ({
+    chatConversations: state.chatConversations,
+    chatActiveConversation: state.chatActiveConversation,
+    chatSendingConversationIds: state.chatSendingConversationIds,
+    chatToolApprovalRequests: state.chatToolApprovalRequests,
+    chatActiveChannels: state.chatActiveChannels,
+    chatActiveChannelCount: state.chatActiveChannels.size,
+    discoverRows: state.discoverRows,
+    chatServiceOptions: state.chatServiceOptions,
+    chatSelectedServiceValue: state.chatSelectedServiceValue,
+    chatSelectedPeerId: state.chatSelectedPeerId,
+  }), shallowEqual);
   const actions = useActions();
   const conversations = Array.isArray(chatConversations) ? chatConversations : EMPTY_CONVERSATIONS;
   const allConversations = conversations as ConvRecord[];
@@ -672,6 +684,7 @@ function ChatSidebar({ onSelectView }: { onSelectView: (view: ViewName) => void 
   }, [allConversations, recentNow]);
 
   const handleSelectConv = useCallback((id: string) => {
+    void preloadView('chat');
     void actions.openConversation(id);
     onSelectView('chat');
   }, [actions, onSelectView]);
@@ -714,6 +727,7 @@ function ChatSidebar({ onSelectView }: { onSelectView: (view: ViewName) => void 
   }, [actions]);
 
   const handleStartNewChatWithCurrentPeer = useCallback(() => {
+    void preloadView('chat');
     actions.startNewChat();
     if (newChatTarget) {
       actions.handleServiceChange(newChatTarget.serviceValue, newChatTarget.peerId);
@@ -768,10 +782,18 @@ type NavLayoutCache = {
 };
 
 export function Sidebar({ activeView, onSelectView }: SidebarProps) {
-  const { devMode } = useUiSnapshot();
+  const devMode = useUiSelector((state) => state.devMode);
   const navEntries = [...baseEntries, ...configEntries];
   const sidebarRef = useRef<HTMLElement | null>(null);
   const navRef = useRef<HTMLUListElement | null>(null);
+  const handleSelectView = useCallback((view: ViewName) => {
+    void preloadView(view);
+    onSelectView(view);
+  }, [onSelectView]);
+
+  const handlePreloadView = useCallback((view: ViewName) => {
+    void preloadView(view);
+  }, []);
 
   // Per-button refs. We hand both the icon-wrapper span and the label
   // span their own refs so the scroll-driven interpolation can write
@@ -997,7 +1019,10 @@ export function Sidebar({ activeView, onSelectView }: SidebarProps) {
                 data-view={view}
                 role="tab"
                 aria-selected={isActive ? 'true' : 'false'}
-                onClick={() => onSelectView(view)}
+                onPointerEnter={() => handlePreloadView(view)}
+                onFocus={() => handlePreloadView(view)}
+                onPointerDown={() => handlePreloadView(view)}
+                onClick={() => handleSelectView(view)}
                 title={label}
               >
                 <span
@@ -1039,7 +1064,10 @@ export function Sidebar({ activeView, onSelectView }: SidebarProps) {
                     data-view={view}
                     role="tab"
                     aria-selected={isActive ? 'true' : 'false'}
-                    onClick={() => onSelectView(view)}
+                    onPointerEnter={() => handlePreloadView(view)}
+                    onFocus={() => handlePreloadView(view)}
+                    onPointerDown={() => handlePreloadView(view)}
+                    onClick={() => handleSelectView(view)}
                   >
                     <HugeiconsIcon icon={icon} size={16} strokeWidth={1.5} />
                     {label}

--- a/apps/desktop/src/renderer/ui/components/StreamingIndicator.tsx
+++ b/apps/desktop/src/renderer/ui/components/StreamingIndicator.tsx
@@ -1,11 +1,15 @@
 import { useState, useEffect } from 'react';
-import { useUiSnapshot } from '../hooks/useUiSnapshot';
+import { shallowEqual, useUiSelector } from '../hooks/useUiSelector';
 import styles from './StreamingIndicator.module.scss';
 
 declare const __APP_VERSION__: string;
 
 export function StreamingIndicator() {
-  const { chatStreamingIndicatorText, chatStreamingActive, runtimeActivity } = useUiSnapshot();
+  const { chatStreamingIndicatorText, chatStreamingActive, runtimeActivity } = useUiSelector((state) => ({
+    chatStreamingIndicatorText: state.chatStreamingIndicatorText,
+    chatStreamingActive: state.chatStreamingActive,
+    runtimeActivity: state.runtimeActivity,
+  }), shallowEqual);
   const [appVersion, setAppVersion] = useState<string>(typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '');
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/ui/components/TitleBar.tsx
+++ b/apps/desktop/src/renderer/ui/components/TitleBar.tsx
@@ -4,17 +4,11 @@ import { Sun02Icon } from '@hugeicons/core-free-icons';
 import { Moon02Icon } from '@hugeicons/core-free-icons';
 import { Button } from '@antseed/ui';
 import { AntStationLogo } from './AntStationLogo';
-import { useUiSnapshot } from '../hooks/useUiSnapshot';
+import { shallowEqual, useUiSelector } from '../hooks/useUiSelector';
 import { useActions } from '../hooks/useActions';
 import styles from './TitleBar.module.scss';
 
 const THEME_STORAGE_KEY = 'antseed:theme';
-
-const CHAIN_LABELS: Record<string, string> = {
-  'base-sepolia': 'Base Sepolia',
-  'base-mainnet': 'Base Mainnet',
-  'base-local': 'Local',
-};
 
 export function TitleBar() {
   const [isDark, setIsDark] = useState(() => {
@@ -63,13 +57,14 @@ export function TitleBar() {
     creditsReservedUsdc,
     creditsOperatorAddress,
     creditsEvmAddress,
-    configFormData,
-  } = useUiSnapshot();
+  } = useUiSelector((state) => ({
+    creditsAvailableUsdc: state.creditsAvailableUsdc,
+    creditsReservedUsdc: state.creditsReservedUsdc,
+    creditsOperatorAddress: state.creditsOperatorAddress,
+    creditsEvmAddress: state.creditsEvmAddress,
+  }), shallowEqual);
   const actions = useActions();
   const [creditsDropdownOpen, setCreditsDropdownOpen] = useState(false);
-
-  const chainId = configFormData?.cryptoChainId || 'base-mainnet';
-  const chainLabel = CHAIN_LABELS[chainId] ?? chainId;
 
   const creditsDisplay = parseFloat(creditsAvailableUsdc) > 0
     ? `$${parseFloat(creditsAvailableUsdc).toFixed(2)}`

--- a/apps/desktop/src/renderer/ui/components/ViewHost.tsx
+++ b/apps/desktop/src/renderer/ui/components/ViewHost.tsx
@@ -1,29 +1,33 @@
+import { Suspense } from 'react';
 import type { ViewName } from '../types';
-import { ChatView } from './views/ChatView';
-import { ConfigView } from './views/ConfigView';
-import { ConnectionView } from './views/ConnectionView';
-import { DesktopView } from './views/DesktopView';
-import { DiscoverView } from './views/DiscoverView';
-import { ExternalClientsView } from './views/ExternalClientsView';
-import { OverviewView } from './views/OverviewView';
-import { PeersView } from './views/PeersView';
+import { getViewRegistryEntry } from './viewRegistry';
 
 type ViewHostProps = {
   activeView: ViewName;
   onSelectView: (view: ViewName) => void;
 };
 
+function ViewLoadingFallback() {
+  return (
+    <div className="view active route-loading" role="status" aria-live="polite" aria-label="Loading view">
+      <span className="route-loading-spinner" aria-hidden="true" />
+    </div>
+  );
+}
+
 export function ViewHost({ activeView, onSelectView }: ViewHostProps) {
+  const { component: ActiveView, receivesOnSelectView } = getViewRegistryEntry(activeView);
+
   return (
     <section className="view-host">
-      <OverviewView active={activeView === 'overview'} />
-      <PeersView active={activeView === 'peers'} />
-      <ChatView active={activeView === 'chat'} onSelectView={onSelectView} />
-      <ConnectionView active={activeView === 'connection'} />
-      <ConfigView active={activeView === 'config'} />
-      <DesktopView active={activeView === 'desktop'} />
-      <ExternalClientsView active={activeView === 'external-clients'} />
-      <DiscoverView active={activeView === 'discover'} onSelectView={onSelectView} />
+      <Suspense fallback={<ViewLoadingFallback />}>
+        <ActiveView
+          // ViewHost only mounts the active page; legacy view-level `active`
+          // effects can keep using the prop as an always-true invariant.
+          active={true}
+          {...(receivesOnSelectView ? { onSelectView } : {})}
+        />
+      </Suspense>
     </section>
   );
 }

--- a/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/DiscoverWelcome.tsx
@@ -5,7 +5,7 @@ import { Copy01Icon, Tick02Icon, ContractsIcon, GithubIcon, Globe02Icon } from '
 import Skeleton from 'react-loading-skeleton';
 import 'react-loading-skeleton/dist/skeleton.css';
 import type { ChatServiceOptionEntry, DiscoverRow, DiscoverVerificationLink } from '../../../core/state';
-import { useUiSnapshot } from '../../hooks/useUiSnapshot';
+import { useUiSelector } from '../../hooks/useUiSelector';
 import { useDiscoverFilters } from '../../hooks/useDiscoverFilters';
 import {
   type DiscoverSortKey,
@@ -465,8 +465,7 @@ function buildPaginationTokens(page: number, totalPages: number): PaginationToke
 }
 
 export function DiscoverWelcome({ serviceOptions, onStartChatting }: DiscoverWelcomeProps) {
-  const snap = useUiSnapshot();
-  const rows = snap.discoverRows;
+  const rows = useUiSelector((state) => state.discoverRows);
 
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(() => estimatePageSize());

--- a/apps/desktop/src/renderer/ui/components/chat/SessionApprovalCard.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/SessionApprovalCard.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Card } from '@antseed/ui';
-import { useUiSnapshot } from '../../hooks/useUiSnapshot';
+import { useUiSelector } from '../../hooks/useUiSelector';
 import styles from './SessionApprovalCard.module.scss';
 
 type SessionApprovalCardProps = {
@@ -29,7 +29,7 @@ export function SessionApprovalCard({
   onRetry,
   onCancel,
 }: SessionApprovalCardProps) {
-  const { creditsAvailableUsdc } = useUiSnapshot();
+  const creditsAvailableUsdc = useUiSelector((state) => state.creditsAvailableUsdc);
   const balance = parseFloat(creditsAvailableUsdc);
   const required = parseFloat(amount || '0');
   const hasCredits = balance > 0 && balance >= required;

--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.test.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import {
   matchesSearch, matchesMaxInputPrice, matchesMaxOutputPrice,

--- a/apps/desktop/src/renderer/ui/components/viewRegistry.test.ts
+++ b/apps/desktop/src/renderer/ui/components/viewRegistry.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { VIEW_NAMES, type ViewName } from '../types';
+import { getViewRegistryEntry, preloadView, preloadViews, VIEW_REGISTRY } from './viewRegistry';
+
+describe('view registry', () => {
+  it('registers exactly one lazy component for every known view', () => {
+    expect(Object.keys(VIEW_REGISTRY).sort()).toEqual([...VIEW_NAMES].sort());
+
+    for (const view of VIEW_NAMES) {
+      const entry = getViewRegistryEntry(view);
+      expect(entry.component).toBe(VIEW_REGISTRY[view].component);
+      expect(typeof entry.preload).toBe('function');
+      expect(typeof entry.receivesOnSelectView).toBe('boolean');
+    }
+  });
+
+  it('passes navigation callbacks only to views that need to change pages', () => {
+    const navigationViews = VIEW_NAMES.filter((view) => getViewRegistryEntry(view).receivesOnSelectView);
+
+    expect(navigationViews).toEqual(['chat', 'discover'] satisfies ViewName[]);
+  });
+
+  it('reuses the same preload promise for repeated preload requests', () => {
+    const entry = getViewRegistryEntry('connection');
+
+    expect(entry.preload()).toBe(entry.preload());
+  });
+
+  it('can preload multiple views through the public helper', async () => {
+    const loaded = await preloadViews(['connection']);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toBe(await preloadView('connection'));
+  });
+});

--- a/apps/desktop/src/renderer/ui/components/viewRegistry.ts
+++ b/apps/desktop/src/renderer/ui/components/viewRegistry.ts
@@ -1,0 +1,78 @@
+import { lazy } from 'react';
+import type { ComponentType, LazyExoticComponent } from 'react';
+import type { ViewName } from '../types';
+
+export type RoutedViewProps = {
+  active: boolean;
+  onSelectView?: (view: ViewName) => void;
+};
+
+export type ViewRegistryEntry = {
+  component: LazyExoticComponent<ComponentType<RoutedViewProps>>;
+  preload: () => Promise<ComponentType<RoutedViewProps>>;
+  receivesOnSelectView: boolean;
+};
+
+function createViewEntry(
+  loader: () => Promise<ComponentType<RoutedViewProps>>,
+  receivesOnSelectView: boolean,
+): ViewRegistryEntry {
+  let loadPromise: Promise<ComponentType<RoutedViewProps>> | null = null;
+  const preload = () => {
+    loadPromise ??= loader();
+    return loadPromise;
+  };
+
+  return {
+    component: lazy(async () => ({ default: await preload() })),
+    preload,
+    receivesOnSelectView,
+  };
+}
+
+export const VIEW_REGISTRY = {
+  chat: createViewEntry(
+    async () => (await import('./views/ChatView')).ChatView as ComponentType<RoutedViewProps>,
+    true,
+  ),
+  overview: createViewEntry(
+    async () => (await import('./views/OverviewView')).OverviewView as ComponentType<RoutedViewProps>,
+    false,
+  ),
+  peers: createViewEntry(
+    async () => (await import('./views/PeersView')).PeersView as ComponentType<RoutedViewProps>,
+    false,
+  ),
+  connection: createViewEntry(
+    async () => (await import('./views/ConnectionView')).ConnectionView as ComponentType<RoutedViewProps>,
+    false,
+  ),
+  config: createViewEntry(
+    async () => (await import('./views/ConfigView')).ConfigView as ComponentType<RoutedViewProps>,
+    false,
+  ),
+  desktop: createViewEntry(
+    async () => (await import('./views/DesktopView')).DesktopView as ComponentType<RoutedViewProps>,
+    false,
+  ),
+  'external-clients': createViewEntry(
+    async () => (await import('./views/ExternalClientsView')).ExternalClientsView as ComponentType<RoutedViewProps>,
+    false,
+  ),
+  discover: createViewEntry(
+    async () => (await import('./views/DiscoverView')).DiscoverView as ComponentType<RoutedViewProps>,
+    true,
+  ),
+} satisfies Record<ViewName, ViewRegistryEntry>;
+
+export function getViewRegistryEntry(view: ViewName): ViewRegistryEntry {
+  return VIEW_REGISTRY[view];
+}
+
+export function preloadView(view: ViewName): Promise<ComponentType<RoutedViewProps>> {
+  return getViewRegistryEntry(view).preload();
+}
+
+export function preloadViews(views: readonly ViewName[]): Promise<unknown[]> {
+  return Promise.all(views.map((view) => preloadView(view)));
+}

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -358,7 +358,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const fileInputId = useId();
   const lastConversationIdRef = useRef<string | null>(snap.chatActiveConversation);
-  const wasActiveRef = useRef<boolean>(active);
+  const wasActiveRef = useRef<boolean>(false);
   const isUserScrolledUp = useRef(false);
   const isDragging = useRef(false);
   const permissionMenuRef = useRef<HTMLDivElement>(null);

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -17,8 +17,9 @@ import {
   Shield01Icon,
   Tick02Icon
 } from '@hugeicons/core-free-icons';
-import { useUiSnapshot } from '../../hooks/useUiSnapshot';
+import { shallowEqual, useUiSelector } from '../../hooks/useUiSelector';
 import { useActions } from '../../hooks/useActions';
+import { useRetainedState } from '../../hooks/useRetainedState';
 import { ChatBubble } from '../chat/ChatBubble';
 import { hasSearchPhraseMatch, isToolResultOnlyMessage } from '../chat/chat-utils.js';
 import { WalkingAnt } from '../chat/WalkingAnt';
@@ -37,13 +38,12 @@ import type { ChatPermissionMode, ChatWorkspaceGitStatus, RawChatAttachment } fr
 import { getPeerDisplayName } from '../../../core/peer-utils';
 import { AntStationStackedLogo } from '../AntStationLogo';
 import { cancelVoiceRecording, startVoiceRecording, stopVoiceRecording } from '../../lib/voice-recorder';
+import styles from './ChatView.module.scss';
+import bubbleStyles from '../chat/ChatBubble.module.scss';
 
 const SWITCH_DIALOG_DISMISSED_KEY = 'antseed:switchServiceConfirmDismissed';
 const SWITCH_TOOLTIP_DISMISSED_KEY = 'antseed:serviceSwitchTooltipDismissed';
 const LOW_REPUTATION_SCORE_THRESHOLD = 50;
-
-import styles from './ChatView.module.scss';
-import bubbleStyles from '../chat/ChatBubble.module.scss';
 
 const MAX_INPUT_HEIGHT = 220;
 const PREVIEW_MIN_WIDTH = 280;
@@ -202,45 +202,142 @@ type ChatViewProps = {
   onSelectView?: (view: import('../../types').ViewName) => void;
 };
 
+type PendingDraft = {
+  id: string;
+  conversationId: string | null;
+  text: string;
+  attachments: RawChatAttachment[];
+};
+
+type ChatViewCache = {
+  inputValue: string;
+  attachedFiles: RawChatAttachment[];
+  attachmentError: string | null;
+  attachmentWarning: string | null;
+  voiceError: string | null;
+  voiceState: 'idle' | 'recording' | 'transcribing';
+  voiceElapsedMs: number;
+  isDragOver: boolean;
+  previewOpen: boolean;
+  previewFraction: number;
+  previewTargetUrl: string | null;
+  switchDialogOpen: boolean;
+  pendingSwitchValue: string | null;
+  messageSearchOpen: boolean;
+  messageSearchQuery: string;
+  selectedSearchIndex: number;
+  lowReputationDialogOpen: boolean;
+  pendingLowReputationSend: { text: string; attachments: RawChatAttachment[] } | null;
+  pendingQueue: PendingDraft[];
+  previewAttachment: ViewerAttachment | null;
+  permissionMenuOpen: boolean;
+  isNearBottom: boolean;
+  hasNewActivityWhileScrolledUp: boolean;
+  approvedLowReputationPeers: Set<string>;
+};
+
+// Renderer-lifetime cache: lazy navigation unmounts ChatView, but drafts and
+// transient composer state should survive until the app process exits.
+const chatViewCache: ChatViewCache = {
+  inputValue: '',
+  attachedFiles: [],
+  attachmentError: null,
+  attachmentWarning: null,
+  voiceError: null,
+  voiceState: 'idle',
+  voiceElapsedMs: 0,
+  isDragOver: false,
+  previewOpen: false,
+  previewFraction: DEFAULT_PREVIEW_FRACTION,
+  previewTargetUrl: null,
+  switchDialogOpen: false,
+  pendingSwitchValue: null,
+  messageSearchOpen: false,
+  messageSearchQuery: '',
+  selectedSearchIndex: 0,
+  lowReputationDialogOpen: false,
+  pendingLowReputationSend: null,
+  pendingQueue: [],
+  previewAttachment: null,
+  permissionMenuOpen: false,
+  isNearBottom: true,
+  hasNewActivityWhileScrolledUp: false,
+  approvedLowReputationPeers: new Set(),
+};
+
 export function ChatView({ active, onSelectView }: ChatViewProps) {
-  const snap = useUiSnapshot();
+  const snap = useUiSelector((state) => ({
+    browserPreviewRequestId: state.browserPreviewRequestId,
+    browserPreviewUrl: state.browserPreviewUrl,
+    chatAbortVisible: state.chatAbortVisible,
+    chatActiveConversation: state.chatActiveConversation,
+    chatConversations: state.chatConversations,
+    chatConversationsLoaded: state.chatConversationsLoaded,
+    chatDiscoverRowsLoaded: state.chatDiscoverRowsLoaded,
+    chatError: state.chatError,
+    chatInputDisabled: state.chatInputDisabled,
+    chatLifetimeSpentUsdc: state.chatLifetimeSpentUsdc,
+    chatLifetimeTotalTokens: state.chatLifetimeTotalTokens,
+    chatLowBalanceWarning: state.chatLowBalanceWarning,
+    chatMessages: state.chatMessages,
+    chatOpeningConversationId: state.chatOpeningConversationId,
+    chatPaymentApprovalAmount: state.chatPaymentApprovalAmount,
+    chatPaymentApprovalError: state.chatPaymentApprovalError,
+    chatPaymentApprovalPeerInfo: state.chatPaymentApprovalPeerInfo,
+    chatPaymentApprovalPeerName: state.chatPaymentApprovalPeerName,
+    chatPaymentApprovalVisible: state.chatPaymentApprovalVisible,
+    chatPermissionMode: state.chatPermissionMode,
+    chatRoutedPeer: state.chatRoutedPeer,
+    chatRoutedPeerId: state.chatRoutedPeerId,
+    chatSelectedPeerId: state.chatSelectedPeerId,
+    chatSelectedServiceValue: state.chatSelectedServiceValue,
+    chatSendDisabled: state.chatSendDisabled,
+    chatSending: state.chatSending,
+    chatSendingConversationId: state.chatSendingConversationId,
+    chatSendingConversationIds: state.chatSendingConversationIds,
+    chatServiceOptions: state.chatServiceOptions,
+    chatServiceSelectDisabled: state.chatServiceSelectDisabled,
+    chatSessionAccumulatedCostUsd: state.chatSessionAccumulatedCostUsd,
+    chatSessionReservedUsdc: state.chatSessionReservedUsdc,
+    chatSessionStarted: state.chatSessionStarted,
+    chatSessionTotalTokens: state.chatSessionTotalTokens,
+    chatStreamingMessage: state.chatStreamingMessage,
+    chatThinkingElapsedMs: state.chatThinkingElapsedMs,
+    chatThinkingPhase: state.chatThinkingPhase,
+    chatToolApprovalRequests: state.chatToolApprovalRequests,
+    chatWorkspaceDefaultPath: state.chatWorkspaceDefaultPath,
+    chatWorkspacePath: state.chatWorkspacePath,
+    creditsAvailableUsdc: state.creditsAvailableUsdc,
+    discoverRows: state.discoverRows,
+  }), shallowEqual);
   const actions = useActions();
-  const [inputValue, setInputValue] = useState('');
-  const [attachedFiles, setAttachedFiles] = useState<RawChatAttachment[]>([]);
-  const [attachmentError, setAttachmentError] = useState<string | null>(null);
-  const [attachmentWarning, setAttachmentWarning] = useState<string | null>(null);
-  const [voiceError, setVoiceError] = useState<string | null>(null);
-  const [voiceState, setVoiceState] = useState<'idle' | 'recording' | 'transcribing'>('idle');
-  const [voiceElapsedMs, setVoiceElapsedMs] = useState(0);
-  const [isDragOver, setIsDragOver] = useState(false);
-  const [previewOpen, setPreviewOpen] = useState(false);
-  const [previewFraction, setPreviewFraction] = useState(DEFAULT_PREVIEW_FRACTION);
-  const [previewTargetUrl, setPreviewTargetUrl] = useState<string | null>(null);
-  const [switchDialogOpen, setSwitchDialogOpen] = useState(false);
-  const [pendingSwitchValue, setPendingSwitchValue] = useState<string | null>(null);
-  const [messageSearchOpen, setMessageSearchOpen] = useState(false);
-  const [messageSearchQuery, setMessageSearchQuery] = useState('');
-  const [selectedSearchIndex, setSelectedSearchIndex] = useState(0);
-  const [lowReputationDialogOpen, setLowReputationDialogOpen] = useState(false);
-  const [pendingLowReputationSend, setPendingLowReputationSend] = useState<{
-    text: string;
-    attachments: RawChatAttachment[];
-  } | null>(null);
+  const [inputValue, setInputValue] = useRetainedState(chatViewCache, 'inputValue');
+  const [attachedFiles, setAttachedFiles] = useRetainedState(chatViewCache, 'attachedFiles');
+  const [attachmentError, setAttachmentError] = useRetainedState(chatViewCache, 'attachmentError');
+  const [attachmentWarning, setAttachmentWarning] = useRetainedState(chatViewCache, 'attachmentWarning');
+  const [voiceError, setVoiceError] = useRetainedState(chatViewCache, 'voiceError');
+  const [voiceState, setVoiceState] = useRetainedState(chatViewCache, 'voiceState');
+  const [voiceElapsedMs, setVoiceElapsedMs] = useRetainedState(chatViewCache, 'voiceElapsedMs');
+  const [isDragOver, setIsDragOver] = useRetainedState(chatViewCache, 'isDragOver');
+  const [previewOpen, setPreviewOpen] = useRetainedState(chatViewCache, 'previewOpen');
+  const [previewFraction, setPreviewFraction] = useRetainedState(chatViewCache, 'previewFraction');
+  const [previewTargetUrl, setPreviewTargetUrl] = useRetainedState(chatViewCache, 'previewTargetUrl');
+  const [switchDialogOpen, setSwitchDialogOpen] = useRetainedState(chatViewCache, 'switchDialogOpen');
+  const [pendingSwitchValue, setPendingSwitchValue] = useRetainedState(chatViewCache, 'pendingSwitchValue');
+  const [messageSearchOpen, setMessageSearchOpen] = useRetainedState(chatViewCache, 'messageSearchOpen');
+  const [messageSearchQuery, setMessageSearchQuery] = useRetainedState(chatViewCache, 'messageSearchQuery');
+  const [selectedSearchIndex, setSelectedSearchIndex] = useRetainedState(chatViewCache, 'selectedSearchIndex');
+  const [lowReputationDialogOpen, setLowReputationDialogOpen] = useRetainedState(chatViewCache, 'lowReputationDialogOpen');
+  const [pendingLowReputationSend, setPendingLowReputationSend] = useRetainedState(chatViewCache, 'pendingLowReputationSend');
   // While the LLM is streaming we still let the user type/paste.
   // Drafts the user confirms (Enter / Send) are parked in this queue as
   // cards above the composer and ship one-per-turn as soon as the current
   // stream ends (naturally or via Stop). See issue #59.
-  type PendingDraft = {
-    id: string;
-    conversationId: string | null;
-    text: string;
-    attachments: RawChatAttachment[];
-  };
-  const [pendingQueue, setPendingQueue] = useState<PendingDraft[]>([]);
-  const [previewAttachment, setPreviewAttachment] = useState<ViewerAttachment | null>(null);
-  const [permissionMenuOpen, setPermissionMenuOpen] = useState(false);
-  const [isNearBottom, setIsNearBottom] = useState(true);
-  const [hasNewActivityWhileScrolledUp, setHasNewActivityWhileScrolledUp] = useState(false);
+  const [pendingQueue, setPendingQueue] = useRetainedState(chatViewCache, 'pendingQueue');
+  const [previewAttachment, setPreviewAttachment] = useRetainedState(chatViewCache, 'previewAttachment');
+  const [permissionMenuOpen, setPermissionMenuOpen] = useRetainedState(chatViewCache, 'permissionMenuOpen');
+  const [isNearBottom, setIsNearBottom] = useRetainedState(chatViewCache, 'isNearBottom');
+  const [hasNewActivityWhileScrolledUp, setHasNewActivityWhileScrolledUp] = useRetainedState(chatViewCache, 'hasNewActivityWhileScrolledUp');
   const [tooltipDismissed, setTooltipDismissed] = useState<boolean>(() => {
     if (typeof window === 'undefined') return true;
     return window.localStorage.getItem(SWITCH_TOOLTIP_DISMISSED_KEY) === 'true';
@@ -256,7 +353,7 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   const messageSearchInputRef = useRef<HTMLInputElement>(null);
   const messageRefs = useRef(new Map<string, HTMLDivElement>());
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const approvedLowReputationPeersRef = useRef<Set<string>>(new Set());
+  const approvedLowReputationPeersRef = useRef<Set<string>>(chatViewCache.approvedLowReputationPeers);
   const scrollRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const fileInputId = useId();
@@ -980,7 +1077,11 @@ export function ChatView({ active, onSelectView }: ChatViewProps) {
   }, [voiceState]);
 
   useEffect(() => {
-    return () => { void cancelVoiceRecording(); };
+    return () => {
+      chatViewCache.voiceState = 'idle';
+      chatViewCache.voiceElapsedMs = 0;
+      void cancelVoiceRecording();
+    };
   }, []);
 
   const handleKeyDown = useCallback(

--- a/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import { Button } from '@antseed/ui';
-import { useUiSnapshot } from '../../hooks/useUiSnapshot';
+import { shallowEqual, useUiSelector } from '../../hooks/useUiSelector';
 import { useActions } from '../../hooks/useActions';
+import { useRetainedState } from '../../hooks/useRetainedState';
 
 type ConfigViewProps = {
   active: boolean;
@@ -14,27 +15,46 @@ type VoiceModelStatus = {
   models: Array<{ id: string; label: string; size: string; installed: boolean; selected: boolean; bundled: boolean }>;
 };
 
+// Renderer-lifetime cache: settings edits survive lazy page unmounts until the
+// form is saved or the app process exits.
+const configViewCache = {
+  proxyPort: '8377',
+  minRep: '0',
+  chainId: 'base-mainnet',
+  disableMetadataV2Services: false,
+  dirty: false,
+  initialized: false,
+  voiceStatus: null as VoiceModelStatus | null,
+  voiceInstalling: false,
+  voiceMessage: null as string | null,
+};
+
 function isVoiceModelStatus(value: unknown): value is VoiceModelStatus {
   const record = value && typeof value === 'object' ? value as Record<string, unknown> : null;
   return Boolean(record && Array.isArray(record.models));
 }
 
 export function ConfigView({ active }: ConfigViewProps) {
-  const { configFormData, configSaving, devMode, configMessage } = useUiSnapshot();
+  const { configFormData, configSaving, devMode, configMessage } = useUiSelector((state) => ({
+    configFormData: state.configFormData,
+    configSaving: state.configSaving,
+    devMode: state.devMode,
+    configMessage: state.configMessage,
+  }), shallowEqual);
   const actions = useActions();
 
   // Local form state — initialized from config, edited locally, saved on button click
-  const [proxyPort, setProxyPort] = useState('8377');
-  const [minRep, setMinRep] = useState('0');
-  const [chainId, setChainId] = useState('base-mainnet');
-  const [disableMetadataV2Services, setDisableMetadataV2Services] = useState(false);
-  const [dirty, setDirty] = useState(false);
-  const [voiceStatus, setVoiceStatus] = useState<VoiceModelStatus | null>(null);
-  const [voiceInstalling, setVoiceInstalling] = useState(false);
-  const [voiceMessage, setVoiceMessage] = useState<string | null>(null);
+  const [proxyPort, setProxyPort] = useRetainedState(configViewCache, 'proxyPort');
+  const [minRep, setMinRep] = useRetainedState(configViewCache, 'minRep');
+  const [chainId, setChainId] = useRetainedState(configViewCache, 'chainId');
+  const [disableMetadataV2Services, setDisableMetadataV2Services] = useRetainedState(configViewCache, 'disableMetadataV2Services');
+  const [dirty, setDirty] = useRetainedState(configViewCache, 'dirty');
+  const [voiceStatus, setVoiceStatus] = useRetainedState(configViewCache, 'voiceStatus');
+  const [voiceInstalling, setVoiceInstalling] = useRetainedState(configViewCache, 'voiceInstalling');
+  const [voiceMessage, setVoiceMessage] = useRetainedState(configViewCache, 'voiceMessage');
 
   // Sync from config on first load only
-  const [initialized, setInitialized] = useState(false);
+  const [initialized, setInitialized] = useRetainedState(configViewCache, 'initialized');
   useEffect(() => {
     if (configFormData && !initialized) {
       setProxyPort(String(configFormData.proxyPort));
@@ -43,9 +63,9 @@ export function ConfigView({ active }: ConfigViewProps) {
       setDisableMetadataV2Services(configFormData.disableMetadataV2Services);
       setInitialized(true);
     }
-  }, [configFormData, initialized]);
+  }, [configFormData, initialized, setChainId, setDisableMetadataV2Services, setInitialized, setMinRep, setProxyPort]);
 
-  const markDirty = useCallback(() => setDirty(true), []);
+  const markDirty = useCallback(() => setDirty(true), [setDirty]);
 
   const refreshVoiceStatus = useCallback(async () => {
     const result = await window.antseedDesktop?.voiceGetStatus?.();

--- a/apps/desktop/src/renderer/ui/components/views/ConnectionView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ConnectionView.tsx
@@ -1,4 +1,4 @@
-import { useUiSnapshot } from '../../hooks/useUiSnapshot';
+import { shallowEqual, useUiSelector } from '../../hooks/useUiSelector';
 
 type ConnectionViewProps = {
   active: boolean;
@@ -6,7 +6,13 @@ type ConnectionViewProps = {
 
 export function ConnectionView({ active }: ConnectionViewProps) {
   const { connectionMeta, connectionStatus, connectionNetwork, connectionSources, connectionNotes } =
-    useUiSnapshot();
+    useUiSelector((state) => ({
+      connectionMeta: state.connectionMeta,
+      connectionStatus: state.connectionStatus,
+      connectionNetwork: state.connectionNetwork,
+      connectionSources: state.connectionSources,
+      connectionNotes: state.connectionNotes,
+    }), shallowEqual);
 
   return (
     <section className={`view${active ? ' active' : ''}`} role="tabpanel">

--- a/apps/desktop/src/renderer/ui/components/views/DesktopView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/DesktopView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useUiSnapshot } from '../../hooks/useUiSnapshot';
+import { shallowEqual, useUiSelector } from '../../hooks/useUiSelector';
 import { useActions } from '../../hooks/useActions';
 import { formatClock } from '../../../core/format';
 
@@ -19,7 +19,10 @@ function downloadLogs(logs: { timestamp: number; mode: string; stream: string; l
 }
 
 export function DesktopView({ active }: DesktopViewProps) {
-  const { logs, daemonState } = useUiSnapshot();
+  const { logs, daemonState } = useUiSelector((state) => ({
+    logs: state.logs,
+    daemonState: state.daemonState,
+  }), shallowEqual);
   const actions = useActions();
   const logsEndRef = useRef<HTMLDivElement>(null);
 

--- a/apps/desktop/src/renderer/ui/components/views/DiscoverView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/DiscoverView.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useUiSnapshot } from '../../hooks/useUiSnapshot';
+import { useUiSelector } from '../../hooks/useUiSelector';
 import { useActions } from '../../hooks/useActions';
 import { DiscoverWelcome } from '../chat/DiscoverWelcome';
 import type { ViewName } from '../../types';
@@ -10,7 +10,7 @@ type DiscoverViewProps = {
 };
 
 export function DiscoverView({ active, onSelectView }: DiscoverViewProps) {
-  const snap = useUiSnapshot();
+  const serviceOptions = useUiSelector((state) => state.chatServiceOptions);
   const actions = useActions();
 
   const handleStartChatting = useCallback(
@@ -28,7 +28,7 @@ export function DiscoverView({ active, onSelectView }: DiscoverViewProps) {
   return (
     <section className={`view${active ? ' active' : ''}`} role="tabpanel">
       <DiscoverWelcome
-        serviceOptions={snap.chatServiceOptions}
+        serviceOptions={serviceOptions}
         onStartChatting={handleStartChatting}
       />
     </section>

--- a/apps/desktop/src/renderer/ui/components/views/ExternalClientsView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ExternalClientsView.tsx
@@ -8,7 +8,8 @@ import {
   BookOpen01Icon,
   Loading03Icon,
 } from '@hugeicons/core-free-icons';
-import { useUiSnapshot } from '../../hooks/useUiSnapshot';
+import { shallowEqual, useUiSelector } from '../../hooks/useUiSelector';
+import { useRetainedState } from '../../hooks/useRetainedState';
 import type { ChatServiceOptionEntry } from '../../../core/state';
 import styles from './ExternalClientsView.module.scss';
 
@@ -268,6 +269,13 @@ type TryState =
   | { kind: 'result'; status: number; body: string }
   | { kind: 'error'; error: string };
 
+// Renderer-lifetime cache: API playground selections and results survive lazy
+// page unmounts while the app stays open.
+const externalClientsViewCache = {
+  tryServiceValue: '',
+  tryState: { kind: 'idle' } as TryState,
+};
+
 export function ExternalClientsView({ active }: ExternalClientsViewProps) {
   const {
     chatProxyStatus,
@@ -275,7 +283,13 @@ export function ExternalClientsView({ active }: ExternalClientsViewProps) {
     chatServiceOptions,
     chatSelectedServiceValue,
     discoverRows,
-  } = useUiSnapshot();
+  } = useUiSelector((state) => ({
+    chatProxyStatus: state.chatProxyStatus,
+    chatProxyPort: state.chatProxyPort,
+    chatServiceOptions: state.chatServiceOptions,
+    chatSelectedServiceValue: state.chatSelectedServiceValue,
+    discoverRows: state.discoverRows,
+  }), shallowEqual);
   const isOnline = chatProxyStatus.tone === 'active' && chatProxyPort > 0;
   const displayPort = isOnline ? chatProxyPort : 8377;
 
@@ -306,7 +320,7 @@ export function ExternalClientsView({ active }: ExternalClientsViewProps) {
     [chatServiceOptions, peerChannelCounts],
   );
 
-  const [tryServiceValue, setTryServiceValue] = useState<string>('');
+  const [tryServiceValue, setTryServiceValue] = useRetainedState(externalClientsViewCache, 'tryServiceValue');
 
   useEffect(() => {
     if (freeOptions.length === 0) {
@@ -325,7 +339,7 @@ export function ExternalClientsView({ active }: ExternalClientsViewProps) {
   const request = useMemo(() => buildRequest(targetOption, displayPort), [targetOption, displayPort]);
   const curl = useMemo(() => formatCurl(displayPort, request), [displayPort, request]);
 
-  const [tryState, setTryState] = useState<TryState>({ kind: 'idle' });
+  const [tryState, setTryState] = useRetainedState(externalClientsViewCache, 'tryState');
   const [openTool, setOpenTool] = useState<Tool | null>(null);
 
   const canTry = Boolean(targetOption) && isOnline && !!window.antseedDesktop?.apiTryProxyRequest;

--- a/apps/desktop/src/renderer/ui/components/views/OverviewView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/OverviewView.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useUiSnapshot } from '../../hooks/useUiSnapshot';
+import { shallowEqual, useUiSelector } from '../../hooks/useUiSelector';
 import { formatShortId, formatInt } from '../../../core/format';
 import {
   buildPeerReputationScoreMap,
@@ -23,7 +23,18 @@ export function OverviewView({ active }: OverviewViewProps) {
     ovPeersCount,
     overviewPeers,
     discoverRows,
-  } = useUiSnapshot();
+  } = useUiSelector((state) => ({
+    overviewBadge: state.overviewBadge,
+    ovNodeState: state.ovNodeState,
+    ovPeers: state.ovPeers,
+    ovDhtHealth: state.ovDhtHealth,
+    ovProxyPort: state.ovProxyPort,
+    ovServiceCount: state.ovServiceCount,
+    ovLastScan: state.ovLastScan,
+    ovPeersCount: state.ovPeersCount,
+    overviewPeers: state.overviewPeers,
+    discoverRows: state.discoverRows,
+  }), shallowEqual);
 
   const reputationScoresByPeerId = useMemo(
     () => buildPeerReputationScoreMap(discoverRows),

--- a/apps/desktop/src/renderer/ui/components/views/PeersView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/PeersView.tsx
@@ -1,6 +1,7 @@
-import { useState, useMemo, useCallback } from 'react';
-import { useUiSnapshot } from '../../hooks/useUiSnapshot';
+import { useMemo, useCallback } from 'react';
+import { shallowEqual, useUiSelector } from '../../hooks/useUiSelector';
 import { useActions } from '../../hooks/useActions';
+import { useRetainedState } from '../../hooks/useRetainedState';
 import { formatShortId, formatInt, formatEndpoint } from '../../../core/format';
 import {
   buildPeerReputationScoreMap,
@@ -81,24 +82,35 @@ const COLUMNS: { key: string; label: string; sortable: boolean }[] = [
   { key: 'endpoint', label: 'Endpoint', sortable: false },
 ];
 
+// Renderer-lifetime cache: table controls survive lazy page unmounts.
+const peersViewCache = {
+  sortKey: 'reputation',
+  sortDir: 'desc' as SortDirection,
+  filter: '',
+};
+
 export function PeersView({ active }: PeersViewProps) {
-  const { lastPeers, peersMeta, peersMessage, discoverRows } = useUiSnapshot();
+  const { lastPeers, peersMessage, discoverRows } = useUiSelector((state) => ({
+    lastPeers: state.lastPeers,
+    peersMessage: state.peersMessage,
+    discoverRows: state.discoverRows,
+  }), shallowEqual);
   const actions = useActions();
 
-  const [sortKey, setSortKey] = useState('reputation');
-  const [sortDir, setSortDir] = useState<SortDirection>('desc');
-  const [filter, setFilter] = useState('');
+  const [sortKey, setSortKey] = useRetainedState(peersViewCache, 'sortKey');
+  const [sortDir, setSortDir] = useRetainedState(peersViewCache, 'sortDir');
+  const [filter, setFilter] = useRetainedState(peersViewCache, 'filter');
 
   const handleSort = useCallback(
     (key: string) => {
       if (sortKey === key) {
-        setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+        setSortDir((dir) => dir === 'asc' ? 'desc' : 'asc');
       } else {
         setSortKey(key);
         setSortDir('asc');
       }
     },
-    [sortKey],
+    [setSortDir, setSortKey, sortKey],
   );
 
   const reputationScoresByPeerId = useMemo(

--- a/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.test.ts
+++ b/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.test.ts
@@ -1,5 +1,4 @@
-import { test } from 'node:test';
-import assert from 'node:assert/strict';
+import { expect, test } from 'vitest';
 import {
   applyFilters, applySort, paginate, totalPagesFor,
   MAX_INPUT_PRICE_SLIDER_USD, MAX_OUTPUT_PRICE_SLIDER_USD,
@@ -33,12 +32,12 @@ test('pipeline: filter → sort → paginate on 25 rows', () => {
     minStakeUsdc: 0,
     minReputationScore: 0,
   });
-  assert.equal(filtered.length, 25);
+  expect(filtered).toHaveLength(25);
   const sorted = applySort(filtered, 'recentlyUsed', 'desc');
-  assert.equal(sorted[0]!.serviceLabel, 'Svc25');
+  expect(sorted[0]!.serviceLabel).toBe('Svc25');
   const paged = paginate(sorted, 1, 5);
-  assert.equal(paged.length, 5);
-  assert.equal(totalPagesFor(sorted.length, 5), 5);
+  expect(paged).toHaveLength(5);
+  expect(totalPagesFor(sorted.length, 5)).toBe(5);
 });
 
 test('pipeline: stake + reputation filters', () => {
@@ -54,6 +53,6 @@ test('pipeline: stake + reputation filters', () => {
     minStakeUsdc: 50,
     minReputationScore: 50,
   });
-  assert.equal(filtered.length, 1);
-  assert.equal(filtered[0]!.serviceLabel, 'Svc100');
+  expect(filtered).toHaveLength(1);
+  expect(filtered[0]!.serviceLabel).toBe('Svc100');
 });

--- a/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.ts
+++ b/apps/desktop/src/renderer/ui/hooks/useDiscoverFilters.ts
@@ -1,7 +1,8 @@
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useCallback } from 'react';
 import type { DiscoverRow } from '../../core/state';
 import { getPeerGradient } from '../../core/peer-utils';
 import { getKnownProxy, type KnownProxy } from '../../core/known-proxies';
+import { useRetainedState } from './useRetainedState';
 import {
   applyFilters, applySort, rowReputationScore,
   MAX_INPUT_PRICE_SLIDER_USD, MAX_OUTPUT_PRICE_SLIDER_USD,
@@ -50,15 +51,35 @@ export type DiscoverFilterState = {
   resetAll: () => void;
 };
 
+// Renderer-lifetime cache: discover filters survive lazy page unmounts.
+const discoverFilterCache = {
+  search: '',
+  categorySet: new Set<string>(),
+  peerSet: new Set<string>(),
+  maxInputPrice: MAX_INPUT_PRICE_SLIDER_USD,
+  maxOutputPrice: MAX_OUTPUT_PRICE_SLIDER_USD,
+  minStakeUsdc: 0,
+  minReputationScore: DEFAULT_MIN_REPUTATION_SCORE,
+  sortKey: 'reputationDesc' as DiscoverSortKey,
+};
+
 export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
-  const [search, setSearch] = useState('');
-  const [categorySet, setCategorySet] = useState<Set<string>>(() => new Set());
-  const [peerSet, setPeerSet] = useState<Set<string>>(() => new Set());
-  const [maxInputPrice, setMaxInputPrice] = useState<number>(MAX_INPUT_PRICE_SLIDER_USD);
-  const [maxOutputPrice, setMaxOutputPrice] = useState<number>(MAX_OUTPUT_PRICE_SLIDER_USD);
-  const [minStakeUsdc, setMinStakeUsdc] = useState<number>(0);
-  const [minReputationScore, setMinReputationScore] = useState<number>(DEFAULT_MIN_REPUTATION_SCORE);
-  const [sortKey, setSortKey] = useState<DiscoverSortKey>('reputationDesc');
+  const [search, setSearch] = useRetainedState(discoverFilterCache, 'search');
+  const [categorySet, setCategorySet] = useRetainedState(
+    discoverFilterCache,
+    'categorySet',
+    (value) => new Set(value),
+  );
+  const [peerSet, setPeerSet] = useRetainedState(
+    discoverFilterCache,
+    'peerSet',
+    (value) => new Set(value),
+  );
+  const [maxInputPrice, setMaxInputPrice] = useRetainedState(discoverFilterCache, 'maxInputPrice');
+  const [maxOutputPrice, setMaxOutputPrice] = useRetainedState(discoverFilterCache, 'maxOutputPrice');
+  const [minStakeUsdc, setMinStakeUsdc] = useRetainedState(discoverFilterCache, 'minStakeUsdc');
+  const [minReputationScore, setMinReputationScore] = useRetainedState(discoverFilterCache, 'minReputationScore');
+  const [sortKey, setSortKey] = useRetainedState(discoverFilterCache, 'sortKey');
 
   const toggleCategory = useCallback((cat: string) => {
     setCategorySet((prev) => {
@@ -68,7 +89,7 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
       else next.add(key);
       return next;
     });
-  }, []);
+  }, [setCategorySet]);
 
   const togglePeer = useCallback((peerId: string) => {
     setPeerSet((prev) => {
@@ -77,7 +98,7 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
       else next.add(peerId);
       return next;
     });
-  }, []);
+  }, [setPeerSet]);
 
   const resetAll = useCallback(() => {
     setSearch('');
@@ -88,7 +109,16 @@ export function useDiscoverFilters(rows: DiscoverRow[]): DiscoverFilterState {
     setMinStakeUsdc(0);
     setMinReputationScore(DEFAULT_MIN_REPUTATION_SCORE);
     setSortKey('reputationDesc');
-  }, []);
+  }, [
+    setCategorySet,
+    setMaxInputPrice,
+    setMaxOutputPrice,
+    setMinReputationScore,
+    setMinStakeUsdc,
+    setPeerSet,
+    setSearch,
+    setSortKey,
+  ]);
 
   const availableCategories = useMemo(() => {
     const set = new Set<string>();

--- a/apps/desktop/src/renderer/ui/hooks/useRetainedState.test.ts
+++ b/apps/desktop/src/renderer/ui/hooks/useRetainedState.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRetainedUpdate, writeRetainedState } from './useRetainedState';
+
+describe('resolveRetainedUpdate', () => {
+  it('returns direct state values', () => {
+    expect(resolveRetainedUpdate('old', 'new')).toBe('new');
+  });
+
+  it('resolves functional state updates from the current value', () => {
+    expect(resolveRetainedUpdate(2, (current) => current + 3)).toBe(5);
+  });
+});
+
+describe('writeRetainedState', () => {
+  it('writes the resolved value through to the retained cache', () => {
+    const cache = { search: 'old', count: 1 };
+
+    const value = writeRetainedState(cache, 'search', 'new');
+
+    expect(value).toBe('new');
+    expect(cache.search).toBe('new');
+    expect(cache.count).toBe(1);
+  });
+});

--- a/apps/desktop/src/renderer/ui/hooks/useRetainedState.ts
+++ b/apps/desktop/src/renderer/ui/hooks/useRetainedState.ts
@@ -1,0 +1,40 @@
+import { useCallback, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
+export function resolveRetainedUpdate<T>(current: T, next: SetStateAction<T>): T {
+  return typeof next === 'function'
+    ? (next as (value: T) => T)(current)
+    : next;
+}
+
+export function writeRetainedState<TCache extends object, K extends keyof TCache>(
+  cache: TCache,
+  key: K,
+  value: TCache[K],
+): TCache[K] {
+  cache[key] = value;
+  return value;
+}
+
+/**
+ * Keeps page-local state in a renderer-lifetime cache so lazy-unmounted views
+ * remount with their previous draft/filter/form values. Pass `cloneInitialValue`
+ * for mutable cached values such as Sets so component state cannot mutate the
+ * retained object in place.
+ */
+export function useRetainedState<TCache extends object, K extends keyof TCache>(
+  cache: TCache,
+  key: K,
+  cloneInitialValue?: (value: TCache[K]) => TCache[K],
+): [TCache[K], Dispatch<SetStateAction<TCache[K]>>] {
+  const [value, setValueState] = useState<TCache[K]>(() => {
+    const cachedValue = cache[key];
+    return cloneInitialValue ? cloneInitialValue(cachedValue) : cachedValue;
+  });
+
+  const setValue = useCallback<Dispatch<SetStateAction<TCache[K]>>>((next) => {
+    setValueState((current) => writeRetainedState(cache, key, resolveRetainedUpdate(current, next)));
+  }, [cache, key]);
+
+  return [value, setValue];
+}

--- a/apps/desktop/src/renderer/ui/hooks/useUiSelector.test.ts
+++ b/apps/desktop/src/renderer/ui/hooks/useUiSelector.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { createInitialUiState } from '../../core/state';
+import { createSelectedSnapshotGetter, shallowEqual } from './useUiSelector';
+
+describe('shallowEqual', () => {
+  it('compares plain objects by key and reference value', () => {
+    expect(shallowEqual({ count: 1, label: 'ready' }, { count: 1, label: 'ready' })).toBe(true);
+    expect(shallowEqual({ count: 1 }, { count: 2 })).toBe(false);
+    expect(shallowEqual({ count: 1 }, { count: 1, extra: true })).toBe(false);
+  });
+
+  it('does not treat arrays as shallow-equal selected objects', () => {
+    expect(shallowEqual([1], [1])).toBe(false);
+  });
+});
+
+describe('createSelectedSnapshotGetter', () => {
+  it('reuses the selected object when unrelated state changes', () => {
+    let state = createInitialUiState();
+    state.chatActiveConversation = 'conv-1';
+    state.connectState = 'idle';
+
+    const getSnapshot = createSelectedSnapshotGetter(
+      (current) => ({
+        activeConversation: current.chatActiveConversation,
+        sending: current.chatSending,
+      }),
+      shallowEqual,
+      () => state,
+    );
+
+    const first = getSnapshot();
+
+    state = {
+      ...state,
+      connectState: 'changed outside selector',
+    };
+    const unrelatedChange = getSnapshot();
+
+    state = {
+      ...state,
+      chatSending: true,
+    };
+    const selectedChange = getSnapshot();
+
+    expect(unrelatedChange).toBe(first);
+    expect(selectedChange).not.toBe(first);
+    expect(selectedChange).toEqual({
+      activeConversation: 'conv-1',
+      sending: true,
+    });
+  });
+
+  it('can use stable wrappers around changing selector implementations', () => {
+    let state = createInitialUiState();
+    state.chatSending = false;
+
+    let selector = (current: typeof state) => ({
+      sending: current.chatSending,
+    });
+    let isEqual = shallowEqual<{ sending: boolean }>;
+
+    const getSnapshot = createSelectedSnapshotGetter(
+      (current) => selector(current),
+      (left, right) => isEqual(left, right),
+      () => state,
+    );
+
+    const first = getSnapshot();
+
+    selector = (current) => ({
+      sending: current.chatSending,
+    });
+    isEqual = shallowEqual;
+
+    expect(getSnapshot()).toBe(first);
+
+    state = {
+      ...state,
+      chatSending: true,
+    };
+
+    expect(getSnapshot()).toEqual({ sending: true });
+  });
+});

--- a/apps/desktop/src/renderer/ui/hooks/useUiSelector.ts
+++ b/apps/desktop/src/renderer/ui/hooks/useUiSelector.ts
@@ -1,0 +1,69 @@
+import { useMemo, useRef, useSyncExternalStore } from 'react';
+import { getUiStateRef, subscribe } from '../../core/store';
+import type { RendererUiState } from '../../core/state';
+
+export function shallowEqual<T>(left: T, right: T): boolean {
+  if (Object.is(left, right)) return true;
+  if (
+    !left ||
+    !right ||
+    typeof left !== 'object' ||
+    typeof right !== 'object' ||
+    Array.isArray(left) ||
+    Array.isArray(right)
+  ) {
+    return false;
+  }
+
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const leftKeys = Object.keys(leftRecord);
+  const rightKeys = Object.keys(rightRecord);
+  if (leftKeys.length !== rightKeys.length) return false;
+
+  for (const key of leftKeys) {
+    if (!Object.prototype.hasOwnProperty.call(rightRecord, key)) return false;
+    if (!Object.is(leftRecord[key], rightRecord[key])) return false;
+  }
+
+  return true;
+}
+
+export function createSelectedSnapshotGetter<T>(
+  selector: (state: RendererUiState) => T,
+  isEqual: (left: T, right: T) => boolean = Object.is,
+  getState: () => RendererUiState = getUiStateRef,
+): () => T {
+  let initialized = false;
+  let previous: T;
+
+  return () => {
+    const next = selector(getState());
+    if (initialized && isEqual(previous, next)) {
+      return previous;
+    }
+    initialized = true;
+    previous = next;
+    return next;
+  };
+}
+
+export function useUiSelector<T>(
+  selector: (state: RendererUiState) => T,
+  isEqual: (left: T, right: T) => boolean = Object.is,
+): T {
+  const selectorRef = useRef(selector);
+  const isEqualRef = useRef(isEqual);
+  selectorRef.current = selector;
+  isEqualRef.current = isEqual;
+
+  const getSelectedSnapshot = useMemo(
+    () => createSelectedSnapshotGetter(
+      (state) => selectorRef.current(state),
+      (left, right) => isEqualRef.current(left, right),
+    ),
+    [],
+  );
+
+  return useSyncExternalStore(subscribe, getSelectedSnapshot, getSelectedSnapshot);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@20.19.33)(jiti@1.21.7)(sass@1.97.3)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@20.19.33)(sass@1.97.3)(terser@5.46.0)
       wait-on:
         specifier: ^8.0.1
         version: 8.0.5
@@ -3197,7 +3200,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
+    deprecated: 'The package is now available as "qr": npm install qr'
 
   '@peculiar/asn1-cms@2.6.1':
     resolution: {integrity: sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==}


### PR DESCRIPTION
## Description

Changes the Desktop renderer so only the active view is mounted, with route chunks lazy-loaded through a shared registry. Adds preloading for likely next views, a lightweight loading fallback for first navigation, retained view-local state helpers, and renderer tests for the new routing/state behavior.

## Release Notes

- Reduced Desktop renderer memory and initial bundle pressure by loading only the active view.
- Added Desktop route preloading and a lightweight loading state so first chat navigation does not appear blank while the chat view chunk loads.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

Verification:
- `pnpm -C apps/desktop run test:renderer`
- `pnpm -C apps/desktop run typecheck:renderer`
- `pnpm -C apps/desktop run build:renderer`
- `pnpm -C apps/desktop run test`
- `git diff --check`