### PR TITLE
fix(node): Drop closed payment frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed seller crashes when sending `PaymentRequired` to a buyer that disconnected before the payment terms could be delivered.
 - Fixed the buyer's Responses→Chat Completions request adapter to group parallel tool calls into a single assistant `tool_calls` message. Previously each call became its own assistant message, so strict chat-completions upstreams rejected multi-tool turns with `an assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'`.
 - Fixed the Responses request normalizer to drop non-message input items with no renderable text (e.g. Codex `reasoning` items) instead of converting them into empty user messages mid-history.
 

--- a/packages/node/src/p2p/payment-mux.ts
+++ b/packages/node/src/p2p/payment-mux.ts
@@ -13,7 +13,7 @@ import type {
 import { encodeFrame } from './message-protocol.js';
 import type { FramedMessage } from '../types/protocol.js';
 import * as codec from './payment-codec.js';
-import { debugLog } from '../utils/debug.js';
+import { debugLog, debugWarn } from '../utils/debug.js';
 
 const MESSAGE_TYPE_NAME: Record<number, string> = {
   [MessageType.SpendingAuth]: 'SpendingAuth',
@@ -147,12 +147,19 @@ export class PaymentMux {
   }
 
   private _send(type: MessageType, payload: Uint8Array): void {
-    debugLog(`[PaymentMux] → send ${MESSAGE_TYPE_NAME[type] ?? `0x${type.toString(16)}`} (${payload.length}b)`);
+    const name = MESSAGE_TYPE_NAME[type] ?? `0x${type.toString(16)}`;
+    debugLog(`[PaymentMux] → send ${name} (${payload.length}b)`);
     const frame = encodeFrame({
       type,
       messageId: this._messageIdCounter++ & 0xffffffff,
       payload,
     });
-    this._connection.send(frame);
+    try {
+      this._connection.send(frame);
+    } catch (err) {
+      debugWarn(
+        `[PaymentMux] drop ${name} because connection closed: ${err instanceof Error ? err.message : err}`,
+      );
+    }
   }
 }

--- a/packages/node/tests/payment-mux.test.ts
+++ b/packages/node/tests/payment-mux.test.ts
@@ -204,5 +204,20 @@ describe('PaymentMux', () => {
       const sentFrame = (conn.send as ReturnType<typeof vi.fn>).mock.calls[0][0];
       expect(sentFrame).toBeInstanceOf(Uint8Array);
     });
+
+    it('drops PaymentRequired when the transport is already closed', () => {
+      const conn = mockConnection();
+      (conn.send as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error('Cannot send to peer: no writable transport');
+      });
+      const mux = new PaymentMux(conn);
+
+      expect(() => mux.sendPaymentRequired({
+        minBudgetPerRequest: '10000',
+        suggestedAmount: '100000',
+        requestId: 'req-closed',
+      })).not.toThrow();
+      expect(conn.send).toHaveBeenCalledOnce();
+    });
   });
 });


### PR DESCRIPTION
## Description

Makes payment mux sends best-effort when the underlying peer transport has already closed. This prevents seller request handling from crashing while attempting to deliver `PaymentRequired` or other payment frames to a disconnected buyer.

## Release Notes

- Fixed seller crashes when sending payment-required responses to buyers that disconnected mid-request.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
