### PR TITLE
fix(payments): Defer transient tx backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ This project uses selective package publishing. Each release entry lists the pub
 - Fixed API adapter cache-token accounting so Anthropic cache reads and OpenAI cached token details stay separate from fresh input tokens across response and streaming transforms.
 - Fixed API adapter request transforms to propagate a per-session `prompt_cache_key` (derived from Anthropic `metadata.user_id`) to OpenAI Responses upstreams, improving prompt cache hit rates for cross-protocol buyers.
 - Fixed buyer reserve replay after channel top-ups so reconnecting buyers resend the original first-reserve amount instead of an expanded top-up ceiling that can exceed the on-chain first-sign cap.
+- Fixed seller payment handling so temporary delegated-account transaction queue backpressure defers top-ups and retries closes instead of permanently rejecting active buyer sessions.
 
 ## 2026-06-15 — Buyer peer failure accounting and desktop stream responsiveness
 

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -46,8 +46,9 @@ const DEFAULT_MIN_SETTLE_DELTA = BigInt(DEFAULT_MIN_SETTLE_DELTA_STR);
 
 const TOP_UP_THRESHOLD_NOT_MET_SELECTOR = '0x1ea4506b';
 const INSUFFICIENT_BALANCE_SELECTOR = '0xf4d678b8';
+const IN_FLIGHT_TX_LIMIT_PHRASE = 'in-flight transaction limit';
 
-type TopUpFailureKind = 'retryable-threshold' | 'insufficient-balance' | 'non-retryable';
+type TopUpFailureKind = 'retryable-threshold' | 'retryable-tx-backpressure' | 'insufficient-balance' | 'non-retryable';
 
 /** Stored auth entry for buyer's SpendingAuth signature. */
 interface LatestAuth {
@@ -572,12 +573,14 @@ export class SellerPaymentManager {
           debugLog(`[SellerPayment] Top-up completed: channel=${channelId.slice(0, 18)}... new ceiling=${newMaxAmount}`);
         } catch (topUpErr) {
           const failureKind = this._classifyTopUpFailure(topUpErr);
-          if (failureKind === 'retryable-threshold') {
-            // TopUpThresholdNotMet is a timing/settlement race: keep the
-            // ReserveAuth pending and retry after a later SpendingAuth raises
-            // the settle amount enough to satisfy the contract's 85% gate.
+          if (failureKind === 'retryable-threshold' || failureKind === 'retryable-tx-backpressure') {
+            // TopUpThresholdNotMet is a timing/settlement race; tx backpressure
+            // means the RPC/delegated-account queue is saturated. In both cases
+            // keep the ReserveAuth pending and retry after a later SpendingAuth
+            // instead of treating the active channel as permanently broken.
+            const reason = failureKind === 'retryable-threshold' ? 'threshold not met' : 'transaction backpressure';
             debugWarn(
-              `[SellerPayment] Top-up threshold not met: channel=${channelId.slice(0, 18)}... ` +
+              `[SellerPayment] Top-up ${reason}: channel=${channelId.slice(0, 18)}... ` +
               `error=${this._formatError(topUpErr)} — ` +
               `deferring topUp (will retry after next SpendingAuth)`,
             );
@@ -720,10 +723,20 @@ export class SellerPaymentManager {
     if (text.includes('topupthresholdnotmet') || text.includes(TOP_UP_THRESHOLD_NOT_MET_SELECTOR)) {
       return 'retryable-threshold';
     }
+    if (this._isRetryableTxSubmissionFailure(text)) {
+      return 'retryable-tx-backpressure';
+    }
     if (text.includes('insufficientbalance') || text.includes(INSUFFICIENT_BALANCE_SELECTOR)) {
       return 'insufficient-balance';
     }
     return 'non-retryable';
+  }
+
+  private _isRetryableTxSubmissionFailure(errOrText: unknown): boolean {
+    const text = typeof errOrText === 'string'
+      ? errOrText.toLowerCase()
+      : this._flattenErrorText(errOrText).toLowerCase();
+    return text.includes(IN_FLIGHT_TX_LIMIT_PHRASE);
   }
 
   private _flattenErrorText(value: unknown, seen = new Set<object>(), depth = 0): string {
@@ -842,9 +855,10 @@ export class SellerPaymentManager {
       return 'succeeded';
     } catch (retryErr) {
       const failureKind = this._classifyTopUpFailure(retryErr);
-      if (failureKind === 'retryable-threshold') {
+      if (failureKind === 'retryable-threshold' || failureKind === 'retryable-tx-backpressure') {
+        const reason = failureKind === 'retryable-threshold' ? 'threshold not met' : 'transaction backpressure';
         debugWarn(
-          `[SellerPayment] Deferred topUp threshold not met: channel=${channelId.slice(0, 18)}... ` +
+          `[SellerPayment] Deferred topUp ${reason}: channel=${channelId.slice(0, 18)}... ` +
           `error=${this._formatError(retryErr)} — keeping pending`,
         );
         this._storePendingTopUp(channelId, pendingTopUp);
@@ -1035,6 +1049,16 @@ export class SellerPaymentManager {
           this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.SETTLED, amount.toString());
           this._closeRetryCount.delete(channelId);
         } catch (err) {
+          if (this._isRetryableTxSubmissionFailure(err)) {
+            debugWarn(
+              `[SellerPayment] Close hit transaction backpressure for ${channelId.slice(0, 18)}... ` +
+              `— keeping channel state for retry: ${this._formatError(err)}`,
+            );
+            if (cleanupOnFailure) {
+              this._activeBuyers.delete(buyerPeerId);
+            }
+            return;
+          }
           debugWarn(`[SellerPayment] Failed to close channel (attempt ${retries + 1}): ${err instanceof Error ? err.message : err}`);
           this._closeRetryCount.set(channelId, retries + 1);
           if (!cleanupOnFailure) return;
@@ -1071,7 +1095,8 @@ export class SellerPaymentManager {
       const accepted = this._acceptedCumulative.get(session.sessionId) ?? 0n;
       if (accepted > 0n) {
         debugLog(`[SellerPayment] Buyer ${buyerPeerId.slice(0, 12)}... disconnected — closing channel immediately`);
-        // Fire and forget settlement — clean up maps even if close() fails
+        // Fire and forget settlement. Permanent close failures clean up according
+        // to cleanupOnFailure; transient tx backpressure keeps channel state for retry.
         this.settleSession(buyerPeerId, { cleanupOnFailure: true }).catch((err) => {
           debugWarn(`[SellerPayment] Failed to close on disconnect: ${err instanceof Error ? err.message : err}`);
         });
@@ -1177,8 +1202,15 @@ export class SellerPaymentManager {
       this._closeRetryCount.delete(channelId);
       this._evictStaleChannel(channelId, peerId, 'zombie closed on-chain', CHANNEL_STATUS.SETTLED);
     } catch (err) {
-      this._closeRetryCount.set(channelId, retries + 1);
-      debugWarn(`[SellerPayment] Zombie close failed (attempt ${retries + 1}): ${err instanceof Error ? err.message : err}`);
+      if (this._isRetryableTxSubmissionFailure(err)) {
+        debugWarn(
+          `[SellerPayment] Zombie close hit transaction backpressure for ${channelId.slice(0, 18)}... ` +
+          `— keeping channel for retry: ${this._formatError(err)}`,
+        );
+      } else {
+        this._closeRetryCount.set(channelId, retries + 1);
+        debugWarn(`[SellerPayment] Zombie close failed (attempt ${retries + 1}): ${err instanceof Error ? err.message : err}`);
+      }
     } finally {
       this._closingChannels.delete(channelId);
     }

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -122,6 +122,16 @@ function makeOnChainChannel(buyer: Identity, seller: Identity, overrides: Record
   };
 }
 
+function makeInFlightTxLimitError(): Error & { error: { code: number; message: string }; code: string } {
+  return Object.assign(new Error('could not coalesce error'), {
+    error: {
+      code: -32000,
+      message: 'in-flight transaction limit reached for delegated accounts',
+    },
+    code: 'UNKNOWN_ERROR',
+  });
+}
+
 describe('SellerPaymentManager', () => {
   let tempDir: string;
   let store: ChannelStore;
@@ -350,6 +360,41 @@ describe('SellerPaymentManager', () => {
     expect(topUpSpy.mock.calls[1]?.[5]).toBe(3_000_000n);
   });
 
+  it('defers top-up when delegated account tx backpressure rejects submission', async () => {
+    const channelId = makeChannelId(106);
+
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    const auth900k = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 900_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, auth900k, mux);
+    manager.recordSpend(channelId, 900_000n);
+
+    const topUpSpy = vi.spyOn(manager.channelsClient, 'topUp')
+      .mockRejectedValue(makeInFlightTxLimitError());
+
+    const topUp2m = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '2000000',
+      salt: '0x' + '08'.repeat(32),
+    });
+
+    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp2m, mux)).toBe('accepted');
+    expect(topUpSpy).toHaveBeenCalledOnce();
+    expect(manager.hasPendingTopUp(channelId)).toBe(true);
+    expect(manager.getReserveMax(channelId)).toBe(1_000_000n);
+    expect(manager.isChannelBlocked(channelId)).toBe(false);
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
+    expect(manager.channelsClient.close).not.toHaveBeenCalled();
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
+  });
+
   it('rejects a top-up that fails because buyer deposits are insufficient', async () => {
     const channelId = makeChannelId(103);
 
@@ -417,6 +462,52 @@ describe('SellerPaymentManager', () => {
     expect(manager.hasPendingTopUp(channelId)).toBe(false);
     expect(manager.isChannelBlocked(channelId)).toBe(true);
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
+  });
+
+  it('keeps a deferred top-up pending when retry hits delegated account tx backpressure', async () => {
+    const channelId = makeChannelId(107);
+
+    const reservePayload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reservePayload, mux);
+
+    const auth900k = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 900_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, auth900k, mux);
+    manager.recordSpend(channelId, 900_000n);
+
+    const topUpSpy = vi.spyOn(manager.channelsClient, 'topUp')
+      .mockRejectedValueOnce(new Error('TopUpThresholdNotMet'))
+      .mockRejectedValueOnce(makeInFlightTxLimitError());
+
+    const topUp2m = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '2000000',
+      salt: '0x' + '09'.repeat(32),
+    });
+    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, topUp2m, mux)).toBe('accepted');
+    expect(manager.hasPendingTopUp(channelId)).toBe(true);
+
+    const withinReserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 950_000n,
+      reserveMaxAmount: '1000000',
+    });
+    delete withinReserve.reserveSalt;
+    delete withinReserve.reserveMaxAmount;
+    delete withinReserve.reserveDeadline;
+    expect(await manager.handleSpendingAuth(buyerIdentity.peerId, withinReserve, mux)).toBe('accepted');
+
+    expect(topUpSpy).toHaveBeenCalledTimes(2);
+    expect(manager.hasPendingTopUp(channelId)).toBe(true);
+    expect(manager.getReserveMax(channelId)).toBe(1_000_000n);
+    expect(manager.isChannelBlocked(channelId)).toBe(false);
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
+    expect(manager.channelsClient.close).not.toHaveBeenCalled();
     expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
   });
 
@@ -801,6 +892,44 @@ describe('SellerPaymentManager', () => {
     expect(closeArgs[4]).toBe(payload2.spendingAuthSig);
   });
 
+  it('keeps session state when close hits delegated account tx backpressure on disconnect', async () => {
+    const channelId = makeChannelId(13);
+
+    const payload1 = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { isReserve: true });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, payload1, mux);
+
+    const payload2 = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { cumulativeAmount: 200_000n });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, payload2, mux);
+    manager.recordSpend(channelId, 50_000n);
+
+    vi.spyOn(manager.channelsClient, 'close').mockRejectedValue(makeInFlightTxLimitError());
+
+    manager.onBuyerDisconnect(buyerIdentity.peerId);
+    while ((manager.channelsClient.close as ReturnType<typeof vi.fn>).mock.calls.length === 0) {
+      await new Promise<void>((r) => setImmediate(r));
+    }
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
+    expect(manager.getAcceptedCumulative(channelId)).toBe(200_000n);
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
+
+    vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(
+      makeOnChainChannel(buyerIdentity, sellerIdentity, {
+        deposit: 1_000_000n,
+        settled: 0n,
+        status: 1,
+      }),
+    );
+    (manager.channelsClient.close as ReturnType<typeof vi.fn>).mockResolvedValue('0xclose-hash');
+
+    await manager.checkTimeouts();
+
+    expect(manager.channelsClient.close).toHaveBeenCalledTimes(2);
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
+  });
+
   it('settleSession suppresses duplicate in-flight close attempts for the same channel', async () => {
     const channelId = makeChannelId(12);
 
@@ -1016,6 +1145,35 @@ describe('SellerPaymentManager', () => {
     await manager.checkTimeouts();
 
     expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
+  });
+
+  it('checkTimeouts keeps retrying zombie close when delegated account tx backpressure persists', async () => {
+    const channelId = makeChannelId(75);
+    const reserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+      deadline: Math.floor(Date.now() / 1000) - 1,
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reserve, mux);
+    manager.onBuyerDisconnect(buyerIdentity.peerId);
+
+    vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(
+      makeOnChainChannel(buyerIdentity, sellerIdentity, {
+        deposit: 1_000_000n,
+        settled: 0n,
+        status: 1,
+      }),
+    );
+    vi.spyOn(manager.channelsClient, 'close').mockRejectedValue(makeInFlightTxLimitError());
+
+    await manager.checkTimeouts();
+    await manager.checkTimeouts();
+    await manager.checkTimeouts();
+    await manager.checkTimeouts();
+
+    expect(manager.channelsClient.close).toHaveBeenCalledTimes(4);
     expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
   });


### PR DESCRIPTION
## Description

Treats temporary delegated-account transaction queue saturation as retryable seller payment backpressure. Top-ups are deferred instead of being classified as permanent failures, and close attempts preserve channel state so timeout cleanup can retry rather than dropping active buyer sessions.

## Release Notes

- Fixed seller payment handling so temporary delegated-account transaction queue backpressure defers top-ups and retries closes instead of permanently rejecting active buyer sessions.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
