### PR TITLE
fix(node): Preserve payment send errors

### DIFF
--- a/packages/node/src/p2p/payment-mux.ts
+++ b/packages/node/src/p2p/payment-mux.ts
@@ -13,7 +13,7 @@ import type {
 import { encodeFrame } from './message-protocol.js';
 import type { FramedMessage } from '../types/protocol.js';
 import * as codec from './payment-codec.js';
-import { debugLog, debugWarn } from '../utils/debug.js';
+import { debugLog } from '../utils/debug.js';
 
 const MESSAGE_TYPE_NAME: Record<number, string> = {
   [MessageType.SpendingAuth]: 'SpendingAuth',
@@ -154,12 +154,6 @@ export class PaymentMux {
       messageId: this._messageIdCounter++ & 0xffffffff,
       payload,
     });
-    try {
-      this._connection.send(frame);
-    } catch (err) {
-      debugWarn(
-        `[PaymentMux] drop ${name} because connection closed: ${err instanceof Error ? err.message : err}`,
-      );
-    }
+    this._connection.send(frame);
   }
 }

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -141,7 +141,7 @@ export class SellerRequestHandler {
               headers: { "content-type": "application/json" },
               body: new TextEncoder().encode(paymentBody),
             });
-            paymentMux.sendPaymentRequired(requirements);
+            this._sendPaymentRequiredBestEffort(paymentMux, requirements, buyerPeerId, 'missing-session');
           } else {
             debugWarn(`[SellerHandler] No payment session — returning 402`);
             mux.sendProxyResponse({
@@ -291,7 +291,7 @@ export class SellerRequestHandler {
                 ...(requirements.cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion: requirements.cachedInputUsdPerMillion } : {}),
               })),
             });
-            paymentMux.sendPaymentRequired(requirements);
+            this._sendPaymentRequiredBestEffort(paymentMux, requirements, buyerPeerId, 'budget-exhausted');
             // Auto-sign catch-up via NeedAuth so a transient underfund recovers
             // without the 402 round-tripping to the user.
             if (!isFullyExhausted) {
@@ -703,6 +703,21 @@ export class SellerRequestHandler {
     } catch (err) {
       debugWarn(
         `[SellerHandler] NeedAuth send skipped (${phase}) for ${buyerPeerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+
+  private _sendPaymentRequiredBestEffort(
+    paymentMux: PaymentMux,
+    payload: Parameters<PaymentMux['sendPaymentRequired']>[0],
+    buyerPeerId: string,
+    phase: 'missing-session' | 'budget-exhausted',
+  ): void {
+    try {
+      paymentMux.sendPaymentRequired(payload);
+    } catch (err) {
+      debugWarn(
+        `[SellerHandler] PaymentRequired send skipped (${phase}) for ${buyerPeerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`,
       );
     }
   }

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -323,6 +323,35 @@ describe('SellerRequestHandler payment pricing selection', () => {
     expect(BigInt(sendNeedAuth.mock.calls[0]![0].requiredCumulativeAmount)).toBeLessThanOrEqual(reserveMax);
   });
 
+  it('does not crash when PaymentRequired cannot be sent to a disconnected first-time buyer', async () => {
+    const provider = makeProvider(10, 20, { name: 'paid-tier', services: ['local-test'] });
+    provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));
+
+    const sendPaymentRequired = vi.fn(() => {
+      throw new Error('Cannot send to buyer: no writable transport');
+    });
+    const handler = new SellerRequestHandler({
+      providers: [provider],
+      sellerPaymentManager: makeSpmMock({ hasSession: () => false, getChannelByPeer: () => undefined }),
+      sessionTracker: null,
+      channelsClient: {} as any,
+      announcer: null,
+      emit: () => false,
+    });
+
+    const sentFrames: Uint8Array[] = [];
+    const conn = makeConn(sentFrames);
+    const paymentMux = { sendNeedAuth: vi.fn(), sendPaymentRequired } as any;
+    const { mux } = handler.handleConnection(conn, 'b'.repeat(40), paymentMux);
+
+    await expect(mux.handleFrame({ type: MessageType.HttpRequest, messageId: 1, payload: encodeHttpRequest({ requestId: 'req-closed-payment-required', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'local-test' })) }) })).resolves.toBeUndefined();
+
+    expect(provider.handleRequest).not.toHaveBeenCalled();
+    expect(sendPaymentRequired).toHaveBeenCalledOnce();
+    const response = decodeHttpResponse(decodeFrame(sentFrames[0]!)!.message.payload);
+    expect(response.statusCode).toBe(402);
+  });
+
   it('skips the 402 / ReserveAuth handshake when a first-time buyer requests a free service', async () => {
     const provider = makeProvider(0, 0, { name: 'free-tier', services: ['local-test'] });
     provider.handleRequest = vi.fn(async (req) => ({ requestId: req.requestId, statusCode: 200, headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ ok: true })) }));

--- a/packages/node/tests/payment-mux.test.ts
+++ b/packages/node/tests/payment-mux.test.ts
@@ -205,7 +205,7 @@ describe('PaymentMux', () => {
       expect(sentFrame).toBeInstanceOf(Uint8Array);
     });
 
-    it('drops PaymentRequired when the transport is already closed', () => {
+    it('propagates PaymentRequired send errors to callers', () => {
       const conn = mockConnection();
       (conn.send as ReturnType<typeof vi.fn>).mockImplementation(() => {
         throw new Error('Cannot send to peer: no writable transport');
@@ -216,7 +216,7 @@ describe('PaymentMux', () => {
         minBudgetPerRequest: '10000',
         suggestedAmount: '100000',
         requestId: 'req-closed',
-      })).not.toThrow();
+      })).toThrow('no writable transport');
       expect(conn.send).toHaveBeenCalledOnce();
     });
   });


### PR DESCRIPTION
## Description

Restores `PaymentMux` send-error propagation so buyer-side free-usage managers can roll back state when `FreeUsageOpen` or `FreeUsageAuth` delivery fails. Keeps the seller crash fix by catching `PaymentRequired` send failures only at the seller request-handler call sites that emit best-effort 402 payment terms.

## Release Notes

- Fixed payment send error handling so buyer retry state remains consistent while sellers still avoid crashes when buyers disconnect during payment-required responses.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
