### PR TITLE
fix(adapter): Preserve cache token usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ This project uses selective package publishing. Each release entry lists the pub
 - Fixed Desktop Discover overflow tag tooltips so the `+N` category indicator works on service cards in the first row.
 - Fixed `antseed seller emissions claim` so it only checks and claims seller rewards, leaving buyer rewards to the buyer command.
 - Fixed buyer proxy protocol transforms so requests routed to OpenAI Responses always set upstream `stream: true` without forcing non-stream clients to receive SSE.
+- Fixed API adapter cache-token accounting so Anthropic cache reads and OpenAI cached token details stay separate from fresh input tokens across response and streaming transforms.
 
 ## 2026-06-15 — Buyer peer failure accounting and desktop stream responsiveness
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ This project uses selective package publishing. Each release entry lists the pub
 - Fixed `antseed seller emissions claim` so it only checks and claims seller rewards, leaving buyer rewards to the buyer command.
 - Fixed buyer proxy protocol transforms so requests routed to OpenAI Responses always set upstream `stream: true` without forcing non-stream clients to receive SSE.
 - Fixed API adapter cache-token accounting so Anthropic cache reads and OpenAI cached token details stay separate from fresh input tokens across response and streaming transforms.
+- Fixed API adapter request transforms to propagate a per-session `prompt_cache_key` (derived from Anthropic `metadata.user_id`) to OpenAI Responses upstreams, improving prompt cache hit rates for cross-protocol buyers.
 
 ## 2026-06-15 — Buyer peer failure accounting and desktop stream responsiveness
 

--- a/packages/api-adapter/src/canonical.ts
+++ b/packages/api-adapter/src/canonical.ts
@@ -3,6 +3,7 @@ import {
   mapFinishReasonToAnthropicStopReason,
   parseJsonSafe,
   toStringContent,
+  type TokenUsage,
 } from './utils.js';
 
 export interface CanonicalFunctionTool {
@@ -46,7 +47,7 @@ export interface CanonicalLlmResponse {
   model: string;
   output: CanonicalOutputItem[];
   stopReason: string | null;
-  usage: { inputTokens: number; outputTokens: number };
+  usage: TokenUsage;
 }
 
 function responseFunctionCallId(id: string): string {
@@ -436,9 +437,9 @@ export function normalizeOpenAIChatResponseBody(
     });
   }
 
-  const { inputTokens, outputTokens } = extractUsage(body);
+  const usage = extractUsage(body);
   const stopReason = typeof firstChoice.finish_reason === 'string' ? firstChoice.finish_reason : null;
-  return { id, model, output, stopReason, usage: { inputTokens, outputTokens } };
+  return { id, model, output, stopReason, usage };
 }
 
 export function normalizeOpenAIResponsesResponseBody(
@@ -471,9 +472,9 @@ export function normalizeOpenAIResponsesResponseBody(
     }
   }
 
-  const { inputTokens, outputTokens } = extractUsage(body);
+  const usage = extractUsage(body);
   const stopReason = openAIResponsesStopReason(body, output);
-  return { id, model, output, stopReason, usage: { inputTokens, outputTokens } };
+  return { id, model, output, stopReason, usage };
 }
 
 function openAIResponsesStopReason(
@@ -521,9 +522,9 @@ export function normalizeAnthropicMessagesResponseBody(
     }
   }
 
-  const { inputTokens, outputTokens } = extractUsage(body);
+  const usage = extractUsage(body);
   const stopReason = anthropicStopReasonToOpenAI(body.stop_reason);
-  return { id, model, output, stopReason, usage: { inputTokens, outputTokens } };
+  return { id, model, output, stopReason, usage };
 }
 
 export function renderCanonicalResponseToOpenAIChatBody(response: CanonicalLlmResponse): Record<string, unknown> {
@@ -553,11 +554,7 @@ export function renderCanonicalResponseToOpenAIChatBody(response: CanonicalLlmRe
       },
       finish_reason: response.stopReason ?? (toolCalls.length > 0 ? 'tool_calls' : 'stop'),
     }],
-    usage: {
-      prompt_tokens: response.usage.inputTokens,
-      completion_tokens: response.usage.outputTokens,
-      total_tokens: response.usage.inputTokens + response.usage.outputTokens,
-    },
+    usage: openAIChatUsage(response.usage),
   };
 }
 
@@ -598,11 +595,7 @@ export function renderCanonicalResponseToOpenAIResponsesBody(response: Canonical
     created_at: Math.floor(Date.now() / 1000),
     output,
     output_text: text,
-    usage: {
-      input_tokens: response.usage.inputTokens,
-      output_tokens: response.usage.outputTokens,
-      total_tokens: response.usage.inputTokens + response.usage.outputTokens,
-    },
+    usage: openAIResponsesUsage(response.usage),
   };
 }
 
@@ -625,10 +618,37 @@ export function renderCanonicalResponseToAnthropicMessagesBody(response: Canonic
     content,
     stop_reason: mapFinishReasonToAnthropicStopReason(response.stopReason),
     stop_sequence: null,
-    usage: {
-      input_tokens: response.usage.inputTokens,
-      output_tokens: response.usage.outputTokens,
-    },
+    usage: anthropicUsage(response.usage),
+  };
+}
+
+function openAIChatUsage(usage: TokenUsage): Record<string, unknown> {
+  return {
+    prompt_tokens: usage.inputTokens,
+    completion_tokens: usage.outputTokens,
+    total_tokens: usage.inputTokens + usage.outputTokens,
+    ...(usage.cachedInputTokens > 0
+      ? { prompt_tokens_details: { cached_tokens: usage.cachedInputTokens } }
+      : {}),
+  };
+}
+
+function openAIResponsesUsage(usage: TokenUsage): Record<string, unknown> {
+  return {
+    input_tokens: usage.inputTokens,
+    output_tokens: usage.outputTokens,
+    total_tokens: usage.inputTokens + usage.outputTokens,
+    ...(usage.cachedInputTokens > 0
+      ? { input_tokens_details: { cached_tokens: usage.cachedInputTokens } }
+      : {}),
+  };
+}
+
+function anthropicUsage(usage: TokenUsage): Record<string, unknown> {
+  return {
+    input_tokens: usage.freshInputTokens,
+    output_tokens: usage.outputTokens,
+    ...(usage.cachedInputTokens > 0 ? { cache_read_input_tokens: usage.cachedInputTokens } : {}),
   };
 }
 

--- a/packages/api-adapter/src/canonical.ts
+++ b/packages/api-adapter/src/canonical.ts
@@ -36,6 +36,7 @@ export interface CanonicalLlmRequest {
   toolChoice?: CanonicalToolChoice;
   metadata?: Record<string, unknown>;
   user?: string;
+  promptCacheKey?: string;
 }
 
 export type CanonicalOutputItem =
@@ -175,6 +176,7 @@ export function renderCanonicalRequestToOpenAIResponsesBody(request: CanonicalLl
   if (toolChoice !== undefined) body.tool_choice = toolChoice;
   if (request.metadata) body.metadata = request.metadata;
   if (request.user) body.user = request.user;
+  if (request.promptCacheKey) body.prompt_cache_key = request.promptCacheKey;
   return body;
 }
 
@@ -274,6 +276,7 @@ export function normalizeAnthropicMessagesRequestBody(body: Record<string, unkno
     if (typeof metadata.user_id === 'string') request.user = metadata.user_id;
   }
   if (request.user === undefined && typeof body.user === 'string') request.user = body.user;
+  if (request.user !== undefined) request.promptCacheKey = request.user;
   return request;
 }
 
@@ -343,6 +346,9 @@ export function normalizeOpenAIChatRequestBody(body: Record<string, unknown>): C
     request.metadata = body.metadata as Record<string, unknown>;
   }
   if (typeof body.user === 'string') request.user = body.user;
+  if (typeof body.prompt_cache_key === 'string' && body.prompt_cache_key.length > 0) {
+    request.promptCacheKey = body.prompt_cache_key;
+  }
   return request;
 }
 
@@ -401,6 +407,9 @@ export function normalizeOpenAIResponsesRequestBody(body: Record<string, unknown
     request.metadata = body.metadata as Record<string, unknown>;
   }
   if (typeof body.user === 'string') request.user = body.user;
+  if (typeof body.prompt_cache_key === 'string' && body.prompt_cache_key.length > 0) {
+    request.promptCacheKey = body.prompt_cache_key;
+  }
   return request;
 }
 

--- a/packages/api-adapter/src/stream-transform.ts
+++ b/packages/api-adapter/src/stream-transform.ts
@@ -2,12 +2,13 @@ import type { SerializedHttpResponseChunk, ServiceApiProtocol } from './types.js
 import {
   createChatStreamParser,
   encodeSseEvents,
+  extractUsage,
   makeStreamingStartResponse,
   mapFinishReasonToAnthropicStopReason,
   parseJsonSafe,
   parseSseBuffer,
-  toNonNegativeInt,
   type StreamingResponseAdapter,
+  type TokenUsage,
 } from './utils.js';
 
 export interface ServiceApiStreamTransformOptions {
@@ -24,7 +25,7 @@ interface CanonicalStreamToolCall {
 }
 
 type CanonicalStreamEvent =
-  | { type: 'response_start'; id: string; model: string; inputTokens: number }
+  | { type: 'response_start'; id: string; model: string; usage: TokenUsage }
   | { type: 'text_delta'; delta: string }
   | { type: 'tool_call_start'; index: number; id: string; name: string }
   | { type: 'tool_call_delta'; index: number; argumentsDelta: string }
@@ -33,8 +34,7 @@ type CanonicalStreamEvent =
     id: string;
     model: string;
     finishReason: string | null;
-    inputTokens: number;
-    outputTokens: number;
+    usage: TokenUsage;
     toolCalls: CanonicalStreamToolCall[];
   };
 
@@ -52,6 +52,8 @@ interface ProtocolStreamNormalizer {
 interface ProtocolStreamRenderer {
   render(events: CanonicalStreamEvent[], chunk: SerializedHttpResponseChunk): SerializedHttpResponseChunk[];
 }
+
+const ZERO_USAGE: TokenUsage = { inputTokens: 0, outputTokens: 0, freshInputTokens: 0, cachedInputTokens: 0 };
 
 const STREAM_NORMALIZERS: Partial<Record<ServiceApiProtocol, CanonicalStreamNormalizer>> = {
   'anthropic-messages': createAnthropicStreamNormalizer,
@@ -91,14 +93,14 @@ function createChatStreamNormalizer(options: StreamTransformInternals): Protocol
   const emitted: CanonicalStreamEvent[] = [];
   let responseStarted = false;
 
-  const emitStart = (id: string, model: string, inputTokens = 0): void => {
+  const emitStart = (id: string, model: string, usage: TokenUsage = ZERO_USAGE): void => {
     if (responseStarted) return;
     responseStarted = true;
     emitted.push({
       type: 'response_start',
       id,
       model: model || options.fallbackModel || 'unknown',
-      inputTokens,
+      usage,
     });
   };
 
@@ -115,14 +117,13 @@ function createChatStreamNormalizer(options: StreamTransformInternals): Protocol
       emitted.push({ type: 'tool_call_delta', index, argumentsDelta });
     },
     onFinish(info) {
-      emitStart(info.id, info.model, info.inputTokens);
+      emitStart(info.id, info.model, info.usage);
       emitted.push({
         type: 'response_done',
         id: info.id,
         model: info.model,
         finishReason: info.finishReason,
-        inputTokens: info.inputTokens,
-        outputTokens: info.outputTokens,
+        usage: info.usage,
         toolCalls: info.toolCalls,
       });
     },
@@ -145,8 +146,7 @@ function createAnthropicStreamNormalizer(options: StreamTransformInternals): Pro
   let sseBuffer = '';
   let responseId = '';
   let responseModel = options.fallbackModel ?? 'unknown';
-  let inputTokens = 0;
-  let outputTokens = 0;
+  let usage: TokenUsage = ZERO_USAGE;
   let finishReason: string | null = null;
   let responseStarted = false;
   const toolBlockIndexes = new Map<number, number>();
@@ -167,7 +167,7 @@ function createAnthropicStreamNormalizer(options: StreamTransformInternals): Pro
       type: 'response_start',
       id: responseId,
       model: responseModel,
-      inputTokens,
+      usage,
     });
   };
 
@@ -191,7 +191,7 @@ function createAnthropicStreamNormalizer(options: StreamTransformInternals): Pro
             : {};
           if (typeof message.id === 'string') responseId = message.id;
           if (typeof message.model === 'string') responseModel = message.model;
-          inputTokens = readUsageNumber(message.usage, 'input_tokens');
+          usage = extractUsage({ usage: message.usage });
           emitStart(emitted);
           continue;
         }
@@ -237,7 +237,7 @@ function createAnthropicStreamNormalizer(options: StreamTransformInternals): Pro
             ? data.delta as Record<string, unknown>
             : {};
           finishReason = anthropicStopReasonToCanonical(delta.stop_reason);
-          outputTokens = readUsageNumber(data.usage, 'output_tokens', outputTokens);
+          usage = mergeOutputUsage(usage, extractUsage({ usage: data.usage }));
           continue;
         }
 
@@ -248,8 +248,7 @@ function createAnthropicStreamNormalizer(options: StreamTransformInternals): Pro
             id: responseId,
             model: responseModel,
             finishReason: finishReason ?? 'stop',
-            inputTokens,
-            outputTokens,
+            usage,
             toolCalls: sortedToolCalls(toolCalls),
           });
         }
@@ -261,8 +260,7 @@ function createAnthropicStreamNormalizer(options: StreamTransformInternals): Pro
           id: responseId,
           model: responseModel,
           finishReason: finishReason ?? 'stop',
-          inputTokens,
-          outputTokens,
+          usage,
           toolCalls: sortedToolCalls(toolCalls),
         }];
       }
@@ -277,8 +275,7 @@ function createResponsesStreamNormalizer(options: StreamTransformInternals): Pro
   let sseBuffer = '';
   let responseId = '';
   let responseModel = options.fallbackModel ?? 'unknown';
-  let inputTokens = 0;
-  let outputTokens = 0;
+  let usage: TokenUsage = ZERO_USAGE;
   let responseStarted = false;
   const toolOutputIndexes = new Map<number, number>();
   const toolCalls = new Map<number, CanonicalStreamToolCall>();
@@ -298,7 +295,7 @@ function createResponsesStreamNormalizer(options: StreamTransformInternals): Pro
       type: 'response_start',
       id: responseId,
       model: responseModel,
-      inputTokens,
+      usage,
     });
   };
 
@@ -320,7 +317,7 @@ function createResponsesStreamNormalizer(options: StreamTransformInternals): Pro
           const response = objectValue(data.response);
           if (typeof response.id === 'string') responseId = response.id;
           if (typeof response.model === 'string') responseModel = response.model;
-          inputTokens = readUsageNumber(response.usage, 'input_tokens');
+          usage = extractUsage({ usage: response.usage });
           emitStart(emitted);
           continue;
         }
@@ -360,8 +357,7 @@ function createResponsesStreamNormalizer(options: StreamTransformInternals): Pro
           const response = objectValue(data.response);
           if (typeof response.id === 'string') responseId = response.id;
           if (typeof response.model === 'string') responseModel = response.model;
-          inputTokens = readUsageNumber(response.usage, 'input_tokens', inputTokens);
-          outputTokens = readUsageNumber(response.usage, 'output_tokens', outputTokens);
+          usage = mergeUsage(usage, extractUsage({ usage: response.usage }));
           emitCompletedResponseOutput(response.output, toolCalls, toolOutputIndexes);
           emitStart(emitted);
           emitted.push({
@@ -369,8 +365,7 @@ function createResponsesStreamNormalizer(options: StreamTransformInternals): Pro
             id: responseId,
             model: responseModel,
             finishReason: openAIResponsesStreamFinishReason(response, toolCalls),
-            inputTokens,
-            outputTokens,
+            usage,
             toolCalls: sortedToolCalls(toolCalls),
           });
         }
@@ -441,11 +436,7 @@ function createChatStreamRenderer(options: StreamTransformInternals): ProtocolSt
         }
 
         if (event.type === 'response_done') {
-          chunks.push(renderChunk({}, event.finishReason ?? 'stop', {
-            prompt_tokens: event.inputTokens,
-            completion_tokens: event.outputTokens,
-            total_tokens: event.inputTokens + event.outputTokens,
-          }));
+          chunks.push(renderChunk({}, event.finishReason ?? 'stop', openAIChatUsage(event.usage)));
           chunks.push('data: [DONE]\n\n');
         }
       }
@@ -493,7 +484,7 @@ function createAnthropicStreamRenderer(options: StreamTransformInternals): Proto
           content: [],
           stop_reason: null,
           stop_sequence: null,
-          usage: { input_tokens: event?.inputTokens ?? 0, output_tokens: 0 },
+          usage: anthropicUsage(event?.usage ?? ZERO_USAGE),
         },
       },
     });
@@ -584,7 +575,7 @@ function createAnthropicStreamRenderer(options: StreamTransformInternals): Proto
             data: {
               type: 'message_delta',
               delta: { stop_reason: mapFinishReasonToAnthropicStopReason(event.finishReason), stop_sequence: null },
-              usage: { output_tokens: event.outputTokens },
+              usage: { output_tokens: event.usage.outputTokens },
             },
           });
           emitted.push({ event: 'message_stop', data: { type: 'message_stop' } });
@@ -643,7 +634,7 @@ function createResponsesStreamRenderer(options: StreamTransformInternals): Proto
         created_at: createdAt,
         output: [],
         output_text: '',
-        usage: { input_tokens: event?.inputTokens ?? 0, output_tokens: 0, total_tokens: event?.inputTokens ?? 0 },
+        usage: openAIResponsesUsage(event?.usage ?? ZERO_USAGE),
       },
     });
   };
@@ -814,11 +805,7 @@ function createResponsesStreamRenderer(options: StreamTransformInternals): Proto
                 })),
               ],
               output_text: textBuffer,
-              usage: {
-                input_tokens: event.inputTokens,
-                output_tokens: event.outputTokens,
-                total_tokens: event.inputTokens + event.outputTokens,
-              },
+              usage: openAIResponsesUsage(event.usage),
             },
           });
           emitted.push({ data: '[DONE]' });
@@ -889,10 +876,47 @@ function objectValue(value: unknown): Record<string, unknown> {
     : {};
 }
 
-function readUsageNumber(value: unknown, field: string, fallback = 0): number {
-  const usage = objectValue(value);
-  if (!(field in usage)) return fallback;
-  return toNonNegativeInt(usage[field]);
+function mergeUsage(previous: TokenUsage, next: TokenUsage): TokenUsage {
+  return {
+    inputTokens: next.inputTokens > 0 ? next.inputTokens : previous.inputTokens,
+    outputTokens: next.outputTokens > 0 ? next.outputTokens : previous.outputTokens,
+    freshInputTokens: next.freshInputTokens > 0 ? next.freshInputTokens : previous.freshInputTokens,
+    cachedInputTokens: next.cachedInputTokens > 0 ? next.cachedInputTokens : previous.cachedInputTokens,
+  };
+}
+
+function mergeOutputUsage(previous: TokenUsage, next: TokenUsage): TokenUsage {
+  return { ...previous, outputTokens: next.outputTokens > 0 ? next.outputTokens : previous.outputTokens };
+}
+
+function openAIChatUsage(usage: TokenUsage): Record<string, unknown> {
+  return {
+    prompt_tokens: usage.inputTokens,
+    completion_tokens: usage.outputTokens,
+    total_tokens: usage.inputTokens + usage.outputTokens,
+    ...(usage.cachedInputTokens > 0
+      ? { prompt_tokens_details: { cached_tokens: usage.cachedInputTokens } }
+      : {}),
+  };
+}
+
+function openAIResponsesUsage(usage: TokenUsage): Record<string, unknown> {
+  return {
+    input_tokens: usage.inputTokens,
+    output_tokens: usage.outputTokens,
+    total_tokens: usage.inputTokens + usage.outputTokens,
+    ...(usage.cachedInputTokens > 0
+      ? { input_tokens_details: { cached_tokens: usage.cachedInputTokens } }
+      : {}),
+  };
+}
+
+function anthropicUsage(usage: TokenUsage): Record<string, unknown> {
+  return {
+    input_tokens: usage.freshInputTokens,
+    output_tokens: usage.outputTokens,
+    ...(usage.cachedInputTokens > 0 ? { cache_read_input_tokens: usage.cachedInputTokens } : {}),
+  };
 }
 
 function sortedToolCalls(toolCalls: Map<number, CanonicalStreamToolCall>): CanonicalStreamToolCall[] {

--- a/packages/api-adapter/src/utils.ts
+++ b/packages/api-adapter/src/utils.ts
@@ -86,7 +86,8 @@ export function extractUsage(parsed: Record<string, unknown>): TokenUsage {
   }
 
   const hasPromptTokens = usage.prompt_tokens !== undefined && usage.prompt_tokens !== null;
-  const rawInput = toNonNegativeInt(usage.prompt_tokens ?? usage.input_tokens);
+  const baseInput = toNonNegativeInt(usage.prompt_tokens ?? usage.input_tokens);
+  const cacheCreationInputTokens = toNonNegativeInt(usage.cache_creation_input_tokens);
   const outputTokens = toNonNegativeInt(usage.completion_tokens ?? usage.output_tokens);
 
   // Cache hits arrive in two competing shapes:
@@ -110,6 +111,7 @@ export function extractUsage(parsed: Record<string, unknown>): TokenUsage {
 
   const isSubsetShape = hasPromptTokens || inputDetails.cached_tokens !== undefined;
   const cachedInputTokens = Math.max(subsetCached, separateCached);
+  const rawInput = isSubsetShape ? baseInput : baseInput + cacheCreationInputTokens;
   const freshInputTokens = isSubsetShape
     ? Math.max(0, rawInput - cachedInputTokens)
     : rawInput;
@@ -261,8 +263,7 @@ export function parseChatCompletionResponse(
 export interface ChatStreamFinishInfo {
   id: string;
   model: string;
-  inputTokens: number;
-  outputTokens: number;
+  usage: TokenUsage;
   finishReason: string | null;
   toolCalls: Array<{ index: number; id: string; name: string; arguments: string }>;
 }
@@ -288,8 +289,7 @@ export function createChatStreamParser(
   const streamDecoder = new TextDecoder();
   let id = fallbacks?.id ?? '';
   let model = fallbacks?.model ?? 'unknown';
-  let inputTokens = 0;
-  let outputTokens = 0;
+  let usage: TokenUsage = { inputTokens: 0, outputTokens: 0, freshInputTokens: 0, cachedInputTokens: 0 };
   let finishReason: string | null = null;
   const toolCalls = new Map<number, { id: string; name: string; arguments: string }>();
 
@@ -312,11 +312,8 @@ export function createChatStreamParser(
         if (typeof p.id === 'string' && p.id.length > 0) id = p.id;
         if (typeof p.model === 'string' && p.model.length > 0) model = p.model;
 
-        const usage = p.usage && typeof p.usage === 'object'
-          ? p.usage as Record<string, unknown> : null;
-        if (usage) {
-          inputTokens = toNonNegativeInt(usage.prompt_tokens ?? usage.input_tokens);
-          outputTokens = toNonNegativeInt(usage.completion_tokens ?? usage.output_tokens);
+        if (p.usage && typeof p.usage === 'object') {
+          usage = extractUsage(p);
         }
 
         const choices = Array.isArray(p.choices) ? p.choices : [];
@@ -369,7 +366,7 @@ export function createChatStreamParser(
         const sorted = [...toolCalls.entries()]
           .sort((a, b) => a[0] - b[0])
           .map(([index, tc]) => ({ index, ...tc }));
-        callbacks.onFinish({ id, model, inputTokens, outputTokens, finishReason, toolCalls: sorted });
+        callbacks.onFinish({ id, model, usage, finishReason, toolCalls: sorted });
       }
     },
   };

--- a/packages/api-adapter/tests/adapter.test.ts
+++ b/packages/api-adapter/tests/adapter.test.ts
@@ -291,6 +291,7 @@ describe('transformRequest anthropic to responses', () => {
     expect(body.stop).toEqual(['END']);
     expect(body.metadata).toEqual({ trace: 'abc' });
     expect(body.user).toBe('user-123');
+    expect(body.prompt_cache_key).toBe('user-123');
     expect(body.tool_choice).toEqual({ type: 'function', name: 'write' });
     expect(body.tools).toEqual([{
       type: 'function',
@@ -309,6 +310,37 @@ describe('transformRequest anthropic to responses', () => {
     expect(input).toEqual([
       { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
     ]);
+  });
+
+  it('maps anthropic metadata.user_id to a responses prompt_cache_key', () => {
+    const transformed = transformRequest(makeRequest({
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'claude-sonnet',
+        max_tokens: 256,
+        metadata: { user_id: 'user_abc_session_f00d' },
+        messages: [
+          { role: 'user', content: 'hello' },
+        ],
+      })),
+    }), { from: 'anthropic-messages', to: 'openai-responses' });
+
+    const body = JSON.parse(new TextDecoder().decode(transformed!.request.body)) as Record<string, unknown>;
+    expect(body.prompt_cache_key).toBe('user_abc_session_f00d');
+  });
+
+  it('omits prompt_cache_key when the anthropic request has no session identity', () => {
+    const transformed = transformRequest(makeRequest({
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'claude-sonnet',
+        max_tokens: 256,
+        messages: [
+          { role: 'user', content: 'hello' },
+        ],
+      })),
+    }), { from: 'anthropic-messages', to: 'openai-responses' });
+
+    const body = JSON.parse(new TextDecoder().decode(transformed!.request.body)) as Record<string, unknown>;
+    expect(body.prompt_cache_key).toBeUndefined();
   });
 
   it('forces upstream responses streaming without changing original non-stream preference', () => {
@@ -1303,6 +1335,24 @@ describe('transformRequest chat to responses', () => {
     expect(body.input).toEqual([
       { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hello' }] },
     ]);
+  });
+
+  it('carries an explicit prompt_cache_key through to the responses body', () => {
+    const request: SerializedHttpRequest = {
+      requestId: 'req-chat-cache-key',
+      method: 'POST',
+      path: '/v1/chat/completions',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'gpt-4.1',
+        messages: [{ role: 'user', content: 'hello' }],
+        prompt_cache_key: 'conv-42',
+      })),
+    };
+    const result = transformRequest(request, { from: 'openai-chat-completions', to: 'openai-responses' });
+
+    const body = JSON.parse(new TextDecoder().decode(result!.request.body)) as Record<string, unknown>;
+    expect(body.prompt_cache_key).toBe('conv-42');
   });
 });
 

--- a/packages/api-adapter/tests/adapter.test.ts
+++ b/packages/api-adapter/tests/adapter.test.ts
@@ -1027,6 +1027,61 @@ describe('transformResponse chat to responses', () => {
     expect(usage.total_tokens).toBe(23);
   });
 
+  it('preserves cached input token details in responses usage', () => {
+    const chatResponse = makeOpenAIResponse({
+      body: new TextEncoder().encode(JSON.stringify({
+        id: 'chatcmpl-cache',
+        model: 'gpt-4.1',
+        choices: [{
+          index: 0,
+          finish_reason: 'stop',
+          message: { role: 'assistant', content: 'cached' },
+        }],
+        usage: {
+          prompt_tokens: 1000,
+          completion_tokens: 8,
+          prompt_tokens_details: { cached_tokens: 900 },
+        },
+      })),
+    });
+
+    const result = adaptResponseForTest('openai-chat-completions', 'openai-responses', chatResponse);
+    const body = JSON.parse(new TextDecoder().decode(result.body)) as Record<string, unknown>;
+    expect(body.usage).toMatchObject({
+      input_tokens: 1000,
+      output_tokens: 8,
+      total_tokens: 1008,
+      input_tokens_details: { cached_tokens: 900 },
+    });
+  });
+
+  it('maps Anthropic cache reads to Responses cached token details', () => {
+    const anthropicResponse = makeAnthropicResponse({
+      body: new TextEncoder().encode(JSON.stringify({
+        id: 'msg_cache',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-sonnet',
+        content: [{ type: 'text', text: 'cached' }],
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: 3000,
+          cache_read_input_tokens: 34_500_000,
+          output_tokens: 42,
+        },
+      })),
+    });
+
+    const result = adaptResponseForTest('anthropic-messages', 'openai-responses', anthropicResponse);
+    const body = JSON.parse(new TextDecoder().decode(result.body)) as Record<string, unknown>;
+    expect(body.usage).toMatchObject({
+      input_tokens: 34_503_000,
+      output_tokens: 42,
+      total_tokens: 34_503_042,
+      input_tokens_details: { cached_tokens: 34_500_000 },
+    });
+  });
+
   it('maps tool calls to function_call items', () => {
     const result = adaptResponseForTest('openai-chat-completions', 'openai-responses', makeOpenAIResponse(), {
       fallbackModel: 'fallback',
@@ -1323,6 +1378,40 @@ describe('transformResponse responses to anthropic', () => {
       { type: 'text', text: 'Working on it' },
       { type: 'tool_use', id: 'call_123', name: 'write', input: { path: 'hello.txt' } },
     ]);
+  });
+
+  it('maps cached Responses usage to Anthropic cache fields', () => {
+    const result = adaptResponseForTest('openai-responses', 'anthropic-messages', {
+      requestId: 'req-resp-cache',
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({
+        id: 'resp_cache',
+        model: 'gpt-5.5',
+        status: 'completed',
+        output: [{
+          type: 'message',
+          id: 'msg_1',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'cached' }],
+        }],
+        usage: {
+          input_tokens: 34_503_000,
+          input_tokens_details: { cached_tokens: 34_500_000 },
+          output_tokens: 42,
+        },
+      })),
+    }, {
+      streamRequested: false,
+      fallbackModel: 'claude-sonnet',
+    });
+
+    const body = JSON.parse(new TextDecoder().decode(result.body)) as Record<string, unknown>;
+    expect(body.usage).toEqual({
+      input_tokens: 3000,
+      output_tokens: 42,
+      cache_read_input_tokens: 34_500_000,
+    });
   });
 
   it('maps incomplete responses stop reasons to anthropic stop reasons', () => {

--- a/packages/api-adapter/tests/extract-usage.test.ts
+++ b/packages/api-adapter/tests/extract-usage.test.ts
@@ -69,6 +69,23 @@ describe('extractUsage', () => {
     });
   });
 
+  it('counts Anthropic cache creation tokens as fresh input', () => {
+    const result = extractUsage({
+      usage: {
+        input_tokens: 150,
+        cache_creation_input_tokens: 50,
+        cache_read_input_tokens: 600,
+        output_tokens: 75,
+      },
+    });
+    expect(result).toEqual({
+      inputTokens: 800,
+      outputTokens: 75,
+      freshInputTokens: 200,
+      cachedInputTokens: 600,
+    });
+  });
+
   it('OpenAI cached tokens never produce negative freshInputTokens', () => {
     // Edge case: cached_tokens > prompt_tokens (shouldn't happen but be safe)
     const result = extractUsage({


### PR DESCRIPTION
## Description

Preserves cache-token details across API adapter response normalization and rendering. This keeps Anthropic cache reads, cache creation tokens, and OpenAI cached token details separate from fresh input tokens for JSON and streaming transforms.

## Release Notes

- Fixed API adapter cache-token accounting so cached input tokens are not flattened into fresh input tokens when transforming between Anthropic Messages, OpenAI Chat Completions, and OpenAI Responses.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Validation

- `pnpm --filter @antseed/api-adapter test`
- `pnpm --filter @antseed/api-adapter typecheck`
