### PR TITLE
fix(proxy): Preserve Responses stream mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project uses selective package publishing. Each release entry lists the pub
 - `@antseed/api-adapter`
 - `@antseed/cli`
 - `@antseed/node`
+- `@antseed/provider-openai-responses`
 
 ### Desktop
 
@@ -37,6 +38,7 @@ This project uses selective package publishing. Each release entry lists the pub
 - Changed Desktop renderer navigation to load only the active view, preload likely next views, and show a lightweight loading state while lazily loaded pages resolve.
 - Reduced the default buyer response-auth evidence sample rate from 20% to 0.5% to limit local `verification_samples` growth during high-request sessions.
 - Increased the default free-usage on-chain record flush interval from 10 seconds to 5 minutes to reduce background transaction frequency while preserving batch, disconnect, and shutdown flushes.
+- Increased default seller concurrency from 5 to 50 concurrent requests, including the OpenAI Responses provider default, for bursty clients.
 
 ### Fixed
 
@@ -47,6 +49,7 @@ This project uses selective package publishing. Each release entry lists the pub
 - Fixed Desktop chats for peers that disappear from discovery so the header reports that the peer was not found and disables the composer instead of showing stale peer identifiers.
 - Fixed Desktop Discover overflow tag tooltips so the `+N` category indicator works on service cards in the first row.
 - Fixed `antseed seller emissions claim` so it only checks and claims seller rewards, leaving buyer rewards to the buyer command.
+- Fixed buyer proxy protocol transforms so requests routed to OpenAI Responses always set upstream `stream: true` without forcing non-stream clients to receive SSE.
 
 ## 2026-06-15 — Buyer peer failure accounting and desktop stream responsiveness
 

--- a/apps/cli/src/config/defaults.ts
+++ b/apps/cli/src/config/defaults.ts
@@ -15,7 +15,7 @@ export function createDefaultConfig(): AntseedConfig {
     },
     seller: {
       reserveFloor: 10,
-      maxConcurrentBuyers: 5,
+      maxConcurrentBuyers: 50,
       providers: {},
       publicAddress: '',
     },

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -35,6 +35,12 @@ test('createDefaultConfig includes a Base mainnet crypto payment default', () =>
   assert.deepEqual(config.payments.crypto, { chainId: 'base-mainnet' });
 });
 
+test('createDefaultConfig uses a higher seller concurrency default', () => {
+  const config = createDefaultConfig();
+
+  assert.equal(config.seller.maxConcurrentBuyers, 50);
+});
+
 test('loadConfig reads nested seller.providers[name].services[id] shape', async () => {
   await withTempConfig(
     JSON.stringify({

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -467,6 +467,70 @@ test('/v1/models retryable response reports router success', async () => {
   assert.equal(routerResults[0]?.success, true)
 })
 
+test('non-stream transformed responses requests force upstream stream without streaming to client', async () => {
+  const peer = makePeer('a', ['openai-responses'])
+  peer.providerServiceApiProtocols = {
+    'openai-responses': {
+      services: {
+        'gpt-5.6-sol': ['openai-responses'],
+      },
+    },
+  }
+  let sendRequestCalls = 0
+  let sendRequestStreamCalls = 0
+  let capturedRequestBody: Record<string, unknown> | null = null
+  let capturedRequestHeaders: Record<string, string> | null = null
+  const proxy = makeBuyerProxyWithPeers([peer], [peer])
+  ;(proxy as any)._node.sendRequest = async (
+    _peer: PeerInfo,
+    request: { requestId: string; body: Uint8Array; headers: Record<string, string> },
+  ) => {
+    sendRequestCalls += 1
+    capturedRequestBody = parseJsonBody(request.body)
+    capturedRequestHeaders = request.headers
+    return {
+      requestId: request.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: Buffer.from(JSON.stringify({
+        id: 'resp_1',
+        object: 'response',
+        model: 'gpt-5.6-sol',
+        output: [{
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'hi' }],
+        }],
+        usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+      })),
+    }
+  }
+  ;(proxy as any)._node.sendRequestStream = async () => {
+    sendRequestStreamCalls += 1
+    throw new Error('sendRequestStream should not be used')
+  }
+
+  const res = await invokeProxy(proxy, makeProxyRequest({
+    path: '/v1/messages',
+    headers: {
+      'x-antseed-pin-peer': peer.peerId,
+    },
+    body: {
+      model: 'gpt-5.6-sol',
+      max_tokens: 128,
+      messages: [{ role: 'user', content: 'hello' }],
+    },
+  }))
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(sendRequestCalls, 1)
+  assert.equal(sendRequestStreamCalls, 0)
+  assert.equal(capturedRequestBody?.['stream'], true)
+  assert.equal(capturedRequestHeaders?.['x-antseed-client-stream-requested'], 'false')
+  const body = JSON.parse(res.body) as { content?: Array<{ type: string; text: string }> }
+  assert.equal(body.content?.[0]?.text, 'hi')
+})
+
 test('model peer prefix pins the request peer and strips the routed model', async () => {
   const pinnedPeer = makePeer('a', ['openai'])
   let capturedRequestBody: Record<string, unknown> | null = null

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -53,6 +53,7 @@ function makeProxyResponse(): {
   headersSent: boolean
   writableEnded: boolean
   writeHead: (statusCode: number, headers: Record<string, string>) => unknown
+  write: (chunk: string | Buffer | Uint8Array) => unknown
   end: (chunk?: string | Buffer | Uint8Array) => unknown
   once: () => unknown
 } {
@@ -67,6 +68,10 @@ function makeProxyResponse(): {
       this.headers = headers
       this.headersSent = true
       return this
+    },
+    write(chunk: string | Buffer | Uint8Array) {
+      this.body += Buffer.from(chunk).toString('utf8')
+      return true
     },
     end(chunk?: string | Buffer | Uint8Array) {
       if (chunk !== undefined) {
@@ -529,6 +534,85 @@ test('non-stream transformed responses requests force upstream stream without st
   assert.equal(capturedRequestHeaders?.['x-antseed-client-stream-requested'], 'false')
   const body = JSON.parse(res.body) as { content?: Array<{ type: string; text: string }> }
   assert.equal(body.content?.[0]?.text, 'hi')
+})
+
+test('accept-sse transformed responses requests stream adapted client events without body stream flag', async () => {
+  const peer = makePeer('a', ['openai-responses'])
+  peer.providerServiceApiProtocols = {
+    'openai-responses': {
+      services: {
+        'gpt-5.6-sol': ['openai-responses'],
+      },
+    },
+  }
+  let sendRequestCalls = 0
+  let sendRequestStreamCalls = 0
+  let capturedRequestBody: Record<string, unknown> | null = null
+  let capturedRequestHeaders: Record<string, string> | null = null
+  const proxy = makeBuyerProxyWithPeers([peer], [peer])
+  ;(proxy as any)._node.sendRequest = async () => {
+    sendRequestCalls += 1
+    throw new Error('sendRequest should not be used')
+  }
+  ;(proxy as any)._node.sendRequestStream = async (
+    _peer: PeerInfo,
+    request: { requestId: string; body: Uint8Array; headers: Record<string, string> },
+    callbacks: {
+      onResponseStart: (response: { requestId: string; statusCode: number; headers: Record<string, string>; body: Uint8Array }, metadata: { streaming: boolean }) => void
+      onResponseChunk: (chunk: { requestId: string; data: Uint8Array; done: boolean }) => void
+    },
+  ) => {
+    sendRequestStreamCalls += 1
+    capturedRequestBody = parseJsonBody(request.body)
+    capturedRequestHeaders = request.headers
+    callbacks.onResponseStart({
+      requestId: request.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'text/event-stream' },
+      body: new Uint8Array(),
+    }, { streaming: true })
+    callbacks.onResponseChunk({
+      requestId: request.requestId,
+      data: Buffer.from(
+        'event: response.created\n'
+        + 'data: {"type":"response.created","response":{"id":"resp_1","object":"response","model":"gpt-5.6-sol","status":"in_progress","output":[],"output_text":"","usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0}}}\n\n'
+        + 'event: response.output_text.delta\n'
+        + 'data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_1","content_index":0,"delta":"hi","logprobs":[]}\n\n'
+        + 'event: response.completed\n'
+        + 'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","model":"gpt-5.6-sol","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}\n\n',
+      ),
+      done: false,
+    })
+    return {
+      requestId: request.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'text/event-stream' },
+      body: Buffer.from(''),
+    }
+  }
+
+  const res = await invokeProxy(proxy, makeProxyRequest({
+    path: '/v1/messages',
+    headers: {
+      'accept': 'text/event-stream',
+      'x-antseed-pin-peer': peer.peerId,
+    },
+    body: {
+      model: 'gpt-5.6-sol',
+      max_tokens: 128,
+      messages: [{ role: 'user', content: 'hello' }],
+    },
+  }))
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(sendRequestCalls, 0)
+  assert.equal(sendRequestStreamCalls, 1)
+  assert.equal(capturedRequestBody?.['stream'], true)
+  assert.equal(capturedRequestHeaders?.['x-antseed-client-stream-requested'], 'true')
+  assert.match(res.body, /event: message_start/)
+  assert.match(res.body, /event: content_block_delta/)
+  assert.match(res.body, /"text":"hi"/)
+  assert.doesNotMatch(res.body, /event: response\.completed/)
 })
 
 test('model peer prefix pins the request peer and strips the routed model', async () => {

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -1324,6 +1324,7 @@ export class BuyerProxy {
         'x-antseed-provider': selectedRoutePlan.provider,
       },
     }
+    const clientWantsStreaming = requestWantsStreaming(serializedReq.headers, serializedReq.body)
     let adaptResponse: ((response: SerializedHttpResponse) => SerializedHttpResponse) | null = null
     let streamResponseAdapter: StreamingResponseAdapter | null = null
 
@@ -1377,7 +1378,7 @@ export class BuyerProxy {
     log(`Routing to peer ${selectedPeer.peerId.slice(0, 12)}...`)
 
     // Forward through P2P
-    const wantsStreaming = requestWantsStreaming(requestForPeer.headers, requestForPeer.body)
+    const wantsStreaming = clientWantsStreaming
     const startTime = Date.now()
     try {
       if (wantsStreaming) {

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -1338,7 +1338,11 @@ export class BuyerProxy {
       }
 
       log(`Applying protocol adapter ${transformKey} via provider "${selectedRoutePlan.provider}"`)
-      const transformed = transformRequest(requestForPeer, { from: strategy.from, to: strategy.to })
+      const transformed = transformRequest(requestForPeer, {
+        from: strategy.from,
+        to: strategy.to,
+        streamRequested: clientWantsStreaming,
+      })
       if (!transformed) {
         res.writeHead(502, { 'content-type': 'text/plain' })
         res.end(`Failed to transform request for ${transformKey}`)

--- a/apps/desktop/src/main/config-io.test.ts
+++ b/apps/desktop/src/main/config-io.test.ts
@@ -10,6 +10,7 @@ import {
   DESKTOP_DEFAULT_MIN_PEER_REPUTATION,
   DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS,
   DESKTOP_DEFAULT_METADATA_FETCH_TIMEOUT_MS,
+  DESKTOP_DEFAULT_SELLER_MAX_CONCURRENT_BUYERS,
   ensureConfig,
   readConfig,
 } from './config-io.js';
@@ -42,6 +43,10 @@ test('ensureConfig creates config with desktop buyer max pricing defaults', asyn
   assert.equal((config.buyer as { peerRefreshIntervalMs?: number }).peerRefreshIntervalMs, DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS);
   assert.equal((config.buyer as { metadataFetchTimeoutMs?: number }).metadataFetchTimeoutMs, DESKTOP_DEFAULT_METADATA_FETCH_TIMEOUT_MS);
   assert.equal((config.buyer as { disableMetadataV2Services?: boolean }).disableMetadataV2Services, false);
+  assert.equal(
+    (config.seller as { maxConcurrentBuyers?: number }).maxConcurrentBuyers,
+    DESKTOP_DEFAULT_SELLER_MAX_CONCURRENT_BUYERS,
+  );
 });
 
 test('ensureConfig clamps buyer max pricing above desktop defaults', async (t) => {

--- a/apps/desktop/src/main/config-io.ts
+++ b/apps/desktop/src/main/config-io.ts
@@ -10,12 +10,13 @@ export const DESKTOP_DEFAULT_MAX_OUTPUT_USD_PER_MILLION = 30;
 export const DESKTOP_DEFAULT_MIN_PEER_REPUTATION = 0;
 export const DESKTOP_DEFAULT_PEER_REFRESH_INTERVAL_MS = 5 * 60_000;
 export const DESKTOP_DEFAULT_METADATA_FETCH_TIMEOUT_MS = 1500;
+export const DESKTOP_DEFAULT_SELLER_MAX_CONCURRENT_BUYERS = 50;
 
 const DEFAULT_CONFIG: Record<string, unknown> = {
   identity: { displayName: 'AntSeed Node' },
   seller: {
     reserveFloor: 10,
-    maxConcurrentBuyers: 5,
+    maxConcurrentBuyers: DESKTOP_DEFAULT_SELLER_MAX_CONCURRENT_BUYERS,
     enabledProviders: [],
     pricing: { defaults: { inputUsdPerMillion: 10, outputUsdPerMillion: 10 } },
   },

--- a/apps/website/docs/getting-started/configuration.md
+++ b/apps/website/docs/getting-started/configuration.md
@@ -152,7 +152,7 @@ Everything a seller announces lives under `seller.providers[name]`. The key unde
 {
   "seller": {
     "reserveFloor": 10,
-    "maxConcurrentBuyers": 5,
+    "maxConcurrentBuyers": 50,
     "providers": {
       "together": {
         "plugin": "openai",

--- a/packages/api-adapter/src/request-transform.ts
+++ b/packages/api-adapter/src/request-transform.ts
@@ -21,6 +21,8 @@ export interface ServiceApiRequestTransformOptions {
   to: ServiceApiProtocol;
 }
 
+const CLIENT_STREAM_REQUESTED_HEADER = 'x-antseed-client-stream-requested';
+
 type RequestNormalizer = (body: Record<string, unknown>) => CanonicalLlmRequest;
 type RequestRenderer = (
   request: CanonicalLlmRequest,
@@ -74,12 +76,17 @@ export function transformRequest(
   const render = REQUEST_RENDERERS[options.to];
   if (!render) return null;
   const transformedBody = render(normalized, options);
+  const transformedHeaders = headersForTargetProtocol(request.headers, options.to);
+  if (options.to === 'openai-responses') {
+    transformedBody.stream = true;
+    transformedHeaders[CLIENT_STREAM_REQUESTED_HEADER] = normalized.stream ? 'true' : 'false';
+  }
 
   return {
     request: {
       ...request,
       path,
-      headers: headersForTargetProtocol(request.headers, options.to),
+      headers: transformedHeaders,
       body: encodeJson(transformedBody),
     },
     streamRequested: normalized.stream,

--- a/packages/api-adapter/src/request-transform.ts
+++ b/packages/api-adapter/src/request-transform.ts
@@ -19,6 +19,7 @@ export interface ServiceApiRequestTransformResult {
 export interface ServiceApiRequestTransformOptions {
   from: ServiceApiProtocol;
   to: ServiceApiProtocol;
+  streamRequested?: boolean;
 }
 
 const CLIENT_STREAM_REQUESTED_HEADER = 'x-antseed-client-stream-requested';
@@ -65,21 +66,25 @@ export function transformRequest(
   if (!body) return null;
 
   const normalized = normalize(body);
+  const streamRequested = options.streamRequested ?? normalized.stream;
   if (options.from === options.to) {
     return {
       request,
-      streamRequested: normalized.stream,
+      streamRequested,
       requestedModel: normalized.model,
     };
   }
 
   const render = REQUEST_RENDERERS[options.to];
   if (!render) return null;
-  const transformedBody = render(normalized, options);
+  const requestForRender = streamRequested === normalized.stream
+    ? normalized
+    : { ...normalized, stream: streamRequested };
+  const transformedBody = render(requestForRender, options);
   const transformedHeaders = headersForTargetProtocol(request.headers, options.to);
   if (options.to === 'openai-responses') {
     transformedBody.stream = true;
-    transformedHeaders[CLIENT_STREAM_REQUESTED_HEADER] = normalized.stream ? 'true' : 'false';
+    transformedHeaders[CLIENT_STREAM_REQUESTED_HEADER] = streamRequested ? 'true' : 'false';
   }
 
   return {
@@ -89,7 +94,7 @@ export function transformRequest(
       headers: transformedHeaders,
       body: encodeJson(transformedBody),
     },
-    streamRequested: normalized.stream,
+    streamRequested,
     requestedModel: normalized.model,
   };
 }

--- a/packages/api-adapter/tests/adapter.test.ts
+++ b/packages/api-adapter/tests/adapter.test.ts
@@ -330,6 +330,25 @@ describe('transformRequest anthropic to responses', () => {
     expect(body.stream).toBe(true);
   });
 
+  it('honors an explicit streaming preference when rendering responses requests', () => {
+    const transformed = transformRequest(makeRequest({
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'claude-sonnet',
+        max_tokens: 256,
+        messages: [
+          { role: 'user', content: 'hello' },
+        ],
+      })),
+    }), { from: 'anthropic-messages', to: 'openai-responses', streamRequested: true });
+
+    expect(transformed).not.toBeNull();
+    expect(transformed!.streamRequested).toBe(true);
+    expect(transformed!.request.headers['x-antseed-client-stream-requested']).toBe('true');
+
+    const body = JSON.parse(new TextDecoder().decode(transformed!.request.body)) as Record<string, unknown>;
+    expect(body.stream).toBe(true);
+  });
+
   it('preserves tool calls and tool results through responses input', () => {
     const transformed = transformRequest(makeRequest({
       body: new TextEncoder().encode(JSON.stringify({

--- a/packages/api-adapter/tests/adapter.test.ts
+++ b/packages/api-adapter/tests/adapter.test.ts
@@ -311,6 +311,25 @@ describe('transformRequest anthropic to responses', () => {
     ]);
   });
 
+  it('forces upstream responses streaming without changing original non-stream preference', () => {
+    const transformed = transformRequest(makeRequest({
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'claude-sonnet',
+        max_tokens: 256,
+        messages: [
+          { role: 'user', content: 'hello' },
+        ],
+      })),
+    }), { from: 'anthropic-messages', to: 'openai-responses' });
+
+    expect(transformed).not.toBeNull();
+    expect(transformed!.streamRequested).toBe(false);
+    expect(transformed!.request.headers['x-antseed-client-stream-requested']).toBe('false');
+
+    const body = JSON.parse(new TextDecoder().decode(transformed!.request.body)) as Record<string, unknown>;
+    expect(body.stream).toBe(true);
+  });
+
   it('preserves tool calls and tool results through responses input', () => {
     const transformed = transformRequest(makeRequest({
       body: new TextEncoder().encode(JSON.stringify({
@@ -1200,6 +1219,9 @@ describe('transformRequest chat to responses', () => {
     expect(result).not.toBeNull();
 
     const body = JSON.parse(new TextDecoder().decode(result!.request.body)) as Record<string, unknown>;
+    expect(result!.streamRequested).toBe(false);
+    expect(result!.request.headers['x-antseed-client-stream-requested']).toBe('false');
+    expect(body.stream).toBe(true);
     expect(body.max_output_tokens).toBe(64);
     expect(body.stop).toEqual(['END']);
     expect(body.metadata).toEqual({ trace: 'abc' });

--- a/plugins/provider-openai-responses/README.md
+++ b/plugins/provider-openai-responses/README.md
@@ -29,7 +29,7 @@ antseed seller start
 | `ANTSEED_INPUT_USD_PER_MILLION` | number | No | 10 | Input token price (USD per 1M) |
 | `ANTSEED_OUTPUT_USD_PER_MILLION` | number | No | 10 | Output token price (USD per 1M) |
 | `ANTSEED_SERVICE_PRICING_JSON` | string | No | -- | Per-service pricing as JSON |
-| `ANTSEED_MAX_CONCURRENCY` | number | No | 5 | Max concurrent requests |
+| `ANTSEED_MAX_CONCURRENCY` | number | No | 50 | Max concurrent requests |
 | `ANTSEED_ALLOWED_SERVICES` | string[] | No | -- | Comma-separated service allowlist |
 | `ANTSEED_SERVICE_ALIAS_MAP_JSON` | string | No | -- | Optional JSON map of `announcedService -> upstreamService` |
 

--- a/plugins/provider-openai-responses/src/index.test.ts
+++ b/plugins/provider-openai-responses/src/index.test.ts
@@ -63,6 +63,25 @@ describe('provider-openai-responses plugin', () => {
     rmSync(dirname(authFile), { recursive: true, force: true });
   });
 
+  it('defaults to higher seller concurrency for bursty clients', () => {
+    const authFile = writeAuthFile({
+      tokens: {
+        access_token: makeJwt({
+          'https://api.openai.com/auth': {
+            chatgpt_account_id: 'acct-jwt',
+          },
+        }),
+      },
+    });
+    const provider = plugin.createProvider({
+      OPENAI_RESPONSES_AUTH_FILE: authFile,
+      ANTSEED_ALLOWED_SERVICES: 'gpt-5-codex',
+    });
+
+    expect(provider.maxConcurrency).toBe(50);
+    rmSync(dirname(authFile), { recursive: true, force: true });
+  });
+
   it('reads account id from JWT claim when available', () => {
     const authFile = writeAuthFile({
       tokens: {
@@ -407,6 +426,57 @@ describe('provider-openai-responses plugin', () => {
     expect(response.headers['content-type']).toBe('application/json');
     const body = JSON.parse(new TextDecoder().decode(response.body)) as Record<string, unknown>;
     expect(body.output_text).toBe('hi');
+    rmSync(dirname(authFile), { recursive: true, force: true });
+  });
+
+  it('collapses SSE for transformed non-stream callers when stream is already true', async () => {
+    const authFile = writeAuthFile({
+      tokens: {
+        access_token: makeJwt({}),
+        account_id: 'acct-file',
+      },
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        'event: response.completed\n'
+          + 'data: {"type":"response.completed","response":{"id":"resp_2","object":"response","model":"gpt-5.5","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hello","annotations":[]}]}],"output_text":"hello","usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}}\n\n',
+        {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        },
+      ),
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const provider = plugin.createProvider({
+      OPENAI_RESPONSES_AUTH_FILE: authFile,
+      ANTSEED_ALLOWED_SERVICES: 'gpt-5.5',
+    });
+
+    const response = await provider.handleRequest({
+      requestId: 'req-transformed-non-stream',
+      method: 'POST',
+      path: '/v1/responses',
+      headers: {
+        'content-type': 'application/json',
+        'x-antseed-client-stream-requested': 'false',
+      },
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'gpt-5.5',
+        input: 'hello',
+        stream: true,
+      })),
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const upstreamHeaders = init.headers as Record<string, string>;
+    const upstreamBody = JSON.parse(new TextDecoder().decode((init.body as Uint8Array) ?? new Uint8Array(0))) as Record<string, unknown>;
+    expect(upstreamBody.stream).toBe(true);
+    expect(upstreamHeaders['x-antseed-client-stream-requested']).toBeUndefined();
+    expect(response.headers['content-type']).toBe('application/json');
+    const body = JSON.parse(new TextDecoder().decode(response.body)) as Record<string, unknown>;
+    expect(body.id).toBe('resp_2');
+    expect(body.output_text).toBe('hello');
     rmSync(dirname(authFile), { recursive: true, force: true });
   });
 

--- a/plugins/provider-openai-responses/src/index.ts
+++ b/plugins/provider-openai-responses/src/index.ts
@@ -27,12 +27,13 @@ const OPENAI_TOKEN_URL = 'https://auth.openai.com/oauth/token';
 const OPENAI_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const DEFAULT_INPUT_PRICE = 10;
 const DEFAULT_OUTPUT_PRICE = 10;
-const DEFAULT_MAX_CONCURRENCY = 5;
+const DEFAULT_MAX_CONCURRENCY = 50;
 const REFRESH_BUFFER_MS = 5 * 60 * 1000;
 const FETCH_TIMEOUT_MS = DEFAULT_HTTP_TIMEOUT_MS;
 const RESPONSE_PATH_PREFIX = '/v1/responses';
 const RELAY_PATH = '/responses';
 const AUTH_CLAIM_PATH = 'https://api.openai.com/auth';
+const CLIENT_STREAM_REQUESTED_HEADER = 'x-antseed-client-stream-requested';
 
 function expandHome(path: string): string {
   if (path === '~') return homedir();
@@ -284,7 +285,8 @@ function prepareRequestBody(
   try {
     const parsed = JSON.parse(new TextDecoder().decode(request.body)) as Record<string, unknown>;
     parsed.store ??= false;
-    const forcedStream = parsed.stream !== true;
+    const clientStreamRequested = parseClientStreamRequestedHeader(request.headers);
+    const forcedStream = clientStreamRequested === false || parsed.stream !== true;
     parsed.stream = true;
 
     const requestedService = (parsed.model ?? parsed.service) as string | undefined;
@@ -335,6 +337,7 @@ function prepareRequestBody(
     return {
       request: {
         ...request,
+        headers: withoutHeader(request.headers, CLIENT_STREAM_REQUESTED_HEADER),
         body: new TextEncoder().encode(JSON.stringify(parsed)),
       },
       forcedStream,
@@ -342,6 +345,29 @@ function prepareRequestBody(
   } catch {
     return { request, forcedStream: false };
   }
+}
+
+function parseClientStreamRequestedHeader(headers: Record<string, string>): boolean | undefined {
+  const value = getHeader(headers, CLIENT_STREAM_REQUESTED_HEADER);
+  if (!value) return undefined;
+  return value.toLowerCase() === 'true';
+}
+
+function getHeader(headers: Record<string, string>, name: string): string {
+  const normalizedName = name.toLowerCase();
+  for (const [headerName, value] of Object.entries(headers)) {
+    if (headerName.toLowerCase() === normalizedName) return value;
+  }
+  return '';
+}
+
+function withoutHeader(headers: Record<string, string>, name: string): Record<string, string> {
+  const normalizedName = name.toLowerCase();
+  const next: Record<string, string> = {};
+  for (const [headerName, value] of Object.entries(headers)) {
+    if (headerName.toLowerCase() !== normalizedName) next[headerName] = value;
+  }
+  return next;
 }
 
 function collapseResponsesSseResponse(response: SerializedHttpResponse): SerializedHttpResponse {


### PR DESCRIPTION
## Description

Forces upstream OpenAI Responses requests to use `stream: true` while preserving the original client streaming preference through the buyer proxy and provider boundary. Also raises the default seller concurrency to 50 concurrent requests across CLI, Desktop config defaults, and the OpenAI Responses provider default.

## Release Notes

- Increased default seller concurrency from 5 to 50 concurrent requests.
- Fixed OpenAI Responses protocol transforms so non-stream clients receive JSON responses while upstream requests still satisfy the required streaming mode.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes