### PR TITLE
fix(adapter): Group parallel tool calls into one assistant message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable user-facing changes to AntSeed packages are documented here.
 
 This project uses selective package publishing. Each release entry lists the published packages affected by that release.
 
+## Unreleased
+
+### Fixed
+
+- Fixed the buyer's Responses→Chat Completions request adapter to group parallel tool calls into a single assistant `tool_calls` message. Previously each call became its own assistant message, so strict chat-completions upstreams rejected multi-tool turns with `an assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'`.
+- Fixed the Responses request normalizer to drop non-message input items with no renderable text (e.g. Codex `reasoning` items) instead of converting them into empty user messages mid-history.
+
 ## 2026-07-16 — Gasless deposit sweep live on Base mainnet
 
 ### Published

--- a/packages/api-adapter/src/canonical.ts
+++ b/packages/api-adapter/src/canonical.ts
@@ -93,13 +93,17 @@ export function renderCanonicalRequestToOpenAIChatBody(
         type: 'function',
         function: { name: item.name, arguments: stringifyToolArguments(item.arguments) },
       };
-      if (options.groupAssistantToolCallsWithPreviousMessage) {
-        const previous = messages[messages.length - 1];
-        if (isAssistantMessage(previous)) {
-          const toolCalls = Array.isArray(previous.tool_calls) ? previous.tool_calls : [];
-          previous.tool_calls = [...toolCalls, toolCall];
-          continue;
-        }
+      const previous = messages[messages.length - 1];
+      // Parallel tool calls must share one assistant message: an assistant
+      // message with tool_calls must be immediately followed by its tool
+      // responses, so consecutive function_call items always merge.
+      if (isAssistantMessageWithToolCalls(previous)) {
+        previous.tool_calls = [...previous.tool_calls as unknown[], toolCall];
+        continue;
+      }
+      if (options.groupAssistantToolCallsWithPreviousMessage && isAssistantMessage(previous)) {
+        previous.tool_calls = [toolCall];
+        continue;
       }
       messages.push({
         role: 'assistant',
@@ -392,7 +396,11 @@ export function normalizeOpenAIResponsesRequestBody(body: Record<string, unknown
       }
 
       const role = msg.role === 'assistant' ? 'assistant' : 'user';
-      request.input.push({ type: 'message', role, text: textFromResponsesContent(msg.content) });
+      const text = textFromResponsesContent(msg.content);
+      // Non-message items (reasoning, web_search_call, ...) carry no renderable
+      // text — dropping them avoids injecting empty user messages mid-history.
+      if (type !== 'message' && text.length === 0) continue;
+      request.input.push({ type: 'message', role, text });
     }
   }
 

--- a/packages/api-adapter/tests/adapter.test.ts
+++ b/packages/api-adapter/tests/adapter.test.ts
@@ -957,6 +957,52 @@ describe('transformRequest responses to chat', () => {
     });
   });
 
+  it('groups parallel function calls into a single assistant tool_calls message', () => {
+    const request = makeResponsesRequest({
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'gpt-4.1',
+        input: [
+          { role: 'user', content: 'run two things' },
+          { type: 'function_call', call_id: 'exec_command:0', name: 'exec_command', arguments: '{"cmd":"ls"}' },
+          { type: 'function_call', call_id: 'exec_command:1', name: 'exec_command', arguments: '{"cmd":"pwd"}' },
+          { type: 'function_call_output', call_id: 'exec_command:0', output: 'a b c' },
+          { type: 'function_call_output', call_id: 'exec_command:1', output: '/tmp' },
+        ],
+      })),
+    });
+    const result = transformRequest(request, { from: 'openai-responses', to: 'openai-chat-completions' });
+    const body = JSON.parse(new TextDecoder().decode(result!.request.body)) as Record<string, unknown>;
+    const messages = body.messages as Array<Record<string, unknown>>;
+
+    expect(messages).toHaveLength(4);
+    expect(messages[1].role).toBe('assistant');
+    expect((messages[1].tool_calls as unknown[]).length).toBe(2);
+    expect(messages[2]).toEqual({ role: 'tool', tool_call_id: 'exec_command:0', content: 'a b c' });
+    expect(messages[3]).toEqual({ role: 'tool', tool_call_id: 'exec_command:1', content: '/tmp' });
+  });
+
+  it('drops reasoning items instead of emitting empty user messages', () => {
+    const request = makeResponsesRequest({
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'gpt-4.1',
+        input: [
+          { role: 'user', content: 'hi' },
+          { type: 'reasoning', id: 'rs_1', summary: [] },
+          { type: 'function_call', call_id: 'exec_command:0', name: 'exec_command', arguments: '{}' },
+          { type: 'function_call_output', call_id: 'exec_command:0', output: 'ok' },
+        ],
+      })),
+    });
+    const result = transformRequest(request, { from: 'openai-responses', to: 'openai-chat-completions' });
+    const body = JSON.parse(new TextDecoder().decode(result!.request.body)) as Record<string, unknown>;
+    const messages = body.messages as Array<Record<string, unknown>>;
+
+    expect(messages).toHaveLength(3);
+    expect(messages[0]).toEqual({ role: 'user', content: 'hi' });
+    expect(messages[1].role).toBe('assistant');
+    expect(messages[2].role).toBe('tool');
+  });
+
   it('returns null for unsupported request protocols', () => {
     const request = makeResponsesRequest();
     expect(transformRequest(request, { from: 'openai-completions', to: 'openai-chat-completions' })).toBeNull();


### PR DESCRIPTION
## Description

The buyer-side Responses→Chat Completions request transform rendered each `function_call` input item as its own assistant message with a single `tool_calls` entry. With parallel tool calls, the first assistant `tool_calls` message was followed by another assistant message instead of its `tool` responses, so strict chat-completions upstreams rejected the request.

## Changes

- `renderCanonicalRequestToOpenAIChatBody`: consecutive `function_call` items now merge into the previous assistant message's `tool_calls` array, so parallel calls produce one assistant message followed by all matching `tool` messages. The `groupAssistantToolCallsWithPreviousMessage` option keeps its existing role (merging assistant text + tool calls for anthropic-sourced requests).
- `normalizeOpenAIResponsesRequestBody`: non-message input items with no renderable text (e.g. Codex `reasoning` items) are dropped instead of becoming empty `user` messages mid-history. This also protects the responses→anthropic path, where empty text blocks are rejected outright.

Buyer-side only — `transformRequest` runs in the buyer proxy; sellers need no update. Ships via new `@antseed/api-adapter` + `@antseed/cli`/desktop releases.

## Testing

- Added a test covering parallel tool calls grouping into a single assistant `tool_calls` message.
- Added a test covering `reasoning` items being dropped.
- `tsc` build and all 86 api-adapter vitest tests pass.
