### PR TITLE
fix(diem-staking): Force Base transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed the DIEM staking site so wallet transactions explicitly switch to and execute on Base mainnet instead of following a wallet that remains on Ethereum mainnet.
 - Fixed Desktop auto-update failures so download and install errors appear in the title bar with copyable details, and fixed macOS Quit so the first menu action exits after cleanup instead of requiring a second click.
 - Fixed buyer response-auth timeout warnings for non-inference probes and sellers that do not advertise response-auth support.
 - Fixed buyer discovery so temporarily unreachable metadata endpoints are probed for recovery before the full exponential cooldown expires, allowing recovered peers to reappear in buyer peer lists sooner.

--- a/apps/diem-staking/src/lib/actions.ts
+++ b/apps/diem-staking/src/lib/actions.ts
@@ -8,107 +8,129 @@ import { parseEther, maxUint256 } from 'viem';
 
 import { DIEM_TOKEN, DIEM_STAKING_PROXY } from './addresses';
 import { DIEM_STAKING_PROXY_ABI, DIEM_TOKEN_ABI } from './abi';
+import { DIEM_CHAIN_ID, useDiemNetwork } from './network';
 
 export function useApproveDiem() {
   const { writeContractAsync, isPending, error, reset } = useWriteContract();
+  const { ensureDiemNetwork, isSwitchingChain } = useDiemNetwork();
   const run = useCallback(async () => {
+    await ensureDiemNetwork();
     return writeContractAsync({
       address: DIEM_TOKEN,
       abi: DIEM_TOKEN_ABI,
       functionName: 'approve',
+      chainId: DIEM_CHAIN_ID,
       args: [DIEM_STAKING_PROXY, maxUint256],
     });
-  }, [writeContractAsync]);
-  return { run, isPending, error, reset };
+  }, [ensureDiemNetwork, writeContractAsync]);
+  return { run, isPending: isPending || isSwitchingChain, error, reset };
 }
 
 export function useStake() {
   const { writeContractAsync, isPending, error, reset } = useWriteContract();
+  const { ensureDiemNetwork, isSwitchingChain } = useDiemNetwork();
   const run = useCallback(
     async (amountDiem: string) => {
       const amt = parseEther(amountDiem);
+      await ensureDiemNetwork();
       return writeContractAsync({
         address: DIEM_STAKING_PROXY,
         abi: DIEM_STAKING_PROXY_ABI,
         functionName: 'stake',
+        chainId: DIEM_CHAIN_ID,
         args: [amt],
       });
     },
-    [writeContractAsync],
+    [ensureDiemNetwork, writeContractAsync],
   );
-  return { run, isPending, error, reset };
+  return { run, isPending: isPending || isSwitchingChain, error, reset };
 }
 
 export function useInitiateUnstake() {
   const { writeContractAsync, isPending, error, reset } = useWriteContract();
+  const { ensureDiemNetwork, isSwitchingChain } = useDiemNetwork();
   const run = useCallback(
     async (amountDiem: string) => {
       const amt = parseEther(amountDiem);
+      await ensureDiemNetwork();
       return writeContractAsync({
         address: DIEM_STAKING_PROXY,
         abi: DIEM_STAKING_PROXY_ABI,
         functionName: 'initiateUnstake',
+        chainId: DIEM_CHAIN_ID,
         args: [amt],
       });
     },
-    [writeContractAsync],
+    [ensureDiemNetwork, writeContractAsync],
   );
-  return { run, isPending, error, reset };
+  return { run, isPending: isPending || isSwitchingChain, error, reset };
 }
 
 export function useFlush() {
   const { writeContractAsync, isPending, error, reset } = useWriteContract();
+  const { ensureDiemNetwork, isSwitchingChain } = useDiemNetwork();
   const run = useCallback(async () => {
+    await ensureDiemNetwork();
     return writeContractAsync({
       address: DIEM_STAKING_PROXY,
       abi: DIEM_STAKING_PROXY_ABI,
       functionName: 'flush',
+      chainId: DIEM_CHAIN_ID,
     });
-  }, [writeContractAsync]);
-  return { run, isPending, error, reset };
+  }, [ensureDiemNetwork, writeContractAsync]);
+  return { run, isPending: isPending || isSwitchingChain, error, reset };
 }
 
 export function useClaimUnstakeBatch() {
   const { writeContractAsync, isPending, error, reset } = useWriteContract();
+  const { ensureDiemNetwork, isSwitchingChain } = useDiemNetwork();
   const run = useCallback(
     async (batchId: number) => {
+      await ensureDiemNetwork();
       return writeContractAsync({
         address: DIEM_STAKING_PROXY,
         abi: DIEM_STAKING_PROXY_ABI,
         functionName: 'claimUnstakeBatch',
+        chainId: DIEM_CHAIN_ID,
         args: [batchId],
       });
     },
-    [writeContractAsync],
+    [ensureDiemNetwork, writeContractAsync],
   );
-  return { run, isPending, error, reset };
+  return { run, isPending: isPending || isSwitchingChain, error, reset };
 }
 
 export function useClaimUsdc() {
   const { writeContractAsync, isPending, error, reset } = useWriteContract();
+  const { ensureDiemNetwork, isSwitchingChain } = useDiemNetwork();
   const run = useCallback(async () => {
+    await ensureDiemNetwork();
     return writeContractAsync({
       address: DIEM_STAKING_PROXY,
       abi: DIEM_STAKING_PROXY_ABI,
       functionName: 'claimUsdc',
+      chainId: DIEM_CHAIN_ID,
     });
-  }, [writeContractAsync]);
-  return { run, isPending, error, reset };
+  }, [ensureDiemNetwork, writeContractAsync]);
+  return { run, isPending: isPending || isSwitchingChain, error, reset };
 }
 
 /** Claim ANTS for explicit completed reward epochs. */
 export function useClaimAnts() {
   const { writeContractAsync, isPending, error, reset } = useWriteContract();
+  const { ensureDiemNetwork, isSwitchingChain } = useDiemNetwork();
   const run = useCallback(
     async (rewardEpochs: number[]) => {
+      await ensureDiemNetwork();
       return writeContractAsync({
         address: DIEM_STAKING_PROXY,
         abi: DIEM_STAKING_PROXY_ABI,
         functionName: 'claimAnts',
+        chainId: DIEM_CHAIN_ID,
         args: [rewardEpochs],
       });
     },
-    [writeContractAsync],
+    [ensureDiemNetwork, writeContractAsync],
   );
-  return { run, isPending, error, reset };
+  return { run, isPending: isPending || isSwitchingChain, error, reset };
 }

--- a/apps/diem-staking/src/lib/hooks.ts
+++ b/apps/diem-staking/src/lib/hooks.ts
@@ -6,6 +6,7 @@ import type { Address } from 'viem';
 import { DIEM_TOKEN, DIEM_STAKING_PROXY, isAddressSet } from './addresses';
 import { DIEM_STAKING_PROXY_ABI, DIEM_TOKEN_ABI } from './abi';
 import { computeEpochClock, type EpochClock } from './epoch';
+import { DIEM_CHAIN_ID } from './network';
 
 // First Staked event on the deployed proxy: tx
 // 0x02dd13f8d519d7ac81eceaacd40c3e485f76b2a7f584b094fb7e816b44f822a4
@@ -121,16 +122,16 @@ export function usePoolStats(): PoolStats {
   const { data, isLoading } = useReadContracts({
     allowFailure: true,
     contracts: [
-      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'totalStaked' },
-      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'stakerCount' },
-      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'totalUsdcDistributedEver' },
-      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'maxTotalStake' },
-      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'firstRewardEpoch' },
-      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'syncedRewardEpoch' },
-      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'finalizedRewardEpoch' },
-      { address: DIEM_TOKEN,         abi: DIEM_TOKEN_ABI,         functionName: 'cooldownDuration' },
-      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'minUnstakeBatchOpenSecs' },
-      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'flushableAt' },
+      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'totalStaked', chainId: DIEM_CHAIN_ID },
+      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'stakerCount', chainId: DIEM_CHAIN_ID },
+      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'totalUsdcDistributedEver', chainId: DIEM_CHAIN_ID },
+      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'maxTotalStake', chainId: DIEM_CHAIN_ID },
+      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'firstRewardEpoch', chainId: DIEM_CHAIN_ID },
+      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'syncedRewardEpoch', chainId: DIEM_CHAIN_ID },
+      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'finalizedRewardEpoch', chainId: DIEM_CHAIN_ID },
+      { address: DIEM_TOKEN,         abi: DIEM_TOKEN_ABI,         functionName: 'cooldownDuration', chainId: DIEM_CHAIN_ID },
+      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'minUnstakeBatchOpenSecs', chainId: DIEM_CHAIN_ID },
+      { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'flushableAt', chainId: DIEM_CHAIN_ID },
     ],
     query: { enabled: deployed, refetchInterval: POLL_MS },
   });
@@ -187,10 +188,10 @@ export function useUserStats(): UserStats {
     allowFailure: true,
     contracts: enabled
       ? [
-          { address: DIEM_TOKEN,         abi: DIEM_TOKEN_ABI,         functionName: 'balanceOf', args: [address!] },
-          { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'staked',    args: [address!] },
-          { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'earnedUsdc', args: [address!] },
-          { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'userLastClaimedEpoch', args: [address!] },
+          { address: DIEM_TOKEN,         abi: DIEM_TOKEN_ABI,         functionName: 'balanceOf', args: [address!], chainId: DIEM_CHAIN_ID },
+          { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'staked',    args: [address!], chainId: DIEM_CHAIN_ID },
+          { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'earnedUsdc', args: [address!], chainId: DIEM_CHAIN_ID },
+          { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'userLastClaimedEpoch', args: [address!], chainId: DIEM_CHAIN_ID },
         ]
       : [],
     query: { enabled, refetchInterval: POLL_MS },
@@ -255,6 +256,7 @@ function usePendingAnts(
       address: DIEM_STAKING_PROXY,
       abi: DIEM_STAKING_PROXY_ABI,
       functionName: 'pendingAntsForEpoch' as const,
+      chainId: DIEM_CHAIN_ID,
       args: [user!, e] as const,
     })),
     query: { enabled: epochsToRead.length > 0, refetchInterval: POLL_MS },
@@ -266,6 +268,7 @@ function usePendingAnts(
       address: DIEM_STAKING_PROXY,
       abi: DIEM_STAKING_PROXY_ABI,
       functionName: 'userEpochClaimed' as const,
+      chainId: DIEM_CHAIN_ID,
       args: [user!, e] as const,
     })),
     query: { enabled: epochsToRead.length > 0, refetchInterval: POLL_MS },
@@ -305,8 +308,8 @@ export function useUnstakeState(): { state: UnstakeState; isLoading: boolean } {
     allowFailure: true,
     contracts: deployed
       ? [
-          { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'currentUnstakeBatch' },
-          { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'oldestUnclaimedUnstakeBatch' },
+          { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'currentUnstakeBatch', chainId: DIEM_CHAIN_ID },
+          { address: DIEM_STAKING_PROXY, abi: DIEM_STAKING_PROXY_ABI, functionName: 'oldestUnclaimedUnstakeBatch', chainId: DIEM_CHAIN_ID },
         ]
       : [],
     query: { enabled: deployed, refetchInterval: POLL_MS },
@@ -336,6 +339,7 @@ export function useUnstakeState(): { state: UnstakeState; isLoading: boolean } {
             address: DIEM_STAKING_PROXY,
             abi: DIEM_STAKING_PROXY_ABI,
             functionName: 'unstakeBatchUserAmount' as const,
+            chainId: DIEM_CHAIN_ID,
             args: [batch, address] as const,
           }))
         : [],
@@ -359,6 +363,7 @@ export function useUnstakeState(): { state: UnstakeState; isLoading: boolean } {
     address: DIEM_STAKING_PROXY,
     abi: DIEM_STAKING_PROXY_ABI,
     functionName: 'unstakeBatches',
+    chainId: DIEM_CHAIN_ID,
     args: activeBatchId != null ? [activeBatchId] : undefined,
     query: { enabled: deployed && activeBatchId != null, refetchInterval: POLL_MS },
   });
@@ -406,6 +411,7 @@ export function useDiemAllowance(): { allowance: bigint | null; refetch: () => v
     address: DIEM_TOKEN,
     abi: DIEM_TOKEN_ABI,
     functionName: 'allowance',
+    chainId: DIEM_CHAIN_ID,
     args: enabled ? [address!, DIEM_STAKING_PROXY] : undefined,
     query: { enabled, refetchInterval: POLL_MS },
   });

--- a/apps/diem-staking/src/lib/network.ts
+++ b/apps/diem-staking/src/lib/network.ts
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useChainModal } from '@rainbow-me/rainbowkit';
+import { useAccount, useSwitchChain } from 'wagmi';
+import { base } from 'wagmi/chains';
+
+export const DIEM_CHAIN = base;
+export const DIEM_CHAIN_ID = base.id;
+export const DIEM_CHAIN_NAME = base.name;
+
+export function useDiemNetwork() {
+  const { isConnected, connector } = useAccount();
+  const { switchChainAsync, isPending: isSwitchingChain } = useSwitchChain();
+  const { openChainModal } = useChainModal();
+  const [walletChainId, setWalletChainId] = useState<number | undefined>(undefined);
+
+  const refreshWalletChainId = useCallback(async () => {
+    if (!isConnected || !connector?.getChainId) {
+      setWalletChainId(undefined);
+      return undefined;
+    }
+
+    const chainId = await connector.getChainId();
+    setWalletChainId(chainId);
+    return chainId;
+  }, [connector, isConnected]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function refresh() {
+      try {
+        const chainId = await refreshWalletChainId();
+        if (!cancelled) setWalletChainId(chainId);
+      } catch {
+        if (!cancelled) setWalletChainId(undefined);
+      }
+    }
+
+    void refresh();
+
+    if (!connector?.emitter?.on) {
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const handleChange = (data?: { chainId?: string | number }) => {
+      if (typeof data?.chainId === 'number') {
+        setWalletChainId(data.chainId);
+        return;
+      }
+      if (typeof data?.chainId === 'string') {
+        setWalletChainId(Number(data.chainId));
+        return;
+      }
+      void refresh();
+    };
+
+    connector.emitter.on('change', handleChange);
+
+    return () => {
+      cancelled = true;
+      connector.emitter.off?.('change', handleChange);
+    };
+  }, [connector, refreshWalletChainId]);
+
+  const ensureDiemNetwork = useCallback(async () => {
+    if (!isConnected) {
+      throw new Error('Connect your wallet before continuing.');
+    }
+
+    const currentChainId = await refreshWalletChainId();
+    if (currentChainId === DIEM_CHAIN_ID) {
+      return;
+    }
+
+    if (typeof switchChainAsync === 'function') {
+      await switchChainAsync({ chainId: DIEM_CHAIN_ID });
+
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < 10_000) {
+        const chainId = await refreshWalletChainId();
+        if (chainId === DIEM_CHAIN_ID) {
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 150));
+      }
+    }
+
+    if (typeof openChainModal === 'function') {
+      openChainModal();
+    }
+
+    throw new Error(`Please switch your wallet to ${DIEM_CHAIN_NAME} and try again.`);
+  }, [isConnected, openChainModal, refreshWalletChainId, switchChainAsync]);
+
+  return {
+    expectedChainId: DIEM_CHAIN_ID,
+    walletChainId,
+    wrongChain: Boolean(isConnected && walletChainId && walletChainId !== DIEM_CHAIN_ID),
+    isSwitchingChain,
+    ensureDiemNetwork,
+  };
+}

--- a/apps/diem-staking/src/wagmi-config.ts
+++ b/apps/diem-staking/src/wagmi-config.ts
@@ -14,7 +14,8 @@ import {
   injectedWallet,
 } from '@rainbow-me/rainbowkit/wallets';
 import { createConfig, http, fallback } from 'wagmi';
-import { base } from 'wagmi/chains';
+
+import { DIEM_CHAIN } from './lib/network';
 
 const projectId = '9a1851410cb5589bc351a6dabf17140e';
 
@@ -54,9 +55,9 @@ const connectors = connectorsForWallets(
 // — a shared `packages/wallet-config` is the next step if a third app adopts it.
 export const wagmiConfig = createConfig({
   connectors,
-  chains: [base],
+  chains: [DIEM_CHAIN],
   transports: {
-    [base.id]: fallback([
+    [DIEM_CHAIN.id]: fallback([
       http('https://base-rpc.publicnode.com'),
       http('https://base.gateway.tenderly.co'),
       http('https://base-public.nodies.app'),


### PR DESCRIPTION
## Description

Fixes DIEM staking wallet operations so transactions explicitly switch to Base mainnet before submitting. Adds a shared Base network guard for the staking site, waits for the wallet connector to report Base, and binds contract reads/writes to the Base chain ID.

## Release Notes

- Fixed DIEM staking wallet transactions so connected wallets switch to Base mainnet before approve, lock, withdraw, flush, and claim actions.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
