### PR TITLE
fix(metering): bind unitPrice into receipt signature payload

### DIFF
--- a/packages/node/src/metering/receipt-generator.ts
+++ b/packages/node/src/metering/receipt-generator.ts
@@ -32,6 +32,10 @@ export function buildSignaturePayload(receipt: Omit<UsageReceipt, 'signature'>):
     receipt.sellerPeerId,
     receipt.buyerPeerId,
     receipt.tokens.totalTokens.toString(),
+    // Bind unit price so a verified receipt's rate field cannot be rewritten
+    // post-sign while leaving costCents/totalTokens alone. Settlement still
+    // keys off costCents; this authenticates the pricing metadata consumers read.
+    receipt.unitPriceCentsPerThousandTokens.toString(),
     receipt.costCents.toString(),
   ].join('|');
 }

--- a/packages/node/src/types/metering.ts
+++ b/packages/node/src/types/metering.ts
@@ -79,7 +79,8 @@ export interface UsageReceipt {
   /**
    * secp256k1 signature over the receipt data (hex string).
    * Signs: receiptId + sessionId + eventId + timestamp + provider
-   *        + sellerPeerId + buyerPeerId + totalTokens + costCents
+   *        + sellerPeerId + buyerPeerId + totalTokens
+   *        + unitPriceCentsPerThousandTokens + costCents
    */
   signature: string;
 }

--- a/packages/node/tests/receipt.test.ts
+++ b/packages/node/tests/receipt.test.ts
@@ -75,7 +75,7 @@ describe('buildSignaturePayload', () => {
       costCents: 5,
     });
 
-    expect(payload).toBe('r1|s1|e1|1000|openai|seller|buyer|500|5');
+    expect(payload).toBe('r1|s1|e1|1000|openai|seller|buyer|500|10|5');
   });
 
   it('should be deterministic', () => {
@@ -92,6 +92,24 @@ describe('buildSignaturePayload', () => {
       costCents: 5,
     };
     expect(buildSignaturePayload(data)).toBe(buildSignaturePayload(data));
+  });
+
+  it('binds unitPrice so rewriting the rate changes the signed payload', () => {
+    const base = {
+      receiptId: 'r1',
+      sessionId: 's1',
+      eventId: 'e1',
+      timestamp: 1000,
+      provider: 'openai' as const,
+      sellerPeerId: 'seller',
+      buyerPeerId: 'buyer',
+      tokens: makeTokenCount(500),
+      unitPriceCentsPerThousandTokens: 10,
+      costCents: 5,
+    };
+    const tampered = { ...base, unitPriceCentsPerThousandTokens: 999 };
+    // costCents + totalTokens unchanged — old payload would have matched; new one must not.
+    expect(buildSignaturePayload(tampered)).not.toBe(buildSignaturePayload(base));
   });
 });
 


### PR DESCRIPTION
### Problem
`UsageReceipt` includes `unitPriceCentsPerThousandTokens`, but `buildSignaturePayload` only signed `totalTokens` + `costCents`. A party can rewrite the rate field after signing and `ReceiptVerifier` still reports `signatureValid: true`.

Settlement still keys off **signed** `costCents` / `totalTokens` — this is **not** a forgery of settlement amount. It **is** a real integrity gap for any UI / audit / dispute path that trusts `unitPrice` on a verified receipt.

### Fix
- Include `unitPriceCentsPerThousandTokens` in the canonical signed payload (before `costCents`).
- Update the `UsageReceipt.signature` JSDoc field list.
- Test: payload string includes the rate; rewriting unitPrice alone changes the payload.

### Compatibility note
This **changes the signed string**. Seller and buyer nodes must upgrade together (or receipts issued under the old payload will fail verify under the new one). Happy to dual-verify old+new payloads if you prefer a softer rollout.

### Verification
```
pnpm --filter=@antseed/node exec vitest run tests/receipt.test.ts
# → 14 pass
```

### Context
Found via an [AntFleet](https://antfleet.dev) two-model review of AntSeed; methodology mirror: https://github.com/AntFleet/bench-antseed · agent page: https://www.antfleet.dev/agents/0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263

Sibling filings:
- #727 chain-config (ready)
- #728 proxy headers (ready)
- #729 platform fee / protocolReserve (issue — needs design choice)
