### PR TITLE
fix(desktop): normalize separators in AntStation model search (#599)

### DIFF
--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.test.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.test.ts
@@ -37,6 +37,26 @@ test('matchesSearch finds query in service, peer, categories', () => {
   assert.ok(!matchesSearch(r, 'zzz'));
 });
 
+test('matchesSearch normalizes spaces, hyphens, underscores, dots as equivalent separators', () => {
+  const r = mkRow({ serviceLabel: 'claude-opus-4-7', peerLabel: 'Provider', categories: [] });
+  // space-separated natural language query should match hyphenated slug
+  assert.ok(matchesSearch(r, 'Claude Opus 4.7'));
+  assert.ok(matchesSearch(r, 'claude opus 4 7'));
+  assert.ok(matchesSearch(r, 'Claude-Opus-4.7'));
+  assert.ok(matchesSearch(r, 'opus 4.7'));
+  // exact slug still works
+  assert.ok(matchesSearch(r, 'claude-opus-4-7'));
+  // unrelated query still returns false
+  assert.ok(!matchesSearch(r, 'gemini'));
+});
+
+test('matchesSearch normalizes dot-separated query against space-separated label', () => {
+  const r = mkRow({ serviceLabel: 'Claude Opus 4.7', peerLabel: 'Provider', categories: [] });
+  assert.ok(matchesSearch(r, 'claude-opus-4-7'));
+  assert.ok(matchesSearch(r, 'Claude Opus 4.7'));
+  assert.ok(matchesSearch(r, 'opus 4'));
+});
+
 test('matchesMaxInputPrice filters rows by the input slider ceiling', () => {
   assert.ok(matchesMaxInputPrice(mkRow({ inputUsdPerMillion: 5 }), MAX_INPUT_PRICE_SLIDER_USD));
   assert.ok(matchesMaxInputPrice(mkRow({ inputUsdPerMillion: null }), MAX_INPUT_PRICE_SLIDER_USD));

--- a/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
+++ b/apps/desktop/src/renderer/ui/components/chat/discover-filter-util.ts
@@ -54,15 +54,26 @@ export function hasBeenUsed(row: DiscoverRow): boolean {
     || row.lifetimeLastSessionAt != null;
 }
 
+/** Collapse spaces, hyphens, underscores, and dots so that "Claude Opus 4.7"
+ *  matches the slug form "claude-opus-4-7" and vice-versa. */
+function normalizeForSearch(s: string): string {
+  return s.toLowerCase().replace(/[\s\-_.]+/g, '');
+}
+
 export function matchesSearch(row: DiscoverRow, q: string): boolean {
   if (!q) return true;
   const needle = q.trim().toLowerCase();
   if (!needle) return true;
-  if (row.serviceLabel.toLowerCase().includes(needle)) return true;
-  if ((row.peerDisplayName ?? '').toLowerCase().includes(needle)) return true;
-  if (row.peerLabel.toLowerCase().includes(needle)) return true;
-  for (const c of row.categories) {
-    if (c.toLowerCase().includes(needle)) return true;
+  const normNeedle = normalizeForSearch(needle);
+  const fields = [
+    row.serviceLabel,
+    row.peerDisplayName ?? '',
+    row.peerLabel,
+    ...row.categories,
+  ];
+  for (const field of fields) {
+    if (field.toLowerCase().includes(needle)) return true;
+    if (normNeedle && normalizeForSearch(field).includes(normNeedle)) return true;
   }
   return false;
 }


### PR DESCRIPTION
## Summary

- `matchesSearch` now normalizes spaces, hyphens, underscores, and dots as equivalent separators before comparing
- A query like `Claude Opus 4.7` now matches the slug `claude-opus-4-7`, and `claude-opus-4-7` matches a label `Claude Opus 4.7`
- Existing exact/literal substring matching is preserved as the first-pass check — no regressions

## Changes

- `discover-filter-util.ts`: added `normalizeForSearch()` helper; updated `matchesSearch` to try normalized match as fallback
- `discover-filter-util.test.ts`: added two new test cases covering space→hyphen and hyphen→space normalization

## Test plan

- [x] All 18 existing tests pass
- [x] New tests verify `Claude Opus 4.7` matches `claude-opus-4-7` and vice-versa
- [x] Partial queries like `opus 4.7` still match

Closes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)