### PR TITLE
feat(payments): gasless deposit sweep via permissionless relayers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- Added `AntseedDepositRelay`, an immutable periphery contract that gaslessly sweeps buyer hot-wallet USDC into `AntseedDeposits` via a single EIP-3009 `receiveWithAuthorization` — the swept amount minus a fixed, deploy-time fee (default $0.05) is credited to the buyer's deposits balance, and the fee pays whoever submitted the transaction. The buyer hot wallet never needs ETH.
+- Added the P2P deposit-sweep protocol (`SweepRequest`/`SweepReceipt`, message types 0xA0/0xA1) with seller-side relaying enabled by default. Sellers verify, simulate, and profit-check each request before submitting; opt out with `relayer.enabled: false` or tune the floor with `relayer.minProfitBaseUnits` (may be negative for local testing).
+- Added `antseed buyer sweep [--amount] [--timeout]`, which signs the sweep authorization offline and broadcasts it through a running `buyer start` daemon's existing seller connections (new `/_antseed/sweep` control-plane endpoints), falling back to an ephemeral node when no daemon is running. Pre-flight checks cover the fixed fee, the Deposits first-time minimum, and the credit limit (default sweeps clamp to the remaining headroom).
+- Added `depositRelayAddress` to chain-config presets, EIP-3009 signing helpers (`buildReceiveAuthorization`, `makeUsdcDomain` with an on-chain `DOMAIN_SEPARATOR()` verification guard), and a `DepositRelayClient` to `@antseed/node`.
 - Added a macOS menu bar icon for Desktop with quick actions to show or quit AntSeed.
 - Added System Proxy commands to the CLI and a Desktop System Proxy view/tray controls for connecting supported local tools through AntSeed.
 - Added Desktop runtime log source filters and buyer debug log filtering via `antseed buyer start --log-filter` / `ANTSEED_LOG_FILTER`.

--- a/apps/cli/src/cli/commands/buyer/index.ts
+++ b/apps/cli/src/cli/commands/buyer/index.ts
@@ -3,6 +3,7 @@ import { registerBuyerStartCommand } from './start.js';
 import { registerBuyerStatusCommand } from './status.js';
 import { registerBuyerDepositCommand } from './deposit.js';
 import { registerBuyerWithdrawCommand } from './withdraw.js';
+import { registerBuyerSweepCommand } from './sweep.js';
 import { registerBuyerBalanceCommand } from './balance.js';
 import { registerBuyerConnectionCommand } from './connection.js';
 import { registerBuyerChannelsCommand } from './channels.js';
@@ -18,6 +19,7 @@ export function registerBuyerCommands(program: Command): void {
   registerBuyerStatusCommand(buyerCmd);
   registerBuyerDepositCommand(buyerCmd);
   registerBuyerWithdrawCommand(buyerCmd);
+  registerBuyerSweepCommand(buyerCmd);
   registerBuyerBalanceCommand(buyerCmd);
   registerBuyerConnectionCommand(buyerCmd);
   registerBuyerChannelsCommand(buyerCmd);

--- a/apps/cli/src/cli/commands/buyer/sweep.test.ts
+++ b/apps/cli/src/cli/commands/buyer/sweep.test.ts
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Command } from 'commander';
+import { registerBuyerSweepCommand } from './sweep.js';
+import { createDefaultConfig } from '../../../config/defaults.js';
+import { validateConfig } from '../../../config/validation.js';
+
+test('buyer sweep command registers with expected options', () => {
+  const buyerCmd = new Command('buyer');
+  registerBuyerSweepCommand(buyerCmd);
+
+  const sweep = buyerCmd.commands.find((c) => c.name() === 'sweep');
+  assert.ok(sweep, 'sweep subcommand registered');
+  const optionNames = sweep!.options.map((o) => o.long);
+  assert.ok(optionNames.includes('--amount'));
+  assert.ok(optionNames.includes('--timeout'));
+  assert.ok(!optionNames.includes('--max-fee'), 'fixed-fee design has no --max-fee');
+});
+
+test('default config enables the relayer and passes validation', () => {
+  const config = createDefaultConfig();
+  assert.equal(config.relayer?.enabled, true);
+  assert.deepEqual(validateConfig(config), []);
+});
+
+test('relayer config validation rejects malformed values', () => {
+  const config = createDefaultConfig();
+  config.relayer = {
+    enabled: 'yes' as unknown as boolean,
+    minProfitBaseUnits: '1.5',
+    maxInFlight: 0,
+    maxPerPeerPerMinute: 1.5,
+  };
+  const errors = validateConfig(config);
+  assert.ok(errors.some((e) => e.includes('relayer.enabled')));
+  assert.ok(errors.some((e) => e.includes('relayer.minProfitBaseUnits')));
+  assert.ok(errors.some((e) => e.includes('relayer.maxInFlight')));
+  assert.ok(errors.some((e) => e.includes('relayer.maxPerPeerPerMinute')));
+});
+
+test('relayer config accepts valid values including negative min profit', () => {
+  const config = createDefaultConfig();
+  config.relayer = {
+    enabled: false,
+    minProfitBaseUnits: '-100000000',
+    maxInFlight: 3,
+    maxPerPeerPerMinute: 10,
+  };
+  assert.deepEqual(validateConfig(config), []);
+});

--- a/apps/cli/src/cli/commands/buyer/sweep.ts
+++ b/apps/cli/src/cli/commands/buyer/sweep.ts
@@ -12,7 +12,7 @@ import {
   parseUsdcToBaseUnits,
 } from '../../payment-utils.js'
 import { AntseedNode, buildReceiveAuthorization, makeUsdcDomain } from '@antseed/node'
-import type { DepositsClient, SweepRequestPayload, SweepReceiptPayload } from '@antseed/node'
+import type { DepositRelayClient, DepositsClient, SweepRequestPayload, SweepReceiptPayload } from '@antseed/node'
 import { parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery'
 import { buildBuyerBootstrapEntries } from './start.js'
 
@@ -91,15 +91,24 @@ async function daemonGetReceipt(port: number, nonce: string): Promise<SweepRecei
 interface WaitResult {
   credited: bigint | null
   finalAvailable: bigint
+  finalTotal: bigint
+  confirmation: 'relay-event' | 'authorization' | 'balance' | null
+  blockNumber?: number
+  relayer?: string
   txHash?: string
 }
 
 async function waitForDeposit(
   spinner: Ora,
   depositsClient: DepositsClient,
+  relayClient: DepositRelayClient,
   address: string,
   initialAvailable: bigint,
+  initialTotal: bigint,
   expectedNet: bigint,
+  fee: bigint,
+  usdcAddress: string,
+  authNonce: string,
   timeoutSecs: number,
   getReceipt: () => Promise<SweepReceiptPayload | null>,
 ): Promise<WaitResult> {
@@ -115,16 +124,62 @@ async function waitForDeposit(
       if (receipt.status === 'submitted') {
         spinner.text = 'Relayer accepted the sweep — submitting on-chain...'
       } else if (receipt.status === 'confirmed') {
-        spinner.text = 'Sweep transaction confirmed — waiting for balance...'
+        spinner.text = 'Sweep transaction reported — verifying relay event...'
       }
     }
 
     const current = await depositsClient.getBuyerBalance(address).catch(() => null)
-    if (current && current.available >= initialAvailable + expectedNet) {
-      return { credited: current.available - initialAvailable, finalAvailable: current.available, ...(txHash ? { txHash } : {}) }
+    const finalAvailable = current?.available ?? initialAvailable
+    const finalTotal = current ? current.available + current.reserved : initialTotal
+
+    if (txHash) {
+      const confirmation = await relayClient.getSweepConfirmation(txHash, {
+        buyer: address,
+        deposited: expectedNet,
+        fee,
+        authNonce,
+      }).catch(() => null)
+      if (confirmation) {
+        return {
+          credited: confirmation.deposited,
+          finalAvailable,
+          finalTotal: current ? finalTotal : initialTotal + confirmation.deposited,
+          confirmation: 'relay-event',
+          blockNumber: confirmation.blockNumber,
+          relayer: confirmation.relayer,
+          txHash: confirmation.txHash,
+        }
+      }
+    }
+
+    const authorizationUsed = await relayClient.isAuthorizationUsed(usdcAddress, address, authNonce).catch(() => false)
+    if (authorizationUsed) {
+      return {
+        credited: expectedNet,
+        finalAvailable,
+        finalTotal: current ? finalTotal : initialTotal + expectedNet,
+        confirmation: 'authorization',
+        ...(txHash ? { txHash } : {}),
+      }
+    }
+
+    if (finalTotal >= initialTotal + expectedNet) {
+      return {
+        credited: finalTotal - initialTotal,
+        finalAvailable,
+        finalTotal,
+        confirmation: 'balance',
+        ...(txHash ? { txHash } : {}),
+      }
     }
   }
-  return { credited: null, finalAvailable: initialAvailable, ...(txHash ? { txHash } : {}) }
+  return {
+    credited: null,
+    finalAvailable: initialAvailable,
+    finalTotal: initialTotal,
+    confirmation: null,
+    ...(txHash ? { txHash } : {}),
+  }
 }
 
 export function registerBuyerSweepCommand(buyerCmd: Command): void {
@@ -297,23 +352,36 @@ export function registerBuyerSweepCommand(buyerCmd: Command): void {
         const result = await waitForDeposit(
           netSpinner,
           depositsClient,
+          relayClient,
           address,
           initialDeposits.available,
+          depositsBalance,
           amount - fee,
+          fee,
+          crypto.usdcContractAddress,
+          message.nonce,
           timeoutSecs,
           getReceipt,
         )
 
         if (result.credited !== null) {
-          netSpinner.succeed(chalk.green(`Deposited ${formatUsdc(result.credited)} USDC to your deposits balance`))
+          const confirmationLabel = result.confirmation === 'relay-event'
+            ? 'verified relay event'
+            : result.confirmation === 'authorization'
+              ? 'verified USDC authorization'
+              : 'verified deposits balance'
+          netSpinner.succeed(chalk.green(`Sweep confirmed by ${confirmationLabel}: deposited ${formatUsdc(result.credited)} USDC`))
           console.log(chalk.dim(`New available balance: ${formatUsdc(result.finalAvailable)} USDC`))
+          console.log(chalk.dim(`New deposits total: ${formatUsdc(result.finalTotal)} USDC`))
           if (result.txHash) console.log(chalk.dim(`Transaction: ${result.txHash}`))
+          if (result.blockNumber !== undefined) console.log(chalk.dim(`Block: ${result.blockNumber}`))
+          if (result.relayer) console.log(chalk.dim(`Relayer: ${result.relayer}`))
           if (node) await node.stop()
           process.exit(0)
         }
 
-        netSpinner.fail(chalk.yellow(`No relayer completed the sweep within ${timeoutSecs}s.`))
-        console.log(chalk.dim('Your funds have not moved from the hot wallet — it is safe to retry.'))
+        netSpinner.fail(chalk.yellow(`No on-chain sweep confirmation within ${timeoutSecs}s.`))
+        console.log(chalk.dim('No matching relay event, consumed authorization, or deposits-balance increase was observed.'))
         console.log(chalk.dim(`The signed authorization expires at ${new Date(validBefore * 1000).toISOString()}.`))
         if (result.txHash) console.log(chalk.dim(`Last seen transaction: ${result.txHash}`))
         if (node) await node.stop()

--- a/apps/cli/src/cli/commands/buyer/sweep.ts
+++ b/apps/cli/src/cli/commands/buyer/sweep.ts
@@ -28,6 +28,15 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+function parseTimeoutSecs(value: string | undefined): { value: number; usedDefault: boolean } {
+  if (!value) return { value: DEFAULT_TIMEOUT_SECS, usedDefault: false }
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return { value: DEFAULT_TIMEOUT_SECS, usedDefault: true }
+  }
+  return { value: Math.floor(parsed), usedDefault: false }
+}
+
 // ─── Running-daemon control plane ─────────────────────────────────────
 
 /** Fetch against the local buyer daemon; null when nothing is listening. */
@@ -348,7 +357,10 @@ export function registerBuyerSweepCommand(buyerCmd: Command): void {
           netSpinner.text = `Broadcast sweep request to ${sent} peer${sent === 1 ? '' : 's'} — waiting for a relayer...`
         }
 
-        const timeoutSecs = options.timeout ? parseInt(options.timeout, 10) : DEFAULT_TIMEOUT_SECS
+        const timeout = parseTimeoutSecs(options.timeout)
+        if (timeout.usedDefault) {
+          console.log(chalk.yellow(`Ignoring invalid --timeout value; using ${DEFAULT_TIMEOUT_SECS}s.`))
+        }
         const result = await waitForDeposit(
           netSpinner,
           depositsClient,
@@ -360,7 +372,7 @@ export function registerBuyerSweepCommand(buyerCmd: Command): void {
           fee,
           crypto.usdcContractAddress,
           message.nonce,
-          timeoutSecs,
+          timeout.value,
           getReceipt,
         )
 
@@ -380,8 +392,9 @@ export function registerBuyerSweepCommand(buyerCmd: Command): void {
           process.exit(0)
         }
 
-        netSpinner.fail(chalk.yellow(`No on-chain sweep confirmation within ${timeoutSecs}s.`))
+        netSpinner.fail(chalk.yellow(`No on-chain sweep confirmation within ${timeout.value}s.`))
         console.log(chalk.dim('No matching relay event, consumed authorization, or deposits-balance increase was observed.'))
+        console.log(chalk.dim('Retrying may deposit twice if the first sweep lands late; both deposits credit this same buyer wallet.'))
         console.log(chalk.dim(`The signed authorization expires at ${new Date(validBefore * 1000).toISOString()}.`))
         if (result.txHash) console.log(chalk.dim(`Last seen transaction: ${result.txHash}`))
         if (node) await node.stop()

--- a/apps/cli/src/cli/commands/buyer/sweep.ts
+++ b/apps/cli/src/cli/commands/buyer/sweep.ts
@@ -11,7 +11,7 @@ import {
   formatUsdc,
   parseUsdcToBaseUnits,
 } from '../../payment-utils.js'
-import { AntseedNode, buildReceiveAuthorization, makeUsdcDomain } from '@antseed/node'
+import { AntseedNode, buildReceiveAuthorization, makeUsdcDomain, peerRelaysSweeps } from '@antseed/node'
 import type { DepositRelayClient, DepositsClient, SweepRequestPayload, SweepReceiptPayload } from '@antseed/node'
 import { parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery'
 import { buildBuyerBootstrapEntries } from './start.js'
@@ -76,8 +76,10 @@ async function daemonBroadcast(port: number, payload: SweepRequestPayload): Prom
 async function daemonRefreshAndConnect(port: number): Promise<void> {
   await daemonFetch(port, '/_antseed/peers/refresh', { method: 'POST' }, 30_000)
   const res = await daemonFetch(port, '/_antseed/peers')
-  const body = await res?.json().catch(() => null) as { peers?: Array<{ peerId: string }> } | null
-  const peers = body?.peers ?? []
+  const body = await res?.json().catch(() => null) as {
+    peers?: Array<{ peerId: string; capabilities?: string[]; metadata?: { capabilities?: string[] } }>
+  } | null
+  const peers = (body?.peers ?? []).filter(peerRelaysSweeps)
   await Promise.allSettled(
     peers.slice(0, MAX_PEERS_TO_CONNECT).map((p) =>
       daemonFetch(port, '/_antseed/connect', {
@@ -311,12 +313,12 @@ export function registerBuyerSweepCommand(buyerCmd: Command): void {
 
         if (sent !== null) {
           if (sent === 0) {
-            netSpinner.text = 'Daemon has no connected peers — refreshing discovery...'
+            netSpinner.text = 'Daemon has no connected sweep relayers — refreshing discovery...'
             await daemonRefreshAndConnect(proxyPort)
             sent = await daemonBroadcast(proxyPort, payload) ?? 0
           }
           if (sent === 0) {
-            netSpinner.fail(chalk.red('Buyer daemon is running but could not reach any peers.'))
+            netSpinner.fail(chalk.red('Buyer daemon is running but could not reach any sweep relayers.'))
             console.log(chalk.dim('Your funds have not moved — check the daemon\'s network connectivity and retry.'))
             process.exit(1)
           }
@@ -336,9 +338,9 @@ export function registerBuyerSweepCommand(buyerCmd: Command): void {
           })
           await node.start()
 
-          const peers = await node.discoverPeers()
+          const peers = (await node.discoverPeers()).filter(peerRelaysSweeps)
           if (peers.length === 0) {
-            netSpinner.fail(chalk.red('No peers found on the network. Your funds have not moved — try again later.'))
+            netSpinner.fail(chalk.red('No sweep relayers found on the network. Your funds have not moved — try again later.'))
             process.exit(1)
           }
           await Promise.allSettled(peers.slice(0, MAX_PEERS_TO_CONNECT).map((peer) => node!.connectToPeer(peer)))

--- a/apps/cli/src/cli/commands/buyer/sweep.ts
+++ b/apps/cli/src/cli/commands/buyer/sweep.ts
@@ -1,0 +1,327 @@
+import type { Command } from 'commander'
+import chalk from 'chalk'
+import ora, { type Ora } from 'ora'
+import { getGlobalOptions } from '../types.js'
+import { loadConfig } from '../../../config/loader.js'
+import {
+  loadCryptoContext,
+  createDepositsClient,
+  createDepositRelayClient,
+  requireCryptoConfig,
+  formatUsdc,
+  parseUsdcToBaseUnits,
+} from '../../payment-utils.js'
+import { AntseedNode, buildReceiveAuthorization, makeUsdcDomain } from '@antseed/node'
+import type { DepositsClient, SweepRequestPayload, SweepReceiptPayload } from '@antseed/node'
+import { parseBootstrapList, toBootstrapConfig } from '@antseed/node/discovery'
+import { buildBuyerBootstrapEntries } from './start.js'
+
+const AUTH_VALIDITY_SECS = 3600
+const POLL_INTERVAL_MS = 3000
+const DEFAULT_TIMEOUT_SECS = 120
+const MAX_PEERS_TO_CONNECT = 4
+/** Deposits contract default MIN_BUYER_DEPOSIT (1 USDC); pre-flight only —
+ *  relayers simulate against the live value before submitting. */
+const DEFAULT_MIN_BUYER_DEPOSIT = 1_000_000n
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+// ─── Running-daemon control plane ─────────────────────────────────────
+
+/** Fetch against the local buyer daemon; null when nothing is listening. */
+async function daemonFetch(
+  port: number,
+  path: string,
+  init?: RequestInit,
+  timeoutMs = 10_000,
+): Promise<Response | null> {
+  try {
+    return await fetch(`http://127.0.0.1:${port}${path}`, {
+      ...init,
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+  } catch {
+    return null
+  }
+}
+
+/** POST the signed payload to the daemon. Returns peers-sent count, or null
+ *  when no daemon is reachable on the proxy port. */
+async function daemonBroadcast(port: number, payload: SweepRequestPayload): Promise<number | null> {
+  const res = await daemonFetch(port, '/_antseed/sweep', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!res) return null
+  const body = await res.json().catch(() => null) as { ok?: boolean; sent?: number; error?: string } | null
+  if (!res.ok || !body?.ok || typeof body.sent !== 'number') {
+    throw new Error(`Daemon rejected the sweep request: ${body?.error ?? `HTTP ${res.status}`}`)
+  }
+  return body.sent
+}
+
+/** Ask the daemon to refresh discovery and eagerly connect to a few sellers. */
+async function daemonRefreshAndConnect(port: number): Promise<void> {
+  await daemonFetch(port, '/_antseed/peers/refresh', { method: 'POST' }, 30_000)
+  const res = await daemonFetch(port, '/_antseed/peers')
+  const body = await res?.json().catch(() => null) as { peers?: Array<{ peerId: string }> } | null
+  const peers = body?.peers ?? []
+  await Promise.allSettled(
+    peers.slice(0, MAX_PEERS_TO_CONNECT).map((p) =>
+      daemonFetch(port, '/_antseed/connect', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ peerId: p.peerId }),
+      }, 20_000),
+    ),
+  )
+}
+
+async function daemonGetReceipt(port: number, nonce: string): Promise<SweepReceiptPayload | null> {
+  const res = await daemonFetch(port, `/_antseed/sweep/${nonce}`, undefined, 3000)
+  const body = await res?.json().catch(() => null) as { receipt?: SweepReceiptPayload | null } | null
+  return body?.receipt ?? null
+}
+
+// ─── Shared completion polling ────────────────────────────────────────
+
+interface WaitResult {
+  credited: bigint | null
+  finalAvailable: bigint
+  txHash?: string
+}
+
+async function waitForDeposit(
+  spinner: Ora,
+  depositsClient: DepositsClient,
+  address: string,
+  initialAvailable: bigint,
+  expectedNet: bigint,
+  timeoutSecs: number,
+  getReceipt: () => Promise<SweepReceiptPayload | null>,
+): Promise<WaitResult> {
+  const deadline = Date.now() + timeoutSecs * 1000
+  let txHash: string | undefined
+
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS)
+
+    const receipt = await getReceipt().catch(() => null)
+    if (receipt) {
+      if (receipt.txHash) txHash = receipt.txHash
+      if (receipt.status === 'submitted') {
+        spinner.text = 'Relayer accepted the sweep — submitting on-chain...'
+      } else if (receipt.status === 'confirmed') {
+        spinner.text = 'Sweep transaction confirmed — waiting for balance...'
+      }
+    }
+
+    const current = await depositsClient.getBuyerBalance(address).catch(() => null)
+    if (current && current.available >= initialAvailable + expectedNet) {
+      return { credited: current.available - initialAvailable, finalAvailable: current.available, ...(txHash ? { txHash } : {}) }
+    }
+  }
+  return { credited: null, finalAvailable: initialAvailable, ...(txHash ? { txHash } : {}) }
+}
+
+export function registerBuyerSweepCommand(buyerCmd: Command): void {
+  buyerCmd
+    .command('sweep')
+    .description('Gaslessly sweep hot-wallet USDC into your deposits balance via permissionless relayers (fixed fee paid in USDC)')
+    .option('--amount <usdc>', 'Amount to sweep in human-readable USDC (default: full hot-wallet balance)')
+    .option('--timeout <secs>', `Seconds to wait for the deposit to land (default: ${DEFAULT_TIMEOUT_SECS})`)
+    .action(async (options: { amount?: string; timeout?: string }) => {
+      const globalOpts = getGlobalOptions(buyerCmd)
+      const config = await loadConfig(globalOpts.config)
+
+      let node: AntseedNode | null = null
+      try {
+        const crypto = requireCryptoConfig(config)
+        if (!crypto.depositRelayAddress) {
+          console.error(chalk.red('Error: No deposit relay deployed for this chain.'))
+          console.error(chalk.dim('Set payments.crypto.depositRelayAddress in your config file.'))
+          process.exit(1)
+        }
+
+        const { wallet, address } = await loadCryptoContext(globalOpts.dataDir)
+        const depositsClient = createDepositsClient(config)
+        const relayClient = createDepositRelayClient(config)
+
+        console.log(chalk.dim(`Wallet: ${address}`))
+
+        const balanceSpinner = ora('Checking hot-wallet USDC balance...').start()
+        const [usdcBalance, initialDeposits, creditLimit, fee] = await Promise.all([
+          depositsClient.getUSDCBalance(address),
+          depositsClient.getBuyerBalance(address),
+          depositsClient.getBuyerCreditLimit(address),
+          relayClient.fee(),
+        ])
+        balanceSpinner.succeed(`Hot wallet holds ${formatUsdc(usdcBalance)} USDC — relay fee is fixed at ${formatUsdc(fee)} USDC`)
+
+        // Deposits caps the credited balance at the buyer's credit limit;
+        // the sweep would revert whole if the net pushed past it.
+        const depositsBalance = initialDeposits.available + initialDeposits.reserved
+        const headroom = creditLimit > depositsBalance ? creditLimit - depositsBalance : 0n
+        if (headroom === 0n) {
+          console.error(chalk.red(`Error: Your deposits balance is at its credit limit (${formatUsdc(creditLimit)} USDC).`))
+          console.error(chalk.dim('Spend or withdraw before sweeping more.'))
+          process.exit(1)
+        }
+
+        let amount = options.amount ? parseUsdcToBaseUnits(options.amount) : usdcBalance
+        if (amount === 0n) {
+          console.error(chalk.red('Error: No USDC to sweep.'))
+          process.exit(1)
+        }
+        if (amount > usdcBalance) {
+          console.error(chalk.red(`Error: Amount exceeds hot-wallet balance (${formatUsdc(usdcBalance)} USDC).`))
+          process.exit(1)
+        }
+        if (amount <= fee) {
+          console.error(chalk.red(`Error: Amount must exceed the fixed relay fee (${formatUsdc(fee)} USDC).`))
+          process.exit(1)
+        }
+        if (amount - fee > headroom) {
+          const maxSweep = headroom + fee
+          if (options.amount) {
+            console.error(chalk.red(`Error: Net amount exceeds your credit-limit headroom (${formatUsdc(headroom)} USDC).`))
+            console.error(chalk.dim(`Maximum sweep right now: ${formatUsdc(maxSweep)} USDC (limit ${formatUsdc(creditLimit)} USDC, deposited ${formatUsdc(depositsBalance)} USDC).`))
+            process.exit(1)
+          }
+          amount = maxSweep
+          console.log(chalk.yellow(`Sweeping ${formatUsdc(amount)} USDC (clamped to credit-limit headroom; ${formatUsdc(usdcBalance - amount)} USDC stays in the hot wallet).`))
+        }
+
+        const isFirstDeposit = depositsBalance === 0n
+        if (isFirstDeposit && amount - fee < DEFAULT_MIN_BUYER_DEPOSIT) {
+          console.error(chalk.red(`Error: First deposit must net at least ${formatUsdc(DEFAULT_MIN_BUYER_DEPOSIT)} USDC after the ${formatUsdc(fee)} USDC fee.`))
+          process.exit(1)
+        }
+
+        // Guard against a wrong USDC domain (name/version differ per deployment):
+        // a mismatch here would produce signatures the token silently rejects.
+        const usdcDomain = makeUsdcDomain(crypto.evmChainId, crypto.usdcContractAddress)
+        const domainOk = await relayClient.verifyUsdcDomain(crypto.usdcContractAddress, usdcDomain)
+        if (!domainOk) {
+          console.error(chalk.red('Error: USDC EIP-712 domain mismatch — refusing to sign.'))
+          console.error(chalk.dim('The deployed token does not match the expected "USD Coin"/"2" domain.'))
+          process.exit(1)
+        }
+
+        const signSpinner = ora('Signing sweep authorization (offline)...').start()
+        const nowSecs = Math.floor(Date.now() / 1000)
+        const validAfter = nowSecs - 60
+        const validBefore = nowSecs + AUTH_VALIDITY_SECS
+        // The single EIP-3009 signature, addressed to the relay contract, is
+        // the consent to its immutable fixed FEE — no second signature.
+        const { message, signature: sig3009 } = await buildReceiveAuthorization(wallet, usdcDomain, {
+          to: crypto.depositRelayAddress,
+          value: amount,
+          validAfter: BigInt(validAfter),
+          validBefore: BigInt(validBefore),
+        })
+        signSpinner.succeed(`Signed sweep of ${formatUsdc(amount)} USDC (fixed fee ${formatUsdc(fee)} USDC)`)
+
+        const payload: SweepRequestPayload = {
+          version: 1,
+          evmChainId: crypto.evmChainId,
+          relayAddress: crypto.depositRelayAddress,
+          from: address,
+          amount: amount.toString(),
+          validAfter,
+          validBefore,
+          nonce: message.nonce,
+          sig3009,
+        }
+
+        // Prefer the running buyer daemon: it already holds authenticated
+        // seller connections, and a second node with the same identity would
+        // collide with the daemon's peerId on the network.
+        const proxyPort = config.buyer.proxyPort
+        const netSpinner = ora(`Checking for a running buyer daemon on port ${proxyPort}...`).start()
+        let sent = await daemonBroadcast(proxyPort, payload)
+        let getReceipt: () => Promise<SweepReceiptPayload | null>
+
+        if (sent !== null) {
+          if (sent === 0) {
+            netSpinner.text = 'Daemon has no connected peers — refreshing discovery...'
+            await daemonRefreshAndConnect(proxyPort)
+            sent = await daemonBroadcast(proxyPort, payload) ?? 0
+          }
+          if (sent === 0) {
+            netSpinner.fail(chalk.red('Buyer daemon is running but could not reach any peers.'))
+            console.log(chalk.dim('Your funds have not moved — check the daemon\'s network connectivity and retry.'))
+            process.exit(1)
+          }
+          netSpinner.text = `Broadcast via running daemon to ${sent} peer${sent === 1 ? '' : 's'} — waiting for a relayer...`
+          getReceipt = () => daemonGetReceipt(proxyPort, message.nonce)
+        } else {
+          // Fallback: no daemon — join the network with an ephemeral node.
+          netSpinner.text = 'No running daemon — connecting to P2P network directly...'
+          const bootstrapNodes = toBootstrapConfig(
+            parseBootstrapList(buildBuyerBootstrapEntries(config.network?.bootstrapNodes)),
+          )
+          node = new AntseedNode({
+            role: 'buyer',
+            bootstrapNodes,
+            allowPrivateIPs: true,
+            dataDir: globalOpts.dataDir,
+          })
+          await node.start()
+
+          const peers = await node.discoverPeers()
+          if (peers.length === 0) {
+            netSpinner.fail(chalk.red('No peers found on the network. Your funds have not moved — try again later.'))
+            process.exit(1)
+          }
+          await Promise.allSettled(peers.slice(0, MAX_PEERS_TO_CONNECT).map((peer) => node!.connectToPeer(peer)))
+
+          let latestReceipt: SweepReceiptPayload | null = null
+          node.on('sweep:receipt', (event: { peerId: string; payload: SweepReceiptPayload }) => {
+            if (event.payload.authNonce === message.nonce) latestReceipt = event.payload
+          })
+          getReceipt = async () => latestReceipt
+
+          sent = node.broadcastSweepRequest(payload)
+          if (sent === 0) {
+            netSpinner.fail(chalk.red('Could not reach any peers. Your funds have not moved — try again later.'))
+            process.exit(1)
+          }
+          netSpinner.text = `Broadcast sweep request to ${sent} peer${sent === 1 ? '' : 's'} — waiting for a relayer...`
+        }
+
+        const timeoutSecs = options.timeout ? parseInt(options.timeout, 10) : DEFAULT_TIMEOUT_SECS
+        const result = await waitForDeposit(
+          netSpinner,
+          depositsClient,
+          address,
+          initialDeposits.available,
+          amount - fee,
+          timeoutSecs,
+          getReceipt,
+        )
+
+        if (result.credited !== null) {
+          netSpinner.succeed(chalk.green(`Deposited ${formatUsdc(result.credited)} USDC to your deposits balance`))
+          console.log(chalk.dim(`New available balance: ${formatUsdc(result.finalAvailable)} USDC`))
+          if (result.txHash) console.log(chalk.dim(`Transaction: ${result.txHash}`))
+          if (node) await node.stop()
+          process.exit(0)
+        }
+
+        netSpinner.fail(chalk.yellow(`No relayer completed the sweep within ${timeoutSecs}s.`))
+        console.log(chalk.dim('Your funds have not moved from the hot wallet — it is safe to retry.'))
+        console.log(chalk.dim(`The signed authorization expires at ${new Date(validBefore * 1000).toISOString()}.`))
+        if (result.txHash) console.log(chalk.dim(`Last seen transaction: ${result.txHash}`))
+        if (node) await node.stop()
+        process.exit(1)
+      } catch (err) {
+        console.error(chalk.red(`Sweep failed: ${(err as Error).message}`))
+        if (node) await node.stop().catch(() => {})
+        process.exit(1)
+      }
+    })
+}

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -425,6 +425,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
       const sellerWalletAddress = process.env['ANTSEED_SELLER_WALLET_ADDRESS']
 
       let paymentConfig: PaymentConfig | null = null
+      let depositRelayAddress: string | undefined
       if (preferredMethod === 'crypto') {
         const cc = resolveChainConfig({
           chainId: config.payments.crypto?.chainId,
@@ -437,7 +438,9 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
           usdcContractAddress: config.payments.crypto?.usdcContractAddress,
           identityRegistryAddress: config.payments.crypto?.identityRegistryAddress,
           emissionsContractAddress: config.payments.crypto?.emissionsContractAddress,
+          depositRelayAddress: config.payments.crypto?.depositRelayAddress,
         })
+        depositRelayAddress = cc.depositRelayAddress
         const defaultLockAmountUSDCBaseUnits = toUSDCBaseUnits(
           config.payments.crypto?.defaultLockAmountUSDC ?? defaultDepositAmountUSDC,
           defaultDepositAmountUSDCBaseUnits,
@@ -604,8 +607,10 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
             identityRegistryAddress: resolveChainConfig({ chainId: paymentConfig.crypto.chainId }).identityRegistryAddress,
             stakingAddress: resolveChainConfig({ chainId: paymentConfig.crypto.chainId }).stakingContractAddress,
             chainId: resolveChainConfig({ chainId: paymentConfig.crypto.chainId }).evmChainId,
+            ...(depositRelayAddress ? { depositRelayAddress } : {}),
           } : {}),
         },
+        ...(config.relayer ? { relayer: config.relayer } : {}),
         ...(announcerSellerContract ? { sellerContract: announcerSellerContract } : {}),
       })
 

--- a/apps/cli/src/cli/payment-utils.ts
+++ b/apps/cli/src/cli/payment-utils.ts
@@ -3,6 +3,7 @@ import {
   DepositsClient,
   ChannelsClient,
   StakingClient,
+  DepositRelayClient,
   loadOrCreateIdentity,
   resolveChainConfig,
 } from '@antseed/node';
@@ -105,6 +106,7 @@ type ResolvedCryptoConfig = NonNullable<AntseedConfig['payments']['crypto']> & {
   stakingContractAddress?: string;
   identityRegistryAddress?: string;
   emissionsContractAddress?: string;
+  depositRelayAddress?: string;
   evmChainId: number;
 };
 
@@ -152,6 +154,7 @@ export function requireCryptoConfig(
     stakingContractAddress: crypto.stakingContractAddress || resolved.stakingContractAddress,
     emissionsContractAddress: crypto.emissionsContractAddress || resolved.emissionsContractAddress,
     identityRegistryAddress: crypto.identityRegistryAddress || resolved.identityRegistryAddress,
+    depositRelayAddress: crypto.depositRelayAddress || resolved.depositRelayAddress,
     evmChainId: resolved.evmChainId,
   };
 }
@@ -234,6 +237,22 @@ export function createEmissionsClient(config: AntseedConfig, overrides?: CryptoC
     rpcUrl: crypto.rpcUrl,
     ...fallbackClientOpts(crypto),
     contractAddress: crypto.emissionsContractAddress,
+    evmChainId: crypto.evmChainId,
+  });
+}
+
+/**
+ * Create a DepositRelayClient from the CLI config.
+ */
+export function createDepositRelayClient(config: AntseedConfig, overrides?: CryptoConfigOverrides): DepositRelayClient {
+  const crypto = requireCryptoConfig(config, overrides);
+  if (!crypto.depositRelayAddress) {
+    throw new Error('No deposit relay address configured for this chain. Set payments.crypto.depositRelayAddress in your config file.');
+  }
+  return new DepositRelayClient({
+    rpcUrl: crypto.rpcUrl,
+    ...fallbackClientOpts(crypto),
+    contractAddress: crypto.depositRelayAddress,
     evmChainId: crypto.evmChainId,
   });
 }

--- a/apps/cli/src/config/defaults.ts
+++ b/apps/cli/src/config/defaults.ts
@@ -39,6 +39,9 @@ export function createDefaultConfig(): AntseedConfig {
         chainId: 'base-mainnet',
       },
     },
+    relayer: {
+      enabled: true,
+    },
     network: {
       bootstrapNodes: [],
     },

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -208,9 +208,26 @@ export interface PaymentsCLIConfig {
     identityRegistryAddress?: string;
     /** Deployed AntseedEmissions contract address */
     emissionsContractAddress?: string;
+    /** Deployed AntseedDepositRelay contract address (gasless deposit sweeps) */
+    depositRelayAddress?: string;
     /** Default lock amount per session in human-readable USDC (e.g. "1" = 1 USDC) */
     defaultLockAmountUSDC?: string;
   };
+}
+
+/**
+ * Seller-side deposit-sweep relayer configuration. ON by default (opt-out).
+ */
+export interface RelayerCLIConfig {
+  /** Relay buyer deposit sweeps with the seller wallet. Default: true. */
+  enabled?: boolean;
+  /** Minimum acceptable profit (FEE - estimated gas cost) in USDC base units.
+   *  May be negative to relay at a loss (local testing). Default: "0". */
+  minProfitBaseUnits?: string;
+  /** Max concurrent sweep submissions. Default: 2. */
+  maxInFlight?: number;
+  /** Max sweep requests accepted per peer per minute. Default: 6. */
+  maxPerPeerPerMinute?: number;
 }
 
 /**
@@ -236,6 +253,8 @@ export interface AntseedConfig {
   buyer: BuyerCLIConfig;
   /** Payment settings */
   payments: PaymentsCLIConfig;
+  /** Seller-side deposit-sweep relayer settings (opt-out, ON by default) */
+  relayer?: RelayerCLIConfig;
   /** Network / DHT settings */
   network: NetworkCLIConfig;
   /** Installed plugins */

--- a/apps/cli/src/config/validation.ts
+++ b/apps/cli/src/config/validation.ts
@@ -367,6 +367,21 @@ export function validateConfig(config: AntseedConfig): string[] {
 
   validateVerifications('seller.verifications', config.seller.verifications, errors);
 
+  if (config.relayer !== undefined) {
+    if (config.relayer.enabled !== undefined && typeof config.relayer.enabled !== 'boolean') {
+      errors.push('relayer.enabled must be a boolean');
+    }
+    if (config.relayer.minProfitBaseUnits !== undefined && !/^-?[0-9]+$/.test(config.relayer.minProfitBaseUnits)) {
+      errors.push('relayer.minProfitBaseUnits must be an integer string (USDC base units, may be negative)');
+    }
+    if (config.relayer.maxInFlight !== undefined && (!Number.isInteger(config.relayer.maxInFlight) || config.relayer.maxInFlight < 1)) {
+      errors.push('relayer.maxInFlight must be an integer >= 1');
+    }
+    if (config.relayer.maxPerPeerPerMinute !== undefined && (!Number.isInteger(config.relayer.maxPerPeerPerMinute) || config.relayer.maxPerPeerPerMinute < 1)) {
+      errors.push('relayer.maxPerPeerPerMinute must be an integer >= 1');
+    }
+  }
+
   return errors;
 }
 

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -179,6 +179,63 @@ test('selectCandidatePeersForRouting keeps all peers when no protocol or provide
   assert.equal(result.routePlanByPeerId.size, 0)
 })
 
+test('sweep control endpoint validates and broadcasts via the running node', async () => {
+  const validSweep = {
+    version: 1,
+    evmChainId: 31337,
+    relayAddress: '0x' + '8a'.repeat(20),
+    from: '0x' + '11'.repeat(20),
+    amount: '5000000',
+    validAfter: 0,
+    validBefore: 2_000_000_000,
+    nonce: '0x' + 'aa'.repeat(32),
+    sig3009: '0x' + 'ab'.repeat(65),
+  }
+
+  const broadcasts: unknown[] = []
+  const listeners = new Map<string, (event: unknown) => void>()
+  const proxy = new BuyerProxy({
+    port: 0,
+    dataDir: '/tmp/antseed-test',
+    node: {
+      router: null,
+      on: (event: string, listener: (event: unknown) => void) => listeners.set(event, listener),
+      broadcastSweepRequest: (payload: unknown) => {
+        broadcasts.push(payload)
+        return 3
+      },
+    } as any,
+  })
+
+  const res = await invokeProxy(proxy, makeProxyRequest({ path: '/_antseed/sweep', body: validSweep }))
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(JSON.parse(res.body), { ok: true, sent: 3 })
+  assert.equal(broadcasts.length, 1)
+
+  // Malformed payloads are rejected by the wire codec, not broadcast.
+  const bad = await invokeProxy(proxy, makeProxyRequest({
+    path: '/_antseed/sweep',
+    body: { ...validSweep, sig3009: 'garbage' },
+  }))
+  assert.equal(bad.statusCode, 400)
+  assert.equal(broadcasts.length, 1)
+
+  // Receipts surfaced via node events are readable per-nonce.
+  const emit = listeners.get('sweep:receipt')
+  assert.ok(emit, 'proxy subscribes to sweep:receipt')
+  emit!({ peerId: 'p1', payload: { version: 1, authNonce: validSweep.nonce, status: 'confirmed', txHash: '0x' + '77'.repeat(32) } })
+
+  const receiptRes = await invokeProxy(proxy, makeProxyRequest({ method: 'GET', path: `/_antseed/sweep/${validSweep.nonce}` }))
+  assert.equal(receiptRes.statusCode, 200)
+  const receiptBody = JSON.parse(receiptRes.body) as { ok: boolean; receipt: { status: string; txHash: string } }
+  assert.equal(receiptBody.receipt.status, 'confirmed')
+  assert.equal(receiptBody.receipt.txHash, '0x' + '77'.repeat(32))
+
+  // Unknown nonce returns null receipt.
+  const missing = await invokeProxy(proxy, makeProxyRequest({ method: 'GET', path: `/_antseed/sweep/0x${'bb'.repeat(32)}` }))
+  assert.deepEqual(JSON.parse(missing.body), { ok: true, receipt: null })
+})
+
 test('peer refresh control endpoint triggers immediate refresh', async () => {
   const refreshedPeer = makePeer('a', ['anthropic'])
   const proxy = makeBuyerProxyWithPeers([], [refreshedPeer])

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Readable } from 'node:stream'
 import test from 'node:test'
-import type { PeerInfo } from '@antseed/node'
+import { CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1, type PeerInfo } from '@antseed/node'
 import { DEFAULT_BUYER_PEER_REFRESH_INTERVAL_MS } from '../config/defaults.js'
 import {
   BuyerProxy,
@@ -251,6 +251,18 @@ test('peer refresh control endpoint triggers immediate refresh', async () => {
   assert.equal(refreshCalled, true)
   assert.equal(res.statusCode, 200)
   assert.deepEqual(body, { ok: true, total: 1 })
+})
+
+test('peers control endpoint exposes relay capability metadata', async () => {
+  const peer = makePeer('a', ['openai'])
+  peer.capabilities = [CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1]
+  const proxy = makeBuyerProxyWithPeers([peer])
+
+  const res = await invokeProxy(proxy, makeProxyRequest({ method: 'GET', path: '/_antseed/peers' }))
+  const body = JSON.parse(res.body) as { peers: Array<{ capabilities: string[] }> }
+
+  assert.equal(res.statusCode, 200)
+  assert.deepEqual(body.peers[0]?.capabilities, [CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1])
 })
 
 test('selectCandidatePeersForRouting excludes peers when requested service is not in provider metadata', () => {

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -852,6 +852,7 @@ export class BuyerProxy {
         displayName: p.displayName,
         publicAddress: p.publicAddress,
         providers: p.providers,
+        capabilities: p.capabilities ?? p.metadata?.capabilities ?? [],
         providerPricing: p.providerPricing,
         providerServiceCategories: p.providerServiceCategories,
         providerServiceApiProtocols: p.providerServiceApiProtocols,

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -5,6 +5,7 @@ import { readFile, writeFile, rename, mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import {
   computeOnChainReputationScore,
+  decodeSweepRequest,
   type AntseedNode,
   type PeerInfo,
   type PeerMetadata,
@@ -13,6 +14,7 @@ import {
   type SerializedHttpRequest,
   type SerializedHttpResponse,
   type SerializedHttpResponseChunk,
+  type SweepReceiptPayload,
 } from '@antseed/node'
 import {
   createStreamingAdapter,
@@ -370,6 +372,8 @@ export class BuyerProxy {
   private _lastStaleCacheLogAtMs = 0
   private _bgRefreshHandle: ReturnType<typeof setInterval> | null = null
   private _peerFailures: Map<string, PeerFailureEntry> = new Map()
+  /** Latest relayer receipt per sweep authNonce, for CLI progress polling. */
+  private readonly _sweepReceipts = new Map<string, SweepReceiptPayload>()
 
   constructor(config: BuyerProxyConfig) {
     this._node = config.node
@@ -388,6 +392,19 @@ export class BuyerProxy {
         res.end(`Proxy error: ${err instanceof Error ? err.message : String(err)}`)
       })
     })
+
+    const sweepEventNode = this._node as AntseedNode & {
+      on?: (event: 'sweep:receipt', listener: (event: { peerId: string; payload: SweepReceiptPayload }) => void) => unknown
+    }
+    if (typeof sweepEventNode.on === 'function') {
+      sweepEventNode.on('sweep:receipt', ({ payload }) => {
+        this._sweepReceipts.set(payload.authNonce.toLowerCase(), payload)
+        if (this._sweepReceipts.size > 64) {
+          const oldest = this._sweepReceipts.keys().next().value
+          if (oldest !== undefined) this._sweepReceipts.delete(oldest)
+        }
+      })
+    }
 
     const eventNode = this._node as AntseedNode & {
       on?: (event: 'peers:discovered', listener: (peers: PeerInfo[]) => void) => unknown
@@ -916,6 +933,43 @@ export class BuyerProxy {
       const stats = this._node.getMeteringStatsByPeer(sellerPeerId)
       res.writeHead(200, { 'content-type': 'application/json' })
       res.end(JSON.stringify(stats))
+      return
+    }
+
+    // Broadcast a signed deposit-sweep request over the daemon's existing
+    // seller connections (see docs/protocol/spec/09-deposit-sweep.md).
+    if (path === '/_antseed/sweep' && method === 'POST') {
+      const chunks: Buffer[] = []
+      let totalSize = 0
+      for await (const chunk of req) {
+        totalSize += (chunk as Buffer).length
+        if (totalSize > 8192) {
+          res.writeHead(413, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ ok: false, error: 'Request body too large' }))
+          return
+        }
+        chunks.push(chunk as Buffer)
+      }
+      try {
+        // Re-validate through the wire codec — same rules as inbound P2P frames.
+        const payload = decodeSweepRequest(new Uint8Array(Buffer.concat(chunks)))
+        const sent = this._node.broadcastSweepRequest(payload)
+        log(`Sweep request ${payload.nonce.slice(0, 10)}... broadcast to ${sent} peer(s)`)
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: true, sent }))
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        res.writeHead(400, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: message }))
+      }
+      return
+    }
+
+    const sweepReceiptMatch = path.match(/^\/_antseed\/sweep\/(0x[0-9a-fA-F]{64})$/)
+    if (sweepReceiptMatch && method === 'GET') {
+      const receipt = this._sweepReceipts.get(sweepReceiptMatch[1]!.toLowerCase()) ?? null
+      res.writeHead(200, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({ ok: true, receipt }))
       return
     }
 

--- a/docs/protocol/spec/02-transport.md
+++ b/docs/protocol/spec/02-transport.md
@@ -64,8 +64,14 @@ If `payloadLength` exceeds `MAX_PAYLOAD_SIZE`, the frame MUST be rejected with a
 | 0x22 | HttpResponseChunk  | Seller -> Buyer: streaming chunk |
 | 0x23 | HttpResponseEnd    | Seller -> Buyer: final streaming chunk |
 | 0x24 | HttpResponseError  | Seller -> Buyer: error response |
+| 0xA0 | SweepRequest       | Buyer -> Peers: broadcast signed gasless deposit sweep (see 09-deposit-sweep.md) |
+| 0xA1 | SweepReceipt       | Relayer -> Buyer: optional sweep progress report (see 09-deposit-sweep.md) |
 | 0xF0 | Disconnect         | Graceful disconnect notification |
 | 0xFF | Error              | Protocol-level error |
+
+Ranges 0x50-0x5F (payments), 0x80-0x8F (verification), 0x90-0x9F (reserved:
+delegated verification), and 0xA0-0xAF (deposit sweep) are dispatched to
+dedicated per-range muxes; see their spec files for payload schemas.
 
 ### Streaming Frame Decoder
 

--- a/docs/protocol/spec/09-deposit-sweep.md
+++ b/docs/protocol/spec/09-deposit-sweep.md
@@ -124,3 +124,12 @@ disabled with `relayer.enabled: false`.
 Broadcasting a sweep reveals the buyer address and amount to connected peers.
 The same data becomes public on-chain when the sweep lands; no additional
 mitigation is applied in v1.
+
+## Threat notes
+
+A funded buyer can grief relayers by broadcasting valid authorizations and then
+front-running with `cancelAuthorization`, causing relayer submissions to revert
+after gas is spent. The attacker pays comparable gas to do this, and relayer
+exposure is bounded by the per-peer rate limit (default 6/min), the global
+in-flight cap (default 2), local signature verification, and simulation before
+submission.

--- a/docs/protocol/spec/09-deposit-sweep.md
+++ b/docs/protocol/spec/09-deposit-sweep.md
@@ -49,7 +49,7 @@ unchanged.
 
 | Hex  | Name         | Direction        | Purpose |
 |------|--------------|------------------|---------|
-| 0xA0 | SweepRequest | Buyer -> Peers   | Broadcast a signed sweep for relayers to submit |
+| 0xA0 | SweepRequest | Buyer -> Relay-capable peers | Broadcast a signed sweep for relayers to submit |
 | 0xA1 | SweepReceipt | Relayer -> Buyer | Optional progress report, correlated by the 3009 nonce |
 
 Payloads are UTF-8 JSON (like the payment protocol), capped at **8 KiB**.
@@ -101,6 +101,11 @@ from/to/amount/validity/nonce and the relay's terms (FEE) are immutable,
 addressing it to the relay is complete consent — no second signature exists.
 
 ## Relayer behavior (sellers, opt-out)
+
+Sellers that support deposit sweeps MUST announce the peer metadata capability
+`payments.relays-sweeps.v1`. Sellers set this capability only when the relayer
+is enabled and the configured chain has a deposit relay address. Buyers MUST
+target sweep broadcasts only to peers that announce this capability.
 
 On `SweepRequest`, in order:
 

--- a/docs/protocol/spec/09-deposit-sweep.md
+++ b/docs/protocol/spec/09-deposit-sweep.md
@@ -1,0 +1,126 @@
+# 09 — Deposit Sweep Protocol
+
+Decentralized gasless funding of a buyer's `AntseedDeposits` balance. The buyer
+hot wallet is signing-only — it never holds ETH. USDC arriving at the hot
+wallet (QR deposits, onramp deliveries) is moved into the deposits contract by
+**permissionless relayers** (sellers by default), compensated by a fixed USDC
+fee taken from the swept amount. No centralized paymaster, bundler, or relayer
+service is involved.
+
+## On-chain component
+
+`AntseedDepositRelay` (stateless periphery, swappable tier — holds no funds
+between transactions, no owner, no tunable parameters):
+
+```
+sweepDeposit(
+  address from, uint256 amount,
+  uint256 validAfter, uint256 validBefore, bytes32 nonce, bytes sig3009
+)
+```
+
+1. Pulls `amount` USDC from `from` via EIP-3009 `receiveWithAuthorization`
+   (`to` is pinned to the relay contract, so only the relay can redeem the
+   authorization; the 3009 nonce makes it single-use).
+2. Credits `amount - FEE` to the **buyer's** `AntseedDeposits` balance via
+   `deposit(from, amount - FEE)` — the buyer address itself never receives
+   tokens (iron rule). Requires `amount > FEE`, and mirrors both Deposits
+   guards with clear errors for simulating relayers: a first-time buyer's net
+   must clear `MIN_BUYER_DEPOSIT`, and the credited balance must not exceed
+   `getBuyerCreditLimit(from)`. Buyers should size sweeps to their remaining
+   credit-limit headroom (the CLI clamps automatically).
+3. Transfers the fixed `FEE` to `msg.sender`.
+
+`FEE` is a `uint256 public immutable` constructor parameter (deployed at
+50,000 base units = $0.05). **Single-signature consent:** signing an EIP-3009
+authorization addressed to the relay contract is consent to its public,
+immutable terms — there is no separate fee signature, and no governance that
+could change the fee after a user signed. (A tunable cap was rejected:
+relayers always claim the maximum, so a cap IS the fee.) Changing the fee
+means deploying a new relay at a new address; outstanding authorizations to
+the old address keep the old terms.
+
+Any failure reverts the whole transaction: funds never leave the buyer wallet
+on a failed sweep. Front-running is harmless by design — a front-runner can
+only execute the identical sweep and claim the fee; the buyer outcome is
+unchanged.
+
+## Message Types (0xA0-0xAF)
+
+| Hex  | Name         | Direction        | Purpose |
+|------|--------------|------------------|---------|
+| 0xA0 | SweepRequest | Buyer -> Peers   | Broadcast a signed sweep for relayers to submit |
+| 0xA1 | SweepReceipt | Relayer -> Buyer | Optional progress report, correlated by the 3009 nonce |
+
+Payloads are UTF-8 JSON (like the payment protocol), capped at **8 KiB**.
+uint256 values are decimal strings; addresses, bytes32 values, and signatures
+are 0x-prefixed hex strings. Receivers MUST validate every field (shape,
+length, version) — payloads are untrusted peer input.
+
+### SweepRequest (0xA0)
+
+| Field        | Type   | Description |
+|--------------|--------|-------------|
+| version      | number | Always `1` |
+| evmChainId   | number | EVM chain the sweep targets (e.g. 8453) |
+| relayAddress | string | `AntseedDepositRelay` the buyer signed against |
+| from         | string | Buyer hot wallet (source and credited account) |
+| amount       | string | Total USDC pulled via EIP-3009, base units (uint256 decimal) |
+| validAfter   | number | EIP-3009 window start, unix seconds (exclusive) |
+| validBefore  | number | EIP-3009 window end, unix seconds (exclusive) |
+| nonce        | string | EIP-3009 nonce (bytes32 hex); correlation key |
+| sig3009      | string | 65-byte buyer signature over `ReceiveWithAuthorization` |
+
+### SweepReceipt (0xA1)
+
+| Field     | Type   | Description |
+|-----------|--------|-------------|
+| version   | number | Always `1` |
+| authNonce | string | The SweepRequest's 3009 nonce |
+| status    | string | `submitted` \| `confirmed` \| `rejected` |
+| txHash    | string | Optional transaction hash (bytes32 hex) |
+| reason    | string | Optional human-readable rejection reason (≤256 chars) |
+
+Receipts are informational only. The buyer's source of truth is its on-chain
+Deposits balance; there is no response requirement, and buyers MUST tolerate
+receiving no receipts at all.
+
+## Typed data
+
+The buyer signs exactly one thing — the EIP-3009 authorization on the USDC
+domain (verified against the deployed token; Base mainnet is
+`{name: "USD Coin", version: "2"}`):
+
+```
+ReceiveWithAuthorization(address from,address to,uint256 value,
+  uint256 validAfter,uint256 validBefore,bytes32 nonce)
+```
+
+`to` MUST be the relay contract address. Because the authorization binds
+from/to/amount/validity/nonce and the relay's terms (FEE) are immutable,
+addressing it to the relay is complete consent — no second signature exists.
+
+## Relayer behavior (sellers, opt-out)
+
+On `SweepRequest`, in order:
+
+1. Drop unless `evmChainId` and `relayAddress` match the relayer's **own**
+   configuration — never submit to a peer-supplied contract address.
+2. Drop already-seen nonces (bounded LRU) and enforce per-peer rate limits
+   (default 6/min) and a global in-flight cap (default 2).
+3. Verify the 3009 signature locally and check the validity window.
+4. Simulate the call (`eth_estimateGas`); reject on any revert.
+5. Accept when `FEE - estimatedGasCostUsdc >= relayer.minProfitBaseUnits`
+   (default `"0"`; may be negative to relay at a loss, e.g. local testing
+   where anvil's gas price dwarfs the fee).
+6. Submit with the seller wallet; report `submitted` → `confirmed`/`rejected`.
+
+Losing the submission race (3009 nonce already consumed by another relayer) is
+normal: log and move on. The relayer is enabled by default for sellers and
+disabled with `relayer.enabled: false`.
+
+## Privacy note
+
+Broadcasting a sweep reveals the buyer address and amount to connected peers.
+The same data becomes public on-chain when the sweep lands; no additional
+mitigation is applied in v1.

--- a/packages/contracts/interfaces/IAntseedDepositRelay.sol
+++ b/packages/contracts/interfaces/IAntseedDepositRelay.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+interface IAntseedDepositRelay {
+    function sweepDeposit(
+        address from,
+        uint256 amount,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        bytes calldata sig3009
+    ) external;
+
+    function usdc() external view returns (address);
+    function deposits() external view returns (address);
+    function FEE() external view returns (uint256);
+}

--- a/packages/contracts/interfaces/IAntseedDeposits.sol
+++ b/packages/contracts/interfaces/IAntseedDeposits.sol
@@ -3,6 +3,13 @@ pragma solidity ^0.8.24;
 
 interface IAntseedDeposits {
     function usdc() external view returns (address);
+    function deposit(address buyer, uint256 amount) external;
+    function MIN_BUYER_DEPOSIT() external view returns (uint256);
+    function getBuyerCreditLimit(address buyer) external view returns (uint256);
+    function getBuyerBalance(address buyer)
+        external
+        view
+        returns (uint256 available, uint256 reserved, uint256 lastActivity);
     function lockForChannel(address buyer, uint256 amount) external;
     function chargeAndCreditPayouts(address buyer, address seller, uint256 amount, uint256 platformFee) external;
     function releaseLock(address buyer, uint256 amount) external;

--- a/packages/contracts/interfaces/IERC3009.sol
+++ b/packages/contracts/interfaces/IERC3009.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/**
+ * @title IERC3009
+ * @notice Minimal EIP-3009 surface used by AntseedDepositRelay.
+ *         Circle's FiatToken (USDC) implements this natively; the bytes-signature
+ *         overload is present in FiatTokenV2_2 (deployed on Base).
+ */
+interface IERC3009 {
+    function receiveWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        bytes calldata signature
+    ) external;
+}

--- a/packages/contracts/payments/AntseedDepositRelay.sol
+++ b/packages/contracts/payments/AntseedDepositRelay.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import {IAntseedDeposits} from "../interfaces/IAntseedDeposits.sol";
+import {IERC3009} from "../interfaces/IERC3009.sol";
+
+/**
+ * @title AntseedDepositRelay
+ * @notice Gasless USDC sweep from a buyer hot wallet into AntseedDeposits,
+ *         paid for in USDC by the buyer and executed by permissionless
+ *         relayers. Stateless periphery — holds no funds between transactions
+ *         (swappable tier, like AntseedChannels), fully immutable: no owner,
+ *         no tunable parameters.
+ *
+ *         Single-signature design: the buyer's EIP-3009 authorization is
+ *         addressed to this contract (`to = relay`), which IS the consent to
+ *         its public, immutable terms — the fixed FEE. No second signature,
+ *         and no governance that could change the fee after a user signed.
+ *
+ *         Flow (atomic — any failure reverts and funds never leave the buyer):
+ *           1. Pull `amount` USDC from the buyer via EIP-3009
+ *              receiveWithAuthorization (only this contract can redeem the
+ *              authorization; the 3009 nonce is replay-safe).
+ *           2. Credit `amount - FEE` to the BUYER's AntseedDeposits balance —
+ *              never a token transfer to the buyer address (iron rule: the
+ *              buyer hot wallet never receives funds).
+ *           3. Pay `FEE` to msg.sender (the relayer's compensation).
+ *
+ *         Front-running is harmless by design: a front-runner can only execute
+ *         the identical sweep and claim the fee; the buyer outcome is
+ *         unchanged.
+ */
+contract AntseedDepositRelay is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ─── State ───────────────────────────────────────────────────────
+    IERC20 public immutable usdc;
+    IAntseedDeposits public immutable deposits;
+
+    /// @notice Fixed relayer fee in USDC base units. Immutable — a signed
+    ///         authorization can never face different terms than it consented to.
+    uint256 public immutable FEE;
+
+    // ─── Events ──────────────────────────────────────────────────────
+    event SweepExecuted(
+        address indexed buyer,
+        address indexed relayer,
+        uint256 deposited,
+        uint256 fee,
+        bytes32 authNonce
+    );
+
+    // ─── Custom Errors ───────────────────────────────────────────────
+    error InvalidAddress();
+    error FeeExceedsAmount();
+    error NetBelowMinDeposit();
+    error NetExceedsCreditLimit();
+
+    // ─── Constructor ─────────────────────────────────────────────────
+    constructor(address _usdc, address _deposits, uint256 _fee) {
+        if (_usdc == address(0) || _deposits == address(0)) revert InvalidAddress();
+        usdc = IERC20(_usdc);
+        deposits = IAntseedDeposits(_deposits);
+        FEE = _fee;
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                              SWEEP
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Sweep `amount` USDC from `from` into their AntseedDeposits
+     *         balance, paying the fixed FEE to msg.sender. Anyone can call —
+     *         authorization comes from the buyer's EIP-3009 signature, which
+     *         is addressed to this contract and thereby consents to FEE.
+     * @param from        Buyer hot wallet the USDC is pulled from and credited to.
+     * @param amount      Total USDC pulled via EIP-3009 (FEE is taken from this).
+     * @param validAfter  EIP-3009 window start (exclusive).
+     * @param validBefore EIP-3009 window end (exclusive).
+     * @param nonce       EIP-3009 authorization nonce.
+     * @param sig3009     Buyer signature over the ReceiveWithAuthorization typed data.
+     */
+    function sweepDeposit(
+        address from,
+        uint256 amount,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        bytes calldata sig3009
+    ) external nonReentrant {
+        if (amount <= FEE) revert FeeExceedsAmount();
+        uint256 net = amount - FEE;
+
+        // Mirror the Deposits guards so relayers simulating the call get clear
+        // errors: MIN_BUYER_DEPOSIT applies only to a buyer's first deposit,
+        // and the credited balance may never exceed the buyer's credit limit.
+        (uint256 available, uint256 reserved, ) = deposits.getBuyerBalance(from);
+        uint256 balance = available + reserved;
+        if (balance == 0 && net < deposits.MIN_BUYER_DEPOSIT()) {
+            revert NetBelowMinDeposit();
+        }
+        if (balance + net > deposits.getBuyerCreditLimit(from)) {
+            revert NetExceedsCreditLimit();
+        }
+
+        // Interactions (trusted contracts only: USDC + Deposits).
+        IERC3009(address(usdc)).receiveWithAuthorization(
+            from, address(this), amount, validAfter, validBefore, nonce, sig3009
+        );
+
+        usdc.forceApprove(address(deposits), net);
+        deposits.deposit(from, net);
+
+        if (FEE > 0) {
+            usdc.safeTransfer(msg.sender, FEE);
+        }
+
+        emit SweepExecuted(from, msg.sender, net, FEE, nonce);
+    }
+}

--- a/packages/contracts/script/Deploy.s.sol
+++ b/packages/contracts/script/Deploy.s.sol
@@ -100,6 +100,19 @@ contract Deploy is Script {
         require(emissions != address(0), "Emissions deploy failed");
         console.log("AntseedEmissions:     ", emissions);
 
+        // 10. AntseedDepositRelay(usdc, deposits, FEE)
+        //     Keep this LAST among contract creations — the deterministic anvil
+        //     addresses of everything above (nonces 0-8) are hardcoded in
+        //     scripts/setup-local-test.sh and chain-config base-local.
+        bytes memory relayBytecode = abi.encodePacked(
+            vm.getCode("AntseedDepositRelay.sol:AntseedDepositRelay"),
+            abi.encode(usdc, deposits, uint256(50_000)) // fixed fee: $0.05
+        );
+        address depositRelay;
+        assembly { depositRelay := create(0, add(relayBytecode, 0x20), mload(relayBytecode)) }
+        require(depositRelay != address(0), "DepositRelay deploy failed");
+        console.log("AntseedDepositRelay:  ", depositRelay);
+
         // ---- Wire registry ----
         antseedRegistry.setChannels(channels);
         antseedRegistry.setStats(stats);

--- a/packages/contracts/test/AntseedDepositRelay.t.sol
+++ b/packages/contracts/test/AntseedDepositRelay.t.sol
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import {AntseedDepositRelay} from "../payments/AntseedDepositRelay.sol";
+import {AntseedDeposits} from "../payments/AntseedDeposits.sol";
+import {MockUSDC} from "./mocks/MockUSDC.sol";
+
+contract AntseedDepositRelayTest is Test {
+    uint256 constant BUYER_PK = 0xA11CE;
+    uint256 constant RANDOM_PK = 0xDEAD;
+
+    address buyer;
+    address relayer = address(0xBEEF);
+    address frontRunner = address(0xF00D);
+
+    MockUSDC usdc;
+    AntseedDeposits deposits;
+    AntseedDepositRelay relay;
+
+    uint256 constant MIN_DEPOSIT = 1_000_000; // Deposits default
+    uint256 constant FEE = 50_000; // deploy-time fixed fee ($0.05)
+
+    function setUp() public {
+        buyer = vm.addr(BUYER_PK);
+
+        usdc = new MockUSDC();
+        deposits = new AntseedDeposits(address(usdc));
+        relay = new AntseedDepositRelay(address(usdc), address(deposits), FEE);
+
+        usdc.mint(buyer, 100_000_000); // 100 USDC in the hot wallet
+        vm.warp(1_700_000_000);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────
+
+    function _sign3009(
+        uint256 pk,
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce
+    ) internal view returns (bytes memory) {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                usdc.DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(
+                        usdc.RECEIVE_WITH_AUTHORIZATION_TYPEHASH(), from, to, value, validAfter, validBefore, nonce
+                    )
+                )
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    /// @dev Signs the authorization with default validity window and submits as `submitter`.
+    function _sweep(address submitter, uint256 amount, bytes32 nonce) internal {
+        uint256 validAfter = block.timestamp - 60;
+        uint256 validBefore = block.timestamp + 3600;
+        bytes memory sig3009 = _sign3009(BUYER_PK, buyer, address(relay), amount, validAfter, validBefore, nonce);
+        vm.prank(submitter);
+        relay.sweepDeposit(buyer, amount, validAfter, validBefore, nonce, sig3009);
+    }
+
+    function _buyerDepositBalance() internal view returns (uint256) {
+        (uint256 available,,) = deposits.getBuyerBalance(buyer);
+        return available;
+    }
+
+    // ─── Happy path ──────────────────────────────────────────────────
+
+    function test_sweep_happyPath_exactFixedFeeAccounting() public {
+        uint256 amount = 5_000_000; // 5 USDC
+
+        vm.expectEmit(true, true, false, true, address(relay));
+        emit AntseedDepositRelay.SweepExecuted(buyer, relayer, amount - FEE, FEE, bytes32(uint256(1)));
+        _sweep(relayer, amount, bytes32(uint256(1)));
+
+        assertEq(_buyerDepositBalance(), amount - FEE, "buyer credited exactly amount - FEE");
+        assertEq(usdc.balanceOf(relayer), FEE, "relayer got exactly FEE");
+        assertEq(usdc.balanceOf(buyer), 100_000_000 - amount, "hot wallet debited");
+        assertEq(usdc.balanceOf(address(relay)), 0, "relay holds nothing");
+        assertEq(usdc.allowance(address(relay), address(deposits)), 0, "allowance fully consumed");
+    }
+
+    function test_sweep_feeIsImmutablePublicTerm() public view {
+        assertEq(relay.FEE(), FEE);
+    }
+
+    function test_sweep_zeroFeeDeployment() public {
+        AntseedDepositRelay freeRelay = new AntseedDepositRelay(address(usdc), address(deposits), 0);
+        uint256 amount = 5_000_000;
+        uint256 validAfter = block.timestamp - 60;
+        uint256 validBefore = block.timestamp + 3600;
+        bytes memory sig3009 =
+            _sign3009(BUYER_PK, buyer, address(freeRelay), amount, validAfter, validBefore, bytes32(uint256(2)));
+
+        vm.prank(relayer);
+        freeRelay.sweepDeposit(buyer, amount, validAfter, validBefore, bytes32(uint256(2)), sig3009);
+
+        assertEq(_buyerDepositBalance(), amount, "full amount credited");
+        assertEq(usdc.balanceOf(relayer), 0, "no fee transferred");
+    }
+
+    function test_sweep_frontRunnerGetsFee_buyerOutcomeUnchanged() public {
+        // Whoever submits first wins the fee; the buyer is credited identically.
+        _sweep(frontRunner, 5_000_000, bytes32(uint256(4)));
+
+        assertEq(usdc.balanceOf(frontRunner), FEE);
+        assertEq(usdc.balanceOf(relayer), 0);
+        assertEq(_buyerDepositBalance(), 5_000_000 - FEE);
+    }
+
+    function test_sweep_topUpBelowMinWithExistingBalance() public {
+        _sweep(relayer, 5_000_000, bytes32(uint256(5)));
+
+        // 0.5 USDC top-up is fine once the buyer has a balance.
+        _sweep(relayer, 500_000, bytes32(uint256(6)));
+
+        assertEq(_buyerDepositBalance(), 5_000_000 - FEE + 500_000 - FEE);
+    }
+
+    // ─── Reverts ─────────────────────────────────────────────────────
+
+    function test_sweep_revertsWhenExpired() public {
+        bytes32 nonce = bytes32(uint256(7));
+        uint256 validAfter = block.timestamp - 3600;
+        uint256 validBefore = block.timestamp; // now >= validBefore
+        bytes memory sig3009 =
+            _sign3009(BUYER_PK, buyer, address(relay), 5_000_000, validAfter, validBefore, nonce);
+
+        vm.prank(relayer);
+        vm.expectRevert(MockUSDC.AuthorizationExpired.selector);
+        relay.sweepDeposit(buyer, 5_000_000, validAfter, validBefore, nonce, sig3009);
+    }
+
+    function test_sweep_revertsWhenNotYetValid() public {
+        bytes32 nonce = bytes32(uint256(8));
+        uint256 validAfter = block.timestamp + 600;
+        uint256 validBefore = block.timestamp + 3600;
+        bytes memory sig3009 =
+            _sign3009(BUYER_PK, buyer, address(relay), 5_000_000, validAfter, validBefore, nonce);
+
+        vm.prank(relayer);
+        vm.expectRevert(MockUSDC.AuthorizationNotYetValid.selector);
+        relay.sweepDeposit(buyer, 5_000_000, validAfter, validBefore, nonce, sig3009);
+    }
+
+    function test_sweep_revertsOnReplayedNonce() public {
+        _sweep(relayer, 5_000_000, bytes32(uint256(9)));
+
+        uint256 validAfter = block.timestamp - 60;
+        uint256 validBefore = block.timestamp + 3600;
+        bytes memory sig3009 = _sign3009(
+            BUYER_PK, buyer, address(relay), 5_000_000, validAfter, validBefore, bytes32(uint256(9))
+        );
+
+        vm.prank(relayer);
+        vm.expectRevert(MockUSDC.AuthorizationAlreadyUsed.selector);
+        relay.sweepDeposit(buyer, 5_000_000, validAfter, validBefore, bytes32(uint256(9)), sig3009);
+    }
+
+    function test_sweep_revertsOnWrong3009Signer() public {
+        bytes32 nonce = bytes32(uint256(10));
+        uint256 validAfter = block.timestamp - 60;
+        uint256 validBefore = block.timestamp + 3600;
+        bytes memory sig3009 =
+            _sign3009(RANDOM_PK, buyer, address(relay), 5_000_000, validAfter, validBefore, nonce);
+
+        vm.prank(relayer);
+        vm.expectRevert(MockUSDC.InvalidAuthorizationSignature.selector);
+        relay.sweepDeposit(buyer, 5_000_000, validAfter, validBefore, nonce, sig3009);
+    }
+
+    function test_sweep_revertsWhenAmountNotAboveFee() public {
+        // amount == FEE and amount < FEE both revert
+        for (uint256 amount = FEE - 1; amount <= FEE; amount++) {
+            bytes32 nonce = bytes32(uint256(1000) + amount);
+            uint256 validAfter = block.timestamp - 60;
+            uint256 validBefore = block.timestamp + 3600;
+            bytes memory sig3009 =
+                _sign3009(BUYER_PK, buyer, address(relay), amount, validAfter, validBefore, nonce);
+
+            vm.prank(relayer);
+            vm.expectRevert(AntseedDepositRelay.FeeExceedsAmount.selector);
+            relay.sweepDeposit(buyer, amount, validAfter, validBefore, nonce, sig3009);
+        }
+    }
+
+    function test_sweep_revertsOnFirstDepositBelowMin() public {
+        // net = 1_000_000 - FEE < MIN_BUYER_DEPOSIT for a first-time buyer
+        bytes32 nonce = bytes32(uint256(14));
+        uint256 validAfter = block.timestamp - 60;
+        uint256 validBefore = block.timestamp + 3600;
+        bytes memory sig3009 =
+            _sign3009(BUYER_PK, buyer, address(relay), 1_000_000, validAfter, validBefore, nonce);
+
+        vm.prank(relayer);
+        vm.expectRevert(AntseedDepositRelay.NetBelowMinDeposit.selector);
+        relay.sweepDeposit(buyer, 1_000_000, validAfter, validBefore, nonce, sig3009);
+
+        assertEq(usdc.balanceOf(buyer), 100_000_000, "funds never left the buyer");
+    }
+
+    function test_sweep_firstDepositExactlyAtMinSucceeds() public {
+        // net == MIN_BUYER_DEPOSIT exactly
+        _sweep(relayer, MIN_DEPOSIT + FEE, bytes32(uint256(15)));
+        assertEq(_buyerDepositBalance(), MIN_DEPOSIT);
+    }
+
+    function test_sweep_revertsWhenNetExceedsCreditLimit() public {
+        // Default credit limit is 10 USDC; a 20 USDC sweep must revert whole
+        // with the relay's own mirror error (clear for simulating relayers).
+        bytes32 nonce = bytes32(uint256(16));
+        uint256 validAfter = block.timestamp - 60;
+        uint256 validBefore = block.timestamp + 3600;
+        bytes memory sig3009 =
+            _sign3009(BUYER_PK, buyer, address(relay), 20_000_000, validAfter, validBefore, nonce);
+
+        vm.prank(relayer);
+        vm.expectRevert(AntseedDepositRelay.NetExceedsCreditLimit.selector);
+        relay.sweepDeposit(buyer, 20_000_000, validAfter, validBefore, nonce, sig3009);
+
+        assertEq(usdc.balanceOf(buyer), 100_000_000, "funds never left the buyer");
+        assertEq(_buyerDepositBalance(), 0);
+    }
+
+    function test_sweep_netExactlyAtCreditLimitSucceeds() public {
+        // Deposits allows balance + amount == limit; the relay must mirror
+        // the same boundary (> reverts, == succeeds).
+        uint256 limit = deposits.getBuyerCreditLimit(buyer);
+        _sweep(relayer, limit + FEE, bytes32(uint256(17)));
+        assertEq(_buyerDepositBalance(), limit);
+    }
+
+    function test_sweep_topUpRespectsExistingBalanceInLimitCheck() public {
+        // Fill to the limit, then any further top-up must revert.
+        uint256 limit = deposits.getBuyerCreditLimit(buyer);
+        _sweep(relayer, limit + FEE, bytes32(uint256(18)));
+
+        bytes32 nonce = bytes32(uint256(19));
+        uint256 validAfter = block.timestamp - 60;
+        uint256 validBefore = block.timestamp + 3600;
+        bytes memory sig3009 =
+            _sign3009(BUYER_PK, buyer, address(relay), 500_000, validAfter, validBefore, nonce);
+
+        vm.prank(relayer);
+        vm.expectRevert(AntseedDepositRelay.NetExceedsCreditLimit.selector);
+        relay.sweepDeposit(buyer, 500_000, validAfter, validBefore, nonce, sig3009);
+    }
+
+    function test_constructor_rejectsZeroAddresses() public {
+        vm.expectRevert(AntseedDepositRelay.InvalidAddress.selector);
+        new AntseedDepositRelay(address(0), address(deposits), FEE);
+        vm.expectRevert(AntseedDepositRelay.InvalidAddress.selector);
+        new AntseedDepositRelay(address(usdc), address(0), FEE);
+    }
+
+    // ─── Fuzz ────────────────────────────────────────────────────────
+
+    function testFuzz_sweep_conservation(uint256 amount, bytes32 nonce) public {
+        amount = bound(amount, MIN_DEPOSIT + FEE, 10_000_000); // net >= MIN, within credit limit
+        vm.assume(nonce != bytes32(0));
+
+        _sweep(relayer, amount, nonce);
+
+        assertEq(_buyerDepositBalance(), amount - FEE);
+        assertEq(usdc.balanceOf(relayer), FEE);
+        assertEq(usdc.balanceOf(address(relay)), 0, "relay never retains funds");
+        assertEq(usdc.balanceOf(buyer) + amount, 100_000_000);
+    }
+}

--- a/packages/contracts/test/mocks/MockUSDC.sol
+++ b/packages/contracts/test/mocks/MockUSDC.sol
@@ -4,23 +4,38 @@ pragma solidity ^0.8.24;
 /**
  * @title MockUSDC
  * @notice Minimal ERC20 used for local integration tests and examples.
+ *         Implements the EIP-3009 receiveWithAuthorization (bytes-signature
+ *         overload) with the same EIP-712 domain params as Circle's USDC
+ *         (name "USD Coin", version "2") so off-chain signing code behaves
+ *         identically against base-local and base-mainnet.
  */
 contract MockUSDC {
-    string public constant name = "Mock USD Coin";
+    string public constant name = "USD Coin";
     string public constant symbol = "USDC";
     uint8 public constant decimals = 6;
+
+    bytes32 public constant RECEIVE_WITH_AUTHORIZATION_TYPEHASH = keccak256(
+        "ReceiveWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+    );
 
     uint256 public totalSupply;
 
     mapping(address => uint256) public balanceOf;
     mapping(address => mapping(address => uint256)) public allowance;
+    mapping(address => mapping(bytes32 => bool)) public authorizationState;
 
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner, address indexed spender, uint256 value);
+    event AuthorizationUsed(address indexed authorizer, bytes32 indexed nonce);
 
     error InsufficientBalance();
     error InsufficientAllowance();
     error InvalidAddress();
+    error CallerMustBePayee();
+    error AuthorizationNotYetValid();
+    error AuthorizationExpired();
+    error AuthorizationAlreadyUsed();
+    error InvalidAuthorizationSignature();
 
     function mint(address to, uint256 amount) external {
         if (to == address(0)) revert InvalidAddress();
@@ -60,5 +75,58 @@ contract MockUSDC {
         balanceOf[from] -= amount;
         balanceOf[to] += amount;
         emit Transfer(from, to, amount);
+    }
+
+    // ─── EIP-3009 (receive-only subset, mirrors FiatTokenV2_2 semantics) ──
+
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes(name)),
+                keccak256(bytes("2")),
+                block.chainid,
+                address(this)
+            )
+        );
+    }
+
+    function receiveWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        bytes calldata signature
+    ) external {
+        if (to != msg.sender) revert CallerMustBePayee();
+        if (block.timestamp <= validAfter) revert AuthorizationNotYetValid();
+        if (block.timestamp >= validBefore) revert AuthorizationExpired();
+        if (authorizationState[from][nonce]) revert AuthorizationAlreadyUsed();
+
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(RECEIVE_WITH_AUTHORIZATION_TYPEHASH, from, to, value, validAfter, validBefore, nonce)
+                )
+            )
+        );
+        if (_recover(digest, signature) != from) revert InvalidAuthorizationSignature();
+
+        authorizationState[from][nonce] = true;
+        emit AuthorizationUsed(from, nonce);
+
+        _transfer(from, to, value);
+    }
+
+    function _recover(bytes32 digest, bytes calldata signature) private pure returns (address) {
+        if (signature.length != 65) return address(0);
+        bytes32 r = bytes32(signature[0:32]);
+        bytes32 s = bytes32(signature[32:64]);
+        uint8 v = uint8(signature[64]);
+        return ecrecover(digest, v, r, s);
     }
 }

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -29,7 +29,10 @@ import { bytesToHex } from "../utils/hex.js";
 import type { StakingClient } from "../payments/evm/staking-client.js";
 import type { ChannelsClient } from "../payments/evm/channels-client.js";
 import type { DHTHealthMonitor } from "./dht-health.js";
-import { CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 } from "../types/protocol.js";
+import {
+  CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1,
+  CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+} from "../types/protocol.js";
 
 export interface SellerContractConfig {
   /**
@@ -83,6 +86,8 @@ export interface AnnouncerConfig {
    * `sellerContract.isOperator(peerAddress)`.
    */
   sellerContract?: SellerContractConfig;
+  /** Whether this seller currently supports buyer deposit sweep relaying. */
+  relaysSweeps?: boolean;
 }
 
 /**
@@ -271,13 +276,18 @@ export class PeerAnnouncer {
       return providerAnnouncement;
     });
 
+    const capabilities: string[] = [CONNECTION_CAPABILITY_RESPONSE_AUTH_V1];
+    if (this.config.relaysSweeps) {
+      capabilities.push(CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1);
+    }
+
     const metadata: PeerMetadata = {
       peerId: this.config.identity.peerId,
       version: METADATA_VERSION,
       ...(this.config.displayName ? { displayName: this.config.displayName } : {}),
       ...(this.config.publicAddress ? { publicAddress: this.config.publicAddress } : {}),
       providers,
-      capabilities: [CONNECTION_CAPABILITY_RESPONSE_AUTH_V1],
+      capabilities,
       region: this.config.region,
       timestamp: Date.now(),
       signature: "",

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -77,6 +77,7 @@ export {
   type DepositRelayClientConfig,
   type SweepParams,
   type SweepProfitEstimate,
+  type SweepEventConfirmation,
 } from './payments/evm/deposit-relay-client.js';
 export { DepositRelayer, type DepositRelayerConfig, type SweepHandleResult } from './payments/deposit-relayer.js';
 export { ChannelsClient, type ChannelsClientConfig, type ChannelInfo, type AgentStats } from './payments/evm/channels-client.js';

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -3,6 +3,7 @@ export {
   AntseedNode,
   type NodeConfig,
   type NodePaymentsConfig,
+  type NodeRelayerConfig,
   type RequestStreamCallbacks,
   type RequestStreamResponseMetadata,
   type BuyerUsageTotals,
@@ -71,6 +72,13 @@ export { parsePublicAddress, MAX_PUBLIC_ADDRESS_LENGTH, type ParsedPublicAddress
 export { MeteringStorage } from './metering/storage.js';
 export { BalanceManager } from './payments/balance-manager.js';
 export { DepositsClient, type DepositsClientConfig, type BuyerBalanceInfo } from './payments/evm/deposits-client.js';
+export {
+  DepositRelayClient,
+  type DepositRelayClientConfig,
+  type SweepParams,
+  type SweepProfitEstimate,
+} from './payments/evm/deposit-relay-client.js';
+export { DepositRelayer, type DepositRelayerConfig, type SweepHandleResult } from './payments/deposit-relayer.js';
 export { ChannelsClient, type ChannelsClientConfig, type ChannelInfo, type AgentStats } from './payments/evm/channels-client.js';
 export {
   FreeUsageClient,
@@ -98,14 +106,17 @@ export {
   signFreeUsageOpen,
   signFreeUsageAuth,
   signSetOperator,
+  buildReceiveAuthorization,
   makeChannelsDomain,
   makeDepositsDomain,
   makeFreeUsageDomain,
+  makeUsdcDomain,
   SPENDING_AUTH_TYPES,
   RESERVE_AUTH_TYPES,
   FREE_USAGE_OPEN_TYPES,
   FREE_USAGE_AUTH_TYPES,
   SET_OPERATOR_TYPES,
+  RECEIVE_WITH_AUTHORIZATION_TYPES,
   computeMetadataHash,
   encodeMetadata,
   computeFreeUsageMetadataHash,
@@ -125,6 +136,8 @@ export type {
   SetOperatorMessage,
   FreeUsageOpenMessage,
   FreeUsageAuthMessage,
+  ReceiveAuthorizationMessage,
+  SignedReceiveAuthorization,
   SpendingAuthMetadata,
   SpendingAuthServiceMetadata,
   FreeUsageMetadata,
@@ -145,6 +158,8 @@ export { getChainConfig, resolveChainConfig, DEFAULT_CHAIN_ID, CHAIN_CONFIGS } f
 export type { ChainConfig } from './payments/chain-config.js';
 export { formatUsdc, parseUsdc } from './payments/usdc-utils.js';
 export { ProxyMux } from './proxy/proxy-mux.js';
+export { SweepMux, type SweepMessageHandler } from './p2p/sweep-mux.js';
+export { encodeSweepRequest, decodeSweepRequest, encodeSweepReceipt, decodeSweepReceipt } from './p2p/sweep-codec.js';
 export {
   VerificationMux,
   VerificationSampler,

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -50,7 +50,11 @@ import { PaymentMux } from "./p2p/payment-mux.js";
 import { SweepMux } from "./p2p/sweep-mux.js";
 import { VerificationMux } from "./verification/verification-mux.js";
 import { DepositRelayer } from "./payments/deposit-relayer.js";
-import type { SweepRequestPayload, SweepReceiptPayload } from "./types/protocol.js";
+import {
+  CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1,
+  type SweepRequestPayload,
+  type SweepReceiptPayload,
+} from "./types/protocol.js";
 import { VerificationStorage } from "./verification/storage.js";
 import { VerificationSampler } from "./verification/samples.js";
 import { FrameDecoder, encodeFrame } from "./p2p/message-protocol.js";
@@ -286,6 +290,7 @@ export class AntseedNode extends EventEmitter {
   private _paymentMuxes = new Map<PeerId, PaymentMux>();
   private _verificationMuxes = new Map<PeerId, VerificationMux>();
   private _sweepMuxes = new Map<PeerId, SweepMux>();
+  private _peerCapabilities = new Map<PeerId, Set<string>>();
   /** Seller-side deposit-sweep relayer (initialized when configured + enabled). */
   private _depositRelayer: DepositRelayer | null = null;
   /** Seller-side request handler (provider matching, execution, load tracking). */
@@ -488,6 +493,7 @@ export class AntseedNode extends EventEmitter {
     // Close all proxy muxes
     this._muxes.clear();
     this._paymentMuxes.clear();
+    this._peerCapabilities.clear();
     for (const verificationMux of this._verificationMuxes.values()) {
       verificationMux.close();
     }
@@ -1256,6 +1262,7 @@ export class AntseedNode extends EventEmitter {
         this._muxes.get(peerId)?.abortPendingUploads();
         this._muxes.delete(peerId);
         this._paymentMuxes.delete(peerId);
+        this._peerCapabilities.delete(peerId);
         this._verificationMuxes.get(peerId)?.close();
         this._verificationMuxes.delete(peerId);
         this._sweepMuxes.delete(peerId);
@@ -1424,6 +1431,7 @@ export class AntseedNode extends EventEmitter {
         ...(this._channelsClient ? { channelsClient: this._channelsClient } : {}),
         ...(this._stakingClient ? { stakingClient: this._stakingClient, paymentsEnabled: true } : {}),
         ...(this._config.sellerContract ? { sellerContract: this._config.sellerContract } : {}),
+        ...(this._depositRelayer ? { relaysSweeps: true } : {}),
       };
       this._announcer = new PeerAnnouncer(announcerConfig);
       this._announcer.startPeriodicAnnounce();
@@ -1848,6 +1856,8 @@ export class AntseedNode extends EventEmitter {
     }
 
     const existing = this._connectionManager.getConnection(peer.peerId);
+    const peerCapabilities = new Set(peer.capabilities ?? peer.metadata?.capabilities ?? []);
+    this._peerCapabilities.set(peer.peerId, peerCapabilities);
     let endpointChanged = false;
 
     // Check if the peer's endpoint has changed (e.g. IP rotation).
@@ -1860,6 +1870,7 @@ export class AntseedNode extends EventEmitter {
       if (currentEndpoint && (currentEndpoint.host !== newHost || currentEndpoint.port !== newPort)) {
         debugLog(`[Node] Peer ${peer.peerId.slice(0, 12)}... endpoint changed from ${currentEndpoint.host}:${currentEndpoint.port} to ${newHost}:${newPort}, reconnecting`);
         existing.close();
+        this._peerCapabilities.set(peer.peerId, peerCapabilities);
         endpointChanged = true;
       }
     }
@@ -1921,6 +1932,7 @@ export class AntseedNode extends EventEmitter {
     });
 
     debugLog(`[Node] Connected to ${peer.peerId.slice(0, 12)}...`);
+    this._peerCapabilities.set(peer.peerId, peerCapabilities);
     this._wireConnection(conn, peer.peerId);
     return conn;
   }
@@ -1975,6 +1987,8 @@ export class AntseedNode extends EventEmitter {
     }
     let sent = 0;
     for (const peerId of this._muxes.keys()) {
+      const capabilities = this._peerCapabilities.get(peerId);
+      if (!capabilities?.has(CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1)) continue;
       const conn = this._connectionManager.getConnection(peerId);
       if (!conn) continue;
       if (conn.state !== ConnectionState.Open && conn.state !== ConnectionState.Authenticated) continue;

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -47,7 +47,10 @@ import {
 import { HttpMetadataResolver } from "./discovery/http-metadata-resolver.js";
 import { ProxyMux } from "./proxy/proxy-mux.js";
 import { PaymentMux } from "./p2p/payment-mux.js";
+import { SweepMux } from "./p2p/sweep-mux.js";
 import { VerificationMux } from "./verification/verification-mux.js";
+import { DepositRelayer } from "./payments/deposit-relayer.js";
+import type { SweepRequestPayload, SweepReceiptPayload } from "./types/protocol.js";
 import { VerificationStorage } from "./verification/storage.js";
 import { VerificationSampler } from "./verification/samples.js";
 import { FrameDecoder, encodeFrame } from "./p2p/message-protocol.js";
@@ -155,6 +158,20 @@ export interface NodePaymentsConfig {
   maxReserveAmountUsdc?: string;
   /** Disable per-service buyer attribution in metadata v2. Default: false. */
   disableMetadataV2Services?: boolean;
+  /** Deployed AntseedDepositRelay contract address (gasless deposit sweeps). */
+  depositRelayAddress?: string;
+}
+
+export interface NodeRelayerConfig {
+  /** Relay buyer deposit sweeps with the seller wallet. Default: true (opt-out). */
+  enabled?: boolean;
+  /** Minimum acceptable profit (FEE - estimated gas cost) in USDC base units.
+   *  May be negative to relay at a loss (local testing). Default: "0". */
+  minProfitBaseUnits?: string;
+  /** Max concurrent sweep submissions. Default: 2. */
+  maxInFlight?: number;
+  /** Max sweep requests accepted per peer per minute. Default: 6. */
+  maxPerPeerPerMinute?: number;
 }
 
 export interface NodeVerificationConfig {
@@ -195,6 +212,8 @@ export interface NodeConfig {
   dhtOperationTimeoutMs?: number;
   /** Optional seller-side payment runtime wiring. */
   payments?: NodePaymentsConfig;
+  /** Seller-side deposit-sweep relayer settings (opt-out, ON by default). */
+  relayer?: NodeRelayerConfig;
   /** Optional buyer-side verification storage and sampling settings. */
   verification?: NodeVerificationConfig;
   /** Pluggable identity storage backend. When set, takes precedence over dataDir for identity loading. */
@@ -266,6 +285,9 @@ export class AntseedNode extends EventEmitter {
   private _identityClient: IdentityClient | null = null;
   private _paymentMuxes = new Map<PeerId, PaymentMux>();
   private _verificationMuxes = new Map<PeerId, VerificationMux>();
+  private _sweepMuxes = new Map<PeerId, SweepMux>();
+  /** Seller-side deposit-sweep relayer (initialized when configured + enabled). */
+  private _depositRelayer: DepositRelayer | null = null;
   /** Seller-side request handler (provider matching, execution, load tracking). */
   private _sellerHandler: SellerRequestHandler | null = null;
   /** Buyer-side payment manager (initialized when buyer has payment config). */
@@ -1177,6 +1199,7 @@ export class AntseedNode extends EventEmitter {
       const proxyMux = this._muxes.get(peerId);
       const paymentMux = this._paymentMuxes.get(peerId);
       const verificationMux = this._verificationMuxes.get(peerId);
+      const sweepMux = this._sweepMuxes.get(peerId);
       for (const frame of frames) {
         // Keepalive: respond to Ping, dispatch Pong to manager
         if (frame.type === MessageType.Ping) {
@@ -1202,6 +1225,11 @@ export class AntseedNode extends EventEmitter {
           verificationMux.handleFrame(frame).catch((err) => {
             const message = err instanceof Error ? err.message : String(err);
             debugWarn(`[Node] Failed to handle verification frame from ${peerId.slice(0, 12)}...: ${message}`);
+          });
+        } else if (sweepMux && SweepMux.isSweepMessage(frame.type)) {
+          sweepMux.handleFrame(frame).catch((err) => {
+            const message = err instanceof Error ? err.message : String(err);
+            debugWarn(`[Node] Failed to handle sweep frame from ${peerId.slice(0, 12)}...: ${message}`);
           });
         } else if (proxyMux) {
           proxyMux.handleFrame(frame).catch((err) => {
@@ -1230,6 +1258,7 @@ export class AntseedNode extends EventEmitter {
         this._paymentMuxes.delete(peerId);
         this._verificationMuxes.get(peerId)?.close();
         this._verificationMuxes.delete(peerId);
+        this._sweepMuxes.delete(peerId);
         this._decoders.delete(peerId);
         // Clean up buyer-side payment state on disconnect
         this._buyerNegotiator?.onPeerDisconnect(peerId);
@@ -1581,6 +1610,18 @@ export class AntseedNode extends EventEmitter {
     this._paymentMuxes.set(buyerPeerId, paymentMux);
     this._verificationMuxes.set(buyerPeerId, verificationMux);
 
+    // Deposit-sweep relaying (seller side, opt-out)
+    const sweepMux = new SweepMux(conn);
+    if (this._depositRelayer) {
+      const relayer = this._depositRelayer;
+      sweepMux.onSweepRequest((payload) => {
+        void relayer.handleSweepRequest(buyerPeerId, payload, sweepMux).catch((err) => {
+          debugWarn(`[Node] Sweep relay handler error for ${buyerPeerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
+        });
+      });
+    }
+    this._sweepMuxes.set(buyerPeerId, sweepMux);
+
     const { mux } = this._sellerHandler!.handleConnection(conn, buyerPeerId, paymentMux, verificationMux);
 
     this._muxes.set(buyerPeerId, mux);
@@ -1724,6 +1765,26 @@ export class AntseedNode extends EventEmitter {
       };
       this._sellerPaymentManager = new SellerPaymentManager(this._identity, sellerConfig, this._channelStore);
       debugLog(`[Node] SellerPaymentManager initialized`);
+
+      // Deposit-sweep relayer (opt-out — ON by default when the chain has a relay)
+      const relayerConfig = this._config.relayer;
+      if (relayerConfig?.enabled !== false && payments.depositRelayAddress && payments.usdcAddress) {
+        this._depositRelayer = new DepositRelayer(this._identity, {
+          rpcUrl: payments.rpcUrl,
+          ...(fallbackRpcUrls ? { fallbackRpcUrls } : {}),
+          relayAddress: payments.depositRelayAddress,
+          usdcAddress: payments.usdcAddress,
+          evmChainId: payments.chainId ?? 8453,
+          ...(relayerConfig?.minProfitBaseUnits !== undefined
+            ? { minProfitBaseUnits: BigInt(relayerConfig.minProfitBaseUnits) }
+            : {}),
+          ...(relayerConfig?.maxInFlight !== undefined ? { maxInFlight: relayerConfig.maxInFlight } : {}),
+          ...(relayerConfig?.maxPerPeerPerMinute !== undefined
+            ? { maxPerPeerPerMinute: relayerConfig.maxPerPeerPerMinute }
+            : {}),
+        });
+        debugLog(`[Node] DepositRelayer initialized (relay=${payments.depositRelayAddress.slice(0, 10)}...)`);
+      }
 
       // Startup recovery: validate hydrated channels against on-chain state, then check timeouts
       await this._sellerPaymentManager.validateHydratedChannels();
@@ -1886,6 +1947,45 @@ export class AntseedNode extends EventEmitter {
     const mux = new VerificationMux(conn);
     this._verificationMuxes.set(peerId, mux);
     return mux;
+  }
+
+  private _getOrCreateSweepMux(peerId: PeerId, conn: PeerConnection): SweepMux {
+    const existing = this._sweepMuxes.get(peerId);
+    if (existing) {
+      return existing;
+    }
+
+    const mux = new SweepMux(conn);
+    // Buyer side: surface relayer progress reports as node events.
+    mux.onSweepReceipt((payload: SweepReceiptPayload) => {
+      this.emit('sweep:receipt', { peerId, payload });
+    });
+    this._sweepMuxes.set(peerId, mux);
+    return mux;
+  }
+
+  /**
+   * Broadcast a signed deposit-sweep request to all currently connected peers.
+   * Relayers submit it on-chain permissionlessly; progress reports arrive as
+   * 'sweep:receipt' events. Returns the number of peers the request was sent to.
+   */
+  broadcastSweepRequest(payload: SweepRequestPayload): number {
+    if (!this._connectionManager) {
+      throw new Error('Node not started');
+    }
+    let sent = 0;
+    for (const peerId of this._muxes.keys()) {
+      const conn = this._connectionManager.getConnection(peerId);
+      if (!conn) continue;
+      if (conn.state !== ConnectionState.Open && conn.state !== ConnectionState.Authenticated) continue;
+      try {
+        this._getOrCreateSweepMux(peerId, conn).sendSweepRequest(payload);
+        sent++;
+      } catch (err) {
+        debugWarn(`[Node] Failed to send sweep request to ${peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
+      }
+    }
+    return sent;
   }
 
   private _resolvePublicAddress(result: LookupResult): string {

--- a/packages/node/src/p2p/sweep-codec.ts
+++ b/packages/node/src/p2p/sweep-codec.ts
@@ -1,0 +1,83 @@
+import type { SweepRequestPayload, SweepReceiptPayload, SweepReceiptStatus } from '../types/protocol.js';
+import { parseJsonObject, requireStringField, requireFiniteNumberField } from '../utils/json-codec.js';
+
+const encoder = new TextEncoder();
+
+// Sweep payloads are small and fixed-shape; cap well below the payment codec.
+const MAX_PAYLOAD_SIZE = 8192; // 8KB
+
+const ADDRESS_RE = /^0x[0-9a-fA-F]{40}$/;
+const BYTES32_RE = /^0x[0-9a-fA-F]{64}$/;
+const SIGNATURE_RE = /^0x[0-9a-fA-F]{130}$/; // 65-byte r||s||v
+const UINT256_DECIMAL_RE = /^[0-9]{1,78}$/;
+
+const RECEIPT_STATUSES: readonly SweepReceiptStatus[] = ['submitted', 'confirmed', 'rejected'];
+
+function parseSweepJson(data: Uint8Array): Record<string, unknown> {
+  return parseJsonObject(data, {
+    maxBytes: MAX_PAYLOAD_SIZE,
+    payloadName: 'Sweep payload',
+  });
+}
+
+function requirePatternField(obj: Record<string, unknown>, field: string, re: RegExp, kind: string): string {
+  const value = requireStringField(obj, field);
+  if (!re.test(value)) {
+    throw new Error(`Sweep payload field "${field}" is not a valid ${kind}`);
+  }
+  return value;
+}
+
+// --- Encoders ---
+
+export function encodeSweepRequest(payload: SweepRequestPayload): Uint8Array {
+  return encoder.encode(JSON.stringify(payload));
+}
+
+export function encodeSweepReceipt(payload: SweepReceiptPayload): Uint8Array {
+  return encoder.encode(JSON.stringify(payload));
+}
+
+// --- Decoders (with runtime validation — payloads are untrusted peer input) ---
+
+export function decodeSweepRequest(data: Uint8Array): SweepRequestPayload {
+  const obj = parseSweepJson(data);
+  if (obj.version !== 1) {
+    throw new Error('Unsupported sweep request version');
+  }
+  const validAfter = requireFiniteNumberField(obj, 'validAfter');
+  const validBefore = requireFiniteNumberField(obj, 'validBefore');
+  if (validAfter < 0 || validBefore <= 0) {
+    throw new Error('Sweep payload validity window out of range');
+  }
+  return {
+    version: 1,
+    evmChainId: requireFiniteNumberField(obj, 'evmChainId'),
+    relayAddress: requirePatternField(obj, 'relayAddress', ADDRESS_RE, 'address'),
+    from: requirePatternField(obj, 'from', ADDRESS_RE, 'address'),
+    amount: requirePatternField(obj, 'amount', UINT256_DECIMAL_RE, 'uint256 decimal string'),
+    validAfter,
+    validBefore,
+    nonce: requirePatternField(obj, 'nonce', BYTES32_RE, 'bytes32'),
+    sig3009: requirePatternField(obj, 'sig3009', SIGNATURE_RE, 'signature'),
+  };
+}
+
+export function decodeSweepReceipt(data: Uint8Array): SweepReceiptPayload {
+  const obj = parseSweepJson(data);
+  if (obj.version !== 1) {
+    throw new Error('Unsupported sweep receipt version');
+  }
+  const status = requireStringField(obj, 'status') as SweepReceiptStatus;
+  if (!RECEIPT_STATUSES.includes(status)) {
+    throw new Error(`Sweep receipt status must be one of: ${RECEIPT_STATUSES.join(', ')}`);
+  }
+  const result: SweepReceiptPayload = {
+    version: 1,
+    authNonce: requirePatternField(obj, 'authNonce', BYTES32_RE, 'bytes32'),
+    status,
+  };
+  if (typeof obj.txHash === 'string' && BYTES32_RE.test(obj.txHash)) result.txHash = obj.txHash;
+  if (typeof obj.reason === 'string' && obj.reason.length <= 256) result.reason = obj.reason;
+  return result;
+}

--- a/packages/node/src/p2p/sweep-mux.ts
+++ b/packages/node/src/p2p/sweep-mux.ts
@@ -1,0 +1,81 @@
+import type { PeerConnection } from './connection-manager.js';
+import { MessageType } from '../types/protocol.js';
+import type { SweepRequestPayload, SweepReceiptPayload, FramedMessage } from '../types/protocol.js';
+import { encodeFrame } from './message-protocol.js';
+import * as codec from './sweep-codec.js';
+import { debugLog } from '../utils/debug.js';
+
+const MESSAGE_TYPE_NAME: Record<number, string> = {
+  [MessageType.SweepRequest]: 'SweepRequest',
+  [MessageType.SweepReceipt]: 'SweepReceipt',
+};
+
+export type SweepMessageHandler<T> = (payload: T) => void | Promise<void>;
+
+/**
+ * Multiplexes deposit-sweep messages over a PeerConnection.
+ * Buyers broadcast SweepRequest to connected peers; relayers (sellers by
+ * default) reply with optional SweepReceipt progress reports.
+ */
+export class SweepMux {
+  private _connection: PeerConnection;
+  private _messageIdCounter = 0;
+
+  private _onSweepRequest?: SweepMessageHandler<SweepRequestPayload>;
+  private _onSweepReceipt?: SweepMessageHandler<SweepReceiptPayload>;
+
+  constructor(connection: PeerConnection) {
+    this._connection = connection;
+  }
+
+  // --- Handler registration ---
+  onSweepRequest(handler: SweepMessageHandler<SweepRequestPayload>): void {
+    this._onSweepRequest = handler;
+  }
+  onSweepReceipt(handler: SweepMessageHandler<SweepReceiptPayload>): void {
+    this._onSweepReceipt = handler;
+  }
+
+  // --- Sending ---
+  sendSweepRequest(payload: SweepRequestPayload): void {
+    this._send(MessageType.SweepRequest, codec.encodeSweepRequest(payload));
+  }
+  sendSweepReceipt(payload: SweepReceiptPayload): void {
+    this._send(MessageType.SweepReceipt, codec.encodeSweepReceipt(payload));
+  }
+
+  // --- Receiving ---
+  /**
+   * Returns true if this frame is a sweep message and was handled.
+   */
+  async handleFrame(frame: FramedMessage): Promise<boolean> {
+    const name = MESSAGE_TYPE_NAME[frame.type];
+    if (!name) return false;
+    debugLog(`[SweepMux] ← recv ${name} (${frame.payload.length}b)`);
+    switch (frame.type) {
+      case MessageType.SweepRequest:
+        await this._onSweepRequest?.(codec.decodeSweepRequest(frame.payload));
+        return true;
+      case MessageType.SweepReceipt:
+        await this._onSweepReceipt?.(codec.decodeSweepReceipt(frame.payload));
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /** Check if a message type is in the deposit-sweep range (0xA0-0xAF). */
+  static isSweepMessage(type: number): boolean {
+    return type >= 0xa0 && type <= 0xaf;
+  }
+
+  private _send(type: MessageType, payload: Uint8Array): void {
+    debugLog(`[SweepMux] → send ${MESSAGE_TYPE_NAME[type] ?? `0x${type.toString(16)}`} (${payload.length}b)`);
+    const frame = encodeFrame({
+      type,
+      messageId: this._messageIdCounter++ & 0xffffffff,
+      payload,
+    });
+    this._connection.send(frame);
+  }
+}

--- a/packages/node/src/payments/chain-config.ts
+++ b/packages/node/src/payments/chain-config.ts
@@ -29,6 +29,8 @@ export interface ChainConfig {
   statsDeployBlock?: number;
   /** Public URL of the @antseed/network-stats aggregator that indexes the stats contract for this chain. */
   networkStatsUrl?: string;
+  /** AntseedDepositRelay contract for gasless USDC sweeps from buyer hot wallets. */
+  depositRelayAddress?: string;
 }
 
 /**
@@ -59,6 +61,7 @@ const CHAIN_CONFIGS: Record<ChainId, ChainConfig> = {
     statsContractAddress: '0x15649ff076bfa5e37e24ee3154a00503149954fd',
     statsDeployBlock: 44469557,
     networkStatsUrl: 'https://network.antseed.com',
+    // depositRelayAddress: TODO — set after AntseedDepositRelay mainnet deployment
   },
   'base-sepolia': {
     chainId: 'base-sepolia',
@@ -70,18 +73,20 @@ const CHAIN_CONFIGS: Record<ChainId, ChainConfig> = {
     stakingContractAddress: '0x1CB76B197a20E41f9AA01806B41C59e16Cad46a7',
     emissionsContractAddress: '0x9B30DAcfC20F0927fFD49fB0B84cf3EB83976a33',
     identityRegistryAddress: '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+    // depositRelayAddress: TODO — set after AntseedDepositRelay sepolia deployment
   },
   'base-local': {
     chainId: 'base-local',
     evmChainId: 31337,
     rpcUrl: 'http://127.0.0.1:8545',
-    // Nonce sequence: 0=USDC, 1=Registry, 2=ANTSToken, 3=AntseedRegistry, 4=Staking, 5=Deposits, 6=Channels, 7=Stats, 8=Emissions
+    // Nonce sequence: 0=USDC, 1=Registry, 2=ANTSToken, 3=AntseedRegistry, 4=Staking, 5=Deposits, 6=Channels, 7=Stats, 8=Emissions, 9=DepositRelay
     usdcContractAddress: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
     identityRegistryAddress: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
     stakingContractAddress: '0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9',
     depositsContractAddress: '0x5FC8d32690cc91D4c39d9d3abcBD16989F875707',
     channelsContractAddress: '0x0165878A594ca255338adfa4d48449f69242Eb8F',
     emissionsContractAddress: '0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6',
+    depositRelayAddress: '0x8A791620dd6260079BF849Dc5567aDC3F2FdC318',
   },
 };
 
@@ -114,6 +119,7 @@ export function resolveChainConfig(overrides?: {
   emissionsContractAddress?: string;
   legacyEmissionsContractAddress?: string;
   antsTokenAddress?: string;
+  depositRelayAddress?: string;
 }): ChainConfig {
   const base = getChainConfig(overrides?.chainId);
   // If the caller overrode the primary rpcUrl without providing their own
@@ -135,6 +141,7 @@ export function resolveChainConfig(overrides?: {
     ...(overrides?.emissionsContractAddress ? { emissionsContractAddress: overrides.emissionsContractAddress } : {}),
     ...(overrides?.legacyEmissionsContractAddress ? { legacyEmissionsContractAddress: overrides.legacyEmissionsContractAddress } : {}),
     ...(overrides?.antsTokenAddress ? { antsTokenAddress: overrides.antsTokenAddress } : {}),
+    ...(overrides?.depositRelayAddress ? { depositRelayAddress: overrides.depositRelayAddress } : {}),
   };
 }
 

--- a/packages/node/src/payments/deposit-relayer.ts
+++ b/packages/node/src/payments/deposit-relayer.ts
@@ -114,11 +114,7 @@ export class DepositRelayer {
       return 'rejected';
     }
 
-    this._seenNonces.add(nonceKey);
-    if (this._seenNonces.size > SEEN_NONCES_MAX) {
-      const oldest = this._seenNonces.values().next().value;
-      if (oldest !== undefined) this._seenNonces.delete(oldest);
-    }
+    this._rememberNonce(nonceKey);
 
     const params = {
       from: payload.from,
@@ -139,6 +135,7 @@ export class DepositRelayer {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         debugLog(`[Relayer] Simulation failed for nonce ${payload.nonce.slice(0, 10)}...: ${message}`);
+        this._seenNonces.delete(nonceKey);
         this._sendReceipt(mux, payload, 'rejected', undefined, 'simulation failed');
         return 'rejected';
       }
@@ -146,6 +143,7 @@ export class DepositRelayer {
       const minProfit = this._config.minProfitBaseUnits ?? DEFAULT_MIN_PROFIT;
       if (estimate.profitUsdc < minProfit) {
         debugLog(`[Relayer] Unprofitable sweep for nonce ${payload.nonce.slice(0, 10)}...: fee=${estimate.fee} gasEst=${estimate.estGasCostUsdc} profit=${estimate.profitUsdc} min=${minProfit}`);
+        this._seenNonces.delete(nonceKey);
         this._sendReceipt(mux, payload, 'rejected', undefined, 'unprofitable for relayer');
         return 'rejected';
       }
@@ -163,6 +161,14 @@ export class DepositRelayer {
       return 'rejected';
     } finally {
       this._inFlight--;
+    }
+  }
+
+  private _rememberNonce(nonceKey: string): void {
+    this._seenNonces.add(nonceKey);
+    if (this._seenNonces.size > SEEN_NONCES_MAX) {
+      const oldest = this._seenNonces.values().next().value;
+      if (oldest !== undefined) this._seenNonces.delete(oldest);
     }
   }
 

--- a/packages/node/src/payments/deposit-relayer.ts
+++ b/packages/node/src/payments/deposit-relayer.ts
@@ -1,0 +1,224 @@
+import { verifyTypedData } from 'ethers';
+import type { Identity } from '../p2p/identity.js';
+import type { PeerId } from '../types/peer.js';
+import type { SweepRequestPayload, SweepReceiptPayload } from '../types/protocol.js';
+import type { SweepMux } from '../p2p/sweep-mux.js';
+import { DepositRelayClient } from './evm/deposit-relay-client.js';
+import { RECEIVE_WITH_AUTHORIZATION_TYPES, makeUsdcDomain } from './evm/signatures.js';
+import { debugLog, debugWarn } from '../utils/debug.js';
+
+export interface DepositRelayerConfig {
+  rpcUrl: string;
+  fallbackRpcUrls?: string[];
+  /** The relayer's own configured AntseedDepositRelay address. Requests
+   *  pointing anywhere else are dropped — never submit to a peer-supplied
+   *  contract address. */
+  relayAddress: string;
+  usdcAddress: string;
+  evmChainId: number;
+  /** Minimum acceptable profit (FEE - estimated gas cost) in USDC base units.
+   *  May be negative to relay at a loss (e.g. local testing where anvil's gas
+   *  price dwarfs the fee). Default: 0. */
+  minProfitBaseUnits?: bigint;
+  /** Max concurrent sweep submissions. Default: 2. */
+  maxInFlight?: number;
+  /** Max sweep requests accepted per peer per minute. Default: 6. */
+  maxPerPeerPerMinute?: number;
+}
+
+export type SweepHandleResult = 'submitted' | 'rejected' | 'dropped';
+
+const DEFAULT_MIN_PROFIT = 0n;
+const DEFAULT_MAX_IN_FLIGHT = 2;
+const DEFAULT_MAX_PER_PEER_PER_MINUTE = 6;
+const SEEN_NONCES_MAX = 1024;
+const RATE_WINDOW_MS = 60_000;
+/** Don't bother submitting when the authorization expires too soon to land. */
+const MIN_REMAINING_VALIDITY_SECS = 30;
+
+/**
+ * Seller-side permissionless relayer for buyer deposit sweeps.
+ *
+ * On SweepRequest: verify the buyer's EIP-3009 signature locally, simulate
+ * the call, check the fixed FEE clears gas cost by the configured minimum
+ * profit, then submit sweepDeposit with the seller's funded wallet and report
+ * progress via SweepReceipt. Losing a submission race to another relayer
+ * (EIP-3009 nonce already used) is normal — logged and dropped.
+ */
+export class DepositRelayer {
+  private readonly _identity: Identity;
+  private readonly _config: DepositRelayerConfig;
+  private readonly _client: DepositRelayClient;
+  private readonly _seenNonces = new Set<string>();
+  private readonly _requestTimes = new Map<PeerId, number[]>();
+  private _inFlight = 0;
+
+  constructor(identity: Identity, config: DepositRelayerConfig) {
+    this._identity = identity;
+    this._config = config;
+    this._client = new DepositRelayClient({
+      rpcUrl: config.rpcUrl,
+      ...(config.fallbackRpcUrls ? { fallbackRpcUrls: config.fallbackRpcUrls } : {}),
+      contractAddress: config.relayAddress,
+      evmChainId: config.evmChainId,
+    });
+  }
+
+  get client(): DepositRelayClient { return this._client; }
+
+  async handleSweepRequest(
+    peerId: PeerId,
+    payload: SweepRequestPayload,
+    mux: SweepMux,
+  ): Promise<SweepHandleResult> {
+    // Never submit to a contract a peer told us about — only our own config.
+    if (payload.evmChainId !== this._config.evmChainId ||
+        payload.relayAddress.toLowerCase() !== this._config.relayAddress.toLowerCase()) {
+      debugLog(`[Relayer] Dropping sweep from ${peerId.slice(0, 12)}...: chain/relay mismatch`);
+      return 'dropped';
+    }
+
+    const nonceKey = payload.nonce.toLowerCase();
+    if (this._seenNonces.has(nonceKey)) {
+      debugLog(`[Relayer] Dropping sweep from ${peerId.slice(0, 12)}...: nonce already seen`);
+      return 'dropped';
+    }
+
+    if (!this._admitPeerRequest(peerId)) {
+      debugWarn(`[Relayer] Rate limit exceeded for ${peerId.slice(0, 12)}...`);
+      return 'dropped';
+    }
+
+    const maxInFlight = this._config.maxInFlight ?? DEFAULT_MAX_IN_FLIGHT;
+    if (this._inFlight >= maxInFlight) {
+      debugLog(`[Relayer] Dropping sweep from ${peerId.slice(0, 12)}...: ${this._inFlight} sweeps already in flight`);
+      return 'dropped';
+    }
+
+    const nowSecs = Math.floor(Date.now() / 1000);
+    if (nowSecs <= payload.validAfter || nowSecs >= payload.validBefore - MIN_REMAINING_VALIDITY_SECS) {
+      this._sendReceipt(mux, payload, 'rejected', undefined, 'authorization window invalid or expiring');
+      return 'rejected';
+    }
+
+    let amount: bigint;
+    try {
+      amount = BigInt(payload.amount);
+    } catch {
+      this._sendReceipt(mux, payload, 'rejected', undefined, 'malformed amount');
+      return 'rejected';
+    }
+
+    if (!this._verifySignature(payload, amount)) {
+      this._sendReceipt(mux, payload, 'rejected', undefined, 'invalid signature');
+      return 'rejected';
+    }
+
+    this._seenNonces.add(nonceKey);
+    if (this._seenNonces.size > SEEN_NONCES_MAX) {
+      const oldest = this._seenNonces.values().next().value;
+      if (oldest !== undefined) this._seenNonces.delete(oldest);
+    }
+
+    const params = {
+      from: payload.from,
+      amount,
+      validAfter: BigInt(payload.validAfter),
+      validBefore: BigInt(payload.validBefore),
+      nonce: payload.nonce,
+      sig3009: payload.sig3009,
+    };
+
+    this._inFlight++;
+    try {
+      // Simulation failure (used nonce, bad sig, amount <= FEE, min-deposit,
+      // credit limit) → reject.
+      let estimate;
+      try {
+        estimate = await this._client.estimateSweepProfit(this._identity.wallet, params);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        debugLog(`[Relayer] Simulation failed for nonce ${payload.nonce.slice(0, 10)}...: ${message}`);
+        this._sendReceipt(mux, payload, 'rejected', undefined, 'simulation failed');
+        return 'rejected';
+      }
+
+      const minProfit = this._config.minProfitBaseUnits ?? DEFAULT_MIN_PROFIT;
+      if (estimate.profitUsdc < minProfit) {
+        debugLog(`[Relayer] Unprofitable sweep for nonce ${payload.nonce.slice(0, 10)}...: fee=${estimate.fee} gasEst=${estimate.estGasCostUsdc} profit=${estimate.profitUsdc} min=${minProfit}`);
+        this._sendReceipt(mux, payload, 'rejected', undefined, 'unprofitable for relayer');
+        return 'rejected';
+      }
+
+      this._sendReceipt(mux, payload, 'submitted');
+      const txHash = await this._client.sweep(this._identity.wallet, params);
+      debugLog(`[Relayer] Sweep confirmed for ${payload.from.slice(0, 10)}...: tx=${txHash} fee=${estimate.fee}`);
+      this._sendReceipt(mux, payload, 'confirmed', txHash);
+      return 'submitted';
+    } catch (err) {
+      // Losing the submission race (nonce consumed by another relayer) is normal.
+      const message = err instanceof Error ? err.message : String(err);
+      debugLog(`[Relayer] Sweep submission failed for nonce ${payload.nonce.slice(0, 10)}...: ${message}`);
+      this._sendReceipt(mux, payload, 'rejected', undefined, 'submission failed');
+      return 'rejected';
+    } finally {
+      this._inFlight--;
+    }
+  }
+
+  private _verifySignature(payload: SweepRequestPayload, amount: bigint): boolean {
+    try {
+      const usdcDomain = makeUsdcDomain(this._config.evmChainId, this._config.usdcAddress);
+      const recovered = verifyTypedData(usdcDomain, RECEIVE_WITH_AUTHORIZATION_TYPES, {
+        from: payload.from,
+        to: this._config.relayAddress,
+        value: amount,
+        validAfter: BigInt(payload.validAfter),
+        validBefore: BigInt(payload.validBefore),
+        nonce: payload.nonce,
+      }, payload.sig3009);
+      return recovered.toLowerCase() === payload.from.toLowerCase();
+    } catch {
+      return false;
+    }
+  }
+
+  private _admitPeerRequest(peerId: PeerId): boolean {
+    const limit = this._config.maxPerPeerPerMinute ?? DEFAULT_MAX_PER_PEER_PER_MINUTE;
+    const now = Date.now();
+    const times = (this._requestTimes.get(peerId) ?? []).filter((t) => now - t < RATE_WINDOW_MS);
+    if (times.length >= limit) {
+      this._requestTimes.set(peerId, times);
+      return false;
+    }
+    times.push(now);
+    this._requestTimes.set(peerId, times);
+    // Bound the map: drop stale peers opportunistically.
+    if (this._requestTimes.size > 512) {
+      for (const [key, value] of this._requestTimes) {
+        if (value.every((t) => now - t >= RATE_WINDOW_MS)) this._requestTimes.delete(key);
+      }
+    }
+    return true;
+  }
+
+  private _sendReceipt(
+    mux: SweepMux,
+    payload: SweepRequestPayload,
+    status: SweepReceiptPayload['status'],
+    txHash?: string,
+    reason?: string,
+  ): void {
+    try {
+      mux.sendSweepReceipt({
+        version: 1,
+        authNonce: payload.nonce,
+        status,
+        ...(txHash ? { txHash } : {}),
+        ...(reason ? { reason } : {}),
+      });
+    } catch (err) {
+      debugLog(`[Relayer] Failed to send receipt: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+}

--- a/packages/node/src/payments/evm/deposit-relay-client.ts
+++ b/packages/node/src/payments/evm/deposit-relay-client.ts
@@ -1,4 +1,4 @@
-import { Contract, TypedDataEncoder } from 'ethers';
+import { Contract, Interface, TypedDataEncoder } from 'ethers';
 import type { AbstractSigner, TypedDataDomain } from 'ethers';
 import { BaseEvmClient } from './base-evm-client.js';
 
@@ -28,6 +28,16 @@ export interface SweepProfitEstimate {
   profitUsdc: bigint;
 }
 
+export interface SweepEventConfirmation {
+  txHash: string;
+  blockNumber: number;
+  buyer: string;
+  relayer: string;
+  deposited: bigint;
+  fee: bigint;
+  authNonce: string;
+}
+
 /** Conservative ETH/USD assumption for profitability checks when the caller
  *  provides no price. Overestimating ETH makes the check stricter, never
  *  unprofitable-but-accepted. */
@@ -38,7 +48,10 @@ const DEPOSIT_RELAY_ABI = [
   'function FEE() external view returns (uint256)',
   'function usdc() external view returns (address)',
   'function deposits() external view returns (address)',
+  'event SweepExecuted(address indexed buyer, address indexed relayer, uint256 deposited, uint256 fee, bytes32 authNonce)',
 ] as const;
+
+const DEPOSIT_RELAY_INTERFACE = new Interface(DEPOSIT_RELAY_ABI);
 
 export class DepositRelayClient extends BaseEvmClient {
   constructor(config: DepositRelayClientConfig) {
@@ -102,6 +115,72 @@ export class DepositRelayClient extends BaseEvmClient {
   async fee(): Promise<bigint> {
     const contract = new Contract(this._contractAddress, DEPOSIT_RELAY_ABI, this._provider);
     return contract.getFunction('FEE')() as Promise<bigint>;
+  }
+
+  /**
+   * Confirm a relayer-reported transaction by reading its receipt and matching
+   * the relay's SweepExecuted event against the buyer authorization nonce.
+   */
+  async getSweepConfirmation(
+    txHash: string,
+    expected?: {
+      buyer?: string;
+      deposited?: bigint;
+      fee?: bigint;
+      authNonce?: string;
+    },
+  ): Promise<SweepEventConfirmation | null> {
+    const receipt = await this._provider.getTransactionReceipt(txHash);
+    if (!receipt || receipt.status !== 1) return null;
+
+    for (const log of receipt.logs) {
+      if (log.address.toLowerCase() !== this._contractAddress.toLowerCase()) continue;
+      const parsed = (() => {
+        try {
+          return DEPOSIT_RELAY_INTERFACE.parseLog(log);
+        } catch {
+          return null;
+        }
+      })();
+      if (!parsed || parsed.name !== 'SweepExecuted') continue;
+      const args = parsed.args as unknown as {
+        buyer: string;
+        relayer: string;
+        deposited: bigint;
+        fee: bigint;
+        authNonce: string;
+      };
+      if (expected?.buyer && args.buyer.toLowerCase() !== expected.buyer.toLowerCase()) continue;
+      if (expected?.deposited !== undefined && args.deposited !== expected.deposited) continue;
+      if (expected?.fee !== undefined && args.fee !== expected.fee) continue;
+      if (expected?.authNonce && args.authNonce.toLowerCase() !== expected.authNonce.toLowerCase()) continue;
+      return {
+        txHash: receipt.hash,
+        blockNumber: receipt.blockNumber,
+        buyer: args.buyer,
+        relayer: args.relayer,
+        deposited: args.deposited,
+        fee: args.fee,
+        authNonce: args.authNonce,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Check whether USDC has consumed the EIP-3009 authorization nonce. Because
+   * sweep authorizations are signed with `to = AntseedDepositRelay`, and the
+   * relay call is atomic, a consumed nonce is a strong fallback confirmation
+   * that the sweep transaction landed even when no relayer tx hash was reported.
+   */
+  async isAuthorizationUsed(usdcAddress: string, from: string, nonce: string): Promise<boolean> {
+    const usdc = new Contract(
+      usdcAddress,
+      ['function authorizationState(address authorizer, bytes32 nonce) external view returns (bool)'],
+      this._provider,
+    );
+    return usdc.getFunction('authorizationState')(from, nonce) as Promise<boolean>;
   }
 
   /**

--- a/packages/node/src/payments/evm/deposit-relay-client.ts
+++ b/packages/node/src/payments/evm/deposit-relay-client.ts
@@ -1,0 +1,122 @@
+import { Contract, TypedDataEncoder } from 'ethers';
+import type { AbstractSigner, TypedDataDomain } from 'ethers';
+import { BaseEvmClient } from './base-evm-client.js';
+
+export interface DepositRelayClientConfig {
+  rpcUrl: string;
+  fallbackRpcUrls?: string[];
+  contractAddress: string;
+  evmChainId?: number;
+}
+
+export interface SweepParams {
+  from: string;
+  amount: bigint;
+  validAfter: bigint;
+  validBefore: bigint;
+  nonce: string; // bytes32 hex
+  sig3009: string;
+}
+
+export interface SweepProfitEstimate {
+  gasEstimate: bigint;
+  /** Estimated gas cost converted to USDC base units (6 decimals). */
+  estGasCostUsdc: bigint;
+  /** The contract's fixed FEE the relayer earns. */
+  fee: bigint;
+  /** fee - estGasCostUsdc; negative when relaying costs more than it pays. */
+  profitUsdc: bigint;
+}
+
+/** Conservative ETH/USD assumption for profitability checks when the caller
+ *  provides no price. Overestimating ETH makes the check stricter, never
+ *  unprofitable-but-accepted. */
+const DEFAULT_ETH_PRICE_USD = 10_000n;
+
+const DEPOSIT_RELAY_ABI = [
+  'function sweepDeposit(address from, uint256 amount, uint256 validAfter, uint256 validBefore, bytes32 nonce, bytes sig3009) external',
+  'function FEE() external view returns (uint256)',
+  'function usdc() external view returns (address)',
+  'function deposits() external view returns (address)',
+] as const;
+
+export class DepositRelayClient extends BaseEvmClient {
+  constructor(config: DepositRelayClientConfig) {
+    super(config.rpcUrl, config.contractAddress, config.fallbackRpcUrls, config.evmChainId);
+  }
+
+  // ─── Relayer Operations ────────────────────────────────────────────
+
+  async sweep(signer: AbstractSigner, params: SweepParams): Promise<string> {
+    return this._execWrite(
+      signer,
+      DEPOSIT_RELAY_ABI,
+      'sweepDeposit',
+      params.from,
+      params.amount,
+      params.validAfter,
+      params.validBefore,
+      params.nonce,
+      params.sig3009,
+    );
+  }
+
+  /**
+   * Simulate the sweep and estimate the relayer's profit against the fixed
+   * FEE. Throws if the simulation reverts (bad signature, used nonce, expired
+   * window, min-deposit violation, ...) — callers should treat a throw as
+   * "do not relay".
+   */
+  async estimateSweepProfit(
+    signer: AbstractSigner,
+    params: SweepParams,
+    opts?: { ethPriceUsd?: bigint },
+  ): Promise<SweepProfitEstimate> {
+    const connected = this._ensureConnected(signer);
+    const contract = new Contract(this._contractAddress, DEPOSIT_RELAY_ABI, connected);
+    const populated = await contract.getFunction('sweepDeposit').populateTransaction(
+      params.from,
+      params.amount,
+      params.validAfter,
+      params.validBefore,
+      params.nonce,
+      params.sig3009,
+    );
+    const [gasEstimate, feeData, fee] = await Promise.all([
+      connected.estimateGas(populated),
+      this._provider.getFeeData(),
+      this.fee(),
+    ]);
+
+    const gasPriceWei = feeData.maxFeePerGas ?? feeData.gasPrice ?? 0n;
+    const ethPriceUsd = opts?.ethPriceUsd ?? DEFAULT_ETH_PRICE_USD;
+    // wei * usd/eth → USDC base units (6 decimals): / 1e18 * 1e6 = / 1e12
+    const estGasCostUsdc = (gasEstimate * gasPriceWei * ethPriceUsd) / 10n ** 12n;
+
+    return { gasEstimate, estGasCostUsdc, fee, profitUsdc: fee - estGasCostUsdc };
+  }
+
+  // ─── View Functions ─────────────────────────────────────────────────
+
+  /** The contract's fixed, immutable relayer fee in USDC base units. */
+  async fee(): Promise<bigint> {
+    const contract = new Contract(this._contractAddress, DEPOSIT_RELAY_ABI, this._provider);
+    return contract.getFunction('FEE')() as Promise<bigint>;
+  }
+
+  /**
+   * Compare a locally computed EIP-712 domain against the deployed USDC
+   * token's DOMAIN_SEPARATOR(). Circle's domain params (name/version) vary by
+   * deployment — call this before signing EIP-3009 authorizations so a
+   * mismatch fails loudly instead of producing signatures the token rejects.
+   */
+  async verifyUsdcDomain(usdcAddress: string, domain: TypedDataDomain): Promise<boolean> {
+    const usdc = new Contract(
+      usdcAddress,
+      ['function DOMAIN_SEPARATOR() external view returns (bytes32)'],
+      this._provider,
+    );
+    const onChain = await usdc.getFunction('DOMAIN_SEPARATOR')() as string;
+    return onChain.toLowerCase() === TypedDataEncoder.hashDomain(domain).toLowerCase();
+  }
+}

--- a/packages/node/src/payments/evm/signatures.ts
+++ b/packages/node/src/payments/evm/signatures.ts
@@ -1,4 +1,4 @@
-import { type AbstractSigner, type TypedDataDomain, AbiCoder, id, keccak256 } from 'ethers';
+import { type AbstractSigner, type TypedDataDomain, AbiCoder, hexlify, id, keccak256, randomBytes } from 'ethers';
 
 // =========================================================================
 // EIP-712 Types — AntSeed SpendingAuth (cumulative payment authorization)
@@ -44,6 +44,31 @@ export const FREE_USAGE_AUTH_TYPES = {
 };
 
 // =========================================================================
+// EIP-712 Types — EIP-3009 (USDC)
+// =========================================================================
+
+/**
+ * EIP-3009 receiveWithAuthorization typed data, as implemented by Circle's
+ * FiatToken (USDC). Must match the token's typehash exactly:
+ *   ReceiveWithAuthorization(address from,address to,uint256 value,
+ *     uint256 validAfter,uint256 validBefore,bytes32 nonce)
+ *
+ * For deposit sweeps this is the ONLY buyer signature: addressing the
+ * authorization to the AntseedDepositRelay contract is consent to its
+ * public, immutable fixed FEE.
+ */
+export const RECEIVE_WITH_AUTHORIZATION_TYPES = {
+  ReceiveWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+};
+
+// =========================================================================
 // Message interfaces
 // =========================================================================
 
@@ -74,6 +99,15 @@ export interface FreeUsageAuthMessage {
   sequence: bigint;
   metadataHash: string;
   deadline: bigint;
+}
+
+export interface ReceiveAuthorizationMessage {
+  from: string;
+  to: string;
+  value: bigint;
+  validAfter: bigint;
+  validBefore: bigint;
+  nonce: string; // bytes32 hex
 }
 
 // =========================================================================
@@ -332,6 +366,22 @@ export function makeFreeUsageDomain(chainId: number, contractAddress: string): T
   };
 }
 
+/**
+ * EIP-712 domain of Circle's USDC (FiatTokenV2). Verified against the deployed
+ * Base mainnet token (0x8335...2913): name "USD Coin", version "2". MockUSDC
+ * on base-local mirrors the same params. Callers with RPC access should verify
+ * via the token's DOMAIN_SEPARATOR() before first use (the params can differ
+ * on other deployments).
+ */
+export function makeUsdcDomain(chainId: number, usdcAddress: string): TypedDataDomain {
+  return {
+    name: 'USD Coin',
+    version: '2',
+    chainId,
+    verifyingContract: usdcAddress,
+  };
+}
+
 // =========================================================================
 // Signing functions — EIP-712 (on-chain)
 // =========================================================================
@@ -374,4 +424,37 @@ export async function signFreeUsageAuth(
   msg: FreeUsageAuthMessage,
 ): Promise<string> {
   return signer.signTypedData(domain, FREE_USAGE_AUTH_TYPES, msg);
+}
+
+export interface SignedReceiveAuthorization {
+  message: ReceiveAuthorizationMessage;
+  signature: string;
+}
+
+/**
+ * Build and sign an EIP-3009 ReceiveWithAuthorization for USDC. Works with a
+ * provider-less signer — the hot wallet never needs RPC access to sign.
+ * A random 32-byte nonce is generated when none is supplied.
+ */
+export async function buildReceiveAuthorization(
+  signer: AbstractSigner,
+  domain: TypedDataDomain,
+  params: {
+    to: string;
+    value: bigint;
+    validAfter: bigint;
+    validBefore: bigint;
+    nonce?: string;
+  },
+): Promise<SignedReceiveAuthorization> {
+  const message: ReceiveAuthorizationMessage = {
+    from: await signer.getAddress(),
+    to: params.to,
+    value: params.value,
+    validAfter: params.validAfter,
+    validBefore: params.validBefore,
+    nonce: params.nonce ?? hexlify(randomBytes(32)),
+  };
+  const signature = await signer.signTypedData(domain, RECEIVE_WITH_AUTHORIZATION_TYPES, message);
+  return { message, signature };
 }

--- a/packages/node/src/types/protocol.ts
+++ b/packages/node/src/types/protocol.ts
@@ -45,6 +45,12 @@ export enum MessageType {
 }
 
 export const CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 = 'verification.response-auth.v1' as const;
+export const CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1 = 'payments.relays-sweeps.v1' as const;
+
+export function peerRelaysSweeps(peer: { capabilities?: string[]; metadata?: { capabilities?: string[] } }): boolean {
+  return peer.capabilities?.includes(CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1) === true
+    || peer.metadata?.capabilities?.includes(CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1) === true;
+}
 
 export interface FramedMessage {
   type: MessageType;

--- a/packages/node/src/types/protocol.ts
+++ b/packages/node/src/types/protocol.ts
@@ -34,6 +34,12 @@ export enum MessageType {
   // Verification / attestation protocol (0x80-0x8F)
   VerificationResponseAuth = 0x80,
 
+  // 0x90-0x9F reserved: delegated-verification protocol (feat/verifier-network)
+
+  // Deposit sweep protocol (0xA0-0xAF)
+  SweepRequest = 0xA0,
+  SweepReceipt = 0xA1,
+
   Disconnect = 0xF0,
   Error = 0xFF,
 }
@@ -192,6 +198,48 @@ export interface NeedAuthPayload {
   freshInputTokens?: string;
   /** Service/model name for service-specific pricing validation. */
   service?: string;
+}
+
+// ─── Deposit Sweep Messages ─────────────────────────────────────
+
+/**
+ * Buyer broadcasts a signed gasless deposit sweep for permissionless relayers
+ * (sellers by default) to submit on-chain. Carries everything
+ * AntseedDepositRelay.sweepDeposit needs; the relayer earns the contract's
+ * fixed, immutable FEE in USDC. The single EIP-3009 signature — addressed to
+ * the relay contract — is the buyer's consent to those terms. Replay-safe via
+ * the EIP-3009 nonce; losing a submission race is harmless.
+ */
+export interface SweepRequestPayload {
+  version: 1;
+  evmChainId: number;
+  /** AntseedDepositRelay address the buyer signed against. Relayers must only
+   *  submit when this matches their own configured relay address. */
+  relayAddress: string;
+  from: string;
+  /** Total USDC pulled via EIP-3009, base units (uint256 decimal string). */
+  amount: string;
+  validAfter: number;
+  validBefore: number;
+  /** EIP-3009 authorization nonce (bytes32 hex). Also the correlation key. */
+  nonce: string;
+  /** Buyer signature over the USDC ReceiveWithAuthorization typed data. */
+  sig3009: string;
+}
+
+export type SweepReceiptStatus = 'submitted' | 'confirmed' | 'rejected';
+
+/**
+ * Optional relayer progress report for a SweepRequest, correlated by the
+ * EIP-3009 nonce. Purely informational — the buyer's source of truth is its
+ * Deposits balance on-chain.
+ */
+export interface SweepReceiptPayload {
+  version: 1;
+  authNonce: string;
+  status: SweepReceiptStatus;
+  txHash?: string;
+  reason?: string;
 }
 
 // ─── Bilateral Verification Messages ───────────────────────────

--- a/packages/node/tests/announcer.test.ts
+++ b/packages/node/tests/announcer.test.ts
@@ -4,7 +4,10 @@ import { Wallet } from 'ethers';
 import { PeerAnnouncer, type AnnouncerConfig } from '../src/discovery/announcer.js';
 import { bytesToHex } from '../src/p2p/identity.js';
 import { toPeerId } from '../src/types/peer.js';
-import { CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 } from '../src/types/protocol.js';
+import {
+  CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1,
+  CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+} from '../src/types/protocol.js';
 
 function makeBaseConfig(): AnnouncerConfig {
   const privateKey = randomBytes(32);
@@ -60,5 +63,18 @@ describe('PeerAnnouncer capabilities', () => {
     await announcer.announce();
     const meta = announcer.getLatestMetadata();
     expect(meta?.capabilities).toEqual([CONNECTION_CAPABILITY_RESPONSE_AUTH_V1]);
+  });
+
+  it('publishes sweep relay support only when configured', async () => {
+    const announcer = new PeerAnnouncer({
+      ...makeBaseConfig(),
+      relaysSweeps: true,
+    });
+    await announcer.announce();
+    const meta = announcer.getLatestMetadata();
+    expect(meta?.capabilities).toEqual([
+      CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+      CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1,
+    ]);
   });
 });

--- a/packages/node/tests/deposit-relay-client.test.ts
+++ b/packages/node/tests/deposit-relay-client.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Interface } from 'ethers';
+import { DepositRelayClient } from '../src/payments/evm/deposit-relay-client.js';
+
+const RELAY = '0x8A791620dd6260079BF849Dc5567aDC3F2FdC318';
+const BUYER = '0x1111111111111111111111111111111111111111';
+const RELAYER = '0x2222222222222222222222222222222222222222';
+const NONCE = '0x' + 'aa'.repeat(32);
+const TX_HASH = '0x' + '77'.repeat(32);
+
+const RELAY_IFACE = new Interface([
+  'event SweepExecuted(address indexed buyer, address indexed relayer, uint256 deposited, uint256 fee, bytes32 authNonce)',
+]);
+
+function makeClientWithReceipt(receipt: unknown): DepositRelayClient {
+  const client = new DepositRelayClient({
+    rpcUrl: 'http://127.0.0.1:1',
+    contractAddress: RELAY,
+    evmChainId: 31337,
+  });
+  vi.spyOn(client.provider, 'getTransactionReceipt').mockResolvedValue(receipt as never);
+  return client;
+}
+
+describe('DepositRelayClient', () => {
+  it('confirms a matching SweepExecuted event from a transaction receipt', async () => {
+    const encoded = RELAY_IFACE.encodeEventLog(
+      RELAY_IFACE.getEvent('SweepExecuted')!,
+      [BUYER, RELAYER, 4_950_000n, 50_000n, NONCE],
+    );
+    const client = makeClientWithReceipt({
+      status: 1,
+      hash: TX_HASH,
+      blockNumber: 123,
+      logs: [{ address: RELAY, topics: encoded.topics, data: encoded.data }],
+    });
+
+    const confirmation = await client.getSweepConfirmation(TX_HASH, {
+      buyer: BUYER,
+      deposited: 4_950_000n,
+      fee: 50_000n,
+      authNonce: NONCE,
+    });
+
+    expect(confirmation).toEqual({
+      txHash: TX_HASH,
+      blockNumber: 123,
+      buyer: BUYER,
+      relayer: RELAYER,
+      deposited: 4_950_000n,
+      fee: 50_000n,
+      authNonce: NONCE,
+    });
+  });
+
+  it('does not confirm receipts whose relay event does not match the requested nonce', async () => {
+    const encoded = RELAY_IFACE.encodeEventLog(
+      RELAY_IFACE.getEvent('SweepExecuted')!,
+      [BUYER, RELAYER, 4_950_000n, 50_000n, NONCE],
+    );
+    const client = makeClientWithReceipt({
+      status: 1,
+      hash: TX_HASH,
+      blockNumber: 123,
+      logs: [{ address: RELAY, topics: encoded.topics, data: encoded.data }],
+    });
+
+    await expect(client.getSweepConfirmation(TX_HASH, {
+      buyer: BUYER,
+      deposited: 4_950_000n,
+      fee: 50_000n,
+      authNonce: '0x' + 'bb'.repeat(32),
+    })).resolves.toBeNull();
+  });
+});

--- a/packages/node/tests/deposit-relayer.test.ts
+++ b/packages/node/tests/deposit-relayer.test.ts
@@ -184,6 +184,33 @@ describe('DepositRelayer', () => {
     );
   });
 
+  it('allows a nonce to be retried after transient simulation failure', async () => {
+    const { relayer, estimateSpy, sweepSpy } = makeRelayer();
+    const payload = await makeValidPayload();
+
+    estimateSpy.mockRejectedValueOnce(new Error('rpc timeout'));
+
+    expect(await relayer.handleSweepRequest(PEER, payload, makeMux())).toBe('rejected');
+    expect(await relayer.handleSweepRequest(PEER, payload, makeMux())).toBe('submitted');
+    expect(sweepSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a nonce to be retried when the sweep is temporarily unprofitable', async () => {
+    const { relayer, estimateSpy, sweepSpy } = makeRelayer();
+    const payload = await makeValidPayload();
+
+    estimateSpy.mockResolvedValueOnce({
+      gasEstimate: 200_000n,
+      estGasCostUsdc: 80_000n,
+      fee: FEE,
+      profitUsdc: FEE - 80_000n,
+    });
+
+    expect(await relayer.handleSweepRequest(PEER, payload, makeMux())).toBe('rejected');
+    expect(await relayer.handleSweepRequest(PEER, payload, makeMux())).toBe('submitted');
+    expect(sweepSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('reports rejected when the submission loses the race', async () => {
     const { relayer, sweepSpy } = makeRelayer();
     sweepSpy.mockRejectedValue(new Error('authorization is used or canceled'));

--- a/packages/node/tests/deposit-relayer.test.ts
+++ b/packages/node/tests/deposit-relayer.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Wallet } from 'ethers';
+import { DepositRelayer } from '../src/payments/deposit-relayer.js';
+import { identityFromPrivateKeyHex } from '../src/p2p/identity.js';
+import { makeUsdcDomain, buildReceiveAuthorization } from '../src/payments/evm/signatures.js';
+import type { SweepRequestPayload } from '../src/types/protocol.js';
+import type { SweepMux } from '../src/p2p/sweep-mux.js';
+import type { PeerId } from '../src/types/peer.js';
+
+const RELAY = '0x8A791620dd6260079BF849Dc5567aDC3F2FdC318';
+const USDC = '0x5FbDB2315678afecb367f032d93F642f64180aa3';
+const CHAIN_ID = 31337;
+const FEE = 50_000n;
+
+const buyer = new Wallet('0x' + 'a1'.repeat(32));
+const sellerIdentity = identityFromPrivateKeyHex('b2'.repeat(32));
+
+const PEER = 'peer-buyer-1' as PeerId;
+
+function makeMux() {
+  return { sendSweepReceipt: vi.fn() } as unknown as SweepMux & { sendSweepReceipt: ReturnType<typeof vi.fn> };
+}
+
+async function makeValidPayload(overrides?: Partial<SweepRequestPayload>): Promise<SweepRequestPayload> {
+  const now = Math.floor(Date.now() / 1000);
+  const validAfter = now - 60;
+  const validBefore = now + 3600;
+  const { message, signature } = await buildReceiveAuthorization(buyer, makeUsdcDomain(CHAIN_ID, USDC), {
+    to: RELAY,
+    value: 5_000_000n,
+    validAfter: BigInt(validAfter),
+    validBefore: BigInt(validBefore),
+  });
+  return {
+    version: 1,
+    evmChainId: CHAIN_ID,
+    relayAddress: RELAY,
+    from: buyer.address,
+    amount: '5000000',
+    validAfter,
+    validBefore,
+    nonce: message.nonce,
+    sig3009: signature,
+    ...overrides,
+  };
+}
+
+function makeRelayer(config?: Partial<ConstructorParameters<typeof DepositRelayer>[1]>) {
+  const relayer = new DepositRelayer(sellerIdentity, {
+    rpcUrl: 'http://127.0.0.1:1',
+    relayAddress: RELAY,
+    usdcAddress: USDC,
+    evmChainId: CHAIN_ID,
+    ...config,
+  });
+  const estimateSpy = vi.spyOn(relayer.client, 'estimateSweepProfit').mockResolvedValue({
+    gasEstimate: 200_000n,
+    estGasCostUsdc: 5_000n,
+    fee: FEE,
+    profitUsdc: FEE - 5_000n,
+  });
+  const sweepSpy = vi.spyOn(relayer.client, 'sweep').mockResolvedValue('0x' + '77'.repeat(32));
+  return { relayer, estimateSpy, sweepSpy };
+}
+
+describe('DepositRelayer', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('verifies, simulates, submits, and reports receipts for a valid request', async () => {
+    const { relayer, sweepSpy } = makeRelayer();
+    const mux = makeMux();
+    const payload = await makeValidPayload();
+
+    const result = await relayer.handleSweepRequest(PEER, payload, mux);
+
+    expect(result).toBe('submitted');
+    expect(sweepSpy).toHaveBeenCalledTimes(1);
+    const statuses = mux.sendSweepReceipt.mock.calls.map((c) => c[0].status);
+    expect(statuses).toEqual(['submitted', 'confirmed']);
+    expect(mux.sendSweepReceipt.mock.calls[1][0].txHash).toBe('0x' + '77'.repeat(32));
+    expect(mux.sendSweepReceipt.mock.calls[1][0].authNonce).toBe(payload.nonce);
+  });
+
+  it('drops requests for a different relay address without submitting', async () => {
+    const { relayer, sweepSpy } = makeRelayer();
+    const mux = makeMux();
+    const payload = await makeValidPayload({ relayAddress: '0x' + '99'.repeat(20) });
+
+    expect(await relayer.handleSweepRequest(PEER, payload, mux)).toBe('dropped');
+    expect(sweepSpy).not.toHaveBeenCalled();
+    expect(mux.sendSweepReceipt).not.toHaveBeenCalled();
+  });
+
+  it('drops requests for a different chain', async () => {
+    const { relayer, sweepSpy } = makeRelayer();
+    const payload = await makeValidPayload({ evmChainId: 8453 });
+    expect(await relayer.handleSweepRequest(PEER, payload, makeMux())).toBe('dropped');
+    expect(sweepSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects tampered payloads (3009 signature mismatch)', async () => {
+    const { relayer, sweepSpy } = makeRelayer();
+    const mux = makeMux();
+    const payload = await makeValidPayload();
+    // Signed for 5 USDC; a tampered amount must fail signature recovery.
+    payload.amount = '6000000';
+
+    expect(await relayer.handleSweepRequest(PEER, payload, mux)).toBe('rejected');
+    expect(sweepSpy).not.toHaveBeenCalled();
+    expect(mux.sendSweepReceipt).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'rejected', reason: 'invalid signature' }),
+    );
+  });
+
+  it('rejects expired authorization windows', async () => {
+    const { relayer } = makeRelayer();
+    const mux = makeMux();
+    const now = Math.floor(Date.now() / 1000);
+    const payload = await makeValidPayload({ validBefore: now + 5 }); // inside safety margin
+
+    expect(await relayer.handleSweepRequest(PEER, payload, mux)).toBe('rejected');
+    expect(mux.sendSweepReceipt).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'rejected', reason: expect.stringContaining('window') }),
+    );
+  });
+
+  it('drops replayed nonces', async () => {
+    const { relayer, sweepSpy } = makeRelayer();
+    const payload = await makeValidPayload();
+
+    expect(await relayer.handleSweepRequest(PEER, payload, makeMux())).toBe('submitted');
+    expect(await relayer.handleSweepRequest(PEER, payload, makeMux())).toBe('dropped');
+    expect(sweepSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when profit is below the configured minimum', async () => {
+    const { relayer, sweepSpy } = makeRelayer({ minProfitBaseUnits: FEE }); // requires zero gas cost
+    const mux = makeMux();
+
+    expect(await relayer.handleSweepRequest(PEER, await makeValidPayload(), mux)).toBe('rejected');
+    expect(sweepSpy).not.toHaveBeenCalled();
+    expect(mux.sendSweepReceipt).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'rejected', reason: 'unprofitable for relayer' }),
+    );
+  });
+
+  it('rejects unprofitable sweeps with the default zero minimum', async () => {
+    const { relayer, estimateSpy, sweepSpy } = makeRelayer();
+    estimateSpy.mockResolvedValue({
+      gasEstimate: 200_000n,
+      estGasCostUsdc: 80_000n,
+      fee: FEE,
+      profitUsdc: FEE - 80_000n, // negative
+    });
+
+    expect(await relayer.handleSweepRequest(PEER, await makeValidPayload(), makeMux())).toBe('rejected');
+    expect(sweepSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts unprofitable sweeps when minProfit is negative (local testing)', async () => {
+    const { relayer, estimateSpy, sweepSpy } = makeRelayer({ minProfitBaseUnits: -100_000_000n });
+    estimateSpy.mockResolvedValue({
+      gasEstimate: 200_000n,
+      estGasCostUsdc: 4_100_150n, // anvil-scale gas cost
+      fee: FEE,
+      profitUsdc: FEE - 4_100_150n,
+    });
+
+    expect(await relayer.handleSweepRequest(PEER, await makeValidPayload(), makeMux())).toBe('submitted');
+    expect(sweepSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when simulation fails', async () => {
+    const { relayer, estimateSpy, sweepSpy } = makeRelayer();
+    estimateSpy.mockRejectedValue(new Error('execution reverted'));
+    const mux = makeMux();
+
+    expect(await relayer.handleSweepRequest(PEER, await makeValidPayload(), mux)).toBe('rejected');
+    expect(sweepSpy).not.toHaveBeenCalled();
+    expect(mux.sendSweepReceipt).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'rejected', reason: 'simulation failed' }),
+    );
+  });
+
+  it('reports rejected when the submission loses the race', async () => {
+    const { relayer, sweepSpy } = makeRelayer();
+    sweepSpy.mockRejectedValue(new Error('authorization is used or canceled'));
+    const mux = makeMux();
+
+    expect(await relayer.handleSweepRequest(PEER, await makeValidPayload(), mux)).toBe('rejected');
+    const statuses = mux.sendSweepReceipt.mock.calls.map((c) => c[0].status);
+    expect(statuses).toEqual(['submitted', 'rejected']);
+  });
+
+  it('rate-limits per peer', async () => {
+    const { relayer, sweepSpy } = makeRelayer({ maxPerPeerPerMinute: 2 });
+
+    expect(await relayer.handleSweepRequest(PEER, await makeValidPayload(), makeMux())).toBe('submitted');
+    expect(await relayer.handleSweepRequest(PEER, await makeValidPayload(), makeMux())).toBe('submitted');
+    expect(await relayer.handleSweepRequest(PEER, await makeValidPayload(), makeMux())).toBe('dropped');
+    expect(sweepSpy).toHaveBeenCalledTimes(2);
+
+    // A different peer is unaffected.
+    expect(await relayer.handleSweepRequest('peer-buyer-2' as PeerId, await makeValidPayload(), makeMux())).toBe('submitted');
+  });
+});

--- a/packages/node/tests/sweep-broadcast-capability.test.ts
+++ b/packages/node/tests/sweep-broadcast-capability.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AntseedNode } from '../src/node.js';
+import { ConnectionState } from '../src/types/connection.js';
+import {
+  CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1,
+  type SweepRequestPayload,
+} from '../src/types/protocol.js';
+import { toPeerId } from '../src/types/peer.js';
+
+function makePayload(): SweepRequestPayload {
+  return {
+    version: 1,
+    evmChainId: 31337,
+    relayAddress: '0x' + '8a'.repeat(20),
+    from: '0x' + '11'.repeat(20),
+    amount: '5000000',
+    validAfter: 0,
+    validBefore: 2_000_000_000,
+    nonce: '0x' + 'aa'.repeat(32),
+    sig3009: '0x' + 'ab'.repeat(65),
+  };
+}
+
+describe('AntseedNode sweep broadcast capabilities', () => {
+  it('only sends sweep requests to connected peers that advertise sweep relaying', () => {
+    const relayPeer = toPeerId('a'.repeat(40));
+    const nonRelayPeer = toPeerId('b'.repeat(40));
+    const node = new AntseedNode({ role: 'buyer' });
+    const sendSweepRequest = vi.fn();
+
+    const connections = new Map([
+      [relayPeer, { state: ConnectionState.Open }],
+      [nonRelayPeer, { state: ConnectionState.Open }],
+    ]);
+
+    (node as unknown as {
+      _connectionManager: { getConnection: (peerId: string) => { state: ConnectionState } | undefined };
+      _muxes: Map<string, unknown>;
+      _peerCapabilities: Map<string, Set<string>>;
+      _getOrCreateSweepMux: () => { sendSweepRequest: typeof sendSweepRequest };
+    })._connectionManager = {
+      getConnection: (peerId: string) => connections.get(peerId),
+    };
+    (node as unknown as { _muxes: Map<string, unknown> })._muxes = new Map([
+      [relayPeer, {}],
+      [nonRelayPeer, {}],
+    ]);
+    (node as unknown as { _peerCapabilities: Map<string, Set<string>> })._peerCapabilities = new Map([
+      [relayPeer, new Set([CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1])],
+      [nonRelayPeer, new Set()],
+    ]);
+    (node as unknown as {
+      _getOrCreateSweepMux: () => { sendSweepRequest: typeof sendSweepRequest };
+    })._getOrCreateSweepMux = () => ({ sendSweepRequest });
+
+    expect(node.broadcastSweepRequest(makePayload())).toBe(1);
+    expect(sendSweepRequest).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/node/tests/sweep-protocol.test.ts
+++ b/packages/node/tests/sweep-protocol.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { keccak256, toUtf8Bytes, verifyTypedData, TypedDataEncoder, Wallet } from 'ethers';
+import {
+  RECEIVE_WITH_AUTHORIZATION_TYPES,
+  makeUsdcDomain,
+  buildReceiveAuthorization,
+} from '../src/payments/evm/signatures.js';
+import {
+  encodeSweepRequest,
+  decodeSweepRequest,
+  encodeSweepReceipt,
+  decodeSweepReceipt,
+} from '../src/p2p/sweep-codec.js';
+import type { SweepRequestPayload, SweepReceiptPayload } from '../src/types/protocol.js';
+
+const BUYER = new Wallet('0x' + 'a1'.repeat(32));
+const RELAY = '0x8A791620dd6260079BF849Dc5567aDC3F2FdC318';
+const USDC = '0x5FbDB2315678afecb367f032d93F642f64180aa3';
+
+describe('EIP-3009 sweep compatibility', () => {
+  it('RECEIVE_WITH_AUTHORIZATION_TYPES typehash matches Circle FiatTokenV2', () => {
+    // Circle's published RECEIVE_WITH_AUTHORIZATION_TYPEHASH constant.
+    const CIRCLE_TYPEHASH = '0xd099cc98ef71107a616c4f0f941f04c322d8e254fe26b3c6668db87aae413de8';
+    const fields = RECEIVE_WITH_AUTHORIZATION_TYPES.ReceiveWithAuthorization;
+    const tsTypeString = `ReceiveWithAuthorization(${fields.map((f) => `${f.type} ${f.name}`).join(',')})`;
+    expect(keccak256(toUtf8Bytes(tsTypeString))).toBe(CIRCLE_TYPEHASH);
+  });
+
+  it('makeUsdcDomain reproduces the deployed Base mainnet USDC domain separator', () => {
+    // Read from the deployed token (0x8335...2913) via DOMAIN_SEPARATOR() on 2026-07-12.
+    const ONCHAIN_SEPARATOR = '0x02fa7265e7c5d81118673727957699e4d68f74cd74b7db77da710fe8a2c7834f';
+    const domain = makeUsdcDomain(8453, '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913');
+    expect(TypedDataEncoder.hashDomain(domain)).toBe(ONCHAIN_SEPARATOR);
+  });
+
+  it('buildReceiveAuthorization signs and recovers, generating a random nonce', async () => {
+    const domain = makeUsdcDomain(31337, USDC);
+    const { message, signature } = await buildReceiveAuthorization(BUYER, domain, {
+      to: RELAY,
+      value: 5_000_000n,
+      validAfter: 0n,
+      validBefore: 2_000_000_000n,
+    });
+    expect(message.from.toLowerCase()).toBe(BUYER.address.toLowerCase());
+    expect(message.nonce).toMatch(/^0x[0-9a-f]{64}$/);
+    const recovered = verifyTypedData(domain, RECEIVE_WITH_AUTHORIZATION_TYPES, message, signature);
+    expect(recovered.toLowerCase()).toBe(BUYER.address.toLowerCase());
+
+    const second = await buildReceiveAuthorization(BUYER, domain, {
+      to: RELAY,
+      value: 5_000_000n,
+      validAfter: 0n,
+      validBefore: 2_000_000_000n,
+    });
+    expect(second.message.nonce).not.toBe(message.nonce);
+  });
+});
+
+describe('sweep codec', () => {
+  const validRequest: SweepRequestPayload = {
+    version: 1,
+    evmChainId: 31337,
+    relayAddress: RELAY,
+    from: BUYER.address,
+    amount: '5000000',
+    validAfter: 0,
+    validBefore: 2_000_000_000,
+    nonce: '0x' + '11'.repeat(32),
+    sig3009: '0x' + 'ab'.repeat(65),
+  };
+
+  it('roundtrips a SweepRequest', () => {
+    expect(decodeSweepRequest(encodeSweepRequest(validRequest))).toEqual(validRequest);
+  });
+
+  it('roundtrips a SweepReceipt', () => {
+    const receipt: SweepReceiptPayload = {
+      version: 1,
+      authNonce: '0x' + '11'.repeat(32),
+      status: 'confirmed',
+      txHash: '0x' + '22'.repeat(32),
+    };
+    expect(decodeSweepReceipt(encodeSweepReceipt(receipt))).toEqual(receipt);
+  });
+
+  it('rejects unsupported versions', () => {
+    const bad = { ...validRequest, version: 2 };
+    expect(() => decodeSweepRequest(encodeSweepRequest(bad as unknown as SweepRequestPayload))).toThrow(/version/);
+  });
+
+  it('rejects malformed addresses', () => {
+    const bad = { ...validRequest, relayAddress: 'not-an-address' };
+    expect(() => decodeSweepRequest(encodeSweepRequest(bad))).toThrow(/relayAddress/);
+  });
+
+  it('rejects non-decimal amounts', () => {
+    const bad = { ...validRequest, amount: '0xff' };
+    expect(() => decodeSweepRequest(encodeSweepRequest(bad))).toThrow(/amount/);
+  });
+
+  it('rejects malformed nonces and signatures', () => {
+    expect(() => decodeSweepRequest(encodeSweepRequest({ ...validRequest, nonce: '0x1234' }))).toThrow(/nonce/);
+    expect(() => decodeSweepRequest(encodeSweepRequest({ ...validRequest, sig3009: '0xzz' }))).toThrow(/sig3009/);
+  });
+
+  it('rejects missing fields and non-objects', () => {
+    const { sig3009: _sig3009, ...missing } = validRequest;
+    expect(() => decodeSweepRequest(encodeSweepRequest(missing as SweepRequestPayload))).toThrow(/sig3009/);
+    expect(() => decodeSweepRequest(new TextEncoder().encode('[1,2,3]'))).toThrow(/object/i);
+  });
+
+  it('rejects oversized payloads', () => {
+    const bloated = { ...validRequest, reason: 'x'.repeat(10_000) };
+    expect(() => decodeSweepRequest(encodeSweepRequest(bloated as SweepRequestPayload))).toThrow(/too large/);
+  });
+
+  it('rejects invalid receipt statuses', () => {
+    const bad = { version: 1, authNonce: '0x' + '11'.repeat(32), status: 'maybe' };
+    expect(() => decodeSweepReceipt(new TextEncoder().encode(JSON.stringify(bad)))).toThrow(/status/);
+  });
+
+  it('drops malformed optional receipt fields instead of failing', () => {
+    const raw = {
+      version: 1,
+      authNonce: '0x' + '11'.repeat(32),
+      status: 'rejected',
+      txHash: 'garbage',
+      reason: 'x'.repeat(1000),
+    };
+    const decoded = decodeSweepReceipt(new TextEncoder().encode(JSON.stringify(raw)));
+    expect(decoded.txHash).toBeUndefined();
+    expect(decoded.reason).toBeUndefined();
+  });
+});

--- a/scripts/setup-local-test.sh
+++ b/scripts/setup-local-test.sh
@@ -12,6 +12,7 @@ STAKING=0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9       # nonce 4
 DEPOSITS=0x5FC8d32690cc91D4c39d9d3abcBD16989F875707      # nonce 5
 CHANNELS=0x0165878A594ca255338adfa4d48449f69242Eb8F      # nonce 6
 # Stats = nonce 7, Emissions = nonce 8
+DEPOSIT_RELAY=0x8A791620dd6260079BF849Dc5567aDC3F2FdC318 # nonce 9
 
 cd /Users/shahafan/Development/antseed
 
@@ -44,8 +45,13 @@ cat > ~/.antseed-seller/config.json << EOF
       "channelsContractAddress": "$CHANNELS",
       "stakingContractAddress": "$STAKING",
       "usdcContractAddress": "$USDC",
-      "identityRegistryAddress": "$REGISTRY"
+      "identityRegistryAddress": "$REGISTRY",
+      "depositRelayAddress": "$DEPOSIT_RELAY"
     }
+  },
+  "relayer": {
+    "enabled": true,
+    "minProfitBaseUnits": "-100000000"
   },
   "providers": [
     { "name": "openai-responses", "services": ["codex"] }
@@ -128,12 +134,14 @@ echo "  Registry:  $REGISTRY"
 echo "  Staking:   $STAKING"
 echo "  Deposits:  $DEPOSITS"
 echo "  Channels:  $CHANNELS"
+echo "  DepositRelay: $DEPOSIT_RELAY"
 echo ""
 echo "Desktop config (Settings > Chain Config):"
 echo "  Chain ID:    base-local"
 echo "  RPC URL:     $RPC"
 echo "  Deposits:    $DEPOSITS"
 echo "  Channels:    $CHANNELS"
+echo "  DepositRelay: $DEPOSIT_RELAY"
 echo ""
 echo "Start seller:"
 echo "  node apps/cli/dist/cli/index.js --data-dir ~/.antseed-seller seller start --provider openai-responses --verbose --config ~/.antseed-seller/config.json"


### PR DESCRIPTION
## Description

Buyer hot wallets are signing-only and must never hold ETH, yet USDC arriving there (QR deposits, onramp deliveries) has to reach `AntseedDeposits`. This PR adds a fully decentralized, gasless path: the buyer signs a single EIP-3009 `receiveWithAuthorization` addressed to a new `AntseedDepositRelay` contract and broadcasts it over the P2P network; any relayer (sellers by default) submits it on-chain and earns a fixed USDC fee taken from the swept amount. No centralized paymaster, bundler, or API keys. Replaces the Pimlico-based sweep prototyped on `feature/vpr` (desktop integration lands after both merge).

### Design
- **Single-signature, fixed-fee, immutable contract**: no `Ownable`, no tunable cap — `FEE` is a deploy-time immutable ($0.05). Addressing the 3009 authorization to the relay IS consent to its public terms; changing the fee requires a new deployment, so signed authorizations can never face different terms. Relayers always claim the max, so a cap would BE the fee.
- **Atomicity + iron rule**: any failure reverts whole — funds never leave the buyer wallet; the net is credited to the buyer's Deposits balance, never transferred to the buyer address. The contract mirrors both Deposits guards (`MIN_BUYER_DEPOSIT`, credit limit) with clear errors for simulating relayers.
- **Front-running is harmless**: the 3009 auth pins `to = relay`; a front-runner can only execute the identical sweep and claim the fee.
- **Protocol**: `SweepRequest`/`SweepReceipt` (0xA0/0xA1, JSON payloads, defensive validation). 0x90-0x9F left reserved for the in-flight delegated-verification branch to avoid a merge collision.
- **Seller relayer (opt-out, ON by default)**: own-relay-address enforcement (never submits to peer-supplied contracts), nonce dedupe, per-peer rate limits, in-flight cap, local signature verification, simulate-then-submit, profit floor via `relayer.minProfitBaseUnits` (may be negative for local testing).
- **CLI**: `antseed buyer sweep` signs offline, then broadcasts through a running `buyer start` daemon's existing seller connections (new `/_antseed/sweep` control-plane endpoints — avoids a duplicate-peerId collision with the daemon) with an ephemeral-node fallback when no daemon is running. Pre-flight covers fee, first-deposit minimum, credit-limit headroom (default sweeps clamp), and verifies the USDC EIP-712 domain against the token's on-chain `DOMAIN_SEPARATOR()`.

### Verification
- `forge test`: 571 tests (17 new relay tests: fixed-fee accounting, boundary reverts, replay, wrong signer, min/limit mirrors, zero-fee deploy, conservation fuzz)
- `packages/node` vitest: 753 tests (codec hostile-input, relayer acceptance matrix, EIP-712 anchors: Circle typehash constant + Base mainnet `DOMAIN_SEPARATOR()` byte-match)
- CLI `node --test`: 147 tests (incl. control-plane sweep endpoint)
- Full workspace typecheck
- Anvil E2E: deploy via `Deploy.s.sol` (deterministic nonce-9 address), offline signing with a zero-ETH random wallet, relayer submission, exact fee accounting, replay rejection, over-credit-limit simulation rejection
- `receiveWithAuthorization` bytes overload verified present in the deployed Base USDC implementation; the EIP-712 domain ("USD Coin"/"2") verified against mainnet

### User-facing changes
CHANGELOG.md updated under Unreleased: new contract, sweep protocol, `antseed buyer sweep`, `relayer` config section, `depositRelayAddress` chain config, and `@antseed/node` signing helpers/client.

### Out of scope
- Desktop UI integration (follows after `feature/vpr` merges)
- Mainnet/sepolia relay deployment — `depositRelayAddress` stays unset in those presets until deployed (base-local is wired via `setup-local-test.sh`)