### PR TITLE
feat(node): pluggable verifier sdks

### DIFF
--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -11,11 +11,11 @@ import { AntseedNode, DepositsClient, getInstance, resolveChainConfig } from '@a
 import type { NodePaymentsConfig } from '@antseed/node'
 import { OFFICIAL_BOOTSTRAP_NODES, parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery'
 import { setupShutdownHandler } from '../../shutdown.js'
-import { loadRouterPlugin, buildPluginConfig, getPackageVersions } from '../../../plugins/loader.js'
+import { loadRouterPlugin, loadVerifierPlugin, buildPluginConfig, getPackageVersions } from '../../../plugins/loader.js'
 import { ensurePluginsUpToDate } from '../../../plugins/drift.js'
 import { resolvePluginPackage } from '../../../plugins/registry.js'
 import { BuyerProxy } from '../../../proxy/buyer-proxy.js'
-import { normalizeVerifierIds, type VerifierPolicy } from '../../../plugins/verifier.js'
+import { curatedVerifierIds, resolveVerifierPolicy, type VerifierPolicy } from '../../../plugins/verifier.js'
 import { resolveEffectiveBuyerConfig, type BuyerRuntimeOverrides } from '../../../config/effective.js'
 import type { BuyerCLIConfig } from '../../../config/types.js'
 
@@ -414,17 +414,31 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
       const proxyPort = effectiveBuyerConfig.proxyPort
       const proxySpinner = ora(`Starting local proxy on port ${proxyPort}...`).start()
       let verifierPolicy: VerifierPolicy | undefined
-      if (options.verifier === false) {
-        verifierPolicy = undefined
-      } else {
-        try {
-          verifierPolicy = {
-            prefer: normalizeVerifierIds(String(options.verifiers ?? '')),
-            require: Boolean(options.requireVerifier),
+      try {
+        verifierPolicy = resolveVerifierPolicy({
+          verifier: options.verifier,
+          verifiers: options.verifiers,
+          requireVerifier: options.requireVerifier,
+        })
+      } catch (err) {
+        console.error(chalk.red((err as Error).message))
+        process.exit(1)
+      }
+
+      // Keep the request path import-only; the seller-specific default is known per peer.
+      if (verifierPolicy) {
+        const toPreload = verifierPolicy.prefer?.length ? verifierPolicy.prefer : [...curatedVerifierIds()]
+        for (const id of toPreload) {
+          try {
+            await loadVerifierPlugin(id)
+          } catch (err) {
+            const msg = `Verifier "${id}" could not be prepared: ${(err as Error).message}`
+            if (verifierPolicy.require) {
+              proxySpinner.fail(chalk.red(msg))
+              process.exit(1)
+            }
+            console.warn(chalk.yellow(`${msg} — optional verification for this SDK will be skipped.`))
           }
-        } catch (err) {
-          console.error(chalk.red((err as Error).message))
-          process.exit(1)
         }
       }
 

--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -15,6 +15,7 @@ import { loadRouterPlugin, buildPluginConfig, getPackageVersions } from '../../.
 import { ensurePluginsUpToDate } from '../../../plugins/drift.js'
 import { resolvePluginPackage } from '../../../plugins/registry.js'
 import { BuyerProxy } from '../../../proxy/buyer-proxy.js'
+import { normalizeVerifierIds, type VerifierPolicy } from '../../../plugins/verifier.js'
 import { resolveEffectiveBuyerConfig, type BuyerRuntimeOverrides } from '../../../config/effective.js'
 import type { BuyerCLIConfig } from '../../../config/types.js'
 
@@ -198,6 +199,9 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
     .option('--disable-metadata-v2-services', 'runtime-only opt-out from per-service buyer metadata v2 attribution')
     .option('--peer <peerId>', 'pin all requests to a specific peer ID (40-char hex EVM address), bypassing the router')
     .option('--log-filter <sourceOrText>', 'show only debug logs matching a source or text, e.g. ProxyMux')
+    .option('--verifiers <ids>', "ordered, comma-separated verifier SDK ids to verify sellers with (default: the seller's advertised default if trusted)")
+    .option('--require-verifier', 'refuse to route unless a verifier SDK verifies the seller (default: verify but route anyway)')
+    .option('--no-verifier', 'disable seller verification entirely')
     .action(async (options) => {
       const globalOpts = getGlobalOptions(buyerCmd)
       const config = await loadConfig(globalOpts.config)
@@ -409,12 +413,28 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
 
       const proxyPort = effectiveBuyerConfig.proxyPort
       const proxySpinner = ora(`Starting local proxy on port ${proxyPort}...`).start()
+      let verifierPolicy: VerifierPolicy | undefined
+      if (options.verifier === false) {
+        verifierPolicy = undefined
+      } else {
+        try {
+          verifierPolicy = {
+            prefer: normalizeVerifierIds(String(options.verifiers ?? '')),
+            require: Boolean(options.requireVerifier),
+          }
+        } catch (err) {
+          console.error(chalk.red((err as Error).message))
+          process.exit(1)
+        }
+      }
+
       const proxy = new BuyerProxy({
         port: proxyPort,
         node,
         pinnedPeerId,
         dataDir: globalOpts.dataDir,
         backgroundRefreshIntervalMs: effectiveBuyerConfig.peerRefreshIntervalMs,
+        ...(verifierPolicy ? { verifier: verifierPolicy } : {}),
       })
       let ownsProxyListener = false
 
@@ -422,6 +442,12 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
         await proxy.start()
         ownsProxyListener = true
         proxySpinner.succeed(chalk.green(`Proxy listening on http://localhost:${proxyPort}`))
+        if (verifierPolicy) {
+          const sel = verifierPolicy.prefer?.length ? verifierPolicy.prefer.join(', ') : 'seller default (trusted set)'
+          console.log(chalk.dim(`  Verifier: ${sel} (${verifierPolicy.require ? 'required' : 'optional'})`))
+        } else {
+          console.log(chalk.dim('  Verifier: disabled'))
+        }
       } catch (err) {
         if (isAddrInUseError(err) && await isCompatibleBuyerProxy(proxyPort)) {
           proxySpinner.succeed(chalk.yellow(`Proxy port ${proxyPort} already in use; reusing existing local proxy.`))

--- a/apps/cli/src/cli/commands/network/browse.ts
+++ b/apps/cli/src/cli/commands/network/browse.ts
@@ -2,6 +2,7 @@ import type { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
 import Table from 'cli-table3';
+import { parseVerifierCapabilities } from '../../../plugins/verifier.js';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { getGlobalOptions } from '../types.js';
@@ -419,6 +420,7 @@ function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
   // that differs from its peerId (i.e. a delegated/proxy seller).
   const anyDelegatedSeller = peers.some((peer) => delegatedSellerAddress(peer) !== null);
   const anyVerificationLinks = peers.some((peer) => collectPeerVerificationLinks(peer).length > 0);
+  const anyVerifiers = peers.some((peer) => parseVerifierCapabilities(peer.capabilities).supported.length > 0);
 
   const head: string[] = [
     chalk.bold('Peer'),
@@ -428,6 +430,7 @@ function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
     chalk.bold('Name'),
   );
   if (anyVerificationLinks) head.push(chalk.bold('Verified'));
+  if (anyVerifiers) head.push(chalk.bold('Verifier'));
   head.push(
     chalk.bold('Providers'),
     chalk.bold('Services'),
@@ -483,6 +486,14 @@ function renderCompactTable(peers: PeerInfo[], hasChainData: boolean): void {
       peer.displayName ?? chalk.dim('—'),
     );
     if (anyVerificationLinks) row.push(formatVerificationLinks(peer));
+    if (anyVerifiers) {
+      const v = parseVerifierCapabilities(peer.capabilities);
+      row.push(
+        v.supported.length === 0
+          ? chalk.dim('—')
+          : (v.default ?? v.supported[0]!) + (v.supported.length > 1 ? chalk.dim(` +${v.supported.length - 1}`) : ''),
+      );
+    }
     row.push(
       peer.providers.join(', ') || chalk.dim('—'),
       servicesCell,

--- a/apps/cli/src/cli/commands/network/peer.ts
+++ b/apps/cli/src/cli/commands/network/peer.ts
@@ -4,6 +4,7 @@ import ora from 'ora';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { getGlobalOptions } from '../types.js';
+import { parseVerifierCapabilities } from '../../../plugins/verifier.js';
 import { loadConfig } from '../../../config/loader.js';
 import {
   AntseedNode,
@@ -156,6 +157,14 @@ function printPeerDetail(peer: PeerInfo, requestedTags: Set<string>): void {
   console.log(`  ID:              ${peer.peerId}`);
   console.log(`  Display name:    ${peer.displayName ?? chalk.dim('—')}`);
   console.log(`  Public address:  ${peer.publicAddress ?? chalk.dim('—')}`);
+
+  const verifiers = parseVerifierCapabilities(peer.capabilities);
+  if (verifiers.supported.length > 0) {
+    const list = verifiers.supported
+      .map((id) => (id === verifiers.default ? `${id} ${chalk.dim('(default)')}` : id))
+      .join(', ');
+    console.log(`  Verifiers:       ${list}`);
+  }
 
   const sellerAddress = sellerAddressForPeer(peer);
   if (isDelegatedSeller(peer)) {

--- a/apps/cli/src/cli/commands/seller/setup.ts
+++ b/apps/cli/src/cli/commands/seller/setup.ts
@@ -215,6 +215,31 @@ export function registerSellerSetupCommand(sellerCmd: Command): void {
         });
 
         config.seller.providers[providerName] = providerEntry;
+
+        // Optional verifier SDK — advertised in metadata so buyers can attest this node.
+        const verifiers = TRUSTED_PLUGINS.filter((plugin) => plugin.type === 'verifier');
+        if (verifiers.length > 0) {
+          console.log(chalk.bold('\nVerifier SDK (optional — lets buyers cryptographically attest your node):\n'));
+          verifiers.forEach((plugin, index) => {
+            console.log(`  ${chalk.cyan(String(index + 1))}. ${plugin.name.padEnd(28)} ${chalk.dim(plugin.description)}`);
+          });
+          console.log(`  ${chalk.cyan('0')}. ${chalk.dim('None')}`);
+          console.log('');
+          const verifierChoice = await rl.question('Choose a verifier SDK (number, blank for none): ');
+          const verifierNum = parseInt(verifierChoice.trim(), 10);
+          if (verifierNum > 0 && verifierNum <= verifiers.length) {
+            const selectedVerifier = verifiers[verifierNum - 1]!;
+            const verifierSpinner = ora(`Installing ${selectedVerifier.package}...`).start();
+            try {
+              await installPlugin(selectedVerifier.package);
+              verifierSpinner.succeed(chalk.green(`Installed ${selectedVerifier.package}`));
+              config.seller.verifiers = [selectedVerifier.name];
+            } catch (err) {
+              verifierSpinner.fail(chalk.red(`Failed: ${(err as Error).message} — add it later with 'antseed seller start --verifiers ${selectedVerifier.name}'`));
+            }
+          }
+        }
+
         assertValidConfig(config);
         await saveConfig(globalOpts.config, config);
         console.log(chalk.green(`\nProvider "${providerName}" saved to config.`));

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -582,7 +582,10 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
       let requestedVerifierIds: string[]
       try {
         requestedVerifierIds = normalizeVerifierIds(
-          (options.verifiers as string | undefined) ?? process.env[ANTSEED_VERIFIER_SDKS_ENV] ?? '',
+          (options.verifiers as string | undefined)
+            ?? process.env[ANTSEED_VERIFIER_SDKS_ENV]
+            ?? config.seller.verifiers?.join(',')
+            ?? '',
         )
       } catch (err) {
         console.error(chalk.red((err as Error).message))

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -5,7 +5,7 @@ import { writeFile, unlink } from 'node:fs/promises'
 import { join, resolve, isAbsolute, dirname } from 'node:path'
 import { getGlobalOptions } from '../types.js'
 import { loadConfig } from '../../../config/loader.js'
-import { AntseedNode, type Provider, resolveChainConfig, loadOrCreateIdentity } from '@antseed/node'
+import { AntseedNode, type Provider, type Prover, resolveChainConfig, loadOrCreateIdentity } from '@antseed/node'
 import type { PaymentConfig } from '@antseed/node/payments'
 import { checkSellerReadiness, DEFAULT_MIN_SETTLE_DELTA_STR } from '@antseed/node/payments'
 import {
@@ -15,9 +15,10 @@ import {
   resolveBaseRpcUrlOverride,
 } from '../../payment-utils.js'
 import type { AntseedConfig } from '../../../config/types.js'
+import { ANTSEED_VERIFIER_SDKS_ENV, buildVerifierCapabilities, normalizeVerifierIds } from '../../../plugins/verifier.js'
 import { parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery'
 import { setupShutdownHandler } from '../../shutdown.js'
-import { loadProviderPlugin, buildPluginConfig, getPackageVersions } from '../../../plugins/loader.js'
+import { loadProviderPlugin, loadProverPlugin, buildPluginConfig, getPackageVersions } from '../../../plugins/loader.js'
 import { ensurePluginsUpToDate } from '../../../plugins/drift.js'
 import { resolveEffectiveSellerConfig, type SellerRuntimeOverrides } from '../../../config/effective.js'
 import { ensureDerivedIdentityDisplayName } from '../../../config/identity-display-name.js'
@@ -330,6 +331,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
     .option('--min-settle-delta <usdc>', 'minimum unsettled delta (USDC decimal, e.g. 0.002) before idle settle submits a tx')
     .option('--base-rpc-url <url>', `runtime-only Base JSON-RPC URL override (also ${ANTSEED_BASE_RPC_URL_ENV})`)
     .option('--skip-prereq-check', 'skip pre-flight checks (services configured, on-chain registration + stake). Use only for local testing.')
+    .option('--verifiers <ids>', `comma-separated verifier SDK ids this seller supports (first is default; also ${ANTSEED_VERIFIER_SDKS_ENV})`)
     .action(async (options) => {
       const globalOpts = getGlobalOptions(sellerCmd)
       const config = await loadConfig(globalOpts.config)
@@ -576,11 +578,37 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
         ? { sellerContract: sellerContractCfg.address }
         : undefined
 
+      // Load provers before advertising verifier capabilities.
+      let requestedVerifierIds: string[]
+      try {
+        requestedVerifierIds = normalizeVerifierIds(
+          (options.verifiers as string | undefined) ?? process.env[ANTSEED_VERIFIER_SDKS_ENV] ?? '',
+        )
+      } catch (err) {
+        console.error(chalk.red((err as Error).message))
+        process.exit(1)
+      }
+      const loadedProvers: Prover[] = []
+      for (const id of requestedVerifierIds) {
+        try {
+          const prover = await loadProverPlugin(id)
+          if (prover.name !== id) {
+            throw new Error(`its package exported a prover named "${prover.name}" — advertised id and prover name must match`)
+          }
+          loadedProvers.push(prover)
+        } catch (err) {
+          console.error(chalk.red(`Cannot advertise verifier "${id}": ${(err as Error).message.split('\n')[0]}`))
+          process.exit(1)
+        }
+      }
+      const verifierCapabilities = buildVerifierCapabilities(requestedVerifierIds)
+
       const node = new AntseedNode({
         role: 'seller',
         displayName: config.identity.displayName,
         ...(config.seller.publicAddress ? { publicAddress: config.seller.publicAddress } : {}),
         ...(effectiveSellerConfig.verifications ? { verifications: effectiveSellerConfig.verifications } : {}),
+        ...(verifierCapabilities.length > 0 ? { capabilities: verifierCapabilities } : {}),
         bootstrapNodes,
         dataDir: globalOpts.dataDir,
         ...(dhtPort ? { dhtPort } : {}),
@@ -650,12 +678,20 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
         node.registerProvider(provider)
       }
 
+      for (const prover of loadedProvers) {
+        node.registerProver(prover)
+        console.log(chalk.dim(`  Verifier prover embedded: ${prover.name}`))
+      }
+
       try {
         await node.start()
         nodeSpinner.succeed(chalk.green('Seeding active'))
         console.log(chalk.dim(`  Peer ID: ${node.peerId ?? 'unknown'}`))
         console.log(chalk.dim(`  DHT port: ${node.dhtPort}`))
         console.log(chalk.dim(`  Signaling port: ${node.signalingPort}`))
+        if (requestedVerifierIds.length > 0) {
+          console.log(chalk.dim(`  Verifiers advertised: ${requestedVerifierIds.join(', ')}`))
+        }
       } catch (err) {
         nodeSpinner.fail(chalk.red(`Failed to start seeding: ${(err as Error).message}`))
         process.exit(1)

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -125,6 +125,12 @@ export interface SellerCLIConfig {
   verifications?: VerificationConfig;
   /** Maximum upload body size (bytes) accepted from buyers per request. Default: 64 MiB. */
   maxUploadBodyBytes?: number;
+  /**
+   * Verifier SDK ids this seller advertises and runs provers for (first is the
+   * default). Chosen in `antseed seller setup`; overridden at launch by
+   * `--verifiers` or the ANTSEED_VERIFIER_SDKS env var.
+   */
+  verifiers?: string[];
 }
 
 /**

--- a/apps/cli/src/plugins/loader.test.ts
+++ b/apps/cli/src/plugins/loader.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { assertPinnedPluginVersion } from './loader.js'
+
+function withPluginVersion(pkgName: string, version: string, fn: (dir: string) => void): void {
+  const dir = mkdtempSync(join(tmpdir(), 'antseed-loader-test-'))
+  try {
+    const pkgDir = join(dir, 'node_modules', ...pkgName.split('/'))
+    mkdirSync(pkgDir, { recursive: true })
+    writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: pkgName, version }), 'utf-8')
+    fn(dir)
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+test('assertPinnedPluginVersion accepts the locked verifier version', () => {
+  withPluginVersion('@refoundhq/antseed-verifier', '0.1.0', (dir) => {
+    assert.doesNotThrow(() => assertPinnedPluginVersion('@refoundhq/antseed-verifier', dir))
+  })
+})
+
+test('assertPinnedPluginVersion rejects a mismatched verifier version', () => {
+  withPluginVersion('@refoundhq/antseed-verifier', '0.1.1', (dir) => {
+    assert.throws(
+      () => assertPinnedPluginVersion('@refoundhq/antseed-verifier', dir),
+      /version-locked to 0\.1\.0/,
+    )
+  })
+})
+
+test('assertPinnedPluginVersion ignores unpinned trusted packages', () => {
+  withPluginVersion('@antseed/provider-openai', '999.0.0', (dir) => {
+    assert.doesNotThrow(() => assertPinnedPluginVersion('@antseed/provider-openai', dir))
+  })
+})

--- a/apps/cli/src/plugins/loader.test.ts
+++ b/apps/cli/src/plugins/loader.test.ts
@@ -3,7 +3,9 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import test from 'node:test'
-import { assertPinnedPluginVersion } from './loader.js'
+import { assertPinnedPluginVersion, selectPluginExport } from './loader.js'
+
+const TEE_PACKAGE = '@refoundhq/antseed-verifier'
 
 function withPluginVersion(pkgName: string, version: string, fn: (dir: string) => void): void {
   const dir = mkdtempSync(join(tmpdir(), 'antseed-loader-test-'))
@@ -17,23 +19,38 @@ function withPluginVersion(pkgName: string, version: string, fn: (dir: string) =
   }
 }
 
-test('assertPinnedPluginVersion accepts the locked verifier version', () => {
-  withPluginVersion('@refoundhq/antseed-verifier', '0.1.0', (dir) => {
-    assert.doesNotThrow(() => assertPinnedPluginVersion('@refoundhq/antseed-verifier', dir))
+test('assertPinnedPluginVersion handles pinned and unpinned installs', () => {
+  withPluginVersion(TEE_PACKAGE, '0.1.0', (dir) => {
+    assert.doesNotThrow(() => assertPinnedPluginVersion(TEE_PACKAGE, dir))
   })
-})
-
-test('assertPinnedPluginVersion rejects a mismatched verifier version', () => {
-  withPluginVersion('@refoundhq/antseed-verifier', '0.1.1', (dir) => {
-    assert.throws(
-      () => assertPinnedPluginVersion('@refoundhq/antseed-verifier', dir),
-      /version-locked to 0\.1\.0/,
-    )
+  withPluginVersion(TEE_PACKAGE, '0.1.1', (dir) => {
+    assert.throws(() => assertPinnedPluginVersion(TEE_PACKAGE, dir), /version-locked to 0\.1\.0/)
   })
-})
-
-test('assertPinnedPluginVersion ignores unpinned trusted packages', () => {
   withPluginVersion('@antseed/provider-openai', '999.0.0', (dir) => {
     assert.doesNotThrow(() => assertPinnedPluginVersion('@antseed/provider-openai', dir))
   })
+})
+
+test('assertPinnedPluginVersion reports a missing install distinctly from a wrong version', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'antseed-loader-test-'))
+  try {
+    assert.throws(
+      () => assertPinnedPluginVersion(TEE_PACKAGE, dir),
+      /it is not installed/,
+    )
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('selectPluginExport dedupes default export and rejects ambiguous matches', () => {
+  const plugin = { type: 'verifier', verify: () => {} }
+  assert.equal(selectPluginExport({ default: plugin, verifierPlugin: plugin }, 'verifier', 'verify'), plugin)
+  const a = { type: 'verifier', verify: () => {} }
+  const b = { type: 'verifier', verify: () => {} }
+  assert.throws(() => selectPluginExport({ default: a, other: b }, 'verifier', 'verify'), /multiple/)
+  assert.equal(
+    selectPluginExport({ default: { type: 'provider', createProvider: () => {} } }, 'verifier', 'verify'),
+    undefined,
+  )
 })

--- a/apps/cli/src/plugins/loader.test.ts
+++ b/apps/cli/src/plugins/loader.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path'
 import test from 'node:test'
 import { assertPinnedPluginVersion, selectPluginExport } from './loader.js'
 
-const TEE_PACKAGE = '@refoundhq/antseed-verifier'
+const TEE_PACKAGE = '@antseed/antseed-verifier'
 
 function withPluginVersion(pkgName: string, version: string, fn: (dir: string) => void): void {
   const dir = mkdtempSync(join(tmpdir(), 'antseed-loader-test-'))

--- a/apps/cli/src/plugins/loader.ts
+++ b/apps/cli/src/plugins/loader.ts
@@ -4,7 +4,7 @@ import path, { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { getPluginsDir, installPlugin } from './manager.js'
 import { TRUSTED_PLUGINS } from './registry.js'
-import type { AntseedProviderPlugin, AntseedRouterPlugin, PluginConfigKey } from '@antseed/node'
+import type { AntseedProviderPlugin, AntseedRouterPlugin, AntseedVerifierPlugin, Prover, PluginConfigKey } from '@antseed/node'
 
 const NODE_BUILTINS = new Set([
   ...builtinModules,
@@ -24,12 +24,16 @@ function resolvePackageName(nameOrPackage: string): string {
   return trusted?.package ?? nameOrPackage
 }
 
-type PluginKind = 'provider' | 'router'
+function pinnedVersion(pkgName: string): string | undefined {
+  return TRUSTED_PLUGINS.find(p => p.package === pkgName)?.version
+}
+
+type PluginKind = 'provider' | 'router' | 'verifier' | 'prover'
 
 async function loadPlugin<T>(
   nameOrPackage: string,
   kind: PluginKind,
-  methodName: keyof AntseedProviderPlugin | keyof AntseedRouterPlugin
+  methodName: keyof AntseedProviderPlugin | keyof AntseedRouterPlugin | keyof AntseedVerifierPlugin | keyof Prover
 ): Promise<T> {
   const pkgName = resolvePackageName(nameOrPackage)
   const pluginsDir = getPluginsDir()
@@ -49,10 +53,11 @@ async function loadPlugin<T>(
   if (isTrusted) {
     await ensureTrustedPluginInstallReady(pkgName, resolved, pluginsDir)
   }
+  assertPinnedPluginVersion(pkgName, pluginsDir)
 
-  let mod: { default?: unknown }
+  let mod: Record<string, unknown>
   try {
-    mod = await import(pathToFileURL(resolved).href) as { default?: unknown }
+    mod = await import(pathToFileURL(resolved).href) as Record<string, unknown>
   } catch (err) {
     if (isModuleNotFound(err) && !existsSync(resolved)) {
       throw new Error(
@@ -66,18 +71,31 @@ async function loadPlugin<T>(
     }
   }
 
-  const plugin = mod.default
-  if (!plugin || typeof plugin !== 'object' || (plugin as { type?: string }).type !== kind) {
+  // Packages may export multiple plugin types; pick the export matching this loader.
+  const candidates = [mod['default'], ...Object.values(mod)].filter(
+    (p): p is Record<string, unknown> => !!p && typeof p === 'object',
+  )
+  const plugin = candidates.find(
+    (p) => p['type'] === kind && typeof p[methodName as string] === 'function',
+  )
+  if (!plugin) {
     throw new Error(
-      `Plugin "${pkgName}" does not export a valid ${kind} plugin (expected default export with type: '${kind}')`
+      `Plugin "${pkgName}" does not export a valid ${kind} plugin (expected an export with type: '${kind}' and ${String(methodName)}())`
     )
   }
 
-  if (typeof (plugin as Record<string, unknown>)[methodName] !== 'function') {
-    throw new Error(`Plugin "${pkgName}" does not implement ${methodName}()`)
-  }
-
   return plugin as T
+}
+
+export function assertPinnedPluginVersion(pkgName: string, pluginsDir = getPluginsDir()): void {
+  const pin = pinnedVersion(pkgName)
+  if (!pin) return
+  const installed = readPluginPackageVersion(pkgName, pluginsDir)
+  if (installed === pin) return
+  throw new Error(
+    `Plugin "${pkgName}" is version-locked to ${pin} but ${installed ?? 'an unknown version'} is installed.\n` +
+    `Reinstall the pinned version: antseed plugin add ${pkgName}@${pin}`
+  )
 }
 
 async function ensureTrustedPluginInstallReady(
@@ -93,11 +111,11 @@ async function ensureTrustedPluginInstallReady(
   if (isTruthyEnv(process.env['ANTSEED_SKIP_PLUGIN_UPDATE_CHECK'])) return
 
   const action = existsSync(entryPath)
-    ? 'appears incomplete or stale. Reinstalling latest version...'
+    ? 'appears incomplete or stale. Reinstalling...'
     : 'not installed. Installing...'
   console.log(`Plugin "${pkgName}" ${action}`)
   try {
-    await installPlugin(`${pkgName}@latest`)
+    await installPlugin(`${pkgName}@${pinnedVersion(pkgName) ?? 'latest'}`)
   } catch (installErr) {
     const cause = installErr instanceof Error ? installErr.message : String(installErr)
     throw new Error(`Failed to install plugin "${pkgName}".\nCause: ${cause}`)
@@ -146,6 +164,14 @@ export async function loadRouterPlugin(nameOrPackage: string): Promise<AntseedRo
   return loadPlugin<AntseedRouterPlugin>(nameOrPackage, 'router', 'createRouter')
 }
 
+export async function loadVerifierPlugin(nameOrPackage: string): Promise<AntseedVerifierPlugin> {
+  return loadPlugin<AntseedVerifierPlugin>(nameOrPackage, 'verifier', 'verify')
+}
+
+export async function loadProverPlugin(nameOrPackage: string): Promise<Prover> {
+  return loadPlugin<Prover>(nameOrPackage, 'prover', 'prove')
+}
+
 export function buildPluginConfig(
   configKeys: PluginConfigKey[],
   runtimeOverrides?: Record<string, string>,
@@ -172,9 +198,8 @@ export function buildPluginConfig(
  * Read the installed version of a package from the plugins directory.
  * Returns the version string or null if not found.
  */
-function readPluginPackageVersion(pkgName: string): string | null {
+function readPluginPackageVersion(pkgName: string, pluginsDir = getPluginsDir()): string | null {
   try {
-    const pluginsDir = getPluginsDir()
     const pkgJsonPath = join(pluginsDir, 'node_modules', pkgName, 'package.json')
     const resolved = path.resolve(pkgJsonPath)
     if (!resolved.startsWith(path.resolve(pluginsDir))) {

--- a/apps/cli/src/plugins/loader.ts
+++ b/apps/cli/src/plugins/loader.ts
@@ -33,7 +33,8 @@ type PluginKind = 'provider' | 'router' | 'verifier' | 'prover'
 async function loadPlugin<T>(
   nameOrPackage: string,
   kind: PluginKind,
-  methodName: keyof AntseedProviderPlugin | keyof AntseedRouterPlugin | keyof AntseedVerifierPlugin | keyof Prover
+  methodName: keyof AntseedProviderPlugin | keyof AntseedRouterPlugin | keyof AntseedVerifierPlugin | keyof Prover,
+  opts?: { install?: boolean }
 ): Promise<T> {
   const pkgName = resolvePackageName(nameOrPackage)
   const pluginsDir = getPluginsDir()
@@ -49,8 +50,10 @@ async function loadPlugin<T>(
     'code' in err &&
     (err as { code?: string }).code === 'ERR_MODULE_NOT_FOUND'
 
+  // The request hot path passes { install: false } so it never blocks on npm; startup
+  // preloads with installs allowed, so a prepared plugin is import-only here.
   const isTrusted = TRUSTED_PLUGINS.some(p => p.package === pkgName)
-  if (isTrusted) {
+  if (isTrusted && opts?.install !== false) {
     await ensureTrustedPluginInstallReady(pkgName, resolved, pluginsDir)
   }
   assertPinnedPluginVersion(pkgName, pluginsDir)
@@ -61,7 +64,8 @@ async function loadPlugin<T>(
   } catch (err) {
     if (isModuleNotFound(err) && !existsSync(resolved)) {
       throw new Error(
-        `Plugin "${pkgName}" not found. Install it first, then retry your command.\nRun: antseed plugin add ${pkgName}`
+        `Plugin "${pkgName}" not found. Install it first, then retry your command.\n` +
+        `Run: cd ${pluginsDir} && npm install --ignore-scripts ${pkgName}`
       )
     } else {
       const cause = err instanceof Error ? err.message : String(err)
@@ -71,13 +75,12 @@ async function loadPlugin<T>(
     }
   }
 
-  // Packages may export multiple plugin types; pick the export matching this loader.
-  const candidates = [mod['default'], ...Object.values(mod)].filter(
-    (p): p is Record<string, unknown> => !!p && typeof p === 'object',
-  )
-  const plugin = candidates.find(
-    (p) => p['type'] === kind && typeof p[methodName as string] === 'function',
-  )
+  let plugin: Record<string, unknown> | undefined
+  try {
+    plugin = selectPluginExport(mod, kind, methodName as string)
+  } catch {
+    throw new Error(`Plugin "${pkgName}" exports multiple ${kind} plugins; expected exactly one.`)
+  }
   if (!plugin) {
     throw new Error(
       `Plugin "${pkgName}" does not export a valid ${kind} plugin (expected an export with type: '${kind}' and ${String(methodName)}())`
@@ -87,14 +90,32 @@ async function loadPlugin<T>(
   return plugin as T
 }
 
+export function selectPluginExport(
+  mod: Record<string, unknown>,
+  kind: PluginKind,
+  methodName: string,
+): Record<string, unknown> | undefined {
+  const candidates = Array.from(new Set([mod['default'], ...Object.values(mod)])).filter(
+    (p): p is Record<string, unknown> => !!p && typeof p === 'object',
+  )
+  const matches = candidates.filter(
+    (p) => p['type'] === kind && typeof p[methodName] === 'function',
+  )
+  if (matches.length > 1) {
+    throw new Error(`multiple matching ${kind} exports`)
+  }
+  return matches[0]
+}
+
 export function assertPinnedPluginVersion(pkgName: string, pluginsDir = getPluginsDir()): void {
   const pin = pinnedVersion(pkgName)
   if (!pin) return
   const installed = readPluginPackageVersion(pkgName, pluginsDir)
   if (installed === pin) return
+  const state = installed ? `version ${installed} is installed` : 'it is not installed'
   throw new Error(
-    `Plugin "${pkgName}" is version-locked to ${pin} but ${installed ?? 'an unknown version'} is installed.\n` +
-    `Reinstall the pinned version: antseed plugin add ${pkgName}@${pin}`
+    `Plugin "${pkgName}" is version-locked to ${pin} but ${state}.\n` +
+    `Reinstall the pinned version: cd ${pluginsDir} && npm install --ignore-scripts ${pkgName}@${pin}`
   )
 }
 
@@ -104,8 +125,11 @@ async function ensureTrustedPluginInstallReady(
   pluginsDir: string,
 ): Promise<void> {
   const pkgJsonPath = join(pluginsDir, 'node_modules', ...pkgName.split('/'), 'package.json')
+  const pin = pinnedVersion(pkgName)
+  const pinMismatch = pin !== undefined && readPluginPackageVersion(pkgName, pluginsDir) !== pin
   const shouldInstall = !existsSync(entryPath)
     || !existsSync(pkgJsonPath)
+    || pinMismatch
     || hasMissingDeclaredDependencyTree(pkgName, pluginsDir)
   if (!shouldInstall) return
   if (isTruthyEnv(process.env['ANTSEED_SKIP_PLUGIN_UPDATE_CHECK'])) return
@@ -164,8 +188,11 @@ export async function loadRouterPlugin(nameOrPackage: string): Promise<AntseedRo
   return loadPlugin<AntseedRouterPlugin>(nameOrPackage, 'router', 'createRouter')
 }
 
-export async function loadVerifierPlugin(nameOrPackage: string): Promise<AntseedVerifierPlugin> {
-  return loadPlugin<AntseedVerifierPlugin>(nameOrPackage, 'verifier', 'verify')
+export async function loadVerifierPlugin(
+  nameOrPackage: string,
+  opts?: { install?: boolean },
+): Promise<AntseedVerifierPlugin> {
+  return loadPlugin<AntseedVerifierPlugin>(nameOrPackage, 'verifier', 'verify', opts)
 }
 
 export async function loadProverPlugin(nameOrPackage: string): Promise<Prover> {

--- a/apps/cli/src/plugins/manager.ts
+++ b/apps/cli/src/plugins/manager.ts
@@ -7,6 +7,11 @@ import { homedir } from 'node:os'
 
 const execFileAsync = promisify(execFile)
 
+/** Upper bound on a plugin install so an unreachable registry can't hang a caller forever. */
+const INSTALL_TIMEOUT_MS = 120_000
+/** Dedupe concurrent installs of the same package so first-requests can't race npm. */
+const inflightInstalls = new Map<string, Promise<void>>()
+
 export const PLUGINS_DIR = join(homedir(), '.antseed', 'plugins')
 
 function resolvePluginsDir(): string {
@@ -40,8 +45,21 @@ async function ensurePluginsDir(): Promise<void> {
 }
 
 export async function installPlugin(packageName: string): Promise<void> {
-  await ensurePluginsDir()
-  await execFileAsync('npm', ['install', '--ignore-scripts', packageName], { cwd: getPluginsDir() })
+  const existing = inflightInstalls.get(packageName)
+  if (existing) return existing
+  const run = (async () => {
+    await ensurePluginsDir()
+    await execFileAsync('npm', ['install', '--ignore-scripts', packageName], {
+      cwd: getPluginsDir(),
+      timeout: INSTALL_TIMEOUT_MS,
+    })
+  })()
+  inflightInstalls.set(packageName, run)
+  try {
+    await run
+  } finally {
+    inflightInstalls.delete(packageName)
+  }
 }
 
 export async function removePlugin(packageName: string): Promise<void> {

--- a/apps/cli/src/plugins/registry.test.ts
+++ b/apps/cli/src/plugins/registry.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { TRUSTED_PLUGINS, resolvePluginPackage } from './registry.js'
+
+test('curated verifier pins an exact package version', () => {
+  const verifiers = TRUSTED_PLUGINS.filter((p) => p.type === 'verifier')
+  assert.ok(verifiers.length > 0, 'expected a curated verifier')
+  for (const v of verifiers) {
+    assert.match(v.version ?? '', /^\d+\.\d+\.\d+/, `verifier ${v.name} must pin a locked binary version`)
+  }
+})
+
+test('providers are not version-pinned', () => {
+  assert.ok(TRUSTED_PLUGINS.filter((p) => p.type === 'provider').every((p) => !p.version))
+})
+
+test('noop verifier is not curated', () => {
+  assert.equal(TRUSTED_PLUGINS.some((p) => p.name === 'antseed/noop' || p.package === '@antseed/verifier-noop'), false)
+})
+
+test('verifier id resolves to its package (short name, not id=package)', () => {
+  assert.equal(resolvePluginPackage('refoundhq-antseed-verifier'), '@refoundhq/antseed-verifier')
+})

--- a/apps/cli/src/plugins/registry.test.ts
+++ b/apps/cli/src/plugins/registry.test.ts
@@ -1,23 +1,22 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { TRUSTED_PLUGINS, resolvePluginPackage } from './registry.js'
+import { TRUSTED_PLUGINS, TRUSTED_PROVIDER_PLUGINS, TRUSTED_ROUTER_PLUGINS, TRUSTED_VERIFIER_PLUGINS, resolvePluginPackage } from './registry.js'
 
-test('curated verifier pins an exact package version', () => {
+test('trusted plugin registry keeps typed lists and verifier invariants', () => {
+  assert.deepEqual(TRUSTED_PLUGINS, [
+    ...TRUSTED_PROVIDER_PLUGINS,
+    ...TRUSTED_ROUTER_PLUGINS,
+    ...TRUSTED_VERIFIER_PLUGINS,
+  ])
+  assert.ok(TRUSTED_PROVIDER_PLUGINS.every((p) => p.type === 'provider'))
+  assert.ok(TRUSTED_ROUTER_PLUGINS.every((p) => p.type === 'router'))
+  assert.ok(TRUSTED_VERIFIER_PLUGINS.every((p) => p.type === 'verifier'))
   const verifiers = TRUSTED_PLUGINS.filter((p) => p.type === 'verifier')
   assert.ok(verifiers.length > 0, 'expected a curated verifier')
   for (const v of verifiers) {
     assert.match(v.version ?? '', /^\d+\.\d+\.\d+/, `verifier ${v.name} must pin a locked binary version`)
   }
-})
-
-test('providers are not version-pinned', () => {
   assert.ok(TRUSTED_PLUGINS.filter((p) => p.type === 'provider').every((p) => !p.version))
-})
-
-test('noop verifier is not curated', () => {
   assert.equal(TRUSTED_PLUGINS.some((p) => p.name === 'antseed/noop' || p.package === '@antseed/verifier-noop'), false)
-})
-
-test('verifier id resolves to its package (short name, not id=package)', () => {
   assert.equal(resolvePluginPackage('refoundhq-antseed-verifier'), '@refoundhq/antseed-verifier')
 })

--- a/apps/cli/src/plugins/registry.test.ts
+++ b/apps/cli/src/plugins/registry.test.ts
@@ -18,5 +18,5 @@ test('trusted plugin registry keeps typed lists and verifier invariants', () => 
   }
   assert.ok(TRUSTED_PLUGINS.filter((p) => p.type === 'provider').every((p) => !p.version))
   assert.equal(TRUSTED_PLUGINS.some((p) => p.name === 'antseed/noop' || p.package === '@antseed/verifier-noop'), false)
-  assert.equal(resolvePluginPackage('refoundhq-antseed-verifier'), '@refoundhq/antseed-verifier')
+  assert.equal(resolvePluginPackage('antseed-verifier'), '@antseed/antseed-verifier')
 })

--- a/apps/cli/src/plugins/registry.ts
+++ b/apps/cli/src/plugins/registry.ts
@@ -1,8 +1,10 @@
 export interface TrustedPlugin {
   name: string
-  type: 'provider' | 'router'
+  type: 'provider' | 'router' | 'verifier'
   description: string
   package: string
+  /** Exact npm version for trusted verifier packages. */
+  version?: string
 }
 
 export const TRUSTED_PLUGINS: TrustedPlugin[] = [
@@ -47,6 +49,13 @@ export const TRUSTED_PLUGINS: TrustedPlugin[] = [
     type: 'router',
     description: 'Local router for Claude Code, Codex',
     package: '@antseed/router-local',
+  },
+  {
+    name: 'refoundhq-antseed-verifier',
+    type: 'verifier',
+    description: 'TEE attestation verifier + prover (Intel TDX, DCAP)',
+    package: '@refoundhq/antseed-verifier',
+    version: '0.1.0',
   },
 ]
 

--- a/apps/cli/src/plugins/registry.ts
+++ b/apps/cli/src/plugins/registry.ts
@@ -57,10 +57,10 @@ export const TRUSTED_ROUTER_PLUGINS: TrustedPlugin[] = [
 
 export const TRUSTED_VERIFIER_PLUGINS: TrustedPlugin[] = [
   {
-    name: 'refoundhq-antseed-verifier',
+    name: 'antseed-verifier',
     type: 'verifier',
     description: 'TEE attestation verifier + prover (Intel TDX, DCAP)',
-    package: '@refoundhq/antseed-verifier',
+    package: '@antseed/antseed-verifier',
     version: '0.1.0',
   },
 ]

--- a/apps/cli/src/plugins/registry.ts
+++ b/apps/cli/src/plugins/registry.ts
@@ -7,7 +7,7 @@ export interface TrustedPlugin {
   version?: string
 }
 
-export const TRUSTED_PLUGINS: TrustedPlugin[] = [
+export const TRUSTED_PROVIDER_PLUGINS: TrustedPlugin[] = [
   {
     name: 'anthropic',
     type: 'provider',
@@ -44,12 +44,18 @@ export const TRUSTED_PLUGINS: TrustedPlugin[] = [
     description: 'Local LLM provider (Ollama, llama.cpp)',
     package: '@antseed/provider-local-llm',
   },
+]
+
+export const TRUSTED_ROUTER_PLUGINS: TrustedPlugin[] = [
   {
     name: 'local',
     type: 'router',
     description: 'Local router for Claude Code, Codex',
     package: '@antseed/router-local',
   },
+]
+
+export const TRUSTED_VERIFIER_PLUGINS: TrustedPlugin[] = [
   {
     name: 'refoundhq-antseed-verifier',
     type: 'verifier',
@@ -57,6 +63,12 @@ export const TRUSTED_PLUGINS: TrustedPlugin[] = [
     package: '@refoundhq/antseed-verifier',
     version: '0.1.0',
   },
+]
+
+export const TRUSTED_PLUGINS: TrustedPlugin[] = [
+  ...TRUSTED_PROVIDER_PLUGINS,
+  ...TRUSTED_ROUTER_PLUGINS,
+  ...TRUSTED_VERIFIER_PLUGINS,
 ]
 
 export function resolvePluginPackage(nameOrPackage: string): string {

--- a/apps/cli/src/plugins/verifier.test.ts
+++ b/apps/cli/src/plugins/verifier.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { buildVerifierCapabilities, normalizeVerifierIds, parseVerifierCapabilities, selectVerifier } from './verifier.js'
+
+const TEE = 'refoundhq-antseed-verifier'
+
+test('buildVerifierCapabilities: first id is the default; dot-separated (PEER_CAPABILITY_PATTERN-safe)', () => {
+  assert.deepEqual(buildVerifierCapabilities([TEE, 'acme-x']), [
+    'verifier.refoundhq-antseed-verifier',
+    'verifier-default.refoundhq-antseed-verifier',
+    'verifier.acme-x',
+  ])
+})
+
+test('parseVerifierCapabilities: round-trips + ignores unrelated caps', () => {
+  const caps = buildVerifierCapabilities([TEE, 'acme-x'])
+  assert.deepEqual(parseVerifierCapabilities([...caps, 'verification.response-auth.v1']), {
+    supported: [TEE, 'acme-x'],
+    default: TEE,
+  })
+  assert.deepEqual(parseVerifierCapabilities(['verification.response-auth.v1']), { supported: [] })
+})
+
+test('parseVerifierCapabilities: ignores malformed verifier ids', () => {
+  assert.deepEqual(
+    parseVerifierCapabilities([
+      'verifier.@scope/pkg',
+      'verifier-default.has space',
+      'verifier.good-id',
+    ]),
+    { supported: ['good-id'] },
+  )
+})
+
+test('selectVerifier: ordered preference returns first supported, skipping unsupported', () => {
+  const sup = { supported: ['acme-x', TEE], default: 'acme-x' }
+  assert.equal(selectVerifier({ require: false, prefer: ['nope-x', TEE, 'acme-x'] }, sup), TEE)
+})
+
+test('selectVerifier: no preference -> seller default if curated-trusted', () => {
+  const sup = { supported: [TEE], default: TEE }
+  assert.equal(selectVerifier({ require: false }, sup), TEE)
+})
+
+test('selectVerifier: no preference + untrusted default -> null', () => {
+  const sup = { supported: ['acme-untrusted'], default: 'acme-untrusted' }
+  assert.equal(selectVerifier({ require: false }, sup), null)
+})
+
+test('selectVerifier: preference set but none supported -> null', () => {
+  const sup = { supported: [TEE], default: TEE }
+  assert.equal(selectVerifier({ require: false, prefer: ['nope-x'] }, sup), null)
+})
+
+test('normalizeVerifierIds: lowercases, dedupes, drops blanks', () => {
+  assert.deepEqual(
+    normalizeVerifierIds(' Refoundhq-Antseed-Verifier , acme-x , refoundhq-antseed-verifier , '),
+    ['refoundhq-antseed-verifier', 'acme-x'],
+  )
+})
+
+test('normalizeVerifierIds: rejects ids with invalid chars (@ / space)', () => {
+  for (const bad of ['@scope/pkg', 'has space', 'up/slash']) {
+    assert.throws(() => normalizeVerifierIds(bad), /invalid verifier id/)
+  }
+})

--- a/apps/cli/src/plugins/verifier.test.ts
+++ b/apps/cli/src/plugins/verifier.test.ts
@@ -1,8 +1,17 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import { buildVerifierCapabilities, normalizeVerifierIds, parseVerifierCapabilities, selectVerifier } from './verifier.js'
+import { buildVerifierCapabilities, getCachedVerdict, normalizeVerifierIds, parseVerifierCapabilities, resolveVerifierPolicy, selectVerifier, verifierSupportFingerprint, withVerifyTimeout, type CachedVerdict, type VerifyOutcome } from './verifier.js'
 
 const TEE = 'refoundhq-antseed-verifier'
+const OK: VerifyOutcome = { ok: true, verified: true }
+
+function countedRun(outcome: VerifyOutcome = OK): { run: () => Promise<VerifyOutcome>; runs: () => number } {
+  let count = 0
+  return {
+    run: async () => { count++; return outcome },
+    runs: () => count,
+  }
+}
 
 test('buildVerifierCapabilities: first id is the default; dot-separated (PEER_CAPABILITY_PATTERN-safe)', () => {
   assert.deepEqual(buildVerifierCapabilities([TEE, 'acme-x']), [
@@ -32,35 +41,80 @@ test('parseVerifierCapabilities: ignores malformed verifier ids', () => {
   )
 })
 
-test('selectVerifier: ordered preference returns first supported, skipping unsupported', () => {
-  const sup = { supported: ['acme-x', TEE], default: 'acme-x' }
-  assert.equal(selectVerifier({ require: false, prefer: ['nope-x', TEE, 'acme-x'] }, sup), TEE)
+test('selectVerifier: prefers requested trusted SDKs, otherwise trusted seller default', () => {
+  assert.equal(
+    selectVerifier({ require: false, prefer: ['nope-x', TEE, 'acme-x'] }, { supported: ['acme-x', TEE], default: 'acme-x' }),
+    TEE,
+  )
+  assert.equal(selectVerifier({ require: false }, { supported: [TEE], default: TEE }), TEE)
+  assert.equal(selectVerifier({ require: false }, { supported: ['acme-untrusted'], default: 'acme-untrusted' }), null)
+  assert.equal(selectVerifier({ require: false, prefer: ['nope-x'] }, { supported: [TEE], default: TEE }), null)
 })
 
-test('selectVerifier: no preference -> seller default if curated-trusted', () => {
-  const sup = { supported: [TEE], default: TEE }
-  assert.equal(selectVerifier({ require: false }, sup), TEE)
-})
-
-test('selectVerifier: no preference + untrusted default -> null', () => {
-  const sup = { supported: ['acme-untrusted'], default: 'acme-untrusted' }
-  assert.equal(selectVerifier({ require: false }, sup), null)
-})
-
-test('selectVerifier: preference set but none supported -> null', () => {
-  const sup = { supported: [TEE], default: TEE }
-  assert.equal(selectVerifier({ require: false, prefer: ['nope-x'] }, sup), null)
-})
-
-test('normalizeVerifierIds: lowercases, dedupes, drops blanks', () => {
+test('normalizeVerifierIds: lowercases/dedupes/drops-blanks and rejects invalid chars', () => {
   assert.deepEqual(
     normalizeVerifierIds(' Refoundhq-Antseed-Verifier , acme-x , refoundhq-antseed-verifier , '),
     ['refoundhq-antseed-verifier', 'acme-x'],
   )
-})
-
-test('normalizeVerifierIds: rejects ids with invalid chars (@ / space)', () => {
   for (const bad of ['@scope/pkg', 'has space', 'up/slash']) {
     assert.throws(() => normalizeVerifierIds(bad), /invalid verifier id/)
   }
+})
+
+test('resolveVerifierPolicy: resolves valid flags and rejects contradictions', () => {
+  assert.equal(resolveVerifierPolicy({ verifier: false }), undefined)
+  assert.deepEqual(resolveVerifierPolicy({ verifiers: `${TEE},acme-x`, requireVerifier: true }), {
+    prefer: [TEE, 'acme-x'],
+    require: true,
+  })
+  assert.deepEqual(resolveVerifierPolicy({}), { prefer: [], require: false })
+  assert.throws(() => resolveVerifierPolicy({ verifier: false, requireVerifier: true }), /cannot be combined/)
+  assert.throws(() => resolveVerifierPolicy({ verifier: false, verifiers: TEE }), /cannot be combined/)
+})
+
+test('withVerifyTimeout: resolves in time, times out, and surfaces an outer abort', async () => {
+  assert.equal(await withVerifyTimeout(async () => 'ok', undefined, 1000), 'ok')
+  await assert.rejects(withVerifyTimeout(() => new Promise(() => {}), undefined, 10), /timed out/)
+  const ac = new AbortController()
+  ac.abort(new Error('client disconnected'))
+  await assert.rejects(withVerifyTimeout(() => new Promise(() => {}), ac.signal, 1000), /client disconnected/)
+})
+
+test('verifierSupportFingerprint: changes when advertised verifiers change (cache invalidation)', () => {
+  const a = verifierSupportFingerprint(['verifier.refoundhq-antseed-verifier', 'verifier-default.refoundhq-antseed-verifier'])
+  const b = verifierSupportFingerprint(['verifier.acme-x'])
+  assert.notEqual(a, b)
+  assert.equal(a, verifierSupportFingerprint(['verifier-default.refoundhq-antseed-verifier', 'verifier.refoundhq-antseed-verifier']))
+})
+
+test('getCachedVerdict: caches unexpired verdicts, re-runs otherwise, skips transient, and hard-bounds size', async () => {
+  const cache = new Map<string, CachedVerdict>()
+  const { run, runs } = countedRun()
+  const first = await getCachedVerdict(cache, 'k', 0, 1000, 10, run)
+  const second = await getCachedVerdict(cache, 'k', 1, 1000, 10, run)
+  assert.equal(runs(), 1)
+  assert.deepEqual(second, first)
+
+  const changedKey = countedRun()
+  const changedKeyCache = new Map<string, CachedVerdict>()
+  await getCachedVerdict(changedKeyCache, 'peer|A', 0, 1000, 10, changedKey.run)
+  await getCachedVerdict(changedKeyCache, 'peer|B', 0, 1000, 10, changedKey.run)
+  assert.equal(changedKey.runs(), 2)
+
+  const expired = countedRun()
+  const expiredCache = new Map<string, CachedVerdict>()
+  await getCachedVerdict(expiredCache, 'k', 0, 100, 10, expired.run)
+  await getCachedVerdict(expiredCache, 'k', 200, 100, 10, expired.run)
+  assert.equal(expired.runs(), 2)
+
+  const transient = countedRun({ ok: false, verified: false, transient: true })
+  const transientCache = new Map<string, CachedVerdict>()
+  await getCachedVerdict(transientCache, 'k', 0, 1000, 10, transient.run)
+  await getCachedVerdict(transientCache, 'k', 0, 1000, 10, transient.run)
+  assert.equal(transient.runs(), 2)
+  assert.equal(transientCache.size, 0)
+
+  const bounded = new Map<string, CachedVerdict>()
+  for (let i = 0; i < 15; i++) await getCachedVerdict(bounded, `k${i}`, 0, 1_000_000, 10, async () => OK)
+  assert.ok(bounded.size <= 10, `cache size ${bounded.size} exceeded max 10`)
 })

--- a/apps/cli/src/plugins/verifier.test.ts
+++ b/apps/cli/src/plugins/verifier.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { buildVerifierCapabilities, getCachedVerdict, normalizeVerifierIds, parseVerifierCapabilities, resolveVerifierPolicy, selectVerifier, verifierSupportFingerprint, withVerifyTimeout, type CachedVerdict, type VerifyOutcome } from './verifier.js'
 
-const TEE = 'refoundhq-antseed-verifier'
+const TEE = 'antseed-verifier'
 const OK: VerifyOutcome = { ok: true, verified: true }
 
 function countedRun(outcome: VerifyOutcome = OK): { run: () => Promise<VerifyOutcome>; runs: () => number } {
@@ -15,8 +15,8 @@ function countedRun(outcome: VerifyOutcome = OK): { run: () => Promise<VerifyOut
 
 test('buildVerifierCapabilities: first id is the default; dot-separated (PEER_CAPABILITY_PATTERN-safe)', () => {
   assert.deepEqual(buildVerifierCapabilities([TEE, 'acme-x']), [
-    'verifier.refoundhq-antseed-verifier',
-    'verifier-default.refoundhq-antseed-verifier',
+    'verifier.antseed-verifier',
+    'verifier-default.antseed-verifier',
     'verifier.acme-x',
   ])
 })
@@ -53,8 +53,8 @@ test('selectVerifier: prefers requested trusted SDKs, otherwise trusted seller d
 
 test('normalizeVerifierIds: lowercases/dedupes/drops-blanks and rejects invalid chars', () => {
   assert.deepEqual(
-    normalizeVerifierIds(' Refoundhq-Antseed-Verifier , acme-x , refoundhq-antseed-verifier , '),
-    ['refoundhq-antseed-verifier', 'acme-x'],
+    normalizeVerifierIds(' Antseed-Verifier , acme-x , antseed-verifier , '),
+    ['antseed-verifier', 'acme-x'],
   )
   for (const bad of ['@scope/pkg', 'has space', 'up/slash']) {
     assert.throws(() => normalizeVerifierIds(bad), /invalid verifier id/)
@@ -81,10 +81,10 @@ test('withVerifyTimeout: resolves in time, times out, and surfaces an outer abor
 })
 
 test('verifierSupportFingerprint: changes when advertised verifiers change (cache invalidation)', () => {
-  const a = verifierSupportFingerprint(['verifier.refoundhq-antseed-verifier', 'verifier-default.refoundhq-antseed-verifier'])
+  const a = verifierSupportFingerprint(['verifier.antseed-verifier', 'verifier-default.antseed-verifier'])
   const b = verifierSupportFingerprint(['verifier.acme-x'])
   assert.notEqual(a, b)
-  assert.equal(a, verifierSupportFingerprint(['verifier-default.refoundhq-antseed-verifier', 'verifier.refoundhq-antseed-verifier']))
+  assert.equal(a, verifierSupportFingerprint(['verifier-default.antseed-verifier', 'verifier.antseed-verifier']))
 })
 
 test('getCachedVerdict: caches unexpired verdicts, re-runs otherwise, skips transient, and hard-bounds size', async () => {

--- a/apps/cli/src/plugins/verifier.ts
+++ b/apps/cli/src/plugins/verifier.ts
@@ -1,0 +1,113 @@
+import { ANTSEED_ATTEST_PATH, type SellerRequest, type SellerResponse } from '@antseed/node'
+import { loadVerifierPlugin } from './loader.js'
+import { TRUSTED_PLUGINS } from './registry.js'
+
+export const ANTSEED_VERIFIER_SDKS_ENV = 'ANTSEED_VERIFIER_SDKS'
+const VSDK = 'verifier.'
+const VSDK_DEFAULT = 'verifier-default.'
+const VERIFIER_ID_RE = /^[a-z0-9][a-z0-9.-]*$/
+
+function isVerifierId(id: string): boolean {
+  return VERIFIER_ID_RE.test(id)
+}
+
+export function normalizeVerifierIds(raw: string): string[] {
+  const ids = raw.split(',').map((id) => id.trim().toLowerCase()).filter(Boolean)
+  for (const id of ids) {
+    if (!isVerifierId(id)) {
+      throw new Error(`invalid verifier id "${id}": use lowercase letters, digits, hyphen, or dot`)
+    }
+  }
+  return Array.from(new Set(ids))
+}
+
+export function buildVerifierCapabilities(ids: string[]): string[] {
+  const clean = normalizeVerifierIds(ids.join(','))
+  return clean.flatMap((id, i) => (i === 0 ? [`${VSDK}${id}`, `${VSDK_DEFAULT}${id}`] : [`${VSDK}${id}`]))
+}
+
+export function parseVerifierCapabilities(caps: string[] | undefined): { supported: string[]; default?: string } {
+  const supported: string[] = []
+  let dflt: string | undefined
+  for (const cap of caps ?? []) {
+    const isDefault = cap.startsWith(VSDK_DEFAULT)
+    const raw = isDefault
+      ? cap.slice(VSDK_DEFAULT.length)
+      : cap.startsWith(VSDK)
+        ? cap.slice(VSDK.length)
+        : ''
+    const id = raw.trim().toLowerCase()
+    if (!isVerifierId(id)) continue
+    if (!supported.includes(id)) supported.push(id)
+    if (isDefault) dflt = id
+  }
+  return dflt ? { supported, default: dflt } : { supported }
+}
+
+export function curatedVerifierIds(): Set<string> {
+  return new Set(TRUSTED_PLUGINS.filter((p) => p.type === 'verifier').map((p) => p.name))
+}
+
+export interface VerifierPolicy {
+  prefer?: string[]
+  require: boolean
+}
+
+export function selectVerifier(
+  policy: VerifierPolicy,
+  sup: { supported: string[]; default?: string },
+): string | null {
+  for (const id of policy.prefer ?? []) {
+    if (sup.supported.includes(id)) return id
+  }
+  if ((policy.prefer ?? []).length > 0) return null
+  const curated = curatedVerifierIds()
+  if (sup.default && curated.has(sup.default)) return sup.default
+  return sup.supported.find((id) => curated.has(id)) ?? null
+}
+
+export type SellerReach = (req: SellerRequest) => Promise<SellerResponse>
+
+export interface VerifyOutcome {
+  ok: boolean
+  verified: boolean
+  sdk?: string
+  reason?: string
+}
+
+export async function runVerifier(
+  policy: VerifierPolicy,
+  peerId: string,
+  caps: string[] | undefined,
+  reach: SellerReach,
+  signal?: AbortSignal,
+): Promise<VerifyOutcome> {
+  const sup = parseVerifierCapabilities(caps)
+  const chosen = selectVerifier(policy, sup)
+  if (!chosen) return { ok: !policy.require, verified: false, reason: 'no supported + trusted verifier' }
+  let sdk
+  try {
+    sdk = await loadVerifierPlugin(chosen)
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    return { ok: !policy.require, verified: false, sdk: chosen, reason: `install/load failed: ${reason}` }
+  }
+  if (sdk.name !== chosen) {
+    return { ok: !policy.require, verified: false, sdk: chosen, reason: `verifier package exported name "${sdk.name}", expected "${chosen}"` }
+  }
+  try {
+    const result = await sdk.verify({
+      peerId,
+      verifierId: chosen,
+      attestPath: `${ANTSEED_ATTEST_PATH}/${encodeURIComponent(chosen)}`,
+      fetchFromSeller: reach,
+      ...(signal ? { signal } : {}),
+    })
+    if (result.ok) return { ok: true, verified: true, sdk: chosen }
+    const failed = result.claims.filter((c) => !c.ok).map((c) => `${c.claim}: ${c.detail ?? 'failed'}`).join('; ')
+    return { ok: !policy.require, verified: false, sdk: chosen, reason: failed || 'verifier returned not-ok' }
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    return { ok: !policy.require, verified: false, sdk: chosen, reason: `verify error: ${reason}` }
+  }
+}

--- a/apps/cli/src/plugins/verifier.ts
+++ b/apps/cli/src/plugins/verifier.ts
@@ -1,6 +1,6 @@
 import { ANTSEED_ATTEST_PATH, type SellerRequest, type SellerResponse } from '@antseed/node'
 import { loadVerifierPlugin } from './loader.js'
-import { TRUSTED_PLUGINS } from './registry.js'
+import { TRUSTED_VERIFIER_PLUGINS } from './registry.js'
 
 export const ANTSEED_VERIFIER_SDKS_ENV = 'ANTSEED_VERIFIER_SDKS'
 const VSDK = 'verifier.'
@@ -45,12 +45,31 @@ export function parseVerifierCapabilities(caps: string[] | undefined): { support
 }
 
 export function curatedVerifierIds(): Set<string> {
-  return new Set(TRUSTED_PLUGINS.filter((p) => p.type === 'verifier').map((p) => p.name))
+  return new Set(TRUSTED_VERIFIER_PLUGINS.map((p) => p.name))
 }
 
 export interface VerifierPolicy {
   prefer?: string[]
   require: boolean
+}
+
+/**
+ * Resolve buyer verifier CLI flags into a policy. `--no-verifier` (verifier === false)
+ * disables verification; combining it with `--require-verifier` or `--verifiers` is a
+ * contradiction and is rejected rather than silently disabling verification.
+ */
+export function resolveVerifierPolicy(opts: {
+  verifier?: boolean
+  verifiers?: string
+  requireVerifier?: boolean
+}): VerifierPolicy | undefined {
+  if (opts.verifier === false) {
+    if (opts.requireVerifier || opts.verifiers) {
+      throw new Error('--no-verifier cannot be combined with --require-verifier or --verifiers')
+    }
+    return undefined
+  }
+  return { prefer: normalizeVerifierIds(opts.verifiers ?? ''), require: Boolean(opts.requireVerifier) }
 }
 
 export function selectVerifier(
@@ -73,41 +92,119 @@ export interface VerifyOutcome {
   verified: boolean
   sdk?: string
   reason?: string
+  /** True for install/network/timeout failures — a transient outcome must not be cached. */
+  transient?: boolean
+}
+
+/** Stable fingerprint of a peer's verifier-relevant capabilities. */
+export function verifierSupportFingerprint(caps: string[] | undefined): string {
+  const sup = parseVerifierCapabilities(caps)
+  return `${sup.default ?? ''}|${[...sup.supported].sort().join(',')}`
+}
+
+/** Upper bound on a single verification (attest round-trip + quote check). */
+export const VERIFY_TIMEOUT_MS = 30_000
+
+export async function withVerifyTimeout<T>(
+  run: (signal: AbortSignal) => Promise<T>,
+  outer?: AbortSignal,
+  timeoutMs: number = VERIFY_TIMEOUT_MS,
+): Promise<T> {
+  const ac = new AbortController()
+  const abort = (reason: unknown): void => { if (!ac.signal.aborted) ac.abort(reason) }
+  const onOuter = (): void => abort(outer?.reason ?? new Error('verification aborted'))
+  if (outer?.aborted) abort(outer.reason ?? new Error('verification aborted'))
+  else outer?.addEventListener('abort', onOuter, { once: true })
+  const timer = setTimeout(() => abort(new Error(`verification timed out after ${timeoutMs}ms`)), timeoutMs)
+  try {
+    return await Promise.race([
+      run(ac.signal),
+      new Promise<never>((_, reject) => {
+        const fail = (): void => {
+          const r = ac.signal.reason
+          reject(r instanceof Error ? r : new Error('verification aborted'))
+        }
+        // The signal may already be aborted (e.g. the client had disconnected before
+        // we started); a listener added after that never fires, so reject eagerly.
+        if (ac.signal.aborted) fail()
+        else ac.signal.addEventListener('abort', fail, { once: true })
+      }),
+    ])
+  } finally {
+    clearTimeout(timer)
+    outer?.removeEventListener('abort', onOuter)
+  }
 }
 
 export async function runVerifier(
   policy: VerifierPolicy,
   peerId: string,
   caps: string[] | undefined,
-  reach: SellerReach,
+  makeReach: (chosenId: string) => SellerReach,
   signal?: AbortSignal,
 ): Promise<VerifyOutcome> {
   const sup = parseVerifierCapabilities(caps)
   const chosen = selectVerifier(policy, sup)
   if (!chosen) return { ok: !policy.require, verified: false, reason: 'no supported + trusted verifier' }
+  const reach = makeReach(chosen)
   let sdk
   try {
-    sdk = await loadVerifierPlugin(chosen)
+    sdk = await loadVerifierPlugin(chosen, { install: false })
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err)
-    return { ok: !policy.require, verified: false, sdk: chosen, reason: `install/load failed: ${reason}` }
+    return { ok: !policy.require, verified: false, sdk: chosen, reason: `verifier not prepared: ${reason}`, transient: true }
   }
   if (sdk.name !== chosen) {
     return { ok: !policy.require, verified: false, sdk: chosen, reason: `verifier package exported name "${sdk.name}", expected "${chosen}"` }
   }
   try {
-    const result = await sdk.verify({
-      peerId,
-      verifierId: chosen,
-      attestPath: `${ANTSEED_ATTEST_PATH}/${encodeURIComponent(chosen)}`,
-      fetchFromSeller: reach,
-      ...(signal ? { signal } : {}),
-    })
+    const result = await withVerifyTimeout(
+      async (verifySignal) => sdk.verify({
+        peerId,
+        verifierId: chosen,
+        attestPath: `${ANTSEED_ATTEST_PATH}/${encodeURIComponent(chosen)}`,
+        fetchFromSeller: reach,
+        signal: verifySignal,
+      }),
+      signal,
+    )
     if (result.ok) return { ok: true, verified: true, sdk: chosen }
     const failed = result.claims.filter((c) => !c.ok).map((c) => `${c.claim}: ${c.detail ?? 'failed'}`).join('; ')
     return { ok: !policy.require, verified: false, sdk: chosen, reason: failed || 'verifier returned not-ok' }
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err)
-    return { ok: !policy.require, verified: false, sdk: chosen, reason: `verify error: ${reason}` }
+    return { ok: !policy.require, verified: false, sdk: chosen, reason: `verify error: ${reason}`, transient: true }
   }
+}
+
+export interface CachedVerdict {
+  outcome: VerifyOutcome
+  expires: number
+}
+
+export async function getCachedVerdict(
+  cache: Map<string, CachedVerdict>,
+  key: string,
+  now: number,
+  ttlMs: number,
+  maxEntries: number,
+  run: () => Promise<VerifyOutcome>,
+): Promise<VerifyOutcome> {
+  const cached = cache.get(key)
+  if (cached && cached.expires > now) return cached.outcome
+  if (cached) cache.delete(key)
+
+  const outcome = await run()
+  if (!outcome.transient) {
+    if (cache.size >= maxEntries) {
+      for (const [k, v] of cache) if (v.expires <= now) cache.delete(k)
+      while (cache.size >= maxEntries) {
+        const oldest = cache.keys().next().value
+        if (oldest === undefined) break
+        cache.delete(oldest)
+      }
+    }
+    cache.set(key, { outcome, expires: now + ttlMs })
+  }
+  return outcome
 }

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -8,6 +8,7 @@ import { CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1, type PeerInfo } from '@antseed/
 import { DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS } from '../config/defaults.js'
 import {
   BuyerProxy,
+  makeVerifierReach,
   parsePeerPinnedService,
   parsePersistedPeers,
   rewritePeerPinnedServiceInBody,
@@ -1096,4 +1097,29 @@ test('rewritePeerPinnedServiceInBody returns original when body is not a JSON ob
   const result = rewritePeerPinnedServiceInBody(body, jsonHeaders)
   assert.equal(result.body, body)
   assert.equal(result.pinnedPeerId, null)
+})
+
+test('makeVerifierReach: rejects non-attest paths, sends the attest route as a payment-free control-plane request', async () => {
+  const peer = makePeer('a', ['openai'])
+  const signal = new AbortController().signal
+
+  const rejectNode = { sendRequest: async () => ({ statusCode: 200, headers: {}, body: new Uint8Array() }) }
+  await assert.rejects(
+    makeVerifierReach(rejectNode as never, peer, 'refoundhq-antseed-verifier', signal)({ method: 'POST', path: '/v1/chat/completions' }),
+    /may only call its attestation route/,
+  )
+
+  let opts: Record<string, unknown> | undefined
+  const captureNode = {
+    sendRequest: async (_peer: unknown, _req: unknown, o: Record<string, unknown>) => {
+      opts = o
+      return { statusCode: 200, headers: {}, body: new Uint8Array() }
+    },
+  }
+  const resp = await makeVerifierReach(captureNode as never, peer, 'refoundhq-antseed-verifier', signal)(
+    { method: 'POST', path: '/_antseed/attest/refoundhq-antseed-verifier', body: new Uint8Array([1]) },
+  )
+  assert.equal(resp.statusCode, 200)
+  assert.equal(opts!.controlPlane, true)
+  assert.equal(opts!.signal, signal)
 })

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -1105,7 +1105,7 @@ test('makeVerifierReach: rejects non-attest paths, sends the attest route as a p
 
   const rejectNode = { sendRequest: async () => ({ statusCode: 200, headers: {}, body: new Uint8Array() }) }
   await assert.rejects(
-    makeVerifierReach(rejectNode as never, peer, 'refoundhq-antseed-verifier', signal)({ method: 'POST', path: '/v1/chat/completions' }),
+    makeVerifierReach(rejectNode as never, peer, 'antseed-verifier', signal)({ method: 'POST', path: '/v1/chat/completions' }),
     /may only call its attestation route/,
   )
 
@@ -1116,8 +1116,8 @@ test('makeVerifierReach: rejects non-attest paths, sends the attest route as a p
       return { statusCode: 200, headers: {}, body: new Uint8Array() }
     },
   }
-  const resp = await makeVerifierReach(captureNode as never, peer, 'refoundhq-antseed-verifier', signal)(
-    { method: 'POST', path: '/_antseed/attest/refoundhq-antseed-verifier', body: new Uint8Array([1]) },
+  const resp = await makeVerifierReach(captureNode as never, peer, 'antseed-verifier', signal)(
+    { method: 'POST', path: '/_antseed/attest/antseed-verifier', body: new Uint8Array([1]) },
   )
   assert.equal(resp.statusCode, 200)
   assert.equal(opts!.controlPlane, true)

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -47,6 +47,7 @@ import {
   attachStreamingAntseedHeaders,
 } from './telemetry.js'
 import { DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS } from '../config/defaults.js'
+import { runVerifier, type VerifierPolicy, type SellerReach } from '../plugins/verifier.js'
 
 // Re-export for backward compatibility (used by tests and other consumers)
 export { selectCandidatePeersForRouting, type CandidatePeerRouteSelection } from './routing.js'
@@ -72,6 +73,8 @@ export interface BuyerProxyConfig {
    * and allowed by the buyer's pricing policy. A 502 is returned if the peer cannot be reached.
    */
   pinnedPeerId?: string
+  /** Verifier-SDK policy: which verifier the buyer commits to + whether it is required. */
+  verifier?: VerifierPolicy
 }
 
 const RETRYABLE_STATUS_CODES = new Set([408, 429, 500, 502, 503, 504])
@@ -361,6 +364,7 @@ export class BuyerProxy {
   private readonly _stateFile: string
   private _stateFileWatching = false
   private _pinnedPeer: string | null
+  private readonly _verifier?: VerifierPolicy
   private _stateWatchDebounce: ReturnType<typeof setTimeout> | null = null
 
   private _stateWriteChain: Promise<void> = Promise.resolve()
@@ -377,6 +381,7 @@ export class BuyerProxy {
 
   constructor(config: BuyerProxyConfig) {
     this._node = config.node
+    this._verifier = config.verifier
     this._port = config.port
     this._bgRefreshIntervalMs = Math.max(1, config.backgroundRefreshIntervalMs ?? DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS)
     this._peerCacheTtlMs = Math.max(0, config.peerCacheTtlMs ?? Math.max(6 * 60_000, this._bgRefreshIntervalMs + 60_000))
@@ -1253,6 +1258,34 @@ export class BuyerProxy {
         + 'Pick a different service in Discover or adjust your buyer pricing/reputation limits.',
       )
       return
+    }
+
+    if (this._verifier) {
+      const reach: SellerReach = async (r) => {
+        const resp = await this._node.sendRequest(selectedPeer, {
+          requestId: randomUUID(),
+          method: r.method,
+          path: r.path,
+          headers: r.headers ?? {},
+          body: r.body ?? new Uint8Array(),
+        })
+        return { statusCode: resp.statusCode, headers: resp.headers, body: resp.body }
+      }
+      const outcome = await runVerifier(this._verifier, selectedPeer.peerId, selectedPeer.capabilities, reach)
+      const short = selectedPeer.peerId.slice(0, 12)
+      if (outcome.verified) {
+        log(`Verified ${short}... via ${outcome.sdk}`)
+      } else if (outcome.sdk || outcome.reason) {
+        log(`Verification ${outcome.sdk ? `(${outcome.sdk}) ` : ''}did not pass for ${short}...: ${outcome.reason ?? 'failed'}${outcome.ok ? ' (optional — routing anyway)' : ''}`)
+      }
+      if (!outcome.ok) {
+        res.writeHead(502, { 'content-type': 'text/plain' })
+        res.end(
+          `Pinned peer ${short}... failed required verification (${outcome.reason ?? 'failed'}). `
+          + 'Pick a different peer, or run without --require-verifier.',
+        )
+        return
+      }
     }
 
     log(`Using pinned peer ${selectedPeer.peerId.slice(0, 12)}...`)

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -4,6 +4,7 @@ import { watchFile, unwatchFile } from 'node:fs'
 import { readFile, writeFile, rename, mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import {
+  ANTSEED_ATTEST_PATH,
   computeOnChainReputationScore,
   decodeSweepRequest,
   type AntseedNode,
@@ -47,7 +48,7 @@ import {
   attachStreamingAntseedHeaders,
 } from './telemetry.js'
 import { DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS } from '../config/defaults.js'
-import { runVerifier, type VerifierPolicy, type SellerReach } from '../plugins/verifier.js'
+import { getCachedVerdict, runVerifier, verifierSupportFingerprint, type CachedVerdict, type VerifierPolicy, type SellerReach, type VerifyOutcome } from '../plugins/verifier.js'
 
 // Re-export for backward compatibility (used by tests and other consumers)
 export { selectCandidatePeersForRouting, type CandidatePeerRouteSelection } from './routing.js'
@@ -96,6 +97,8 @@ function isRouterSuccess(statusCode: number, path: string, retryableStatusCodes:
  */
 const CARRY_FORWARD_TTL_MS = 2 * 60 * 60_000
 const PEER_FAILURE_WINDOW_MS = 5 * 60_000
+/** Verification is expensive; bound how many verdicts we retain (TTL = peer-cache TTL). */
+const VERIFY_CACHE_MAX_ENTRIES = 1024
 
 type PeerFailureEntry = {
   count: number
@@ -354,6 +357,29 @@ export function parsePersistedPeers(
  * and the proxy transparently routes their API calls through the
  * Antseed P2P network.
  */
+
+export function makeVerifierReach(
+  node: Pick<AntseedNode, 'sendRequest'>,
+  peer: PeerInfo,
+  chosenId: string,
+  signal: AbortSignal,
+): SellerReach {
+  const attestRoute = `${ANTSEED_ATTEST_PATH}/${encodeURIComponent(chosenId)}`
+  return async (r) => {
+    if (r.path !== attestRoute) {
+      throw new Error(`verifier may only call its attestation route (${attestRoute}), not ${r.path}`)
+    }
+    const resp = await node.sendRequest(peer, {
+      requestId: randomUUID(),
+      method: r.method,
+      path: r.path,
+      headers: r.headers ?? {},
+      body: r.body ?? new Uint8Array(),
+    }, { signal, controlPlane: true })
+    return { statusCode: resp.statusCode, headers: resp.headers, body: resp.body }
+  }
+}
+
 export class BuyerProxy {
   private readonly _server: Server
   private readonly _node: AntseedNode
@@ -365,6 +391,7 @@ export class BuyerProxy {
   private _stateFileWatching = false
   private _pinnedPeer: string | null
   private readonly _verifier?: VerifierPolicy
+  private readonly _verifyCache = new Map<string, CachedVerdict>()
   private _stateWatchDebounce: ReturnType<typeof setTimeout> | null = null
 
   private _stateWriteChain: Promise<void> = Promise.resolve()
@@ -1261,17 +1288,9 @@ export class BuyerProxy {
     }
 
     if (this._verifier) {
-      const reach: SellerReach = async (r) => {
-        const resp = await this._node.sendRequest(selectedPeer, {
-          requestId: randomUUID(),
-          method: r.method,
-          path: r.path,
-          headers: r.headers ?? {},
-          body: r.body ?? new Uint8Array(),
-        })
-        return { statusCode: resp.statusCode, headers: resp.headers, body: resp.body }
-      }
-      const outcome = await runVerifier(this._verifier, selectedPeer.peerId, selectedPeer.capabilities, reach)
+      const makeReach = (chosenId: string): SellerReach =>
+        makeVerifierReach(this._node, selectedPeer, chosenId, clientAbortController.signal)
+      const outcome = await this._verifyPeer(selectedPeer, makeReach, clientAbortController.signal)
       const short = selectedPeer.peerId.slice(0, 12)
       if (outcome.verified) {
         log(`Verified ${short}... via ${outcome.sdk}`)
@@ -1307,6 +1326,24 @@ export class BuyerProxy {
       res.writeHead(result.statusCode, result.responseHeaders)
       res.end(result.responseBody)
     }
+  }
+
+  private async _verifyPeer(
+    peer: PeerInfo,
+    makeReach: (chosenId: string) => SellerReach,
+    signal: AbortSignal,
+  ): Promise<VerifyOutcome> {
+    const policy = this._verifier
+    if (!policy) return { ok: true, verified: false }
+    const key = `${peer.peerId}|${verifierSupportFingerprint(peer.capabilities)}`
+    return getCachedVerdict(
+      this._verifyCache,
+      key,
+      Date.now(),
+      this._peerCacheTtlMs,
+      VERIFY_CACHE_MAX_ENTRIES,
+      () => runVerifier(policy, peer.peerId, peer.capabilities, makeReach, signal),
+    )
   }
 
   private _parseMaxUploadBodyBytes(headers: Record<string, string>): number | null {

--- a/e2e/tests/plugin-system.test.ts
+++ b/e2e/tests/plugin-system.test.ts
@@ -225,7 +225,7 @@ describe('Plugin Registry', () => {
   it('all trusted plugins have required fields (name, type, package, description)', () => {
     for (const plugin of TRUSTED_PLUGINS) {
       expect(plugin.name).toBeTruthy();
-      expect(['provider', 'router']).toContain(plugin.type);
+      expect(['provider', 'router', 'verifier']).toContain(plugin.type);
       expect(plugin.package).toBeTruthy();
       expect(plugin.description).toBeTruthy();
     }

--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -34,6 +34,8 @@ export interface RequestStreamCallbacks {
 
 export interface RequestExecutionOptions {
   signal?: AbortSignal;
+  /** Skip payment/free-usage machinery for internal control-plane requests. */
+  controlPlane?: boolean;
 }
 
 export interface BuyerRequestHandlerConfig {
@@ -91,7 +93,7 @@ export class BuyerRequestHandler {
     debugLog(`[BuyerRequest] Connection to ${peer.peerId.slice(0, 12)}... state=${conn.state}`);
     const mux = this._deps.getMux(peer.peerId, conn);
     const verificationMux = this._deps.getVerificationMux(peer.peerId, conn);
-    const negotiator = this._deps.negotiator;
+    const negotiator = options?.controlPlane ? null : this._deps.negotiator;
     if (negotiator) {
       this._deps.registerPaymentMux(peer.peerId, negotiator.getOrCreatePaymentMux(peer.peerId, conn));
     }
@@ -109,7 +111,7 @@ export class BuyerRequestHandler {
     }
 
     // Track which service the buyer requested so auth validation uses buyer's own pricing.
-    const requestedService = extractServiceFromBody(req.body);
+    const requestedService = options?.controlPlane ? undefined : extractServiceFromBody(req.body);
     const isFreeService = requestedService ? isPeerServiceFree(peer, requestedService) : false;
     if (negotiator && requestedService) {
       if (isFreeService) {

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -78,6 +78,8 @@ export interface AnnouncerConfig {
   stakingClient?: StakingClient;
   reannounceIntervalMs: number;
   signalingPort: number;
+  /** Extra peer capability strings to advertise (merged with the built-in set). */
+  capabilities?: string[];
   /** Optional health monitor — if supplied, announce outcomes are recorded. */
   healthMonitor?: DHTHealthMonitor;
   /**
@@ -279,6 +281,9 @@ export class PeerAnnouncer {
     const capabilities: string[] = [CONNECTION_CAPABILITY_RESPONSE_AUTH_V1];
     if (this.config.relaysSweeps) {
       capabilities.push(CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1);
+    }
+    if (this.config.capabilities && this.config.capabilities.length > 0) {
+      capabilities.push(...this.config.capabilities);
     }
 
     const metadata: PeerMetadata = {

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -191,7 +191,8 @@ export {
 } from './proxy/service-api-adapter.js';
 export { DefaultRouter, type DefaultRouterConfig } from './routing/default-router.js';
 
-export type { AntseedPlugin, AntseedProviderPlugin, AntseedRouterPlugin, PluginConfigKey, ConfigField } from './interfaces/plugin.js'
+export type { AntseedPlugin, AntseedProviderPlugin, AntseedRouterPlugin, AntseedVerifierPlugin, Prover, VerifyContext, VerifyResult, ClaimResult, SellerRequest, SellerResponse, PluginConfigKey, ConfigField } from './interfaces/plugin.js'
+export { ANTSEED_ATTEST_PATH } from './interfaces/plugin.js'
 
 // Reputation
 export { UptimeTracker } from './reputation/uptime-tracker.js';

--- a/packages/node/src/interfaces/plugin.ts
+++ b/packages/node/src/interfaces/plugin.ts
@@ -33,4 +33,53 @@ export interface AntseedRouterPlugin extends AntseedPluginBase {
   createRouter(config: Record<string, string>): Router | Promise<Router>
 }
 
-export type AntseedPlugin = AntseedProviderPlugin | AntseedRouterPlugin
+export interface ClaimResult {
+  /** Namespaced claim id, e.g. 'antseed-tee/dcap:hardware-genuine'. */
+  claim: string
+  ok: boolean
+  detail?: string
+}
+
+export interface VerifyResult {
+  /** Overall pass/fail. The buyer applies its own policy (optional vs required). */
+  ok: boolean
+  claims: ClaimResult[]
+}
+
+/** A request the verifier issues to the seller over the existing buyer<->seller comms. */
+export interface SellerRequest {
+  method: string
+  path: string
+  headers?: Record<string, string>
+  body?: Uint8Array
+}
+
+export interface SellerResponse {
+  statusCode: number
+  headers: Record<string, string>
+  body: Uint8Array
+}
+
+export interface VerifyContext {
+  peerId: string
+  /** Verifier id selected by the buyer; must match the SDK name. */
+  verifierId: string
+  /** Seller prover path for this verifier. */
+  attestPath: string
+  fetchFromSeller(req: SellerRequest): Promise<SellerResponse>
+  signal?: AbortSignal
+}
+
+export interface AntseedVerifierPlugin extends AntseedPluginBase {
+  type: 'verifier'
+  verify(ctx: VerifyContext): VerifyResult | Promise<VerifyResult>
+}
+
+export const ANTSEED_ATTEST_PATH = '/_antseed/attest'
+
+export interface Prover extends AntseedPluginBase {
+  type: 'prover'
+  prove(req: SellerRequest): SellerResponse | Promise<SellerResponse>
+}
+
+export type AntseedPlugin = AntseedProviderPlugin | AntseedRouterPlugin | AntseedVerifierPlugin | Prover

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -65,6 +65,7 @@ import type {
   ProviderStreamCallbacks,
 } from "./interfaces/seller-provider.js";
 import type { Router } from "./interfaces/buyer-router.js";
+import type { Prover } from "./interfaces/plugin.js";
 import { NatTraversal } from "./p2p/nat-traversal.js";
 import { signUtf8 } from "./p2p/identity.js";
 import {
@@ -194,6 +195,8 @@ export interface NodeConfig {
   publicAddress?: string;
   /** External ownership claims announced in signed peer metadata. */
   verifications?: PeerVerifications;
+  /** Extra peer capability strings to advertise (e.g. supported verifier SDKs). */
+  capabilities?: string[];
   dataDir?: string;           // Default: ~/.antseed
   dhtPort?: number;           // Default: 6881 for seller, 0 for buyer
   signalingPort?: number;     // Default: 6882 for seller
@@ -268,6 +271,7 @@ export class AntseedNode extends EventEmitter {
   private _dht: DHTNode | null = null;
   private _connectionManager: ConnectionManager | null = null;
   private _providers: Provider[] = [];
+  private _provers: Prover[] = [];
   private _router: Router | null = null;
   private _started = false;
   private _announcer: PeerAnnouncer | null = null;
@@ -343,6 +347,11 @@ export class AntseedNode extends EventEmitter {
 
   registerProvider(provider: Provider): void {
     this._providers.push(provider);
+  }
+
+  /** Register an embedded verifier prover (serves reserved attestation requests). */
+  registerProver(prover: Prover): void {
+    this._provers.push(prover);
   }
 
   setRouter(router: Router): void {
@@ -1413,6 +1422,7 @@ export class AntseedNode extends EventEmitter {
         ...(this._config.displayName ? { displayName: this._config.displayName } : {}),
         ...(this._config.publicAddress ? { publicAddress: this._config.publicAddress } : {}),
         ...(this._config.verifications ? { verifications: this._config.verifications } : {}),
+        ...(this._config.capabilities ? { capabilities: this._config.capabilities } : {}),
         region: "unknown",
         pricing: new Map(
           this._providers.map((p) => [
@@ -1446,6 +1456,7 @@ export class AntseedNode extends EventEmitter {
     this._sellerHandler = new SellerRequestHandler({
       identity,
       providers: this._providers,
+      provers: this._provers,
       sellerPaymentManager: this._sellerPaymentManager,
       sellerFreeUsageManager: this._sellerFreeUsageManager,
       sessionTracker: this._sessionTracker,

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -3,6 +3,7 @@ import type {
   Provider,
   ProviderStreamCallbacks,
 } from './interfaces/seller-provider.js';
+import { ANTSEED_ATTEST_PATH, type Prover } from './interfaces/plugin.js';
 import type { SellerSessionTracker } from './metering/seller-session-tracker.js';
 import type { PaymentMux } from './p2p/payment-mux.js';
 import type { Identity } from './p2p/identity.js';
@@ -26,6 +27,7 @@ import { hasJsonContentType, tryParseJsonObject } from './utils/json-codec.js';
 export interface SellerRequestHandlerDeps {
   identity: Identity;
   providers: Provider[];
+  provers?: Prover[];
   sellerPaymentManager: SellerPaymentManager | null;
   sellerFreeUsageManager?: SellerFreeUsageManager | null;
   sessionTracker: SellerSessionTracker | null;
@@ -80,6 +82,61 @@ export class SellerRequestHandler {
       if (request.method === 'GET' && (pathOnly === '/v1/models' || pathOnly.startsWith('/v1/models/'))) {
         const modelsResponse = this._handleModelsRequest(request);
         mux.sendProxyResponse(modelsResponse);
+        return;
+      }
+
+      // Free attestation route handled before provider and payment logic.
+      if (pathOnly.startsWith(ANTSEED_ATTEST_PATH + '/')) {
+        let verifierId: string;
+        try {
+          verifierId = decodeURIComponent(pathOnly.slice((ANTSEED_ATTEST_PATH + '/').length));
+        } catch {
+          mux.sendProxyResponse({
+            requestId: request.requestId,
+            statusCode: 400,
+            headers: { 'content-type': 'application/json' },
+            body: new TextEncoder().encode(JSON.stringify({
+              error: { message: 'Malformed attestation path.', type: 'invalid_request_error' },
+            })),
+          });
+          return;
+        }
+        const prover = (this._deps.provers ?? []).find((p) => p.name === verifierId);
+        if (!prover) {
+          mux.sendProxyResponse({
+            requestId: request.requestId,
+            statusCode: 404,
+            headers: { 'content-type': 'application/json' },
+            body: new TextEncoder().encode(JSON.stringify({
+              error: { message: `No prover for verifier "${verifierId}".`, type: 'verifier_error', code: 'prover_not_found' },
+            })),
+          });
+          return;
+        }
+        try {
+          const resp = await prover.prove({
+            method: request.method,
+            path: request.path,
+            headers: request.headers,
+            body: request.body,
+          });
+          mux.sendProxyResponse({
+            requestId: request.requestId,
+            statusCode: resp.statusCode,
+            headers: resp.headers,
+            body: resp.body,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          mux.sendProxyResponse({
+            requestId: request.requestId,
+            statusCode: 500,
+            headers: { 'content-type': 'application/json' },
+            body: new TextEncoder().encode(JSON.stringify({
+              error: { message: `Prover failed: ${message}`, type: 'verifier_error' },
+            })),
+          });
+        }
         return;
       }
 

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -42,6 +42,10 @@ export interface SellerRequestHandlerDeps {
 const METADATA_REFRESH_DEBOUNCE_MS = 200;
 /** Time to wait for a catch-up SpendingAuth before returning 402. */
 const DEFAULT_CATCH_UP_WAIT_MS = 5_000;
+/** Per-buyer rate limit for the free attestation route. */
+const ATTEST_RATE_WINDOW_MS = 60_000;
+const ATTEST_RATE_MAX_PER_WINDOW = 10;
+const ATTEST_RATE_MAX_TRACKED_PEERS = 1024;
 /**
  * Handles all seller-side request processing: provider matching, execution,
  * cost tracking, payment auth checks, and load management.
@@ -52,10 +56,31 @@ const DEFAULT_CATCH_UP_WAIT_MS = 5_000;
 export class SellerRequestHandler {
   private readonly _deps: SellerRequestHandlerDeps;
   private readonly _providerLoadCounts = new Map<string, number>();
+  private readonly _attestRateWindows = new Map<string, { start: number; count: number }>();
   private _metadataRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(deps: SellerRequestHandlerDeps) {
     this._deps = deps;
+  }
+
+  private _allowAttest(buyerPeerId: string): boolean {
+    const now = Date.now();
+    const win = this._attestRateWindows.get(buyerPeerId);
+    if (!win || now - win.start >= ATTEST_RATE_WINDOW_MS) {
+      if (this._attestRateWindows.size >= ATTEST_RATE_MAX_TRACKED_PEERS) {
+        for (const [peer, w] of this._attestRateWindows) {
+          if (now - w.start >= ATTEST_RATE_WINDOW_MS) this._attestRateWindows.delete(peer);
+        }
+        if (!this._attestRateWindows.has(buyerPeerId) && this._attestRateWindows.size >= ATTEST_RATE_MAX_TRACKED_PEERS) {
+          return false;
+        }
+      }
+      this._attestRateWindows.set(buyerPeerId, { start: now, count: 1 });
+      return true;
+    }
+    if (win.count >= ATTEST_RATE_MAX_PER_WINDOW) return false;
+    win.count += 1;
+    return true;
   }
 
   /**
@@ -85,7 +110,6 @@ export class SellerRequestHandler {
         return;
       }
 
-      // Free attestation route handled before provider and payment logic.
       if (pathOnly.startsWith(ANTSEED_ATTEST_PATH + '/')) {
         let verifierId: string;
         try {
@@ -109,6 +133,19 @@ export class SellerRequestHandler {
             headers: { 'content-type': 'application/json' },
             body: new TextEncoder().encode(JSON.stringify({
               error: { message: `No prover for verifier "${verifierId}".`, type: 'verifier_error', code: 'prover_not_found' },
+            })),
+          });
+          return;
+        }
+        // Rate-limit only the expensive path (quote generation); cheap 400/404
+        // rejections above don't consume a buyer's attestation quota.
+        if (!this._allowAttest(buyerPeerId)) {
+          mux.sendProxyResponse({
+            requestId: request.requestId,
+            statusCode: 429,
+            headers: { 'content-type': 'application/json' },
+            body: new TextEncoder().encode(JSON.stringify({
+              error: { message: 'Attestation rate limit exceeded.', type: 'rate_limit_error' },
             })),
           });
           return;

--- a/packages/node/tests/node-payment-mux-wiring.test.ts
+++ b/packages/node/tests/node-payment-mux-wiring.test.ts
@@ -86,7 +86,7 @@ describe('BuyerRequestHandler payment mux wiring', () => {
     const request: SerializedHttpRequest = {
       requestId: 'req-control-plane',
       method: 'POST',
-      path: '/_antseed/attest/refoundhq-antseed-verifier',
+      path: '/_antseed/attest/antseed-verifier',
       headers: { 'content-type': 'application/json' },
       body: new Uint8Array(0),
     };

--- a/packages/node/tests/node-payment-mux-wiring.test.ts
+++ b/packages/node/tests/node-payment-mux-wiring.test.ts
@@ -81,6 +81,57 @@ describe('BuyerRequestHandler payment mux wiring', () => {
     ).toBeLessThan(sendProxyRequest.mock.invocationCallOrder[0]);
   });
 
+  it('control-plane requests bypass payment negotiation and return 402 verbatim', async () => {
+    const peer = { peerId: 'b'.repeat(40) } as PeerInfo;
+    const request: SerializedHttpRequest = {
+      requestId: 'req-control-plane',
+      method: 'POST',
+      path: '/_antseed/attest/refoundhq-antseed-verifier',
+      headers: { 'content-type': 'application/json' },
+      body: new Uint8Array(0),
+    };
+
+    const conn = { state: 'open' };
+    const sendProxyRequest = vi.fn((
+      _: SerializedHttpRequest,
+      onResponse: (response: SerializedHttpResponse, metadata: { streamingStart: boolean }) => void,
+    ) => {
+      onResponse({
+        requestId: request.requestId,
+        statusCode: 402,
+        headers: {},
+        body: new Uint8Array(0),
+      }, { streamingStart: false });
+    });
+
+    const handle402 = vi.fn();
+    const getOrCreatePaymentMux = vi.fn().mockReturnValue({});
+    const registerPaymentMux = vi.fn();
+    const handler = new BuyerRequestHandler(
+      {},
+      {
+        localPeerId: 'a'.repeat(40) as PeerId,
+        negotiator: {
+          getOrCreatePaymentMux,
+          handle402,
+          estimateCostFromResponse: vi.fn(),
+        } as any,
+        verificationStorage: null,
+        verificationSampler: null,
+        getConnection: vi.fn(async () => conn) as any,
+        getMux: vi.fn(() => ({ sendProxyRequest, cancelProxyRequest: vi.fn() })) as any,
+        getVerificationMux: vi.fn(() => createNoopVerificationMux()) as any,
+        registerPaymentMux,
+      },
+    );
+
+    const response = await handler.sendRequest(peer, request, undefined, { controlPlane: true });
+
+    expect(response.statusCode).toBe(402);
+    expect(handle402).not.toHaveBeenCalled();
+    expect(getOrCreatePaymentMux).not.toHaveBeenCalled();
+  });
+
   it('opens free usage and skips paid cost tracking for advertised zero-price services', async () => {
     const peer = {
       peerId: 'b'.repeat(40),

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -5,6 +5,7 @@ import type { Provider } from '../src/interfaces/seller-provider.js';
 import { decodeHttpResponse, encodeHttpRequest } from '../src/proxy/request-codec.js';
 import { decodeFrame } from '../src/p2p/message-protocol.js';
 import { MessageType, PAYMENT_CODE_CHANNEL_EXHAUSTED } from '../src/types/protocol.js';
+import { ANTSEED_ATTEST_PATH, type Prover, type SellerRequest } from '../src/interfaces/plugin.js';
 
 function makeProvider(inputUsdPerMillion: number, outputUsdPerMillion: number, opts: {
   name: string;
@@ -139,6 +140,57 @@ describe('SellerRequestHandler payment pricing selection', () => {
     expect(response.statusCode).toBe(200);
     const body = JSON.parse(new TextDecoder().decode(response.body));
     expect(body.id).toBe('gpt-5.5');
+  });
+
+  it('dispatches attestation requests before provider and payment logic', async () => {
+    const provider = makeProvider(1, 1, { name: 'openai', services: ['gpt-5.5'] });
+    provider.handleRequest = vi.fn(provider.handleRequest);
+    const prove = vi.fn(async (req: SellerRequest) => ({
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ ok: true, path: req.path })),
+    }));
+    const prover: Prover = {
+      type: 'prover',
+      name: 'refoundhq-antseed-verifier',
+      displayName: 'Refound verifier',
+      version: '0.1.0',
+      description: 'test prover',
+      prove,
+    };
+    const sendPaymentRequired = vi.fn();
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      provers: [prover],
+      sellerPaymentManager: makeSpmMock({ hasSession: () => false }),
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = makeConn(sentFrames);
+    const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired } as any;
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+    await mux.handleFrame({
+      type: MessageType.HttpRequest,
+      messageId: 1,
+      payload: encodeHttpRequest({
+        requestId: 'req-attest',
+        method: 'POST',
+        path: `${ANTSEED_ATTEST_PATH}/refoundhq-antseed-verifier`,
+        headers: {},
+        body: new Uint8Array([1, 2, 3]),
+      }),
+    });
+
+    const decoded = decodeFrame(sentFrames[0]!);
+    const response = decodeHttpResponse(decoded!.message.payload);
+    expect(response.statusCode).toBe(200);
+    expect(prove).toHaveBeenCalledOnce();
+    expect(provider.handleRequest).not.toHaveBeenCalled();
+    expect(sendPaymentRequired).not.toHaveBeenCalled();
   });
 
   it('matches the requested provider and service pricing instead of using the first provider defaults', () => {

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -7,7 +7,7 @@ import { decodeFrame } from '../src/p2p/message-protocol.js';
 import { MessageType, PAYMENT_CODE_CHANNEL_EXHAUSTED } from '../src/types/protocol.js';
 import { ANTSEED_ATTEST_PATH, type Prover, type SellerRequest } from '../src/interfaces/plugin.js';
 
-const ATTEST_ID = 'refoundhq-antseed-verifier';
+const ATTEST_ID = 'antseed-verifier';
 const ATTEST_ROUTE = `${ANTSEED_ATTEST_PATH}/${ATTEST_ID}`;
 
 function makeProvider(inputUsdPerMillion: number, outputUsdPerMillion: number, opts: {

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -7,6 +7,9 @@ import { decodeFrame } from '../src/p2p/message-protocol.js';
 import { MessageType, PAYMENT_CODE_CHANNEL_EXHAUSTED } from '../src/types/protocol.js';
 import { ANTSEED_ATTEST_PATH, type Prover, type SellerRequest } from '../src/interfaces/plugin.js';
 
+const ATTEST_ID = 'refoundhq-antseed-verifier';
+const ATTEST_ROUTE = `${ANTSEED_ATTEST_PATH}/${ATTEST_ID}`;
+
 function makeProvider(inputUsdPerMillion: number, outputUsdPerMillion: number, opts: {
   name: string;
   services: string[];
@@ -60,6 +63,57 @@ function makeConn(sentFrames: Uint8Array[]): any {
       sentFrames.push(frame);
     },
     hasRemoteCapability: () => false,
+  };
+}
+
+function makeAttestHarness() {
+  const provider = makeProvider(1, 1, { name: 'openai', services: ['gpt-5.5'] });
+  provider.handleRequest = vi.fn(provider.handleRequest);
+  const prove = vi.fn(async (req: SellerRequest) => ({
+    statusCode: 200,
+    headers: { 'content-type': 'application/json' },
+    body: new TextEncoder().encode(JSON.stringify({ ok: true, path: req.path })),
+  }));
+  const prover: Prover = {
+    type: 'prover',
+    name: ATTEST_ID,
+    displayName: 'Refound verifier',
+    version: '0.1.0',
+    description: 'test prover',
+    prove,
+  };
+  const sendPaymentRequired = vi.fn();
+  const handler = new SellerRequestHandler({
+    providers: [provider],
+    provers: [prover],
+    sellerPaymentManager: makeSpmMock({ hasSession: () => false }),
+    sessionTracker: null,
+    channelsClient: {} as any,
+    announcer: null,
+    emit: () => false,
+  });
+  const sentFrames: Uint8Array[] = [];
+  const { mux } = handler.handleConnection(
+    makeConn(sentFrames),
+    'b'.repeat(40),
+    { sendNeedAuth: vi.fn(), sendPaymentRequired } as any,
+  );
+  return {
+    provider,
+    prove,
+    sendPaymentRequired,
+    sendAttest: (i = 0, body = new Uint8Array([1])) => mux.handleFrame({
+      type: MessageType.HttpRequest,
+      messageId: i + 1,
+      payload: encodeHttpRequest({
+        requestId: `req-attest-${i}`,
+        method: 'POST',
+        path: ATTEST_ROUTE,
+        headers: {},
+        body,
+      }),
+    }),
+    responses: () => sentFrames.map((f) => decodeHttpResponse(decodeFrame(f)!.message.payload)),
   };
 }
 
@@ -143,54 +197,47 @@ describe('SellerRequestHandler payment pricing selection', () => {
   });
 
   it('dispatches attestation requests before provider and payment logic', async () => {
-    const provider = makeProvider(1, 1, { name: 'openai', services: ['gpt-5.5'] });
-    provider.handleRequest = vi.fn(provider.handleRequest);
-    const prove = vi.fn(async (req: SellerRequest) => ({
-      statusCode: 200,
-      headers: { 'content-type': 'application/json' },
-      body: new TextEncoder().encode(JSON.stringify({ ok: true, path: req.path })),
-    }));
-    const prover: Prover = {
-      type: 'prover',
-      name: 'refoundhq-antseed-verifier',
-      displayName: 'Refound verifier',
-      version: '0.1.0',
-      description: 'test prover',
-      prove,
-    };
-    const sendPaymentRequired = vi.fn();
-    const handler = new SellerRequestHandler({
-      providers: [provider],
-      provers: [prover],
-      sellerPaymentManager: makeSpmMock({ hasSession: () => false }),
-      sessionTracker: null,
-      channelsClient: {} as any,
-      announcer: null,
-      emit: () => false,
-    });
+    const { provider, prove, sendPaymentRequired, sendAttest, responses } = makeAttestHarness();
+    await sendAttest(0, new Uint8Array([1, 2, 3]));
 
-    const sentFrames: Uint8Array[] = [];
-    const conn = makeConn(sentFrames);
-    const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired } as any;
-    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
-    await mux.handleFrame({
-      type: MessageType.HttpRequest,
-      messageId: 1,
-      payload: encodeHttpRequest({
-        requestId: 'req-attest',
-        method: 'POST',
-        path: `${ANTSEED_ATTEST_PATH}/refoundhq-antseed-verifier`,
-        headers: {},
-        body: new Uint8Array([1, 2, 3]),
-      }),
-    });
-
-    const decoded = decodeFrame(sentFrames[0]!);
-    const response = decodeHttpResponse(decoded!.message.payload);
-    expect(response.statusCode).toBe(200);
+    expect(responses()[0]!.statusCode).toBe(200);
     expect(prove).toHaveBeenCalledOnce();
     expect(provider.handleRequest).not.toHaveBeenCalled();
     expect(sendPaymentRequired).not.toHaveBeenCalled();
+  });
+
+  it('rate-limits the free attestation route per buyer', async () => {
+    const { prove, sendAttest, responses } = makeAttestHarness();
+
+    for (let i = 0; i < 11; i++) {
+      await sendAttest(i);
+    }
+
+    const statuses = responses().map((r) => r.statusCode);
+    expect(statuses.filter((s) => s === 200)).toHaveLength(10);
+    expect(statuses[10]).toBe(429);
+    expect(prove).toHaveBeenCalledTimes(10);
+  });
+
+  it('hard-bounds tracked attestation rate-limit peers', () => {
+    const handler = new SellerRequestHandler({
+      providers: [],
+      sellerPaymentManager: null,
+      sessionTracker: null,
+      channelsClient: null,
+      announcer: null,
+      emit: () => false,
+    }) as unknown as {
+      _allowAttest(peerId: string): boolean;
+      _attestRateWindows: Map<string, unknown>;
+    };
+
+    for (let i = 0; i < 1024; i++) {
+      expect(handler._allowAttest(`peer-${i}`)).toBe(true);
+    }
+    expect(handler._attestRateWindows.size).toBe(1024);
+    expect(handler._allowAttest('peer-overflow')).toBe(false);
+    expect(handler._attestRateWindows.size).toBe(1024);
   });
 
   it('matches the requested provider and service pricing instead of using the first provider defaults', () => {


### PR DESCRIPTION
## What

Introduces Verifier SDKs as antseed plugins allowing sellers to offer verifications of their claims through verification SDKs

## Testing

- Added tests
- Ran test suite
    - pnpm --filter=@antseed/node typecheck
    - pnpm --filter=@antseed/cli typecheck
    - pnpm --filter=@antseed/cli test
    - pnpm --filter=@antseed/node test
- e2e test with first verifier SDK on TDX TEE hardware, running against basic dcap attestation

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run test` passes
- [ ] Breaking changes documented
