### PR TITLE
refactor(contracts): simplify recognized-usage emissions stack

### DIFF
--- a/packages/contracts/emissions/AntseedEmissionsGate.sol
+++ b/packages/contracts/emissions/AntseedEmissionsGate.sol
@@ -167,10 +167,6 @@ contract AntseedEmissionsGate is IAntseedEmissionsGate, Ownable2Step, Reentrancy
         return (minter.controller, minter.shareBps, minter.editable);
     }
 
-    function minterConfig(bytes32 id) external view returns (Minter memory) {
-        return _minters[id];
-    }
-
     function minterEpochBudget(bytes32 id, uint256 epoch) public view returns (uint256) {
         Minter memory minter = _minters[id];
         if (minter.controller == address(0)) return 0;
@@ -204,14 +200,6 @@ contract AntseedEmissionsGate is IAntseedEmissionsGate, Ownable2Step, Reentrancy
 
     function epochDuration() external pure returns (uint256) {
         return EPOCH_DURATION;
-    }
-
-    function halvingInterval() external pure returns (uint256) {
-        return HALVING_INTERVAL;
-    }
-
-    function initialEmission() external pure returns (uint256) {
-        return INITIAL_EMISSION;
     }
 
     /// @notice Total scheduled emission for epochs `0..epochExclusive-1`.

--- a/packages/contracts/emissions/AntseedSellerPoolsRewards.sol
+++ b/packages/contracts/emissions/AntseedSellerPoolsRewards.sol
@@ -54,6 +54,11 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
     IAntseedEmissionsGate public immutable emissionsGate;
     IAntseedSellerPools public immutable sellerPools;
     IAntseedUsageAccounting public immutable usageAccounting;
+    /// @dev ANTS resolved once at construction (same pattern as
+    ///      AntseedSellerPools): the gate this contract mints through pins
+    ///      the same token immutably, so per-claim registry resolution only
+    ///      costs two external calls without buying flexibility.
+    IERC20 private immutable _antsToken;
 
     // ─── Claim State ─────────────────────────────────────────────────
     mapping(uint256 => bool) public epochRemainderSettled;
@@ -81,33 +86,19 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
         bool emitClaimEvents;
     }
 
+    /// @dev Pool-level APY clipping was removed, so the settled pool budget
+    ///      is fully claimable — one amount. Burn/reserve routing happens in
+    ///      `settleEpochRemainder`.
     struct PoolEpochEmission {
         bool settled;
-        uint256 grossAmount;
-        uint256 claimableAmount;
-        // Retained for event/storage compatibility. Pool-level APY clipping
-        // was removed; burn/reserve routing now happens in settleEpochRemainder.
-        uint256 burnedAmount;
-        uint256 reserveAmount;
+        uint256 amount;
     }
 
     // ─── Events ──────────────────────────────────────────────────────
     event StakerUsageRewardRestaked(
-        uint256 indexed sourcePositionId,
-        uint256 indexed newPositionId,
-        address indexed staker,
-        uint256 amount,
-        uint256 burnedAmount,
-        uint256 reserveAmount
+        uint256 indexed sourcePositionId, uint256 indexed newPositionId, address indexed staker, uint256 amount
     );
-    event PoolUsageRewardSettled(
-        uint256 indexed agentId,
-        uint256 indexed epoch,
-        uint256 grossAmount,
-        uint256 claimableAmount,
-        uint256 burnedAmount,
-        uint256 reserveAmount
-    );
+    event PoolUsageRewardSettled(uint256 indexed agentId, uint256 indexed epoch, uint256 amount);
     event PoolUsageRewardIndexed(
         uint256 indexed agentId,
         uint256 indexed epoch,
@@ -145,6 +136,9 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
         sellerPools = IAntseedSellerPools(_sellerPools);
         usageAccounting = IAntseedUsageAccounting(_usageAccounting);
         initialIndexEpoch = IAntseedUsageAccounting(_usageAccounting).currentEpoch();
+        address token = IAntseedSellerPools(_sellerPools).registry().antsToken();
+        if (token == address(0)) revert InvalidAddress();
+        _antsToken = IERC20(token);
     }
 
     // ═══════════════════════════════════════════════════════════════════
@@ -208,7 +202,7 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
             _claimIndexedStakerRewards(positionId, ClaimRoute(address(sellerPools), msg.sender, false));
         if (totalRestaked == 0) revert NothingToClaim();
         newPositionId = sellerPools.stakeMintedReward(msg.sender, positionId, totalRestaked, stakeEpochs);
-        emit StakerUsageRewardRestaked(positionId, newPositionId, msg.sender, totalRestaked, 0, 0);
+        emit StakerUsageRewardRestaked(positionId, newPositionId, msg.sender, totalRestaked);
     }
 
     function restakeStakerRewardsBatch(uint256[] calldata positionIds, uint256 stakeEpochs)
@@ -228,7 +222,7 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
 
             totalRestakedAll += totalRestaked;
             newPositionIds[p] = sellerPools.stakeMintedReward(msg.sender, positionIds[p], totalRestaked, stakeEpochs);
-            emit StakerUsageRewardRestaked(positionIds[p], newPositionIds[p], msg.sender, totalRestaked, 0, 0);
+            emit StakerUsageRewardRestaked(positionIds[p], newPositionIds[p], msg.sender, totalRestaked);
         }
         if (totalRestakedAll == 0) revert NothingToClaim();
     }
@@ -237,14 +231,10 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
     //                        VIEWS
     // ═══════════════════════════════════════════════════════════════════
 
-    function pendingStakerReward(uint256 positionId, uint256 epoch)
-        external
-        view
-        returns (uint256 grossAmount, uint256 claimableAmount, uint256 burnedAmount)
-    {
+    function pendingStakerReward(uint256 positionId, uint256 epoch) external view returns (uint256 amount) {
         (address owner, uint256 agentId,,,,,,) = sellerPools.positions(positionId);
         if (owner == address(0)) revert InvalidValue();
-        (grossAmount, claimableAmount, burnedAmount) = _positionReward(positionId, agentId, epoch);
+        amount = _positionReward(positionId, agentId, epoch);
     }
 
     function pendingIndexedStakerReward(uint256 positionId) external view returns (uint256 claimableAmount) {
@@ -260,7 +250,7 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
         if (closedAtEpoch != 0 && toEpoch > closedAtEpoch) toEpoch = closedAtEpoch;
         if (toEpoch <= fromEpoch) return 0;
 
-        claimableAmount = _positionIndexedReward(positionId, weightAmount, fromEpoch, toEpoch);
+        claimableAmount = _positionIndexedReward(agentId, weightAmount, fromEpoch, toEpoch, positionId);
     }
 
     function poolCumulativeRewardPerWeightAt(uint256 agentId, uint256 epoch) external view returns (uint256) {
@@ -303,20 +293,31 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
     }
 
     function _liveStakerEpochBudget(uint256 epoch) internal view returns (uint256) {
+        return _liveStakerEpochBudget(epoch, emissionsGate.controllerEpochBudget(address(this), epoch));
+    }
+
+    /// @dev `maxBudget` is passed in so a caller that already holds the gate
+    ///      budget saves the duplicate external call.
+    function _liveStakerEpochBudget(uint256 epoch, uint256 maxBudget) internal view returns (uint256) {
         uint256 activeStake = sellerPools.totalActiveStakeAtEpoch(epoch);
         uint32 shareBps =
             AntseedShareMath.saturatingShareBps(activeStake, stakerMinShareBps, stakerMaxShareBps, stakeShareTarget);
         if (shareBps == 0) return 0;
 
         uint256 desiredBudget = Math.mulDiv(emissionsGate.getEpochEmission(epoch), shareBps, GATE_SHARE_DENOMINATOR);
-        uint256 maxBudget = emissionsGate.controllerEpochBudget(address(this), epoch);
         return desiredBudget < maxBudget ? desiredBudget : maxBudget;
     }
 
     function _freezeStakerEpochBudget(uint256 epoch) internal returns (uint256 budget) {
         uint256 frozen = _frozenStakerBudgets[epoch];
         if (frozen != 0) return frozen - 1;
-        budget = _liveStakerEpochBudget(epoch);
+        return _freezeStakerEpochBudget(epoch, emissionsGate.controllerEpochBudget(address(this), epoch));
+    }
+
+    function _freezeStakerEpochBudget(uint256 epoch, uint256 maxBudget) internal returns (uint256 budget) {
+        uint256 frozen = _frozenStakerBudgets[epoch];
+        if (frozen != 0) return frozen - 1;
+        budget = _liveStakerEpochBudget(epoch, maxBudget);
         _frozenStakerBudgets[epoch] = budget + 1;
         emit StakerEpochBudgetFrozen(epoch, budget);
     }
@@ -334,7 +335,7 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
         // settlement, so its whole bucket is remainder — the stake-based
         // budget would otherwise be stranded outside the burn/reserve route.
         uint256 allocatedBudget =
-            usageAccounting.totalWeightedPoolPointsByEpoch(epoch) == 0 ? 0 : _freezeStakerEpochBudget(epoch);
+            usageAccounting.totalWeightedPoolPointsByEpoch(epoch) == 0 ? 0 : _freezeStakerEpochBudget(epoch, maxBudget);
         if (allocatedBudget >= maxBudget) revert NothingToClaim();
 
         uint256 unallocatedAmount = maxBudget - allocatedBudget;
@@ -364,7 +365,7 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
         if (closedAtEpoch != 0 && toEpoch > closedAtEpoch) toEpoch = closedAtEpoch;
         if (toEpoch <= fromEpoch) return 0;
 
-        claimableAmount = _positionIndexedReward(positionId, weightAmount, fromEpoch, toEpoch);
+        claimableAmount = _positionIndexedReward(agentId, weightAmount, fromEpoch, toEpoch, positionId);
         if (claimableAmount == 0) return 0;
 
         positionClaimCursor[positionId] = toEpoch;
@@ -376,11 +377,13 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
         }
     }
 
-    function _positionIndexedReward(uint256 positionId, uint256 weightAmount, uint256 fromEpoch, uint256 toEpoch)
-        internal
-        view
-        returns (uint256 rewardAmount)
-    {
+    function _positionIndexedReward(
+        uint256 agentId,
+        uint256 weightAmount,
+        uint256 fromEpoch,
+        uint256 toEpoch,
+        uint256 positionId
+    ) internal view returns (uint256 rewardAmount) {
         uint256 cursor = fromEpoch;
         while (cursor < toEpoch) {
             (uint256 normalEndEpoch, uint256 maxLockPower, uint256 nextChangeEpoch) =
@@ -389,12 +392,13 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
             if (segmentEnd <= cursor) break;
 
             if (maxLockPower != 0) {
-                uint256 rewardDelta = _cumulativeRewardDelta(positionId, cursor, segmentEnd);
+                uint256 rewardDelta = _cumulativeDelta(_poolCumulativeRewardPerWeight[agentId], cursor, segmentEnd);
                 rewardAmount += Math.mulDiv(maxLockPower, rewardDelta, INDEX_SCALE);
             } else if (normalEndEpoch != 0 && cursor < normalEndEpoch) {
                 if (segmentEnd > normalEndEpoch) segmentEnd = normalEndEpoch;
-                uint256 rewardDelta = _cumulativeRewardDelta(positionId, cursor, segmentEnd);
-                uint256 epochRewardDelta = _cumulativeEpochRewardDelta(positionId, cursor, segmentEnd);
+                uint256 rewardDelta = _cumulativeDelta(_poolCumulativeRewardPerWeight[agentId], cursor, segmentEnd);
+                uint256 epochRewardDelta =
+                    _cumulativeDelta(_poolCumulativeEpochRewardPerWeight[agentId], cursor, segmentEnd);
                 rewardAmount += Math.mulDiv(weightAmount, normalEndEpoch * rewardDelta - epochRewardDelta, INDEX_SCALE);
             }
 
@@ -403,12 +407,12 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
     }
 
     function _indexPoolRewardEpoch(uint256 agentId, uint256 epoch) internal {
-        (PoolEpochEmission storage emission,,) = _settlePoolEpoch(agentId, epoch);
+        PoolEpochEmission storage emission = _settlePoolEpoch(agentId, epoch);
 
         uint256 rewardPerWeight;
         uint256 poolWeight = sellerPools.poolWeightAtEpoch(agentId, epoch);
-        if (poolWeight != 0 && emission.claimableAmount != 0) {
-            rewardPerWeight = Math.mulDiv(emission.claimableAmount, INDEX_SCALE, poolWeight);
+        if (poolWeight != 0 && emission.amount != 0) {
+            rewardPerWeight = Math.mulDiv(emission.amount, INDEX_SCALE, poolWeight);
         }
 
         uint256 cumulativeReward = _poolCumulativeRewardPerWeight[agentId].latest() + rewardPerWeight;
@@ -421,81 +425,51 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
         emit PoolUsageRewardIndexed(agentId, epoch, rewardPerWeight, cumulativeReward, cumulativeEpochReward);
     }
 
-    function _cumulativeRewardDelta(uint256 positionId, uint256 fromEpoch, uint256 toEpoch)
+    function _cumulativeDelta(Checkpoints.Trace256 storage trace, uint256 fromEpoch, uint256 toEpoch)
         internal
         view
         returns (uint256)
     {
-        (, uint256 agentId,,,,,,) = sellerPools.positions(positionId);
-        return _poolCumulativeRewardPerWeight[agentId].upperLookupRecent(toEpoch)
-            - _poolCumulativeRewardPerWeight[agentId].upperLookupRecent(fromEpoch);
-    }
-
-    function _cumulativeEpochRewardDelta(uint256 positionId, uint256 fromEpoch, uint256 toEpoch)
-        internal
-        view
-        returns (uint256)
-    {
-        (, uint256 agentId,,,,,,) = sellerPools.positions(positionId);
-        return _poolCumulativeEpochRewardPerWeight[agentId].upperLookupRecent(toEpoch)
-            - _poolCumulativeEpochRewardPerWeight[agentId].upperLookupRecent(fromEpoch);
+        return trace.upperLookupRecent(toEpoch) - trace.upperLookupRecent(fromEpoch);
     }
 
     function _positionReward(uint256 positionId, uint256 agentId, uint256 epoch)
         internal
         view
-        returns (uint256 grossAmount, uint256 claimableAmount, uint256 burnedAmount)
+        returns (uint256 amount)
     {
-        if (agentId == 0 || epoch < positionClaimCursor[positionId]) return (0, 0, 0);
+        if (agentId == 0 || epoch < positionClaimCursor[positionId]) return 0;
 
         IAntseedSellerPools pools = sellerPools;
         uint256 positionWeight = pools.positionWeightAtEpoch(positionId, epoch);
-        if (positionWeight == 0) return (0, 0, 0);
+        if (positionWeight == 0) return 0;
 
         uint256 poolWeight = pools.poolWeightAtEpoch(agentId, epoch);
-        if (poolWeight == 0) return (0, 0, 0);
+        if (poolWeight == 0) return 0;
 
-        (uint256 poolGrossReward, uint256 poolClaimableReward) = _poolRewardPreview(agentId, epoch);
-        if (poolGrossReward == 0) return (0, 0, 0);
+        uint256 poolReward = _poolRewardPreview(agentId, epoch);
+        if (poolReward == 0) return 0;
 
-        grossAmount = Math.mulDiv(poolGrossReward, positionWeight, poolWeight);
-        claimableAmount = Math.mulDiv(poolClaimableReward, positionWeight, poolWeight);
-        burnedAmount = grossAmount - claimableAmount;
+        amount = Math.mulDiv(poolReward, positionWeight, poolWeight);
     }
 
-    function _settlePoolEpoch(uint256 agentId, uint256 epoch)
-        internal
-        returns (PoolEpochEmission storage emission, uint256 burnedAmount, uint256 reserveAmount)
-    {
+    function _settlePoolEpoch(uint256 agentId, uint256 epoch) internal returns (PoolEpochEmission storage emission) {
         emission = poolEpochEmissions[epoch][agentId];
-        if (emission.settled) return (emission, 0, 0);
+        if (emission.settled) return emission;
 
         _freezeStakerEpochBudget(epoch);
-        (uint256 grossAmount, uint256 claimableAmount) = _poolRewardPreview(agentId, epoch);
+        uint256 amount = _poolRewardPreview(agentId, epoch);
         emission.settled = true;
-        emission.grossAmount = grossAmount;
-        emission.claimableAmount = claimableAmount;
-        emission.burnedAmount = burnedAmount;
-        emission.reserveAmount = reserveAmount;
+        emission.amount = amount;
 
-        _mint(epoch, address(this), claimableAmount);
-        emit PoolUsageRewardSettled(agentId, epoch, grossAmount, claimableAmount, burnedAmount, reserveAmount);
+        _mint(epoch, address(this), amount);
+        emit PoolUsageRewardSettled(agentId, epoch, amount);
     }
 
-    function _poolRewardPreview(uint256 agentId, uint256 epoch)
-        internal
-        view
-        returns (uint256 grossAmount, uint256 claimableAmount)
-    {
+    function _poolRewardPreview(uint256 agentId, uint256 epoch) internal view returns (uint256 amount) {
         PoolEpochEmission memory settledEmission = poolEpochEmissions[epoch][agentId];
-        if (settledEmission.settled) {
-            return (settledEmission.grossAmount, settledEmission.claimableAmount);
-        }
-
-        grossAmount = _poolGrossReward(agentId, epoch);
-        if (grossAmount == 0) return (0, 0);
-
-        claimableAmount = grossAmount;
+        if (settledEmission.settled) return settledEmission.amount;
+        return _poolGrossReward(agentId, epoch);
     }
 
     function _poolGrossReward(uint256 agentId, uint256 epoch) internal view returns (uint256) {
@@ -516,17 +490,12 @@ contract AntseedSellerPoolsRewards is Ownable2Step, Pausable, ReentrancyGuard {
 
     function _transferReward(address recipient, uint256 amount) internal {
         if (amount == 0) return;
-        IERC20(_antsToken()).safeTransfer(recipient, amount);
+        _antsToken.safeTransfer(recipient, amount);
     }
 
     function _emissionsReserve() internal view returns (address reserve) {
         reserve = emissionsGate.emissionsReserve();
         if (reserve == address(0)) reserve = sellerPools.registry().protocolReserve();
         if (reserve == address(0)) revert InvalidAddress();
-    }
-
-    function _antsToken() internal view returns (address token) {
-        token = sellerPools.registry().antsToken();
-        if (token == address(0)) revert InvalidAddress();
     }
 }

--- a/packages/contracts/emissions/AntseedUsageAccounting.sol
+++ b/packages/contracts/emissions/AntseedUsageAccounting.sol
@@ -308,7 +308,7 @@ contract AntseedUsageAccounting is IAntseedUsageAccounting, Ownable2Step, Pausab
         uint256 agentId = pools.agentIdForSeller(seller);
         if (agentId == 0) return;
 
-        uint256 poolPower = pools.poolPowerWeightAtEpoch(agentId, epoch);
+        uint256 poolPower = pools.poolWeightAtEpoch(agentId, epoch);
         if (poolPower < minimumAccountedPoolPower) return;
 
         (uint256 poolWeight, bool poolWeightOk) = _policyPoolWeight(agentId, epoch, poolPower);
@@ -317,44 +317,49 @@ contract AntseedUsageAccounting is IAntseedUsageAccounting, Ownable2Step, Pausab
         (uint256 sellerPoints, uint256 buyerPoints) = _policyPoints(channelId, buyer, seller, rawPoints);
         if (sellerPoints == 0 && buyerPoints == 0) return;
 
-        {
-            UsageTotals storage totalUsage_ = _totalUsage;
-            totalUsage_.buyers.points += buyerPoints;
-            totalUsage_.sellers.points += sellerPoints;
-        }
-        {
-            UsageTotals storage epochUsage_ = _epochUsage[epoch];
-            epochUsage_.buyers.points += buyerPoints;
-            epochUsage_.sellers.points += sellerPoints;
-        }
-        _buyerUsageTotal[buyer].points += buyerPoints;
-        _buyerAgentUsageTotal[buyer][agentId].points += buyerPoints;
-        _buyerEpochUsage[epoch][buyer].points += buyerPoints;
-        _buyerAgentEpochUsage[epoch][buyer][agentId].points += buyerPoints;
-        _agentEpochUsage[epoch][agentId].points += sellerPoints;
-        if (_sellerAgentIdByEpoch[epoch][seller] == 0) _sellerAgentIdByEpoch[epoch][seller] = agentId;
-
         uint256 sellerWeightedPoints = sellerPoints * poolWeight;
         uint256 buyerWeightedPoints = buyerPoints * poolWeight;
 
         {
             UsageTotals storage totalUsage_ = _totalUsage;
+            totalUsage_.buyers.points += buyerPoints;
             totalUsage_.buyers.weightedPoints += buyerWeightedPoints;
+            totalUsage_.sellers.points += sellerPoints;
             totalUsage_.sellers.weightedPoints += sellerWeightedPoints;
-            totalUsage_.sellers.poolPoints += sellerPoints;
         }
         {
             UsageTotals storage epochUsage_ = _epochUsage[epoch];
+            epochUsage_.buyers.points += buyerPoints;
             epochUsage_.buyers.weightedPoints += buyerWeightedPoints;
+            epochUsage_.sellers.points += sellerPoints;
             epochUsage_.sellers.weightedPoints += sellerWeightedPoints;
-            epochUsage_.sellers.poolPoints += sellerPoints;
         }
-        _buyerUsageTotal[buyer].weightedPoints += buyerWeightedPoints;
-        _buyerAgentUsageTotal[buyer][agentId].weightedPoints += buyerWeightedPoints;
-        _buyerEpochUsage[epoch][buyer].weightedPoints += buyerWeightedPoints;
-        _buyerAgentEpochUsage[epoch][buyer][agentId].weightedPoints += buyerWeightedPoints;
-        _agentEpochUsage[epoch][agentId].poolPoints += sellerPoints;
-        _agentEpochUsage[epoch][agentId].weightedPoints += sellerWeightedPoints;
+        {
+            BuyerUsage storage buyerTotal_ = _buyerUsageTotal[buyer];
+            buyerTotal_.points += buyerPoints;
+            buyerTotal_.weightedPoints += buyerWeightedPoints;
+        }
+        {
+            BuyerUsage storage buyerAgentTotal_ = _buyerAgentUsageTotal[buyer][agentId];
+            buyerAgentTotal_.points += buyerPoints;
+            buyerAgentTotal_.weightedPoints += buyerWeightedPoints;
+        }
+        {
+            BuyerUsage storage buyerEpoch_ = _buyerEpochUsage[epoch][buyer];
+            buyerEpoch_.points += buyerPoints;
+            buyerEpoch_.weightedPoints += buyerWeightedPoints;
+        }
+        {
+            BuyerUsage storage buyerAgentEpoch_ = _buyerAgentEpochUsage[epoch][buyer][agentId];
+            buyerAgentEpoch_.points += buyerPoints;
+            buyerAgentEpoch_.weightedPoints += buyerWeightedPoints;
+        }
+        {
+            SellerUsage storage agentEpoch_ = _agentEpochUsage[epoch][agentId];
+            agentEpoch_.points += sellerPoints;
+            agentEpoch_.weightedPoints += sellerWeightedPoints;
+        }
+        if (_sellerAgentIdByEpoch[epoch][seller] == 0) _sellerAgentIdByEpoch[epoch][seller] = agentId;
 
         emit UsagePointsAccrued(
             epoch,
@@ -415,16 +420,14 @@ contract AntseedUsageAccounting is IAntseedUsageAccounting, Ownable2Step, Pausab
         return _epochUsage[epoch].sellers.points;
     }
 
+    /// @notice Alias of `totalSellerPointsByEpoch`: pool points equal seller
+    ///         points (the sole recorder increments both with the same value).
     function totalPoolPointsByEpoch(uint256 epoch) external view returns (uint256) {
-        return _epochUsage[epoch].sellers.poolPoints;
+        return _epochUsage[epoch].sellers.points;
     }
 
     function totalWeightedBuyerPointsByEpoch(uint256 epoch) external view returns (uint256) {
         return _epochUsage[epoch].buyers.weightedPoints;
-    }
-
-    function totalWeightedSellerPointsByEpoch(uint256 epoch) external view returns (uint256) {
-        return _epochUsage[epoch].sellers.weightedPoints;
     }
 
     function buyerPointsByEpoch(uint256 epoch, address buyer) external view returns (uint256) {
@@ -440,17 +443,10 @@ contract AntseedUsageAccounting is IAntseedUsageAccounting, Ownable2Step, Pausab
         return _buyerEpochUsage[epoch][buyer].weightedPoints;
     }
 
-    function weightedAgentSellerPointsByEpoch(uint256 epoch, uint256 agentId) external view returns (uint256) {
-        return _agentEpochUsage[epoch][agentId].weightedPoints;
-    }
-
-    function weightedSellerPointsByEpoch(uint256 epoch, address seller) external view returns (uint256) {
-        uint256 agentId = _sellerAgentIdByEpoch[epoch][seller];
-        return agentId == 0 ? 0 : _agentEpochUsage[epoch][agentId].weightedPoints;
-    }
-
+    /// @notice Alias of `agentEpochUsage(epoch, agentId).points`: pool points
+    ///         equal seller points.
     function agentPoolPointsByEpoch(uint256 epoch, uint256 agentId) external view returns (uint256) {
-        return _agentEpochUsage[epoch][agentId].poolPoints;
+        return _agentEpochUsage[epoch][agentId].points;
     }
 
     function sellerAgentIdByEpoch(uint256 epoch, address seller) external view returns (uint256) {
@@ -460,7 +456,7 @@ contract AntseedUsageAccounting is IAntseedUsageAccounting, Ownable2Step, Pausab
     function poolPointsByEpoch(uint256 epoch, address seller) public view returns (uint256) {
         uint256 agentId = _sellerAgentIdByEpoch[epoch][seller];
         if (agentId == 0) return 0;
-        return _agentEpochUsage[epoch][agentId].poolPoints;
+        return _agentEpochUsage[epoch][agentId].points;
     }
 
     function weightedPoolPointsByEpoch(uint256 epoch, uint256 agentId) public view returns (uint256 weightedPoints) {

--- a/packages/contracts/emissions/AntseedUsageRewards.sol
+++ b/packages/contracts/emissions/AntseedUsageRewards.sol
@@ -287,23 +287,50 @@ contract AntseedUsageRewards is Ownable2Step, Pausable, ReentrancyGuard {
     //                        INTERNAL HELPERS
     // ═══════════════════════════════════════════════════════════════════
 
-    function _claimAgentReward(uint256 agentId, uint256 epoch, address claimant) internal {
+    /// @dev Values shared by the claim and stake tails of a reward: share,
+    ///      frozen-budget amounts, and the verified recipient. Populated by
+    ///      `_prepareAgentReward` / `_prepareBuyerReward`, which also mark
+    ///      the epoch claimed.
+    struct PreparedReward {
+        address recipient;
+        uint256 weightedPoints;
+        uint256 totalWeightedPoints;
+        uint256 grossAmount;
+        uint256 claimableAmount;
+        uint256 reserveAmount;
+    }
+
+    function _prepareAgentReward(uint256 agentId, uint256 epoch, address claimant)
+        internal
+        returns (PreparedReward memory reward)
+    {
         if (agentId == 0) revert InvalidAddress();
         if (agentEpochClaimed[agentId][epoch]) revert AlreadyClaimed();
 
-        (uint256 weightedPoints, uint256 totalWeightedPoints) = _agentShare(agentId, epoch);
+        (reward.weightedPoints, reward.totalWeightedPoints) = _agentShare(agentId, epoch);
         (, uint256 sellerBudget) = _freezeUsageEpochBudgets(epoch);
-        (uint256 grossAmount, uint256 claimableAmount, uint256 reserveAmount) =
-            _rewardAmounts(sellerBudget, weightedPoints, totalWeightedPoints);
+        (reward.grossAmount, reward.claimableAmount, reward.reserveAmount) =
+            _rewardAmounts(sellerBudget, reward.weightedPoints, reward.totalWeightedPoints);
 
-        address seller = _agentOwner(agentId);
-        if (claimant != seller) revert NotRewardRecipient();
+        reward.recipient = _agentOwner(agentId);
+        if (claimant != reward.recipient) revert NotRewardRecipient();
 
         agentEpochClaimed[agentId][epoch] = true;
-        _mintReward(epoch, seller, claimableAmount, reserveAmount);
+    }
+
+    function _claimAgentReward(uint256 agentId, uint256 epoch, address claimant) internal {
+        PreparedReward memory reward = _prepareAgentReward(agentId, epoch, claimant);
+        _mintReward(epoch, reward.recipient, reward.claimableAmount, reward.reserveAmount);
 
         emit SellerOperatorRewardClaimed(
-            seller, agentId, epoch, weightedPoints, totalWeightedPoints, grossAmount, claimableAmount, reserveAmount
+            reward.recipient,
+            agentId,
+            epoch,
+            reward.weightedPoints,
+            reward.totalWeightedPoints,
+            reward.grossAmount,
+            reward.claimableAmount,
+            reward.reserveAmount
         );
     }
 
@@ -311,50 +338,52 @@ contract AntseedUsageRewards is Ownable2Step, Pausable, ReentrancyGuard {
         internal
         returns (uint256 newPositionId)
     {
-        if (agentId == 0) revert InvalidAddress();
-        if (agentEpochClaimed[agentId][epoch]) revert AlreadyClaimed();
-
-        (uint256 weightedPoints, uint256 totalWeightedPoints) = _agentShare(agentId, epoch);
-        (, uint256 sellerBudget) = _freezeUsageEpochBudgets(epoch);
-        (uint256 grossAmount, uint256 claimableAmount, uint256 reserveAmount) =
-            _rewardAmounts(sellerBudget, weightedPoints, totalWeightedPoints);
-
-        address seller = _agentOwner(agentId);
-        if (msg.sender != seller) revert NotRewardRecipient();
-
-        agentEpochClaimed[agentId][epoch] = true;
-        newPositionId = _stakeClaimedReward(seller, agentId, stakeEpochs, epoch, claimableAmount, reserveAmount);
+        PreparedReward memory reward = _prepareAgentReward(agentId, epoch, msg.sender);
+        newPositionId = _stakeClaimedReward(
+            reward.recipient, agentId, stakeEpochs, epoch, reward.claimableAmount, reward.reserveAmount
+        );
 
         emit SellerOperatorRewardStaked(
-            seller,
+            reward.recipient,
             agentId,
             epoch,
             newPositionId,
-            weightedPoints,
-            totalWeightedPoints,
-            grossAmount,
-            claimableAmount,
-            reserveAmount
+            reward.weightedPoints,
+            reward.totalWeightedPoints,
+            reward.grossAmount,
+            reward.claimableAmount,
+            reward.reserveAmount
         );
     }
 
-    function _claimBuyerReward(address buyer, uint256 epoch) internal {
+    function _prepareBuyerReward(address buyer, uint256 epoch) internal returns (PreparedReward memory reward) {
         if (buyer == address(0)) revert InvalidAddress();
         if (buyerEpochClaimed[buyer][epoch]) revert AlreadyClaimed();
 
-        (uint256 weightedPoints, uint256 totalWeightedPoints) = _buyerShare(buyer, epoch);
+        (reward.weightedPoints, reward.totalWeightedPoints) = _buyerShare(buyer, epoch);
         (uint256 buyerBudget,) = _freezeUsageEpochBudgets(epoch);
-        (uint256 grossAmount, uint256 claimableAmount, uint256 reserveAmount) =
-            _rewardAmounts(buyerBudget, weightedPoints, totalWeightedPoints);
+        (reward.grossAmount, reward.claimableAmount, reward.reserveAmount) =
+            _rewardAmounts(buyerBudget, reward.weightedPoints, reward.totalWeightedPoints);
 
-        address recipient = _buyerRewardRecipient(buyer);
-        if (msg.sender != recipient) revert NotRewardRecipient();
+        reward.recipient = _buyerRewardRecipient(buyer);
+        if (msg.sender != reward.recipient) revert NotRewardRecipient();
 
         buyerEpochClaimed[buyer][epoch] = true;
-        _mintReward(epoch, recipient, claimableAmount, reserveAmount);
+    }
+
+    function _claimBuyerReward(address buyer, uint256 epoch) internal {
+        PreparedReward memory reward = _prepareBuyerReward(buyer, epoch);
+        _mintReward(epoch, reward.recipient, reward.claimableAmount, reward.reserveAmount);
 
         emit BuyerUsageRewardClaimed(
-            buyer, recipient, epoch, weightedPoints, totalWeightedPoints, grossAmount, claimableAmount, reserveAmount
+            buyer,
+            reward.recipient,
+            epoch,
+            reward.weightedPoints,
+            reward.totalWeightedPoints,
+            reward.grossAmount,
+            reward.claimableAmount,
+            reward.reserveAmount
         );
     }
 
@@ -362,31 +391,23 @@ contract AntseedUsageRewards is Ownable2Step, Pausable, ReentrancyGuard {
         internal
         returns (uint256 newPositionId)
     {
-        if (buyer == address(0) || stakeAgentId == 0) revert InvalidAddress();
-        if (buyerEpochClaimed[buyer][epoch]) revert AlreadyClaimed();
-
-        (uint256 weightedPoints, uint256 totalWeightedPoints) = _buyerShare(buyer, epoch);
-        (uint256 buyerBudget,) = _freezeUsageEpochBudgets(epoch);
-        (uint256 grossAmount, uint256 claimableAmount, uint256 reserveAmount) =
-            _rewardAmounts(buyerBudget, weightedPoints, totalWeightedPoints);
-
-        address operator = _buyerRewardRecipient(buyer);
-        if (msg.sender != operator) revert NotRewardRecipient();
-
-        buyerEpochClaimed[buyer][epoch] = true;
-        newPositionId = _stakeClaimedReward(operator, stakeAgentId, stakeEpochs, epoch, claimableAmount, reserveAmount);
+        if (stakeAgentId == 0) revert InvalidAddress();
+        PreparedReward memory reward = _prepareBuyerReward(buyer, epoch);
+        newPositionId = _stakeClaimedReward(
+            reward.recipient, stakeAgentId, stakeEpochs, epoch, reward.claimableAmount, reward.reserveAmount
+        );
 
         emit BuyerUsageRewardStaked(
             buyer,
-            operator,
+            reward.recipient,
             stakeAgentId,
             epoch,
             newPositionId,
-            weightedPoints,
-            totalWeightedPoints,
-            grossAmount,
-            claimableAmount,
-            reserveAmount
+            reward.weightedPoints,
+            reward.totalWeightedPoints,
+            reward.grossAmount,
+            reward.claimableAmount,
+            reward.reserveAmount
         );
     }
 
@@ -407,10 +428,22 @@ contract AntseedUsageRewards is Ownable2Step, Pausable, ReentrancyGuard {
     }
 
     function _liveUsageEpochBudgets(uint256 epoch) internal view returns (uint256 buyerBudget, uint256 sellerBudget) {
-        uint256 desiredBuyerBudget = _shareBudget(epoch, _buyerShareBpsAt(epoch));
-        uint256 desiredSellerBudget = _shareBudget(epoch, _sellerShareBpsAt(epoch));
+        return _liveUsageEpochBudgets(epoch, emissionsGate.controllerEpochBudget(address(this), epoch));
+    }
+
+    /// @dev Epoch volume and epoch emission are hoisted so each external
+    ///      fetch happens once for both share budgets; `maxBudget` is passed
+    ///      in so a caller that already holds the gate budget saves the call.
+    function _liveUsageEpochBudgets(uint256 epoch, uint256 maxBudget)
+        internal
+        view
+        returns (uint256 buyerBudget, uint256 sellerBudget)
+    {
+        uint256 epochVolume = _epochVolume(epoch);
+        uint256 epochEmission = emissionsGate.getEpochEmission(epoch);
+        uint256 desiredBuyerBudget = _shareBudget(epochEmission, _buyerShareBpsAt(epochVolume));
+        uint256 desiredSellerBudget = _shareBudget(epochEmission, _sellerShareBpsAt(epochVolume));
         uint256 desiredTotal = desiredBuyerBudget + desiredSellerBudget;
-        uint256 maxBudget = emissionsGate.controllerEpochBudget(address(this), epoch);
         if (desiredTotal <= maxBudget) return (desiredBuyerBudget, desiredSellerBudget);
         if (desiredTotal == 0) return (0, 0);
 
@@ -432,7 +465,7 @@ contract AntseedUsageRewards is Ownable2Step, Pausable, ReentrancyGuard {
         if (epochRemainderSettled[epoch]) revert AlreadyClaimed();
 
         uint256 maxBudget = emissionsGate.controllerEpochBudget(address(this), epoch);
-        (uint256 buyerBudget, uint256 sellerBudget) = _freezeUsageEpochBudgets(epoch);
+        (uint256 buyerBudget, uint256 sellerBudget) = _freezeUsageEpochBudgets(epoch, maxBudget);
         uint256 allocatedBudget = buyerBudget + sellerBudget;
         if (allocatedBudget >= maxBudget) revert NothingToClaim();
 
@@ -445,8 +478,17 @@ contract AntseedUsageRewards is Ownable2Step, Pausable, ReentrancyGuard {
     function _freezeUsageEpochBudgets(uint256 epoch) internal returns (uint256 buyerBudget, uint256 sellerBudget) {
         FrozenUsageBudgets storage frozen = _frozenUsageBudgets[epoch];
         if (frozen.frozen) return (frozen.buyerBudget, frozen.sellerBudget);
+        return _freezeUsageEpochBudgets(epoch, emissionsGate.controllerEpochBudget(address(this), epoch));
+    }
 
-        (buyerBudget, sellerBudget) = _liveUsageEpochBudgets(epoch);
+    function _freezeUsageEpochBudgets(uint256 epoch, uint256 maxBudget)
+        internal
+        returns (uint256 buyerBudget, uint256 sellerBudget)
+    {
+        FrozenUsageBudgets storage frozen = _frozenUsageBudgets[epoch];
+        if (frozen.frozen) return (frozen.buyerBudget, frozen.sellerBudget);
+
+        (buyerBudget, sellerBudget) = _liveUsageEpochBudgets(epoch, maxBudget);
         frozen.frozen = true;
         frozen.buyerBudget = buyerBudget;
         frozen.sellerBudget = sellerBudget;
@@ -499,12 +541,12 @@ contract AntseedUsageRewards is Ownable2Step, Pausable, ReentrancyGuard {
         token.forceApprove(address(pools), 0);
     }
 
-    function _buyerShareBpsAt(uint256 epoch) internal view returns (uint32) {
-        return AntseedShareMath.saturatingShareBps(_epochVolume(epoch), buyerMinShareBps, buyerMaxShareBps, volumeShareTarget);
+    function _buyerShareBpsAt(uint256 epochVolume) internal view returns (uint32) {
+        return AntseedShareMath.saturatingShareBps(epochVolume, buyerMinShareBps, buyerMaxShareBps, volumeShareTarget);
     }
 
-    function _sellerShareBpsAt(uint256 epoch) internal view returns (uint32) {
-        return AntseedShareMath.saturatingShareBps(_epochVolume(epoch), sellerMinShareBps, sellerMaxShareBps, volumeShareTarget);
+    function _sellerShareBpsAt(uint256 epochVolume) internal view returns (uint32) {
+        return AntseedShareMath.saturatingShareBps(epochVolume, sellerMinShareBps, sellerMaxShareBps, volumeShareTarget);
     }
 
     function _epochVolume(uint256 epoch) internal view returns (uint256) {
@@ -514,9 +556,9 @@ contract AntseedUsageRewards is Ownable2Step, Pausable, ReentrancyGuard {
         return buyerPoints > sellerPoints ? buyerPoints : sellerPoints;
     }
 
-    function _shareBudget(uint256 epoch, uint32 shareBps) internal view returns (uint256) {
+    function _shareBudget(uint256 epochEmission, uint32 shareBps) internal pure returns (uint256) {
         if (shareBps == 0) return 0;
-        return Math.mulDiv(emissionsGate.getEpochEmission(epoch), shareBps, GATE_SHARE_DENOMINATOR);
+        return Math.mulDiv(epochEmission, shareBps, GATE_SHARE_DENOMINATOR);
     }
 
     function _emissionsReserve() internal view returns (address reserve) {
@@ -543,8 +585,8 @@ contract AntseedUsageRewards is Ownable2Step, Pausable, ReentrancyGuard {
     {
         IAntseedUsageAccounting accounting = usageAccounting;
         if (address(accounting) == address(0)) revert InvalidAddress();
-        weightedPoints = accounting.weightedAgentSellerPointsByEpoch(epoch, agentId);
-        totalWeightedPoints = accounting.totalWeightedSellerPointsByEpoch(epoch);
+        weightedPoints = accounting.weightedPoolPointsByEpoch(epoch, agentId);
+        totalWeightedPoints = accounting.totalWeightedPoolPointsByEpoch(epoch);
     }
 
     function _agentOwner(uint256 agentId) internal view returns (address owner) {

--- a/packages/contracts/interfaces/IAntseedEmissionsGate.sol
+++ b/packages/contracts/interfaces/IAntseedEmissionsGate.sol
@@ -11,9 +11,7 @@ interface IAntseedEmissionsGate {
     function currentEpoch() external view returns (uint256);
     function effectiveEpoch() external view returns (uint256);
     function getEpochEmission(uint256 epoch) external view returns (uint256);
-    function initialEmission() external view returns (uint256);
     function minters(bytes32 minterId) external view returns (address, uint32, bool);
-    function minterConfig(bytes32 minterId) external view returns (Minter memory);
     function minterEpochBudget(bytes32 minterId, uint256 epoch) external view returns (uint256);
     function controllerEpochBudget(address controller, uint256 epoch) external view returns (uint256);
     function emissionsReserve() external view returns (address);

--- a/packages/contracts/interfaces/IAntseedSellerPools.sol
+++ b/packages/contracts/interfaces/IAntseedSellerPools.sol
@@ -105,8 +105,6 @@ interface IAntseedSellerPools {
         external
         view
         returns (uint256 normalEndEpoch, uint256 maxLockPower, uint256 nextChangeEpoch);
-    function poolPowerWeightAtEpoch(uint256 agentId, uint256 epoch) external view returns (uint256 weight);
-    function poolPowerWeightAtEpoch(address seller, uint256 epoch) external view returns (uint256 weight);
     function totalPowerWeightAtEpoch(uint256 epoch) external view returns (uint256 weight);
     function currentPoolSecurityWeight(uint256 agentId) external returns (uint256 weight);
     function currentPoolSecurityWeight(address seller) external returns (uint256 weight);

--- a/packages/contracts/interfaces/IAntseedUsageAccounting.sol
+++ b/packages/contracts/interfaces/IAntseedUsageAccounting.sol
@@ -10,7 +10,6 @@ interface IAntseedUsageAccounting {
     struct SellerUsage {
         uint256 points;
         uint256 weightedPoints;
-        uint256 poolPoints;
     }
 
     struct UsageTotals {
@@ -81,7 +80,6 @@ interface IAntseedUsageAccounting {
     function totalPoolPointsByEpoch(uint256 epoch) external view returns (uint256);
     function totalWeightedPoolPointsByEpoch(uint256 epoch) external view returns (uint256);
     function totalWeightedBuyerPointsByEpoch(uint256 epoch) external view returns (uint256);
-    function totalWeightedSellerPointsByEpoch(uint256 epoch) external view returns (uint256);
     function sellerAgentIdByEpoch(uint256 epoch, address seller) external view returns (uint256);
     function buyerPointsByEpoch(uint256 epoch, address buyer) external view returns (uint256);
     function sellerPointsByEpoch(uint256 epoch, address seller) external view returns (uint256);
@@ -89,7 +87,5 @@ interface IAntseedUsageAccounting {
     function poolPointsByEpoch(uint256 epoch, address seller) external view returns (uint256);
     function weightedPoolPointsByEpoch(uint256 epoch, uint256 agentId) external view returns (uint256);
     function weightedPoolPointsByEpoch(uint256 epoch, address seller) external view returns (uint256);
-    function weightedAgentSellerPointsByEpoch(uint256 epoch, uint256 agentId) external view returns (uint256);
-    function weightedSellerPointsByEpoch(uint256 epoch, address seller) external view returns (uint256);
     function weightedBuyerPointsByEpoch(uint256 epoch, address buyer) external view returns (uint256);
 }

--- a/packages/contracts/sellers/AntseedSellerPools.sol
+++ b/packages/contracts/sellers/AntseedSellerPools.sol
@@ -518,24 +518,16 @@ contract AntseedSellerPools is IAntseedSellerPools, ERC721, Ownable2Step, Reentr
         activeStake += _totalMaxLockWeightAmount.upperLookupRecent(epoch);
     }
 
-    function poolPowerWeightAtEpoch(uint256 agentId, uint256 epoch) public view returns (uint256) {
-        return poolWeightAtEpoch(agentId, epoch);
-    }
-
-    function poolPowerWeightAtEpoch(address seller, uint256 epoch) public view returns (uint256) {
-        return poolWeightAtEpoch(seller, epoch);
-    }
-
     function totalPowerWeightAtEpoch(uint256 epoch) external view returns (uint256) {
         return _powerAtEpoch(_totalPowerTree, epoch) + _totalMaxLockPowerAtEpoch(epoch);
     }
 
     function currentPoolSecurityWeight(uint256 agentId) external view returns (uint256) {
-        return poolPowerWeightAtEpoch(agentId, currentEpoch());
+        return poolWeightAtEpoch(agentId, currentEpoch());
     }
 
     function currentPoolSecurityWeight(address seller) external view returns (uint256) {
-        return poolPowerWeightAtEpoch(seller, currentEpoch());
+        return poolWeightAtEpoch(seller, currentEpoch());
     }
 
     function currentTotalSecurityWeight() external view returns (uint256) {
@@ -543,9 +535,9 @@ contract AntseedSellerPools is IAntseedSellerPools, ERC721, Ownable2Step, Reentr
         return _powerAtEpoch(_totalPowerTree, epoch) + _totalMaxLockPowerAtEpoch(epoch);
     }
 
-    function currentPoolSecurityShareBps(uint256 agentId) external view returns (uint256 shareBps) {
+    function currentPoolSecurityShareBps(uint256 agentId) public view returns (uint256 shareBps) {
         uint256 epoch = currentEpoch();
-        uint256 poolWeight = poolPowerWeightAtEpoch(agentId, epoch);
+        uint256 poolWeight = poolWeightAtEpoch(agentId, epoch);
         uint256 totalWeight = _powerAtEpoch(_totalPowerTree, epoch) + _totalMaxLockPowerAtEpoch(epoch);
         if (poolWeight == 0 || totalWeight == 0) return 0;
         return (poolWeight * BPS_DENOMINATOR) / totalWeight;
@@ -554,11 +546,7 @@ contract AntseedSellerPools is IAntseedSellerPools, ERC721, Ownable2Step, Reentr
     function currentPoolSecurityShareBps(address seller) external view returns (uint256 shareBps) {
         uint256 agentId = agentIdForSeller(seller);
         if (agentId == 0) return 0;
-        uint256 epoch = currentEpoch();
-        uint256 poolWeight = poolPowerWeightAtEpoch(agentId, epoch);
-        uint256 totalWeight = _powerAtEpoch(_totalPowerTree, epoch) + _totalMaxLockPowerAtEpoch(epoch);
-        if (poolWeight == 0 || totalWeight == 0) return 0;
-        return (poolWeight * BPS_DENOMINATOR) / totalWeight;
+        return currentPoolSecurityShareBps(agentId);
     }
 
     function stakerPositionCount(address staker) public view returns (uint256) {
@@ -726,19 +714,19 @@ contract AntseedSellerPools is IAntseedSellerPools, ERC721, Ownable2Step, Reentr
     }
 
     function _increaseActiveStake(address staker, uint256 agentId, uint256 amount) internal {
-        stakerTotalActiveStake[staker] += amount;
-        stakerAgentActiveStake[staker][agentId] += amount;
-        emit StakerActiveStakeUpdated(
-            staker, agentId, stakerTotalActiveStake[staker], stakerAgentActiveStake[staker][agentId]
-        );
+        uint256 newTotalStake = stakerTotalActiveStake[staker] + amount;
+        uint256 newAgentStake = stakerAgentActiveStake[staker][agentId] + amount;
+        stakerTotalActiveStake[staker] = newTotalStake;
+        stakerAgentActiveStake[staker][agentId] = newAgentStake;
+        emit StakerActiveStakeUpdated(staker, agentId, newTotalStake, newAgentStake);
     }
 
     function _decreaseActiveStake(address staker, uint256 agentId, uint256 amount) internal {
-        stakerTotalActiveStake[staker] -= amount;
-        stakerAgentActiveStake[staker][agentId] -= amount;
-        emit StakerActiveStakeUpdated(
-            staker, agentId, stakerTotalActiveStake[staker], stakerAgentActiveStake[staker][agentId]
-        );
+        uint256 newTotalStake = stakerTotalActiveStake[staker] - amount;
+        uint256 newAgentStake = stakerAgentActiveStake[staker][agentId] - amount;
+        stakerTotalActiveStake[staker] = newTotalStake;
+        stakerAgentActiveStake[staker][agentId] = newAgentStake;
+        emit StakerActiveStakeUpdated(staker, agentId, newTotalStake, newAgentStake);
     }
 
     function _earlyExitSlashBps(uint256 positionId, uint256 effectiveCloseEpoch) internal view returns (uint256) {

--- a/packages/contracts/sellers/AntseedSellerRegistry.sol
+++ b/packages/contracts/sellers/AntseedSellerRegistry.sol
@@ -108,17 +108,21 @@ contract AntseedSellerRegistry is IAntseedStaking, Ownable2Step {
     // ═══════════════════════════════════════════════════════════════════
 
     function getStake(address seller) public view returns (uint256) {
-        IAntseedSellerPools pools = sellerPools;
-        uint256 epoch = pools.currentEpoch();
-        uint256 agentId = getAgentId(seller);
-        if (agentId == 0 || !pools.hasPoolAtEpoch(agentId, epoch)) return 0;
-        return pools.poolActiveStakeAtEpoch(agentId, epoch);
+        return _stakeForAgent(getAgentId(seller));
     }
 
     function isStakedAboveMin(address seller) external view returns (bool) {
-        if (getAgentId(seller) == 0) return false;
-        if (getStake(seller) >= minSellerPoolStake) return true;
+        uint256 agentId = getAgentId(seller);
+        if (agentId == 0) return false;
+        if (_stakeForAgent(agentId) >= minSellerPoolStake) return true;
         return _legacyStakedAboveMin(seller);
+    }
+
+    function _stakeForAgent(uint256 agentId) internal view returns (uint256) {
+        IAntseedSellerPools pools = sellerPools;
+        uint256 epoch = pools.currentEpoch();
+        if (agentId == 0 || !pools.hasPoolAtEpoch(agentId, epoch)) return 0;
+        return pools.poolActiveStakeAtEpoch(agentId, epoch);
     }
 
     function getAgentId(address seller) public view returns (uint256) {

--- a/packages/contracts/snapshots/usage-accounting.json
+++ b/packages/contracts/snapshots/usage-accounting.json
@@ -1,5 +1,5 @@
 {
-  "record-new-agent-in-epoch": "203949",
-  "record-new-buyer-existing-agent": "199586",
-  "record-repeated-same-buyer-agent": "23767"
+  "record-new-agent-in-epoch": "179452",
+  "record-new-buyer-existing-agent": "196989",
+  "record-repeated-same-buyer-agent": "21170"
 }

--- a/packages/contracts/snapshots/usage-accounting.snap
+++ b/packages/contracts/snapshots/usage-accounting.snap
@@ -1,2 +1,2 @@
-AntseedUsageAccountingGasTest:test_minimumAccountedPoolPowerFiltersUsage() (gas: 597620)
-AntseedUsageAccountingGasTest:test_usageAccountingGasSnapshotsRecordUsageCases() (gas: 987976)
+AntseedUsageAccountingGasTest:test_minimumAccountedPoolPowerFiltersUsage() (gas: 526892)
+AntseedUsageAccountingGasTest:test_usageAccountingGasSnapshotsRecordUsageCases() (gas: 889988)

--- a/packages/contracts/test/AntseedEmissionsGate.t.sol
+++ b/packages/contracts/test/AntseedEmissionsGate.t.sol
@@ -719,20 +719,20 @@ contract AntseedEmissionsGateTest is Test {
     function test_poolWeightPolicyDefaultsToLinearPoolPower() public {
         uint256 agentId = _setupUsagePool();
 
-        uint256 poolPower = sellerPools.poolPowerWeightAtEpoch(agentId, 5);
+        uint256 poolPower = sellerPools.poolWeightAtEpoch(agentId, 5);
         assertGt(poolPower, 0);
 
         usageAccounting.accrueSellerPoints(seller, 100);
         usageAccounting.accrueBuyerPoints(buyer, 100);
 
-        assertEq(usageAccounting.weightedAgentSellerPointsByEpoch(5, agentId), 100 * poolPower);
+        assertEq(usageAccounting.weightedPoolPointsByEpoch(5, agentId), 100 * poolPower);
         assertEq(usageAccounting.weightedBuyerPointsByEpoch(5, buyer), 100 * poolPower);
     }
 
     function test_poolWeightPolicyConvertsRawPoolPowerToEffectiveWeight() public {
         uint256 agentId = _setupUsagePool();
 
-        uint256 poolPower = sellerPools.poolPowerWeightAtEpoch(agentId, 5);
+        uint256 poolPower = sellerPools.poolWeightAtEpoch(agentId, 5);
         uint256 cappedWeight = 7;
         assertGt(poolPower, cappedWeight);
         usageAccounting.setPoolWeightPolicy(address(new MockCappedPoolWeightPolicy(cappedWeight)));
@@ -742,7 +742,7 @@ contract AntseedEmissionsGateTest is Test {
 
         // Raw points are unaffected; only the pool multiplier changes.
         assertEq(usageAccounting.sellerPointsByEpoch(5, seller), 100);
-        assertEq(usageAccounting.weightedAgentSellerPointsByEpoch(5, agentId), 100 * cappedWeight);
+        assertEq(usageAccounting.weightedPoolPointsByEpoch(5, agentId), 100 * cappedWeight);
         assertEq(usageAccounting.weightedBuyerPointsByEpoch(5, buyer), 100 * cappedWeight);
     }
 
@@ -752,11 +752,11 @@ contract AntseedEmissionsGateTest is Test {
         usageAccounting.setPoolWeightPolicy(address(new MockCappedPoolWeightPolicy(7)));
         usageAccounting.setPoolWeightPolicy(address(0));
 
-        uint256 poolPower = sellerPools.poolPowerWeightAtEpoch(agentId, 5);
+        uint256 poolPower = sellerPools.poolWeightAtEpoch(agentId, 5);
         usageAccounting.accrueSellerPoints(seller, 100);
         usageAccounting.accrueBuyerPoints(buyer, 100);
 
-        assertEq(usageAccounting.weightedAgentSellerPointsByEpoch(5, agentId), 100 * poolPower);
+        assertEq(usageAccounting.weightedPoolPointsByEpoch(5, agentId), 100 * poolPower);
     }
 
     function test_revertingPoolWeightPolicySkipsAccrualWithoutBlockingSettlement() public {
@@ -770,7 +770,7 @@ contract AntseedEmissionsGateTest is Test {
         usageAccounting.accrueBuyerPoints(buyer, 100);
 
         assertEq(usageAccounting.sellerPointsByEpoch(5, seller), 0);
-        assertEq(usageAccounting.weightedAgentSellerPointsByEpoch(5, agentId), 0);
+        assertEq(usageAccounting.weightedPoolPointsByEpoch(5, agentId), 0);
         assertEq(usageAccounting.weightedBuyerPointsByEpoch(5, buyer), 0);
     }
 
@@ -810,11 +810,8 @@ contract AntseedEmissionsGateTest is Test {
 
         _warpGateEpoch(6);
         uint256 expectedStakerClaim = (sellerPoolsRewards.stakerEpochBudget(5) * 400 ether) / 404 ether;
-        (uint256 grossReward, uint256 claimableReward, uint256 burnedReward) =
-            sellerPoolsRewards.pendingStakerReward(positionId, 5);
-        assertEq(grossReward, expectedStakerClaim);
-        assertEq(claimableReward, expectedStakerClaim);
-        assertEq(burnedReward, 0);
+        uint256 pendingReward = sellerPoolsRewards.pendingStakerReward(positionId, 5);
+        assertEq(pendingReward, expectedStakerClaim);
 
         sellerPoolsRewards.indexPoolRewards(_agentId(poolSeller), 10);
         vm.prank(staker);
@@ -991,8 +988,8 @@ contract AntseedEmissionsGateTest is Test {
         uint256 expectedBudget = sellerPoolsRewards.stakerEpochBudget(6);
         uint256 maxLockPower = 10_400 ether;
         uint256 normalPower = 300 ether;
-        (uint256 maxLockedGross,,) = sellerPoolsRewards.pendingStakerReward(maxLockedPositionId, 6);
-        (uint256 normalGross,,) = sellerPoolsRewards.pendingStakerReward(normalPositionId, 6);
+        uint256 maxLockedGross = sellerPoolsRewards.pendingStakerReward(maxLockedPositionId, 6);
+        uint256 normalGross = sellerPoolsRewards.pendingStakerReward(normalPositionId, 6);
 
         assertEq(maxLockedGross, (expectedBudget * maxLockPower) / (maxLockPower + normalPower));
         assertEq(normalGross, (expectedBudget * normalPower) / (maxLockPower + normalPower));
@@ -1081,8 +1078,8 @@ contract AntseedEmissionsGateTest is Test {
         assertEq(token.balanceOf(staker), 800 ether + expectedClaim);
         assertEq(sellerPoolsRewards.positionClaimCursor(extendedPositionId), 7);
 
-        (uint256 normalEpoch5Gross,,) = sellerPoolsRewards.pendingStakerReward(normalPositionId, 5);
-        (uint256 normalEpoch6Gross,,) = sellerPoolsRewards.pendingStakerReward(normalPositionId, 6);
+        uint256 normalEpoch5Gross = sellerPoolsRewards.pendingStakerReward(normalPositionId, 5);
+        uint256 normalEpoch6Gross = sellerPoolsRewards.pendingStakerReward(normalPositionId, 6);
         assertEq(normalEpoch5Gross, (epoch5Budget * 400 ether) / 800 ether);
         assertEq(normalEpoch6Gross, (epoch6Budget * 300 ether) / 900 ether);
     }
@@ -1114,10 +1111,10 @@ contract AntseedEmissionsGateTest is Test {
         assertEq(_configuredMinter(RESERVE_MINTER_ID), reserveDest);
         assertEq(gate.genesis(), 1_775_728_461);
         assertEq(gate.epochDuration(), 7 days);
-        assertEq(gate.halvingInterval(), 104);
-        assertEq(gate.initialEmission(), 5_000_000 ether);
+        assertEq(gate.HALVING_INTERVAL(), 104);
+        assertEq(gate.INITIAL_EMISSION(), 5_000_000 ether);
         assertEq(gate.effectiveEpoch(), 4);
-        assertEq(gate.currentEmissionRate(), gate.initialEmission() / gate.epochDuration());
+        assertEq(gate.currentEmissionRate(), gate.INITIAL_EMISSION() / gate.epochDuration());
         assertEq(gate.SHARE_DENOMINATOR(), 100_000);
         assertEq(gate.minterEpochBudget(SELLER_POOLS_MINTER_ID, 4), _shareBudget(SELLER_POOLS_SHARE_BPS, 4));
         assertEq(gate.minterEpochBudget(USAGE_MINTER_ID, 4), _shareBudget(USAGE_SHARE_BPS, 4));
@@ -1185,7 +1182,7 @@ contract AntseedEmissionsGateTest is Test {
         gate.renounceOwnership();
         assertEq(gate.owner(), address(0));
         assertEq(gate.minterEpochBudget(SELLER_POOLS_MINTER_ID, 4), _shareBudget(SELLER_POOLS_SHARE_BPS, 4));
-        assertEq(gate.currentEmissionRate(), gate.initialEmission() / gate.epochDuration());
+        assertEq(gate.currentEmissionRate(), gate.INITIAL_EMISSION() / gate.epochDuration());
 
         vm.expectRevert();
         _setSellerPoolsMinter(address(this));
@@ -1287,19 +1284,16 @@ contract AntseedEmissionsGateTest is Test {
 
         IAntseedUsageAccounting.SellerUsage memory sellerAgentUsage = usageAccounting.agentEpochUsage(5, sellerAgentId);
         assertEq(sellerAgentUsage.points, 70);
-        assertEq(sellerAgentUsage.poolPoints, 70);
         assertEq(sellerAgentUsage.weightedPoints, usageAccounting.weightedPoolPointsByEpoch(5, sellerAgentId));
         assertEq(usageAccounting.sellerAgentIdByEpoch(5, seller), sellerAgentId);
 
         IAntseedUsageAccounting.UsageTotals memory epochUsage = usageAccounting.epochUsage(5);
         assertEq(epochUsage.buyers.points, 100);
         assertEq(epochUsage.sellers.points, 100);
-        assertEq(epochUsage.sellers.poolPoints, 100);
 
         IAntseedUsageAccounting.UsageTotals memory totalUsage = usageAccounting.totalUsage();
         assertEq(totalUsage.buyers.points, 100);
         assertEq(totalUsage.sellers.points, 100);
-        assertEq(totalUsage.sellers.poolPoints, 100);
     }
 
     function test_usageAccountingRequiresMinimumAccountedPoolPower() public {
@@ -1312,7 +1306,7 @@ contract AntseedEmissionsGateTest is Test {
         uint256 agentId = _agentId(seller);
 
         _warpGateEpoch(5);
-        uint256 poolPower = sellerPools.poolPowerWeightAtEpoch(agentId, 5);
+        uint256 poolPower = sellerPools.poolWeightAtEpoch(agentId, 5);
         assertGt(poolPower, 0);
         assertEq(usageAccounting.minimumAccountedPoolPower(), 1);
 
@@ -1387,11 +1381,8 @@ contract AntseedEmissionsGateTest is Test {
 
         _warpGateEpoch(6);
         uint256 positionId = sellerPools.nextPositionId() - 1;
-        (uint256 grossReward, uint256 claimableReward, uint256 burnedReward) =
-            sellerPoolsRewards.pendingStakerReward(positionId, 5);
-        assertEq(grossReward, sellerPoolsRewards.stakerEpochBudget(5));
-        assertEq(claimableReward, sellerPoolsRewards.stakerEpochBudget(5));
-        assertEq(burnedReward, 0);
+        uint256 pendingReward = sellerPoolsRewards.pendingStakerReward(positionId, 5);
+        assertEq(pendingReward, sellerPoolsRewards.stakerEpochBudget(5));
 
         assertEq(token.balanceOf(seller), 0);
     }
@@ -1410,17 +1401,17 @@ contract AntseedEmissionsGateTest is Test {
         usageAccounting.accruePoints(keccak256("unverified"), buyer, seller, 10);
         assertEq(usageAccounting.sellerPointsByEpoch(5, seller), 0);
         assertEq(usageAccounting.poolPointsByEpoch(5, poolSeller), 0);
-        assertEq(usageAccounting.weightedSellerPointsByEpoch(5, seller), 0);
+        assertEq(usageAccounting.weightedPoolPointsByEpoch(5, seller), 0);
         assertEq(usageAccounting.weightedPoolPointsByEpoch(5, poolSeller), 0);
 
         policy.setSellerWeightBps(seller, 5_000);
-        uint256 poolPower = sellerPools.poolPowerWeightAtEpoch(poolSeller, 5);
+        uint256 poolPower = sellerPools.poolWeightAtEpoch(poolSeller, 5);
         usageAccounting.accruePoints(keccak256("verified-half"), buyer, seller, 10);
         assertEq(usageAccounting.sellerPointsByEpoch(5, seller), 5);
         assertEq(usageAccounting.buyerPointsByEpoch(5, buyer), 20);
         assertEq(usageAccounting.poolPointsByEpoch(5, poolSeller), 5);
-        assertEq(usageAccounting.weightedSellerPointsByEpoch(5, seller), poolPower * 5);
-        assertEq(usageAccounting.totalWeightedSellerPointsByEpoch(5), poolPower * 5);
+        assertEq(usageAccounting.weightedPoolPointsByEpoch(5, seller), poolPower * 5);
+        assertEq(usageAccounting.totalWeightedPoolPointsByEpoch(5), poolPower * 5);
         assertEq(usageAccounting.weightedPoolPointsByEpoch(5, poolSeller), poolPower * 5);
     }
 
@@ -1456,8 +1447,8 @@ contract AntseedEmissionsGateTest is Test {
         usageAccounting.accruePoints(keccak256("honest"), buyer, seller, 1_000);
         usageAccounting.accruePoints(keccak256("wash"), address(0x21), otherSeller, 1_000_000);
 
-        uint256 honestPower = sellerPools.poolPowerWeightAtEpoch(honestSeller, 5);
-        uint256 washPower = sellerPools.poolPowerWeightAtEpoch(washSeller, 5);
+        uint256 honestPower = sellerPools.poolWeightAtEpoch(honestSeller, 5);
+        uint256 washPower = sellerPools.poolWeightAtEpoch(washSeller, 5);
 
         assertEq(usageAccounting.weightedPoolPointsByEpoch(5, washSeller), 1_000_000 * washPower);
         assertEq(usageAccounting.weightedPoolPointsByEpoch(5, honestSeller), 1_000 * honestPower);
@@ -1507,16 +1498,10 @@ contract AntseedEmissionsGateTest is Test {
         uint256 stakerBudget = sellerPoolsRewards.stakerEpochBudget(5);
         uint256 expectedHonestReward = (stakerBudget * honestPoints) / totalPoints;
         uint256 expectedWashReward = (stakerBudget * washPoints) / totalPoints;
-        (uint256 honestGross, uint256 honestClaimable, uint256 honestBurned) =
-            sellerPoolsRewards.pendingStakerReward(honestPositionId, 5);
-        (uint256 washGross, uint256 washClaimable, uint256 washBurned) =
-            sellerPoolsRewards.pendingStakerReward(washPositionId, 5);
-        assertEq(honestGross, expectedHonestReward);
-        assertEq(washGross, expectedWashReward);
-        assertEq(honestClaimable, honestGross);
-        assertEq(washClaimable, washGross);
-        assertEq(honestBurned, 0);
-        assertEq(washBurned, 0);
+        uint256 honestReward = sellerPoolsRewards.pendingStakerReward(honestPositionId, 5);
+        uint256 washReward = sellerPoolsRewards.pendingStakerReward(washPositionId, 5);
+        assertEq(honestReward, expectedHonestReward);
+        assertEq(washReward, expectedWashReward);
     }
 
     function test_stakerRemainderRoutesThroughGateBurnCapToReserve() public {
@@ -1551,13 +1536,9 @@ contract AntseedEmissionsGateTest is Test {
         assertEq(token.balanceOf(gate.DEAD_ADDRESS()), unallocated < burnCap ? unallocated : burnCap);
         assertEq(token.balanceOf(reserveDest), unallocated > burnCap ? unallocated - burnCap : 0);
         assertEq(gate.epochBurnedAmount(5), unallocated < burnCap ? unallocated : burnCap);
-        (bool settled, uint256 settledGross, uint256 settledClaimable, uint256 settledBurned, uint256 settledReserved) =
-            sellerPoolsRewards.poolEpochEmissions(5, _agentId(otherSeller));
+        (bool settled, uint256 settledAmount) = sellerPoolsRewards.poolEpochEmissions(5, _agentId(otherSeller));
         assertTrue(settled);
-        assertApproxEqAbs(settledGross, indexedClaimableReward, 1);
-        assertApproxEqAbs(settledClaimable, indexedClaimableReward, 1);
-        assertEq(settledBurned, 0);
-        assertEq(settledReserved, 0);
+        assertApproxEqAbs(settledAmount, indexedClaimableReward, 1);
     }
 
     function test_stressWashTradingBuyerRewardRemainsCappedAfterStakerApyCapRemoval() public {
@@ -1609,8 +1590,8 @@ contract AntseedEmissionsGateTest is Test {
 
             uint256 honestAgentId = _agentId(seller);
             uint256 washAgentId = _agentId(otherSeller);
-            uint256 honestPower = sellerPools.poolPowerWeightAtEpoch(honestAgentId, 5);
-            uint256 washPower = sellerPools.poolPowerWeightAtEpoch(washAgentId, 5);
+            uint256 honestPower = sellerPools.poolWeightAtEpoch(honestAgentId, 5);
+            uint256 washPower = sellerPools.poolWeightAtEpoch(washAgentId, 5);
             run.firstWeightedPoints = honestTotalVolume * honestPower;
             run.washWeightedPoints = washVolume * washPower;
             run.expectedTotalWeightedPoints = run.firstWeightedPoints + run.washWeightedPoints;
@@ -1629,18 +1610,12 @@ contract AntseedEmissionsGateTest is Test {
         _warpGateEpoch(6);
         {
             uint256 sellerPoolsBudget = sellerPoolsRewards.stakerEpochBudget(5);
-            (uint256 honestGross, uint256 honestClaimable, uint256 honestBurned) =
-                sellerPoolsRewards.pendingStakerReward(run.firstPositionId, 5);
-            (uint256 washGross, uint256 washClaimable, uint256 washBurned) =
-                sellerPoolsRewards.pendingStakerReward(run.washPositionId, 5);
-            run.firstClaimable = honestClaimable;
-            run.washClaimable = washClaimable;
-            assertEq(honestGross, (sellerPoolsBudget * run.firstWeightedPoints) / run.expectedTotalWeightedPoints);
-            assertEq(washGross, (sellerPoolsBudget * run.washWeightedPoints) / run.expectedTotalWeightedPoints);
-            assertEq(washClaimable, washGross);
-            assertEq(honestClaimable, honestGross);
-            assertEq(washBurned, 0);
-            assertEq(honestBurned, 0);
+            uint256 honestReward = sellerPoolsRewards.pendingStakerReward(run.firstPositionId, 5);
+            uint256 washReward = sellerPoolsRewards.pendingStakerReward(run.washPositionId, 5);
+            run.firstClaimable = honestReward;
+            run.washClaimable = washReward;
+            assertEq(honestReward, (sellerPoolsBudget * run.firstWeightedPoints) / run.expectedTotalWeightedPoints);
+            assertEq(washReward, (sellerPoolsBudget * run.washWeightedPoints) / run.expectedTotalWeightedPoints);
         }
 
         {
@@ -1700,7 +1675,7 @@ contract AntseedEmissionsGateTest is Test {
 
             usageAccounting.accruePoints(keccak256(abi.encodePacked("stress", i)), buyer_, seller_, volume);
 
-            uint256 weightedPoints = volume * sellerPools.poolPowerWeightAtEpoch(_agentId(seller_), 5);
+            uint256 weightedPoints = volume * sellerPools.poolWeightAtEpoch(_agentId(seller_), 5);
             run.expectedTotalWeightedPoints += weightedPoints;
             if (seller_ == firstSeller) run.firstWeightedPoints = weightedPoints;
             if (seller_ == washSeller) run.washWeightedPoints = weightedPoints;
@@ -1721,18 +1696,12 @@ contract AntseedEmissionsGateTest is Test {
             uint256 expectedFirstGross = (sellerPoolsBudget * run.firstWeightedPoints) / run.expectedTotalWeightedPoints;
             uint256 expectedWashGross = (sellerPoolsBudget * run.washWeightedPoints) / run.expectedTotalWeightedPoints;
 
-            (uint256 firstGross, uint256 firstClaimable, uint256 firstBurned) =
-                sellerPoolsRewards.pendingStakerReward(run.firstPositionId, 5);
-            (uint256 washGross, uint256 washClaimable, uint256 washBurned) =
-                sellerPoolsRewards.pendingStakerReward(run.washPositionId, 5);
-            run.firstClaimable = firstClaimable;
-            run.washClaimable = washClaimable;
-            assertEq(firstGross, expectedFirstGross);
-            assertEq(washGross, expectedWashGross);
-            assertEq(firstClaimable, firstGross);
-            assertEq(washClaimable, washGross);
-            assertEq(firstBurned, 0);
-            assertEq(washBurned, 0);
+            uint256 firstReward = sellerPoolsRewards.pendingStakerReward(run.firstPositionId, 5);
+            uint256 washReward = sellerPoolsRewards.pendingStakerReward(run.washPositionId, 5);
+            run.firstClaimable = firstReward;
+            run.washClaimable = washReward;
+            assertEq(firstReward, expectedFirstGross);
+            assertEq(washReward, expectedWashGross);
         }
 
         sellerPoolsRewards.indexPoolRewards(firstAgentId, 10);
@@ -1920,8 +1889,8 @@ contract AntseedEmissionsGateTest is Test {
         usageAccounting.accruePoints(keccak256("high-power"), buyer, seller, 100);
         usageAccounting.accruePoints(keccak256("low-power"), secondBuyer, otherSeller, 100);
 
-        uint256 highPower = sellerPools.poolPowerWeightAtEpoch(seller, 4);
-        uint256 lowPower = sellerPools.poolPowerWeightAtEpoch(otherSeller, 4);
+        uint256 highPower = sellerPools.poolWeightAtEpoch(seller, 4);
+        uint256 lowPower = sellerPools.poolWeightAtEpoch(otherSeller, 4);
         uint256 buyerWeightedPoints = 100 * highPower;
         uint256 secondBuyerWeightedPoints = 100 * lowPower;
         uint256 totalWeightedPoints = buyerWeightedPoints + secondBuyerWeightedPoints;
@@ -2627,8 +2596,8 @@ contract AntseedEmissionsGateTest is Test {
         positionIds[1] = secondPositionId;
         positionIds[2] = noRewardPositionId;
 
-        (uint256 firstGross,,) = sellerPoolsRewards.pendingStakerReward(firstPositionId, 5);
-        (uint256 secondGross,,) = sellerPoolsRewards.pendingStakerReward(secondPositionId, 5);
+        uint256 firstGross = sellerPoolsRewards.pendingStakerReward(firstPositionId, 5);
+        uint256 secondGross = sellerPoolsRewards.pendingStakerReward(secondPositionId, 5);
 
         sellerPoolsRewards.indexPoolRewards(_agentId(poolSeller), 10);
         vm.prank(staker);
@@ -2675,8 +2644,8 @@ contract AntseedEmissionsGateTest is Test {
         positionIds[1] = secondPositionId;
         positionIds[2] = noRewardPositionId;
 
-        (uint256 firstGross,,) = sellerPoolsRewards.pendingStakerReward(firstPositionId, 5);
-        (uint256 secondGross,,) = sellerPoolsRewards.pendingStakerReward(secondPositionId, 5);
+        uint256 firstGross = sellerPoolsRewards.pendingStakerReward(firstPositionId, 5);
+        uint256 secondGross = sellerPoolsRewards.pendingStakerReward(secondPositionId, 5);
 
         sellerPoolsRewards.indexPoolRewards(_agentId(poolSeller), 10);
         vm.prank(staker);

--- a/packages/contracts/test/emissions/AntseedUsageAccountingGas.t.sol
+++ b/packages/contracts/test/emissions/AntseedUsageAccountingGas.t.sol
@@ -133,7 +133,7 @@ contract AntseedUsageAccountingGasTest is Test {
 
     function test_minimumAccountedPoolPowerFiltersUsage() public {
         uint256 agentId = _agentId(seller);
-        uint256 poolPower = sellerPools.poolPowerWeightAtEpoch(agentId, 5);
+        uint256 poolPower = sellerPools.poolWeightAtEpoch(agentId, 5);
         assertGt(poolPower, 0);
         assertEq(usageAccounting.minimumAccountedPoolPower(), 1);
 
@@ -238,18 +238,17 @@ contract AntseedUsageAccountingGasTest is Test {
         policy.setWeights(5_000, 2_500);
         usageAccounting.accruePoints(keccak256("weighted-policy"), buyer, seller, 40);
 
-        uint256 poolPower = sellerPools.poolPowerWeightAtEpoch(agentId, 5);
+        uint256 poolPower = sellerPools.poolWeightAtEpoch(agentId, 5);
         assertEq(usageAccounting.totalBuyerPointsByEpoch(5), 10);
         assertEq(usageAccounting.totalSellerPointsByEpoch(5), 20);
         assertEq(usageAccounting.totalPoolPointsByEpoch(5), 20);
         assertEq(usageAccounting.totalWeightedBuyerPointsByEpoch(5), 10 * poolPower);
-        assertEq(usageAccounting.totalWeightedSellerPointsByEpoch(5), 20 * poolPower);
         assertEq(usageAccounting.totalWeightedPoolPointsByEpoch(5), 20 * poolPower);
         assertEq(usageAccounting.buyerPointsByEpoch(5, buyer), 10);
         assertEq(usageAccounting.sellerPointsByEpoch(5, seller), 20);
         assertEq(usageAccounting.weightedBuyerPointsByEpoch(5, buyer), 10 * poolPower);
-        assertEq(usageAccounting.weightedAgentSellerPointsByEpoch(5, agentId), 20 * poolPower);
-        assertEq(usageAccounting.weightedSellerPointsByEpoch(5, seller), 20 * poolPower);
+        assertEq(usageAccounting.weightedPoolPointsByEpoch(5, agentId), 20 * poolPower);
+        assertEq(usageAccounting.weightedPoolPointsByEpoch(5, seller), 20 * poolPower);
         assertEq(usageAccounting.agentPoolPointsByEpoch(5, agentId), 20);
         assertEq(usageAccounting.poolPointsByEpoch(5, seller), 20);
         assertEq(usageAccounting.sellerAgentIdByEpoch(5, seller), agentId);

--- a/packages/contracts/test/fuzz/AntseedSellerPoolsRewardsFuzz.t.sol
+++ b/packages/contracts/test/fuzz/AntseedSellerPoolsRewardsFuzz.t.sol
@@ -31,10 +31,10 @@ contract MockAgentLookup {
  *         and distributes.
  *
  *         Invariants under any random staker set / usage:
- *           1. The pool epoch settles gross == its share of the controller
- *              dynamic staker budget, and claimable == gross.
+ *           1. The pool epoch settles its share of the controller
+ *              dynamic staker budget as a single fully-claimable amount.
  *           2. The controller never mints past its Gate share budget.
- *           3. Stakers collectively claim <= the claimable amount minted to the
+ *           3. Stakers collectively claim <= the settled amount minted to the
  *              controller — it can NEVER become insolvent. Residual is dust.
  *           4. Each individual position's claim is proportional to its weight and
  *              double-claim is impossible (cursor advances).
@@ -155,21 +155,16 @@ contract AntseedSellerPoolsRewardsFuzzTest is Test {
         rewards.indexPoolRewards(agentId, 10);
 
         // ── Invariant 1: settlement routing ──
-        (bool settled, uint256 gross, uint256 claimable, uint256 burned, uint256 reserveAmt) =
-            rewards.poolEpochEmissions(5, agentId);
+        (bool settled, uint256 settledAmount) = rewards.poolEpochEmissions(5, agentId);
         assertTrue(settled, "epoch not settled");
         // Single pool => it owns the whole dynamic staker budget.
-        assertEq(gross, rewards.stakerEpochBudget(5), "gross != dynamic staker budget");
-        assertLe(gross, controllerBudget, "gross over controller budget");
-        assertEq(claimable, gross, "uncapped pool should have claimable == gross");
-        assertEq(burned, 0, "no burn while uncapped");
-        assertEq(reserveAmt, 0, "no reserve while uncapped");
+        assertEq(settledAmount, rewards.stakerEpochBudget(5), "settled amount != dynamic staker budget");
+        assertLe(settledAmount, controllerBudget, "settled amount over controller budget");
 
-        // ── Invariant 2: controller minted exactly the claimable to itself ──
-        // (gross == claimable here; burn/reserve are 0)
-        assertEq(gate.minterEpochMinted(SELLER_POOLS_MINTER_ID, 5), gross, "minted != gross");
+        // ── Invariant 2: controller minted exactly the settled amount to itself ──
+        assertEq(gate.minterEpochMinted(SELLER_POOLS_MINTER_ID, 5), settledAmount, "minted != settled amount");
         assertLe(gate.minterEpochMinted(SELLER_POOLS_MINTER_ID, 5), controllerBudget, "over budget");
-        assertEq(token.balanceOf(address(rewards)), claimable, "controller did not custody claimable");
+        assertEq(token.balanceOf(address(rewards)), settledAmount, "controller did not custody settled amount");
 
         // ── All positions claim ──
         uint256 totalClaimed;
@@ -184,12 +179,12 @@ contract AntseedSellerPoolsRewardsFuzzTest is Test {
         }
 
         // ── Invariant 3: conservation + solvency ──
-        assertLe(totalClaimed, claimable, "stakers claimed more than minted");
+        assertLe(totalClaimed, settledAmount, "stakers claimed more than minted");
         // The controller holds exactly the undistributed dust; never negative.
-        assertEq(token.balanceOf(address(rewards)), claimable - totalClaimed, "insolvency / leak");
+        assertEq(token.balanceOf(address(rewards)), settledAmount - totalClaimed, "insolvency / leak");
 
         // Dust is bounded by one wei per position (flooring in mulDiv).
-        assertLe(claimable - totalClaimed, positionIds.length, "dust larger than rounding bound");
+        assertLe(settledAmount - totalClaimed, positionIds.length, "dust larger than rounding bound");
 
         // ── Invariant 4: double-claim is impossible ──
         for (uint256 i = 0; i < positionIds.length; i++) {


### PR DESCRIPTION
## Summary

Simplification pass over the recognized-usage contract stack (no behavior changes):

- **AntseedUsageAccounting**: drop the `SellerUsage.poolPoints` field (exact duplicate of `points`; the `poolPoints*` getters keep their names and return `points`); merge `_recordUsage` into a single pass over storage; remove the three `*SellerPointsByEpoch` view aliases (consumers use the `PoolPoints` names).
- **AntseedSellerPoolsRewards**: remove the always-zero burn/reserve plumbing (`PoolEpochEmission` collapses to `{settled, amount}`, events lose hardcoded-zero params); dedupe the claim/stake copy-paste pairs and the twin cumulative-delta helpers (also removes redundant external `positions()` calls per segment); cache the ANTS token as an immutable.
- **AntseedUsageRewards**: hoist duplicate `_epochVolume`/`getEpochEmission` external calls in the live-budget path; dedupe claim/stake preludes; pass the already-fetched gate budget into the freeze helpers.
- **AntseedEmissionsGate**: delete caller-less `minterConfig` and the `initialEmission()`/`halvingInterval()` wrappers shadowing public-constant auto-getters.
- **AntseedSellerPools**: drop the `poolPowerWeightAtEpoch` aliases (callers use `poolWeightAtEpoch`); emit stake totals from locals instead of re-reading storage; `currentPoolSecurityShareBps(address)` delegates to the uint256 overload.
- **AntseedSellerRegistry**: resolve the agent id once in `isStakedAboveMin`/`getStake`.

Gas: new-agent settlement 209,188 → 179,452 (−29.7k); repeated settlement 23,003 → 21,170. Snapshots regenerated (all improved).

## Testing

`forge build` clean, `forge test`: 660 passed, 0 failed (22 suites).

No user-facing change — internal contract refactors on the undeployed recognized-usage stack; CHANGELOG not updated.
