### PR TITLE
fix(proxy): make header lookups truly case-insensitive

### DIFF
--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -23,6 +23,7 @@ import {
   transformResponse,
 } from './service-api-adapter.js'
 import {
+  getHeader,
   DEBUG,
   log,
   extractRequestedService,
@@ -1117,7 +1118,7 @@ export class BuyerProxy {
     }
 
     if (!pinnedDiscovered) {
-      const logSource = serializedReq.headers['x-antseed-pin-peer']
+      const logSource = getHeader(serializedReq.headers, 'x-antseed-pin-peer')
         ? 'x-antseed-pin-peer header'
         : bodyPinnedPeer
           ? 'model peer prefix'
@@ -1222,7 +1223,7 @@ export class BuyerProxy {
   }
 
   private _parseMaxUploadBodyBytes(headers: Record<string, string>): number | null {
-    const raw = headers['x-antseed-max-upload-body-bytes']
+    const raw = getHeader(headers, 'x-antseed-max-upload-body-bytes')
     if (!raw) return null
     const parsed = Number.parseInt(raw, 10)
     return Number.isFinite(parsed) && parsed > 0 ? parsed : null

--- a/apps/cli/src/proxy/header-case.test.ts
+++ b/apps/cli/src/proxy/header-case.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import type { SerializedHttpRequest } from '@antseed/node'
+import { getHeader } from './request-utils.js'
+import { getExplicitPeerIdOverride, getExplicitProviderOverride } from './routing.js'
+
+function makeReq(headers: Record<string, string>): SerializedHttpRequest {
+  return {
+    requestId: 'test',
+    method: 'POST',
+    path: '/v1/chat/completions',
+    headers,
+    body: new Uint8Array(),
+  }
+}
+
+test('getHeader is case-insensitive across common casings', () => {
+  const headers = { 'Content-Type': 'application/json' }
+  assert.equal(getHeader(headers, 'content-type'), 'application/json')
+  assert.equal(getHeader(headers, 'Content-Type'), 'application/json')
+  assert.equal(getHeader(headers, 'CONTENT-TYPE'), 'application/json')
+})
+
+test('getHeader returns empty string when missing', () => {
+  assert.equal(getHeader({}, 'x-antseed-provider'), '')
+})
+
+test('getExplicitProviderOverride accepts mixed-case header names', () => {
+  const req = makeReq({ 'X-Antseed-Provider': '  OpenAI  ' })
+  assert.equal(getExplicitProviderOverride(req), 'openai')
+})
+
+test('getExplicitPeerIdOverride accepts mixed-case header names', () => {
+  const peerId = 'a'.repeat(40)
+  const req = makeReq({ 'X-Antseed-Pin-Peer': peerId })
+  assert.equal(getExplicitPeerIdOverride(req, undefined), peerId)
+})
+
+test('getExplicitPeerIdOverride falls back to session pin when header absent', () => {
+  const session = 'b'.repeat(40)
+  const req = makeReq({})
+  assert.equal(getExplicitPeerIdOverride(req, session), session)
+})

--- a/apps/cli/src/proxy/request-utils.ts
+++ b/apps/cli/src/proxy/request-utils.ts
@@ -18,7 +18,11 @@ export function log(...args: unknown[]): void {
 }
 
 function getHeader(headers: Record<string, string>, name: string): string {
-  return headers[name] ?? headers[name.charAt(0).toUpperCase() + name.slice(1)] ?? ''
+  const target = name.toLowerCase()
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === target) return headers[key] ?? ''
+  }
+  return ''
 }
 
 export function normalizePeerId(value: string): string | null {
@@ -138,8 +142,8 @@ function summarizeMessageShape(messagesRaw: unknown): string {
 export function summarizeRequestShape(request: SerializedHttpRequest): string {
   const contentType = getHeader(request.headers, 'content-type').toLowerCase()
   const accept = getHeader(request.headers, 'accept').toLowerCase()
-  const providerHeader = request.headers['x-antseed-provider'] ?? 'none'
-  const preferPeerHeader = request.headers['x-antseed-prefer-peer'] ?? 'none'
+  const providerHeader = getHeader(request.headers, 'x-antseed-provider') || 'none'
+  const preferPeerHeader = getHeader(request.headers, 'x-antseed-prefer-peer') || 'none'
   const service = extractRequestedService(request) ?? 'none'
   const wantsStreaming = requestWantsStreaming(request.headers, request.body)
 

--- a/apps/cli/src/proxy/request-utils.ts
+++ b/apps/cli/src/proxy/request-utils.ts
@@ -17,7 +17,7 @@ export function log(...args: unknown[]): void {
   if (DEBUG() && shouldEmitProxyLog(args)) console.log('[proxy]', ...args)
 }
 
-function getHeader(headers: Record<string, string>, name: string): string {
+export function getHeader(headers: Record<string, string>, name: string): string {
   const target = name.toLowerCase()
   for (const key of Object.keys(headers)) {
     if (key.toLowerCase() === target) return headers[key] ?? ''

--- a/apps/cli/src/proxy/routing.ts
+++ b/apps/cli/src/proxy/routing.ts
@@ -5,7 +5,7 @@ import {
   type ServiceApiProtocol,
   type TargetProtocolSelection,
 } from './service-api-adapter.js'
-import { log, normalizePeerId } from './request-utils.js'
+import { getHeader, log, normalizePeerId } from './request-utils.js'
 
 export type PeerProtocolRoutePlan = {
   provider: string
@@ -23,8 +23,8 @@ export type CandidatePeerRouteSelection = {
 export type ServiceFilterMode = 'strict' | 'lenient'
 
 export function getExplicitProviderOverride(request: SerializedHttpRequest): string | null {
-  const provider = request.headers['x-antseed-provider']?.trim().toLowerCase()
-  return provider && provider.length > 0 ? provider : null
+  const provider = getHeader(request.headers, 'x-antseed-provider').trim().toLowerCase()
+  return provider.length > 0 ? provider : null
 }
 
 export function getExplicitPeerIdOverride(
@@ -33,8 +33,8 @@ export function getExplicitPeerIdOverride(
   requestPinnedPeerId?: string | null,
 ): string | null {
   // Per-request header takes priority over session pin
-  const header = request.headers['x-antseed-pin-peer']?.trim()
-  if (header && header.length > 0) return normalizePeerId(header) ?? header.toLowerCase()
+  const header = getHeader(request.headers, 'x-antseed-pin-peer').trim()
+  if (header.length > 0) return normalizePeerId(header) ?? header.toLowerCase()
   if (requestPinnedPeerId) return requestPinnedPeerId.toLowerCase()
   return sessionPinnedPeerId?.toLowerCase() ?? null
 }


### PR DESCRIPTION
### Problem
`getHeader` only matched the exact-lowercase name and a capitalized-first-letter variant (`content-type` / `Content-type`), so common casings like `Content-Type` or `CONTENT-TYPE` were missed. Worse, the load-bearing routing path bypassed `getHeader` entirely with direct bracket access (`request.headers['x-antseed-provider']`, `request.headers['x-antseed-pin-peer']`), so provider/peer overrides silently break when a client sends a differently-cased header name.

### Fix
- `getHeader` now scans header entries case-insensitively and is **exported**.
- Load-bearing reads go through it:
  - `getExplicitProviderOverride` / `getExplicitPeerIdOverride` in `routing.ts`
  - `summarizeRequestShape` (`x-antseed-provider`, `x-antseed-prefer-peer`)
  - buyer-proxy pin-peer log source + max-upload body-bytes parser
- Unit tests cover mixed-case header names for getHeader + both routing overrides.

### Verification
```
pnpm --filter=@antseed/cli run build
node --test apps/cli/dist/proxy/*.test.js
# → 57 pass (incl. 5 new header-case cases)
```

Found via an [AntFleet](https://antfleet.dev) two-model review of AntSeed; methodology mirror: https://github.com/AntFleet/bench-antseed · agent page: https://www.antfleet.dev/agents/0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263