### PR TITLE
fix(chain-config): throw on unknown chainId instead of silently defaulting to mainnet

### DIFF
--- a/packages/node/src/payments/chain-config.ts
+++ b/packages/node/src/payments/chain-config.ts
@@ -89,12 +89,21 @@ const DEFAULT_CHAIN_ID: ChainId = 'base-mainnet';
 
 /**
  * Get the chain config for a given chain ID.
- * Falls back to base-sepolia if not found.
+ *
+ * With no chainId, returns the default (base-mainnet). An unrecognized
+ * chainId throws rather than silently defaulting to mainnet — a typo'd or
+ * stale id must not quietly route real funds to the wrong chain.
  */
 export function getChainConfig(chainId?: ChainId | string): ChainConfig {
   if (!chainId) return CHAIN_CONFIGS[DEFAULT_CHAIN_ID];
   const config = CHAIN_CONFIGS[chainId as ChainId];
-  return config ?? CHAIN_CONFIGS[DEFAULT_CHAIN_ID];
+  if (!config) {
+    throw new Error(
+      `Unknown chainId "${chainId}" — refusing to silently default to ${DEFAULT_CHAIN_ID}. ` +
+        `Known chains: ${Object.keys(CHAIN_CONFIGS).join(', ')}.`,
+    );
+  }
+  return config;
 }
 
 /**

--- a/packages/node/tests/chain-config.test.ts
+++ b/packages/node/tests/chain-config.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { getChainConfig, resolveChainConfig, DEFAULT_CHAIN_ID } from '../src/payments/chain-config.js';
+
+describe('getChainConfig', () => {
+  it('returns base-mainnet when chainId is omitted', () => {
+    const cfg = getChainConfig();
+    expect(cfg.chainId).toBe('base-mainnet');
+    expect(cfg.evmChainId).toBe(8453);
+  });
+
+  it('returns the named config for known chain ids', () => {
+    expect(getChainConfig('base-sepolia').chainId).toBe('base-sepolia');
+    expect(getChainConfig('base-local').chainId).toBe('base-local');
+    expect(getChainConfig('base-mainnet').chainId).toBe('base-mainnet');
+  });
+
+  it('throws on unrecognized non-empty chainId (no silent mainnet fallback)', () => {
+    expect(() => getChainConfig('base-goerli')).toThrow(/Unknown chainId "base-goerli"/);
+    expect(() => getChainConfig('typo-mainnet')).toThrow(/Known chains:/);
+    // Must NOT silently resolve to mainnet.
+    expect(() => getChainConfig('base-goerli')).toThrow();
+  });
+
+  it('empty string is treated as unknown (not the no-arg default path)', () => {
+    // Empty string is truthy enough to skip the no-arg branch in the current
+    // implementation (if (!chainId) — empty string is falsy in JS, so it
+    // still returns the default). Document that contract.
+    const cfg = getChainConfig('');
+    expect(cfg.chainId).toBe(DEFAULT_CHAIN_ID);
+  });
+});
+
+describe('resolveChainConfig', () => {
+  it('propagates the unknown-chainId throw from getChainConfig', () => {
+    expect(() => resolveChainConfig({ chainId: 'not-a-chain' })).toThrow(/Unknown chainId/);
+  });
+
+  it('resolves known chain with rpc override', () => {
+    const cfg = resolveChainConfig({
+      chainId: 'base-sepolia',
+      rpcUrl: 'https://example.invalid',
+    });
+    expect(cfg.chainId).toBe('base-sepolia');
+    expect(cfg.rpcUrl).toBe('https://example.invalid');
+    // rpc override without fallbacks → empty fallback list
+    expect(cfg.fallbackRpcUrls).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Problem
`getChainConfig` falls back to `DEFAULT_CHAIN_ID` (`base-mainnet`) for **any** unrecognized `chainId`, while its doc comment claims *\"Falls back to base-sepolia if not found.\"* So a typo'd or stale chain id silently resolves to **mainnet** config — potentially routing real funds to the wrong chain — and the documented behavior is wrong either way.

### Fix
- No-arg call is unchanged (still returns the `base-mainnet` default).
- An **unrecognized** `chainId` now **throws** instead of silently defaulting, naming the known chains. Fail-loud beats silently-mainnet.
- Doc comment corrected to describe the real behavior.
- Unit tests lock the contract (`packages/node/tests/chain-config.test.ts`).

### Note on behavioral change
Callers passing an unknown id previously got mainnet config and now get an error. That's the point of the fix (surface the mistake). Known production callers pass user-config / known chain ids through `resolveChainConfig`; a typo now fails at startup instead of routing funds to the wrong chain.

### Verification
```
pnpm --filter=@antseed/node exec vitest run tests/chain-config.test.ts tests/receipt.test.ts tests/balance-manager.test.ts tests/base-evm-client.test.ts
# → 33 pass
```

Found via an [AntFleet](https://antfleet.dev) two-model review of AntSeed; methodology mirror: https://github.com/AntFleet/bench-antseed · agent page: https://www.antfleet.dev/agents/0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263