### PR TITLE
fix(provider): Normalize responses relay

### DIFF
--- a/plugins/provider-openai-responses/src/index.test.ts
+++ b/plugins/provider-openai-responses/src/index.test.ts
@@ -260,6 +260,244 @@ describe('provider-openai-responses plugin', () => {
     rmSync(dirname(authFile), { recursive: true, force: true });
   });
 
+  it('strips unsupported fields before relaying to the upstream backend', async () => {
+    const authFile = writeAuthFile({
+      tokens: {
+        access_token: makeJwt({}),
+        account_id: 'acct-file',
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: 'resp_1' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = plugin.createProvider({
+      OPENAI_RESPONSES_AUTH_FILE: authFile,
+      ANTSEED_ALLOWED_SERVICES: 'gpt-5.5',
+    });
+
+    await provider.handleRequest({
+      requestId: 'req-metadata',
+      method: 'POST',
+      path: '/v1/responses',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'gpt-5.5',
+        input: 'hello',
+        metadata: { trace: 'abc' },
+        user: 'user-123',
+        temperature: 0.2,
+        top_p: 0.9,
+        stream: false,
+      })),
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(new TextDecoder().decode((init.body as Uint8Array) ?? new Uint8Array(0))) as Record<string, unknown>;
+    expect(body.stream).toBe(true);
+    expect(body.metadata).toBeUndefined();
+    expect(body.user).toBeUndefined();
+    expect(body.temperature).toBeUndefined();
+    expect(body.top_p).toBeUndefined();
+    rmSync(dirname(authFile), { recursive: true, force: true });
+  });
+
+  it('forces upstream streaming and collapses SSE for non-stream callers', async () => {
+    const authFile = writeAuthFile({
+      tokens: {
+        access_token: makeJwt({}),
+        account_id: 'acct-file',
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        'event: response.created\n'
+          + 'data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.5","status":"in_progress","output":[]}}\n\n'
+          + 'event: response.completed\n'
+          + 'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","model":"gpt-5.5","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hi","annotations":[]}]}],"output_text":"hi","usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}}\n\n'
+          + 'data: [DONE]\n\n',
+        {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        },
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = plugin.createProvider({
+      OPENAI_RESPONSES_AUTH_FILE: authFile,
+      ANTSEED_ALLOWED_SERVICES: 'gpt-5.5',
+    });
+
+    const response = await provider.handleRequest({
+      requestId: 'req-stream-required',
+      method: 'POST',
+      path: '/v1/responses',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'gpt-5.5',
+        input: 'hello',
+        stream: false,
+      })),
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const upstreamBody = JSON.parse(new TextDecoder().decode((init.body as Uint8Array) ?? new Uint8Array(0))) as Record<string, unknown>;
+    expect(upstreamBody.stream).toBe(true);
+    expect(response.headers['content-type']).toBe('application/json');
+    const body = JSON.parse(new TextDecoder().decode(response.body)) as Record<string, unknown>;
+    expect(body.id).toBe('resp_1');
+    expect(body.output_text).toBe('hi');
+    rmSync(dirname(authFile), { recursive: true, force: true });
+  });
+
+  it('does not stream callbacks when forced streaming serves a non-stream request', async () => {
+    const authFile = writeAuthFile({
+      tokens: {
+        access_token: makeJwt({}),
+        account_id: 'acct-file',
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        'event: response.completed\n'
+          + 'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","model":"gpt-5.5","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hi","annotations":[]}]}],"output_text":"hi","usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}}\n\n'
+          + 'data: [DONE]\n\n',
+        {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        },
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = plugin.createProvider({
+      OPENAI_RESPONSES_AUTH_FILE: authFile,
+      ANTSEED_ALLOWED_SERVICES: 'gpt-5.5',
+    });
+    const callbacks = {
+      onResponseStart: vi.fn(),
+      onResponseChunk: vi.fn(),
+    };
+
+    const response = await provider.handleRequestStream!({
+      requestId: 'req-forced-stream-callbacks',
+      method: 'POST',
+      path: '/v1/responses',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'gpt-5.5',
+        input: 'hello',
+        stream: false,
+      })),
+    }, callbacks);
+
+    expect(callbacks.onResponseStart).not.toHaveBeenCalled();
+    expect(callbacks.onResponseChunk).not.toHaveBeenCalled();
+    expect(response.headers['content-type']).toBe('application/json');
+    const body = JSON.parse(new TextDecoder().decode(response.body)) as Record<string, unknown>;
+    expect(body.output_text).toBe('hi');
+    rmSync(dirname(authFile), { recursive: true, force: true });
+  });
+
+  it('collapses failed Responses SSE into a JSON error for non-stream callers', async () => {
+    const authFile = writeAuthFile({
+      tokens: {
+        access_token: makeJwt({}),
+        account_id: 'acct-file',
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        'event: response.failed\n'
+          + 'data: {"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"type":"server_error","message":"backend failed"}}}\n\n'
+          + 'data: [DONE]\n\n',
+        {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        },
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = plugin.createProvider({
+      OPENAI_RESPONSES_AUTH_FILE: authFile,
+      ANTSEED_ALLOWED_SERVICES: 'gpt-5.5',
+    });
+
+    const response = await provider.handleRequest({
+      requestId: 'req-failed-stream',
+      method: 'POST',
+      path: '/v1/responses',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'gpt-5.5',
+        input: 'hello',
+        stream: false,
+      })),
+    });
+
+    expect(response.statusCode).toBe(502);
+    expect(response.headers['content-type']).toBe('application/json');
+    const body = JSON.parse(new TextDecoder().decode(response.body)) as Record<string, unknown>;
+    expect(body).toEqual({
+      error: {
+        type: 'server_error',
+        message: 'backend failed',
+      },
+    });
+    rmSync(dirname(authFile), { recursive: true, force: true });
+  });
+
+  it('does not add create-only fields to Responses subresources', async () => {
+    const authFile = writeAuthFile({
+      tokens: {
+        access_token: makeJwt({}),
+        account_id: 'acct-file',
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = plugin.createProvider({
+      OPENAI_RESPONSES_AUTH_FILE: authFile,
+      ANTSEED_ALLOWED_SERVICES: 'gpt-5.5',
+    });
+
+    await provider.handleRequest({
+      requestId: 'req-cancel',
+      method: 'POST',
+      path: '/v1/responses/resp_1/cancel',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: new TextEncoder().encode(JSON.stringify({})),
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/responses\/resp_1\/cancel$/);
+    const body = JSON.parse(new TextDecoder().decode((init.body as Uint8Array) ?? new Uint8Array(0))) as Record<string, unknown>;
+    expect(body).toEqual({});
+    rmSync(dirname(authFile), { recursive: true, force: true });
+  });
+
   it('retries transient upstream failures', async () => {
     const authFile = writeAuthFile({
       tokens: {

--- a/plugins/provider-openai-responses/src/index.ts
+++ b/plugins/provider-openai-responses/src/index.ts
@@ -271,14 +271,21 @@ function extractAccountIdFromTokens(accessToken: string, idToken: string | undef
 function prepareRequestBody(
   request: SerializedHttpRequest,
   serviceRewriteMap: Record<string, string> | undefined,
-): SerializedHttpRequest {
+): { request: SerializedHttpRequest; forcedStream: boolean } {
   if (request.method === 'GET' || request.method === 'HEAD') {
-    return request;
+    return { request, forcedStream: false };
+  }
+
+  const normalizedPath = request.path.split('?')[0] ?? request.path;
+  if (normalizedPath !== RESPONSE_PATH_PREFIX) {
+    return { request, forcedStream: false };
   }
 
   try {
     const parsed = JSON.parse(new TextDecoder().decode(request.body)) as Record<string, unknown>;
     parsed.store ??= false;
+    const forcedStream = parsed.stream !== true;
+    parsed.stream = true;
 
     const requestedService = (parsed.model ?? parsed.service) as string | undefined;
     if (serviceRewriteMap && typeof requestedService === 'string' && requestedService.trim().length > 0) {
@@ -293,10 +300,14 @@ function prepareRequestBody(
     }
     delete parsed.service;
 
-    // Strip parameters the Codex backend doesn't support.
+    // Strip parameters the upstream backend doesn't support.
+    delete parsed.metadata;
+    delete parsed.user;
     delete parsed.max_output_tokens;
+    delete parsed.temperature;
+    delete parsed.top_p;
 
-    // The Codex backend requires `instructions` as a top-level field.
+    // The upstream backend requires `instructions` as a top-level field.
     // Some clients (e.g. pi's openai-responses provider) send the system
     // prompt as a developer/system message in `input` instead. Extract it
     // and move to `instructions` so the request is accepted.
@@ -322,12 +333,103 @@ function prepareRequestBody(
     }
 
     return {
-      ...request,
-      body: new TextEncoder().encode(JSON.stringify(parsed)),
+      request: {
+        ...request,
+        body: new TextEncoder().encode(JSON.stringify(parsed)),
+      },
+      forcedStream,
     };
   } catch {
-    return request;
+    return { request, forcedStream: false };
   }
+}
+
+function collapseResponsesSseResponse(response: SerializedHttpResponse): SerializedHttpResponse {
+  const result = parseResponsesSse(new TextDecoder().decode(response.body));
+  if (!result) {
+    return response;
+  }
+
+  return {
+    ...response,
+    statusCode: result.statusCode ?? response.statusCode,
+    headers: {
+      ...response.headers,
+      'content-type': 'application/json',
+    },
+    body: new TextEncoder().encode(JSON.stringify(result.body)),
+  };
+}
+
+function parseResponsesSse(text: string): { body: Record<string, unknown>; statusCode?: number } | null {
+  for (const block of text.replace(/\r\n/g, '\n').split('\n\n')) {
+    const lines = block.split('\n');
+    const event = lines
+      .find((line) => line.startsWith('event: '))
+      ?.slice('event: '.length)
+      .trim();
+    if (
+      event !== 'response.completed'
+      && event !== 'response.failed'
+      && event !== 'error'
+    ) {
+      continue;
+    }
+
+    const data = lines
+      .filter((line) => line.startsWith('data: '))
+      .map((line) => line.slice('data: '.length))
+      .join('\n')
+      .trim();
+    if (!data || data === '[DONE]') continue;
+
+    try {
+      const parsed = JSON.parse(data) as Record<string, unknown>;
+      if (event === 'error') {
+        return { body: normalizeUpstreamStreamError(parsed), statusCode: 502 };
+      }
+
+      const nested = parsed.response;
+      if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+        const body = nested as Record<string, unknown>;
+        if (event === 'response.failed') {
+          return { body: normalizeUpstreamStreamError(body), statusCode: 502 };
+        }
+        return { body };
+      }
+
+      if (event === 'response.failed') {
+        return { body: normalizeUpstreamStreamError(parsed), statusCode: 502 };
+      }
+
+      if (Array.isArray(parsed.output) || typeof parsed.output_text === 'string') {
+        return { body: parsed };
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+function normalizeUpstreamStreamError(payload: Record<string, unknown>): Record<string, unknown> {
+  const error = payload.error && typeof payload.error === 'object' && !Array.isArray(payload.error)
+    ? payload.error as Record<string, unknown>
+    : {};
+  const message = typeof error.message === 'string'
+    ? error.message
+    : (typeof payload.message === 'string' ? payload.message : 'Responses stream failed');
+  const type = typeof error.type === 'string'
+    ? error.type
+    : (typeof payload.type === 'string' ? payload.type : 'api_error');
+  return {
+    error: {
+      ...error,
+      type,
+      message,
+    },
+  };
 }
 
 function toRelayPath(path: string): string | null {
@@ -467,7 +569,8 @@ class OpenAIResponsesProvider implements Provider {
     if ('response' in prepared) {
       return prepared.response;
     }
-    return this.inner.handleRequest(prepared.request);
+    const response = await this.inner.handleRequest(prepared.request);
+    return prepared.forcedStream ? collapseResponsesSseResponse(response) : response;
   }
 
   async handleRequestStream(
@@ -484,12 +587,15 @@ class OpenAIResponsesProvider implements Provider {
       });
       return prepared.response;
     }
+    if (prepared.forcedStream) {
+      return collapseResponsesSseResponse(await this.inner.handleRequest(prepared.request));
+    }
     return this.inner.handleRequestStream!(prepared.request, callbacks);
   }
 
   private prepareRequest(
     req: SerializedHttpRequest,
-  ): { request: SerializedHttpRequest } | { response: SerializedHttpResponse } {
+  ): { request: SerializedHttpRequest; forcedStream: boolean } | { response: SerializedHttpResponse } {
     const normalizedPath = req.path.split('?')[0] ?? req.path;
     const relayPath = toRelayPath(req.path);
     if (!relayPath) {
@@ -499,9 +605,10 @@ class OpenAIResponsesProvider implements Provider {
     const preparedBody = prepareRequestBody(req, this.serviceRewriteMap);
     return {
       request: {
-        ...preparedBody,
+        ...preparedBody.request,
         path: relayPath,
       },
+      forcedStream: preparedBody.forcedStream,
     };
   }
 }


### PR DESCRIPTION
## Description

Updates the OpenAI Responses provider relay to normalize request fields for stricter upstream backends and preserve the caller's expected response mode. Non-stream requests that require upstream streaming are collapsed back into JSON responses before returning to the buyer.

Verification: provider TypeScript build passed locally, and a compiled smoke test passed for request normalization, forced-stream collapse, streamed error normalization, and subresource pass-through. The package Vitest command is blocked in this local install by a missing Rollup optional native package.

## Release Notes

- Fixed OpenAI Responses provider compatibility with stricter upstream backends
- Prevented non-stream clients from receiving raw streaming event payloads

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [ ] Lint and unit tests pass locally with my changes