### PR TITLE
fix(payments): Cap replayed first reserves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ This project uses selective package publishing. Each release entry lists the pub
 - Fixed buyer proxy protocol transforms so requests routed to OpenAI Responses always set upstream `stream: true` without forcing non-stream clients to receive SSE.
 - Fixed API adapter cache-token accounting so Anthropic cache reads and OpenAI cached token details stay separate from fresh input tokens across response and streaming transforms.
 - Fixed API adapter request transforms to propagate a per-session `prompt_cache_key` (derived from Anthropic `metadata.user_id`) to OpenAI Responses upstreams, improving prompt cache hit rates for cross-protocol buyers.
+- Fixed buyer reserve replay after channel top-ups so reconnecting buyers resend the original first-reserve amount instead of an expanded top-up ceiling that can exceed the on-chain first-sign cap.
 
 ## 2026-06-15 — Buyer peer failure accounting and desktop stream responsiveness
 

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -105,6 +105,9 @@ export class BuyerPaymentManager {
   /** sellerPeerId -> current on-chain reserve ceiling (can grow with top-ups) */
   private readonly _currentReserveCeiling = new Map<string, bigint>();
 
+  /** sellerPeerId -> original first-reserve amount for replaying reserve() safely. */
+  private readonly _initialReserveAmount = new Map<string, bigint>();
+
   /** sellerPeerId -> salt used in the current reserve */
   private readonly _reserveSalt = new Map<string, string>();
 
@@ -208,6 +211,7 @@ export class BuyerPaymentManager {
     this._verifiedCost.delete(sellerPeerId);
     this._sessionPricing.delete(sellerPeerId);
     this._currentReserveCeiling.delete(sellerPeerId);
+    this._initialReserveAmount.delete(sellerPeerId);
     this._reserveSalt.delete(sellerPeerId);
     this._confirmedPeers.delete(sellerPeerId);
     this._rejectedPeers.delete(sellerPeerId);
@@ -338,7 +342,12 @@ export class BuyerPaymentManager {
     // Force a fresh AuthAck after replaying the reserve path.
     this._confirmedPeers.delete(sellerPeerId);
 
-    const maxAmount = this._currentReserveCeiling.get(sellerPeerId) ?? this._config.maxReserveAmountUsdc;
+    const replayAmount = this._initialReserveAmount.get(sellerPeerId)
+      ?? this._currentReserveCeiling.get(sellerPeerId)
+      ?? this._config.maxReserveAmountUsdc;
+    const maxAmount = replayAmount > this._config.maxReserveAmountUsdc
+      ? this._config.maxReserveAmountUsdc
+      : replayAmount;
     const deadline = Math.floor(Date.now() / 1000) + this._config.defaultAuthDurationSecs;
     const reserveMsg: ReserveAuthMessage = {
       channelId: session.sessionId,
@@ -542,6 +551,7 @@ export class BuyerPaymentManager {
     this._metadata.set(sellerPeerId, this._sanitizeMetadata({ ...ZERO_METADATA }));
     this._verifiedCost.set(sellerPeerId, 0n);
     this._currentReserveCeiling.set(sellerPeerId, maxAmount);
+    this._initialReserveAmount.set(sellerPeerId, maxAmount);
     this._reserveSalt.set(sellerPeerId, salt);
 
     // Store session

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -1141,6 +1141,34 @@ describe('BuyerPaymentManager', () => {
     expect(manager.getReserveCeiling(sellerPeerId)).toBe(20_000_000n);
   });
 
+  it('resendReserveAuth replays the original reserve amount after top-up', async () => {
+    store.close();
+    store = new ChannelStore(tempDir);
+    manager = new BuyerPaymentManager(
+      identity,
+      makeConfig(tempDir, { maxReserveAmountUsdc: 100_000n }),
+      store,
+    );
+    manager.setSigner(Wallet.createRandom());
+    mux = createMockPaymentMux();
+
+    const sellerPeerId = fakePeerId('seller-replay-rsv');
+    await manager.authorizeSpending(sellerPeerId, mux, 10_000n, 50_000n, TEST_PRICING);
+    mux.sentSpendingAuths.length = 0;
+
+    await manager.topUpReserve(sellerPeerId, mux);
+    expect((mux.sentSpendingAuths[0] as Record<string, unknown>).reserveMaxAmount).toBe('150000');
+    expect(manager.getReserveCeiling(sellerPeerId)).toBe(150_000n);
+
+    mux.sentSpendingAuths.length = 0;
+    await manager.resendReserveAuth(sellerPeerId, mux);
+
+    expect(mux.sentSpendingAuths).toHaveLength(1);
+    const replay = mux.sentSpendingAuths[0] as Record<string, unknown>;
+    expect(replay.reserveMaxAmount).toBe('50000');
+    expect(manager.getReserveCeiling(sellerPeerId)).toBe(150_000n);
+  });
+
   // parseResponseCost tests removed — method removed (cost flows through NeedAuth now)
 
   // ── Session persistence ────────────────────────────────────────


### PR DESCRIPTION
## Description

Fixes buyer payment-channel reserve replay after a channel has been topped up. Buyers now remember the original first-reserve amount separately from the mutable top-up ceiling, so a replayed fresh reserve cannot accidentally use an expanded amount above the on-chain first-sign cap.

## Release Notes

- Fixed buyer payment negotiation after channel top-ups so reconnecting buyers avoid first-reserve cap reverts when replaying reserve authorization.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
