### PR TITLE
Validate seller payment metadata hash

### DIFF
--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -1,4 +1,4 @@
-import { type AbstractSigner, verifyTypedData } from 'ethers';
+import { type AbstractSigner, keccak256, verifyTypedData } from 'ethers';
 import type { Identity } from '../p2p/identity.js';
 import type { PaymentMux } from '../p2p/payment-mux.js';
 import type {
@@ -412,6 +412,14 @@ export class SellerPaymentManager {
       const cumulativeAmount = BigInt(payload.cumulativeAmount);
       const existingCumulative = this._acceptedCumulative.get(channelId);
 
+      if (!this._metadataMatchesHash(payload)) {
+        debugWarn(
+          `[SellerPayment] Rejecting SpendingAuth: metadataHash mismatch ` +
+          `channel=${channelId.slice(0, 18)}...`,
+        );
+        return 'rejected';
+      }
+
       const { channels: channelsAddr } = await this._resolvedAddresses!;
       const channelsDomain = makeChannelsDomain(this._config.chainId, channelsAddr);
 
@@ -678,6 +686,15 @@ export class SellerPaymentManager {
     } catch (err) {
       debugWarn(`[SellerPayment] Failed to process SpendingAuth: ${err instanceof Error ? err.message : err}`);
       return 'rejected';
+    }
+  }
+
+  private _metadataMatchesHash(payload: SpendingAuthPayload): boolean {
+    try {
+      return keccak256(payload.metadata).toLowerCase() === payload.metadataHash.toLowerCase();
+    } catch (err) {
+      debugWarn(`[SellerPayment] Invalid metadata payload: ${err instanceof Error ? err.message : err}`);
+      return false;
     }
   }
 

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -691,7 +691,8 @@ export class SellerPaymentManager {
 
   private _metadataMatchesHash(payload: SpendingAuthPayload): boolean {
     try {
-      return keccak256(payload.metadata).toLowerCase() === payload.metadataHash.toLowerCase();
+      const metadata = payload.metadata || encodeMetadata(ZERO_METADATA);
+      return keccak256(metadata).toLowerCase() === payload.metadataHash.toLowerCase();
     } catch (err) {
       debugWarn(`[SellerPayment] Invalid metadata payload: ${err instanceof Error ? err.message : err}`);
       return false;

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -191,6 +191,21 @@ describe('SellerPaymentManager', () => {
     expect(manager.getAcceptedCumulative(channelId)).toBe(200_000n);
   });
 
+  it('accepts first reserve with zero metadata', async () => {
+    const channelId = makeChannelId(24);
+
+    const payload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { isReserve: true });
+    payload.metadata = encodeMetadata(ZERO_METADATA);
+    payload.metadataHash = ZERO_METADATA_HASH;
+
+    const result = await manager.handleSpendingAuth(buyerIdentity.peerId, payload, mux);
+
+    expect(result).toBe('reserved');
+    expect(manager.channelsClient.reserve).toHaveBeenCalledOnce();
+    expect(mux.sentAuthAcks.length).toBe(1);
+    expect(store.getChannel(channelId)!.latestMetadata).toBe(encodeMetadata(ZERO_METADATA));
+  });
+
   it('rejects SpendingAuth when raw metadata does not match signed metadataHash', async () => {
     const channelId = makeChannelId(22);
 
@@ -207,6 +222,24 @@ describe('SellerPaymentManager', () => {
       cumulativeOutputTokens: 50n,
       cumulativeRequestCount: 0n,
     });
+
+    const result = await manager.handleSpendingAuth(buyerIdentity.peerId, payload, mux);
+
+    expect(result).toBe('rejected');
+    expect(manager.getAcceptedCumulative(channelId)).toBe(0n);
+    expect(store.getChannel(channelId)!.latestMetadata).toBe(reservePayload.metadata);
+  });
+
+  it('rejects SpendingAuth when raw metadata is malformed non-hex', async () => {
+    const channelId = makeChannelId(25);
+
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { isReserve: true });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    const payload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 200_000n,
+    });
+    payload.metadata = 'not-hex';
 
     const result = await manager.handleSpendingAuth(buyerIdentity.peerId, payload, mux);
 
@@ -735,26 +768,37 @@ describe('SellerPaymentManager', () => {
     expect(metadata.startsWith('0x')).toBe(true);
   });
 
-  it('test_onBuyerDisconnect_close_empty_metadata: rejects invalid metadata before it can be settled', async () => {
+  it('test_onBuyerDisconnect_close_empty_metadata: normalizes empty zero-metadata auth before settling', async () => {
     const channelId = makeChannelId(11);
 
     // Reserve
     const payload1 = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { isReserve: true });
     await manager.handleSpendingAuth(buyerIdentity.peerId, payload1, mux);
 
-    // Mutate metadata to empty string (simulates old/malformed buyer payload)
+    // Empty metadata is accepted only when paired with the zero metadata hash;
+    // settle params mirror the contract-facing fallback to encoded zero metadata.
     const payload2 = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { cumulativeAmount: 200_000n });
     payload2.metadata = '';
+    payload2.metadataHash = ZERO_METADATA_HASH;
+    payload2.spendingAuthSig = await signSpendingAuth(buyerIdentity.wallet, makeChannelsDomain(CHAIN_ID, CONTRACT_ADDR), {
+      channelId,
+      cumulativeAmount: 200_000n,
+      metadataHash: ZERO_METADATA_HASH,
+    });
     const result = await manager.handleSpendingAuth(buyerIdentity.peerId, payload2, mux);
 
-    expect(result).toBe('rejected');
-    expect(manager.getAcceptedCumulative(channelId)).toBe(0n);
+    expect(result).toBe('accepted');
+    expect(manager.getAcceptedCumulative(channelId)).toBe(200_000n);
 
-    // No accepted spend should exist, so disconnect preserves the channel rather
-    // than trying to settle with metadata that the contract would reject.
+    manager.recordSpend(channelId, 50_000n);
     manager.onBuyerDisconnect(buyerIdentity.peerId);
 
-    expect(manager.channelsClient.close).not.toHaveBeenCalled();
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    const closeArgs = (manager.channelsClient.close as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    expect(closeArgs[1]).toBe(channelId);
+    expect(closeArgs[2]).toBe(200_000n);
+    expect(closeArgs[3]).toBe(encodeMetadata(ZERO_METADATA));
+    expect(closeArgs[4]).toBe(payload2.spendingAuthSig);
   });
 
   it('settleSession suppresses duplicate in-flight close attempts for the same channel', async () => {

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -191,6 +191,30 @@ describe('SellerPaymentManager', () => {
     expect(manager.getAcceptedCumulative(channelId)).toBe(200_000n);
   });
 
+  it('rejects SpendingAuth when raw metadata does not match signed metadataHash', async () => {
+    const channelId = makeChannelId(22);
+
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { isReserve: true });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    const payload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 200_000n,
+      cumulativeInputTokens: 100n,
+      cumulativeOutputTokens: 50n,
+    });
+    payload.metadata = encodeMetadata({
+      cumulativeInputTokens: 999n,
+      cumulativeOutputTokens: 50n,
+      cumulativeRequestCount: 0n,
+    });
+
+    const result = await manager.handleSpendingAuth(buyerIdentity.peerId, payload, mux);
+
+    expect(result).toBe('rejected');
+    expect(manager.getAcceptedCumulative(channelId)).toBe(0n);
+    expect(store.getChannel(channelId)!.latestMetadata).toBe(reservePayload.metadata);
+  });
+
   it('waitForPendingAuths drains queued SpendingAuths while an on-chain top-up is in flight', async () => {
     const channelId = makeChannelId(99);
 
@@ -525,6 +549,44 @@ describe('SellerPaymentManager', () => {
     expect(session!.tokensDelivered).toBe('50000');
   });
 
+  it('rejects recovered on-chain session when raw metadata does not match signed metadataHash', async () => {
+    const channelId = makeChannelId(23);
+    vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue({
+      buyer: buyerIdentity.wallet.address,
+      seller: sellerIdentity.wallet.address,
+      deposit: 1_000_000n,
+      settled: 50_000n,
+      metadataHash: ZERO_METADATA_HASH,
+      deadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
+      settledAt: 0n,
+      closeRequestedAt: 0n,
+      status: 1,
+    });
+
+    const payload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 200_000n,
+      cumulativeInputTokens: 100n,
+      cumulativeOutputTokens: 50n,
+      reserveMaxAmount: undefined,
+    });
+    delete payload.reserveSalt;
+    delete payload.reserveMaxAmount;
+    delete payload.reserveDeadline;
+    payload.metadata = encodeMetadata({
+      cumulativeInputTokens: 999n,
+      cumulativeOutputTokens: 50n,
+      cumulativeRequestCount: 0n,
+    });
+
+    const result = await manager.handleSpendingAuth(buyerIdentity.peerId, payload, mux);
+
+    expect(result).toBe('rejected');
+    expect(manager.channelsClient.reserve).not.toHaveBeenCalled();
+    expect(manager.channelsClient.getSession).not.toHaveBeenCalled();
+    expect(mux.sentAuthAcks.length).toBe(0);
+    expect(store.getChannel(channelId)).toBeNull();
+  });
+
   it('awaitAcceptedAtLeast resolves when a SpendingAuth raises accepted to the target', async () => {
     const channelId = makeChannelId(77);
     const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
@@ -673,28 +735,26 @@ describe('SellerPaymentManager', () => {
     expect(metadata.startsWith('0x')).toBe(true);
   });
 
-  it('test_onBuyerDisconnect_close_empty_metadata: falls back to 0x for empty metadata', async () => {
+  it('test_onBuyerDisconnect_close_empty_metadata: rejects invalid metadata before it can be settled', async () => {
     const channelId = makeChannelId(11);
 
     // Reserve
     const payload1 = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { isReserve: true });
     await manager.handleSpendingAuth(buyerIdentity.peerId, payload1, mux);
 
-    // Accept a SpendingAuth but mutate metadata to empty string (simulates old buyer)
+    // Mutate metadata to empty string (simulates old/malformed buyer payload)
     const payload2 = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { cumulativeAmount: 200_000n });
-    payload2.metadata = ''; // simulate old buyer sending empty metadata
-    await manager.handleSpendingAuth(buyerIdentity.peerId, payload2, mux);
+    payload2.metadata = '';
+    const result = await manager.handleSpendingAuth(buyerIdentity.peerId, payload2, mux);
 
-    // Record some spend so close() is attempted
-    manager.recordSpend(channelId, 5_000n);
+    expect(result).toBe('rejected');
+    expect(manager.getAcceptedCumulative(channelId)).toBe(0n);
 
+    // No accepted spend should exist, so disconnect preserves the channel rather
+    // than trying to settle with metadata that the contract would reject.
     manager.onBuyerDisconnect(buyerIdentity.peerId);
 
-    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
-    const closeArgs = (manager.channelsClient.close as ReturnType<typeof vi.fn>).mock.calls[0];
-    const metadata = closeArgs[3] as string;
-    // Should fall back to ABI-encoded zero metadata (matching ZERO_METADATA_HASH)
-    expect(metadata).toBe(encodeMetadata(ZERO_METADATA));
+    expect(manager.channelsClient.close).not.toHaveBeenCalled();
   });
 
   it('settleSession suppresses duplicate in-flight close attempts for the same channel', async () => {


### PR DESCRIPTION
## Summary
- reject paid seller SpendingAuth payloads when `keccak256(metadata)` does not match `metadataHash`
- apply the check before local recovery/reserve/update logic can store mismatched metadata
- update seller payment tests for mismatched and malformed metadata cases

## Why
`AntseedChannels._settleSpend()` recomputes `metadataHash = keccak256(metadata)` before verifying the buyer signature. Without the same seller-side check, a buyer could send a valid signature over hash A with raw metadata B, causing the seller to accept locally but later fail settlement/close/top-up with `InvalidSignature`.

## Tests
- `corepack pnpm --filter=@antseed/node test -- seller-payment-manager.test.ts`
- `corepack pnpm --filter=@antseed/api-adapter build && corepack pnpm --filter=@antseed/node typecheck`