### PR TITLE
feat(app): Add runtime log filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project uses selective package publishing. Each release entry lists the pub
 ### Added
 
 - Added a macOS menu bar icon for Desktop with quick actions to show or quit AntSeed.
+- Added Desktop runtime log source filters and buyer debug log filtering via `antseed buyer start --log-filter` / `ANTSEED_LOG_FILTER`.
 - Added Desktop peer favicons from verified domains, showing fetched site icons in Discover and chat peer avatars when available.
 - Added zero-price free usage authorization for advertised free services, including buyer-signed P2P usage records, seller on-chain reporting through `AntseedFreeUsage`, and CLI configuration for the deployed free usage contract address.
 - Added a buyer-side metadata v2 service attribution opt-out for CLI and Desktop. Buyers can disable per-service attribution while preserving aggregate usage metadata in paid SpendingAuth and free-usage records.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -126,6 +126,13 @@ or:
 ANTSEED_DEBUG=1 antseed <command>
 ```
 
+Filter debug logs by source or text with:
+
+```bash
+antseed buyer start --log-filter ProxyMux
+ANTSEED_LOG_FILTER=PaymentMux,BuyerPayment ANTSEED_DEBUG=1 antseed buyer start
+```
+
 For dashboard frontend debug logging, set:
 
 ```bash

--- a/apps/cli/src/cli/commands/buyer/start.ts
+++ b/apps/cli/src/cli/commands/buyer/start.ts
@@ -197,9 +197,15 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
     .option('--metadata-fetch-timeout-ms <number>', 'runtime-only timeout for each peer metadata HTTP fetch during discovery', Number)
     .option('--disable-metadata-v2-services', 'runtime-only opt-out from per-service buyer metadata v2 attribution')
     .option('--peer <peerId>', 'pin all requests to a specific peer ID (40-char hex EVM address), bypassing the router')
+    .option('--log-filter <sourceOrText>', 'show only debug logs matching a source or text, e.g. ProxyMux')
     .action(async (options) => {
       const globalOpts = getGlobalOptions(buyerCmd)
       const config = await loadConfig(globalOpts.config)
+      const logFilter = typeof options.logFilter === 'string' ? options.logFilter.trim() : ''
+      if (logFilter.length > 0) {
+        process.env['ANTSEED_DEBUG'] = '1'
+        process.env['ANTSEED_LOG_FILTER'] = logFilter
+      }
 
       const pinnedPeerId = options.peer as string | undefined
       if (pinnedPeerId !== undefined && !/^(0x)?[0-9a-f]{40}$/i.test(pinnedPeerId)) {
@@ -346,6 +352,9 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
       console.log(chalk.dim(`  peer refresh interval: ${effectiveBuyerConfig.peerRefreshIntervalMs}ms`))
       console.log(chalk.dim(`  metadata fetch timeout: ${effectiveBuyerConfig.metadataFetchTimeoutMs}ms`))
       console.log(chalk.dim(`  metadata v2 service opt-out: ${effectiveBuyerConfig.disableMetadataV2Services ? 'enabled' : 'disabled'}`))
+      if (logFilter.length > 0) {
+        console.log(chalk.dim(`  debug log filter: ${logFilter}`))
+      }
       console.log(chalk.dim(`  proxy port: ${effectiveBuyerConfig.proxyPort}`))
       if (pinnedPeerId) {
         console.log(chalk.yellow(`  pinned peer: ${pinnedPeerId} (router bypassed)`))
@@ -438,6 +447,7 @@ export function registerBuyerStartCommand(buyerCmd: Command): void {
       }
       console.log('')
       console.log(chalk.dim('Enable debug logs: export ANTSEED_DEBUG=1'))
+      console.log(chalk.dim('Filter debug logs: antseed buyer start --log-filter ProxyMux'))
       console.log('')
 
       setupShutdownHandler(async () => {

--- a/apps/cli/src/proxy/request-utils.ts
+++ b/apps/cli/src/proxy/request-utils.ts
@@ -1,16 +1,20 @@
-import type { PeerInfo, SerializedHttpRequest, SerializedHttpResponse } from '@antseed/node'
+import { shouldEmitDebugLine, type PeerInfo, type SerializedHttpRequest, type SerializedHttpResponse } from '@antseed/node'
 import { parseJsonObject } from '@antseed/api-adapter'
 
-const debugEnabled = ['1', 'true', 'yes', 'on'].includes(
-  (process.env['ANTSEED_DEBUG'] ?? '').trim().toLowerCase(),
-)
+function isTruthyDebugValue(value: string | undefined): boolean {
+  return ['1', 'true', 'yes', 'on'].includes((value ?? '').trim().toLowerCase())
+}
+
+function shouldEmitProxyLog(args: unknown[]): boolean {
+  return shouldEmitDebugLine(`[proxy] ${args.map((arg) => typeof arg === 'string' ? arg : String(arg)).join(' ')}`)
+}
 
 export function DEBUG(): boolean {
-  return debugEnabled
+  return isTruthyDebugValue(process.env['ANTSEED_DEBUG'])
 }
 
 export function log(...args: unknown[]): void {
-  if (debugEnabled) console.log('[proxy]', ...args)
+  if (DEBUG() && shouldEmitProxyLog(args)) console.log('[proxy]', ...args)
 }
 
 function getHeader(headers: Record<string, string>, name: string): string {

--- a/apps/desktop/src/renderer/global.scss
+++ b/apps/desktop/src/renderer/global.scss
@@ -666,8 +666,90 @@ pre,
   height: 100%;
 }
 
+.log-count {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.log-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  min-width: 0;
+}
+
+.log-source-filters {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+
+.log-filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 26px;
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card-alt);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+  padding: 0 8px;
+}
+
+.log-filter-chip:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.log-filter-chip.active {
+  border-color: var(--accent);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.log-filter-chip span {
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.log-search {
+  width: min(260px, 34vw);
+  height: 26px;
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card-alt);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  padding: 0 9px;
+}
+
+.log-search:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.log-search::placeholder {
+  color: var(--text-muted);
+}
+
 .log-entry {
   margin-bottom: 3px;
+}
+
+.log-empty {
+  color: var(--text-muted);
 }
 
 .log-entry.stderr {
@@ -681,6 +763,24 @@ pre,
 .log-entry .ts {
   color: var(--text-muted);
   margin-right: 6px;
+}
+
+.log-source {
+  display: inline-block;
+  min-width: 86px;
+  margin-right: 6px;
+  color: var(--text-muted);
+}
+
+@media (max-width: 760px) {
+  .log-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .log-search {
+    width: 100%;
+  }
 }
 
 /* ===================================================================

--- a/apps/desktop/src/renderer/ui/components/views/DesktopView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/DesktopView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { shallowEqual, useUiSelector } from '../../hooks/useUiSelector';
 import { useActions } from '../../hooks/useActions';
 import { formatClock } from '../../../core/format';
@@ -7,18 +7,107 @@ type DesktopViewProps = {
   active: boolean;
 };
 
-function downloadLogs(logs: { timestamp: number; mode: string; stream: string; line: string }[]): void {
+type RuntimeLogEntry = {
+  timestamp: number;
+  mode: string;
+  stream: string;
+  line: string;
+};
+
+type LogSourceSummary = {
+  source: string;
+  count: number;
+};
+
+const ALL_SOURCES = '__all__';
+
+function normalizeLogSource(source: string): string {
+  const trimmed = source.trim();
+  if (trimmed.length === 0) {
+    return 'runtime';
+  }
+  if (/^proxy$/i.test(trimmed)) {
+    return 'proxy';
+  }
+  return trimmed;
+}
+
+function getLogSource(entry: RuntimeLogEntry): string {
+  if (entry.stream === 'system') {
+    return 'system';
+  }
+
+  const prefixMatch = /^\s*\[([^\]]{1,48})\]/.exec(entry.line);
+  if (prefixMatch?.[1]) {
+    return normalizeLogSource(prefixMatch[1]);
+  }
+
+  return entry.stream === 'stderr' ? 'stderr' : 'runtime';
+}
+
+function sourceSortRank(source: string): number {
+  const normalized = source.toLowerCase();
+  if (normalized === 'proxymux') return 0;
+  if (normalized === 'paymentmux') return 1;
+  if (normalized === 'buyerpayment') return 2;
+  if (normalized === 'buyernegotiator') return 3;
+  if (normalized === 'buyerrequest') return 4;
+  if (normalized === 'proxy') return 5;
+  if (normalized === 'node') return 6;
+  if (normalized === 'system') return 98;
+  if (normalized === 'stderr') return 99;
+  return 50;
+}
+
+function getLogSources(logs: RuntimeLogEntry[]): LogSourceSummary[] {
+  const counts = new Map<string, number>();
+  for (const entry of logs) {
+    const source = getLogSource(entry);
+    counts.set(source, (counts.get(source) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([source, count]) => ({ source, count }))
+    .sort((left, right) => {
+      const rankDelta = sourceSortRank(left.source) - sourceSortRank(right.source);
+      if (rankDelta !== 0) return rankDelta;
+      return left.source.localeCompare(right.source);
+    });
+}
+
+function matchesSearch(entry: RuntimeLogEntry, source: string, query: string): boolean {
+  const normalized = query.trim().toLowerCase();
+  if (normalized.length === 0) {
+    return true;
+  }
+
+  return [
+    source,
+    entry.mode,
+    entry.stream,
+    entry.line,
+  ].some((value) => value.toLowerCase().includes(normalized));
+}
+
+function downloadLogs(logs: RuntimeLogEntry[]): void {
   const text = logs.map((e) => `${formatClock(e.timestamp)} [${e.mode}] [${e.stream}] ${e.line}`).join('\n');
   const blob = new Blob([text], { type: 'text/plain' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
   a.download = `antseed-logs-${new Date().toISOString().replace(/[:.]/g, '-')}.txt`;
-  a.click();
-  URL.revokeObjectURL(url);
+  document.body.appendChild(a);
+  try {
+    a.click();
+  } finally {
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
 }
 
 export function DesktopView({ active }: DesktopViewProps) {
+  const [selectedSource, setSelectedSource] = useState(ALL_SOURCES);
+  const [searchQuery, setSearchQuery] = useState('');
   const { logs, daemonState } = useUiSelector((state) => ({
     logs: state.logs,
     daemonState: state.daemonState,
@@ -26,12 +115,27 @@ export function DesktopView({ active }: DesktopViewProps) {
   const actions = useActions();
   const logsEndRef = useRef<HTMLDivElement>(null);
 
+  const sourceSummaries = useMemo(() => getLogSources(logs), [logs]);
+  const filteredLogs = useMemo(() => logs.filter((entry) => {
+    const source = getLogSource(entry);
+    return (selectedSource === ALL_SOURCES || source === selectedSource)
+      && matchesSearch(entry, source, searchQuery);
+  }), [logs, searchQuery, selectedSource]);
+  const selectedSourceExists = selectedSource === ALL_SOURCES
+    || sourceSummaries.some((summary) => summary.source === selectedSource);
+
   useEffect(() => {
     const el = logsEndRef.current?.parentElement;
     if (el) {
       el.scrollTop = el.scrollHeight;
     }
-  }, [logs.length]);
+  }, [filteredLogs.length]);
+
+  useEffect(() => {
+    if (!selectedSourceExists) {
+      setSelectedSource(ALL_SOURCES);
+    }
+  }, [selectedSourceExists]);
 
   const daemonText = !daemonState || !daemonState.exists
     ? 'No daemon state file found yet.'
@@ -44,8 +148,8 @@ export function DesktopView({ active }: DesktopViewProps) {
       <div className="page-header">
         <h2>Logs</h2>
         <div className="page-header-right">
-          <button className="secondary" onClick={() => downloadLogs(logs)} disabled={logs.length === 0}>
-            Download Logs
+          <button className="secondary" onClick={() => downloadLogs(filteredLogs)} disabled={filteredLogs.length === 0}>
+            Download Visible
           </button>
           <button className="secondary" onClick={() => void actions.clearLogs()}>
             Clear Logs
@@ -59,11 +163,50 @@ export function DesktopView({ active }: DesktopViewProps) {
         <article className="panel">
           <div className="panel-head">
             <h3>Runtime Logs</h3>
+            <span className="log-count">
+              {filteredLogs.length} / {logs.length}
+            </span>
+          </div>
+          <div className="log-toolbar" aria-label="Runtime log filters">
+            <div className="log-source-filters" role="list" aria-label="Log sources">
+              <button
+                type="button"
+                className={`log-filter-chip${selectedSource === ALL_SOURCES ? ' active' : ''}`}
+                onClick={() => setSelectedSource(ALL_SOURCES)}
+              >
+                All
+                <span>{logs.length}</span>
+              </button>
+              {sourceSummaries.map(({ source, count }) => (
+                <button
+                  key={source}
+                  type="button"
+                  className={`log-filter-chip${selectedSource === source ? ' active' : ''}`}
+                  onClick={() => setSelectedSource(source)}
+                  title={`Show only ${source} logs`}
+                >
+                  {source}
+                  <span>{count}</span>
+                </button>
+              ))}
+            </div>
+            <input
+              type="search"
+              className="log-search"
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Filter text, source, stream..."
+              aria-label="Filter logs by text"
+            />
           </div>
           <div className="logs" aria-live="polite">
-            {logs.map((entry, i) => (
-              <div key={i} className={`log-entry ${entry.stream}`}>
+            {filteredLogs.length === 0 && (
+              <div className="log-empty">No logs match the current filter.</div>
+            )}
+            {filteredLogs.map((entry, i) => (
+              <div key={`${entry.timestamp}-${i}-${entry.line}`} className={`log-entry ${entry.stream}`}>
                 <span className="ts">{formatClock(entry.timestamp)}</span>
+                <span className="log-source">{getLogSource(entry)}</span>
                 {`[${entry.mode}] ${entry.line}`}
               </div>
             ))}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -89,6 +89,10 @@ export {
 } from './payments/evm/stats-client.js';
 export { signData, verifySignature, signUtf8, verifyUtf8 } from './p2p/identity.js';
 export {
+  getDebugFilters,
+  shouldEmitDebugLine,
+} from './utils/debug.js';
+export {
   signSpendingAuth,
   signReserveAuth,
   signFreeUsageOpen,

--- a/packages/node/src/utils/debug.ts
+++ b/packages/node/src/utils/debug.ts
@@ -2,6 +2,41 @@ function normalizeDebugValue(value: string | undefined): string {
   return (value ?? '').trim().toLowerCase();
 }
 
+let cachedDebugFilters: string[] | null = null;
+
+export function getDebugFilters(): readonly string[] {
+  if (cachedDebugFilters) {
+    return cachedDebugFilters;
+  }
+
+  const raw = process.env['ANTSEED_LOG_FILTER'] ?? process.env['ANTSEED_DEBUG_FILTER'] ?? '';
+  cachedDebugFilters = raw
+    .split(',')
+    .map((part) => part.trim().toLowerCase())
+    .filter((part) => part.length > 0);
+  return cachedDebugFilters;
+}
+
+function getDebugSource(line: string): string | null {
+  const match = /^\s*\[([^\]]{1,48})\]/.exec(line);
+  return match?.[1]?.trim().toLowerCase() ?? null;
+}
+
+export function shouldEmitDebugLine(line: string): boolean {
+  const filters = getDebugFilters();
+  if (filters.length === 0) {
+    return true;
+  }
+
+  const normalizedLine = line.toLowerCase();
+  const source = getDebugSource(line);
+  return filters.some((filter) => source === filter || normalizedLine.includes(filter));
+}
+
+function shouldEmitDebug(args: unknown[]): boolean {
+  return shouldEmitDebugLine(args.map((arg) => typeof arg === 'string' ? arg : String(arg)).join(' '));
+}
+
 export function isDebugEnabled(): boolean {
   const fromAntseed = normalizeDebugValue(process.env['ANTSEED_DEBUG']);
   if (
@@ -18,13 +53,13 @@ export function isDebugEnabled(): boolean {
 }
 
 export function debugLog(...args: unknown[]): void {
-  if (isDebugEnabled()) {
+  if (isDebugEnabled() && shouldEmitDebug(args)) {
     console.log(...args);
   }
 }
 
 export function debugWarn(...args: unknown[]): void {
-  if (isDebugEnabled()) {
+  if (isDebugEnabled() && shouldEmitDebug(args)) {
     console.warn(...args);
   }
 }


### PR DESCRIPTION
## Description

Adds source-aware filtering to the Desktop Runtime Logs panel so noisy runtime output can be narrowed to sources like ProxyMux, PaymentMux, proxy, Node, or matching text. Adds buyer debug log filtering through `antseed buyer start --log-filter` and the `ANTSEED_LOG_FILTER` / `ANTSEED_DEBUG_FILTER` environment variables.

## Release Notes

- Added Desktop runtime log source filters and text search for easier debugging.
- Added buyer debug log filtering with `antseed buyer start --log-filter <sourceOrText>` and `ANTSEED_LOG_FILTER`.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [ ] Lint and unit tests pass locally with my changes

Validation run locally:

- `pnpm -C apps/desktop run typecheck:renderer`
- `pnpm -C apps/desktop run build:renderer`
- `pnpm -C packages/node run build`
- `pnpm -C apps/cli run build`
- Smoke checked `ANTSEED_LOG_FILTER=ProxyMux` against the built debug helper.