### PR TITLE
fix(payments): stop seller close() retry loop after ReserveAuth mispersist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed the seller persisting the initial ReserveAuth signature in the SpendingAuth column, so restart hydration restored it under the wrong EIP-712 type and every subsequent `close()` reverted with `InvalidSignature`.
+- Fixed sellers retrying a failing signed `close()` forever: once the retry limit is exhausted the channel is now persisted as timed out, so `checkTimeouts()` and restarts fall back to the timeout path instead of replaying the same doomed close.
 - Fixed seller crashes when sending `PaymentRequired` to a buyer that disconnected before the payment terms could be delivered.
 - Fixed the buyer's Responses→Chat Completions request adapter to group parallel tool calls into a single assistant `tool_calls` message. Previously each call became its own assistant message, so strict chat-completions upstreams rejected multi-tool turns with `an assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'`.
 - Fixed the Responses request normalizer to drop non-message input items with no renderable text (e.g. Codex `reasoning` items) instead of converting them into empty user messages mid-history.

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -490,7 +490,10 @@ export class SellerPaymentManager {
           settledAmount: null,
           status: CHANNEL_STATUS.ACTIVE,
           latestBuyerSig: payload.spendingAuthSig,
-          latestSpendingAuthSig: payload.spendingAuthSig,
+          // The initial signature is a ReserveAuth, not a SpendingAuth. Keep it
+          // out of the persisted SpendingAuth column so restart hydration cannot
+          // restore it under the wrong EIP-712 type and repeatedly fail close().
+          latestSpendingAuthSig: null,
           latestMetadata: payload.metadata,
           createdAt: now,
           updatedAt: now,
@@ -1041,6 +1044,7 @@ export class SellerPaymentManager {
       const retries = this._closeRetryCount.get(channelId) ?? 0;
       if (retries >= SellerPaymentManager.MAX_CLOSE_RETRIES) {
         debugWarn(`[SellerPayment] close() failed ${retries} times for ${channelId.slice(0, 18)}... — falling back to timeout path`);
+        this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.TIMEOUT);
       } else {
         debugLog(`[SellerPayment] Closing channel ${channelId.slice(0, 18)}... cumulative=${amount} (attempt ${retries + 1}/${SellerPaymentManager.MAX_CLOSE_RETRIES})`);
         this._closingChannels.add(channelId);
@@ -1059,9 +1063,20 @@ export class SellerPaymentManager {
             }
             return;
           }
-          debugWarn(`[SellerPayment] Failed to close channel (attempt ${retries + 1}): ${err instanceof Error ? err.message : err}`);
-          this._closeRetryCount.set(channelId, retries + 1);
-          if (!cleanupOnFailure) return;
+
+          const failedAttempts = retries + 1;
+          debugWarn(`[SellerPayment] Failed to close channel (attempt ${failedAttempts}): ${err instanceof Error ? err.message : err}`);
+          this._closeRetryCount.set(channelId, failedAttempts);
+
+          if (failedAttempts < SellerPaymentManager.MAX_CLOSE_RETRIES) {
+            if (cleanupOnFailure) {
+              this._activeBuyers.delete(buyerPeerId);
+            }
+            return;
+          }
+
+          debugWarn(`[SellerPayment] close() failed ${failedAttempts} times for ${channelId.slice(0, 18)}... — falling back to timeout path`);
+          this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.TIMEOUT);
         } finally {
           this._closingChannels.delete(channelId);
         }

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -184,6 +184,8 @@ describe('SellerPaymentManager', () => {
     expect(session).not.toBeNull();
     expect(session!.role).toBe('seller');
     expect(session!.status).toBe(CHANNEL_STATUS.ACTIVE);
+    expect(session!.latestBuyerSig).toBe(payload.spendingAuthSig);
+    expect(session!.latestSpendingAuthSig).toBeNull();
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
   });
 
@@ -1006,7 +1008,7 @@ describe('SellerPaymentManager', () => {
     expect(manager.hasSession('nonexistent-peer')).toBe(false);
   });
 
-  it('checkTimeouts restores persisted SpendingAuth before zombie close fallback', async () => {
+  it('checkTimeouts retries the latest SpendingAuth after a disconnect close failure', async () => {
     const channelId = makeChannelId(69);
     const reserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
       isReserve: true,
@@ -1035,7 +1037,7 @@ describe('SellerPaymentManager', () => {
 
     expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
-    expect(manager.getAcceptedCumulative(channelId)).toBe(0n);
+    expect(manager.getAcceptedCumulative(channelId)).toBe(300_000n);
 
     vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(
       makeOnChainChannel(buyerIdentity, sellerIdentity, {
@@ -1055,6 +1057,47 @@ describe('SellerPaymentManager', () => {
     expect(retryArgs[4]).toBe(auth.spendingAuthSig);
     expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
     expect(store.getChannel(channelId)!.settledAmount).toBe('300000');
+  });
+
+  it('stops retrying and persists timeout after signed close retries are exhausted', async () => {
+    const channelId = makeChannelId(76);
+    const reserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reserve, mux);
+
+    const auth = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 300_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, auth, mux);
+    manager.recordSpend(channelId, 300_000n);
+
+    const closeSpy = manager.channelsClient.close as ReturnType<typeof vi.fn>;
+    closeSpy.mockRejectedValue(new Error('execution reverted: InvalidSignature'));
+
+    await manager.settleSession(buyerIdentity.peerId);
+    await manager.settleSession(buyerIdentity.peerId);
+    await manager.settleSession(buyerIdentity.peerId);
+    await manager.settleSession(buyerIdentity.peerId);
+
+    expect(closeSpy).toHaveBeenCalledTimes(3);
+    expect(store.getChannel(channelId)!.status).toBe(CHANNEL_STATUS.TIMEOUT);
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(false);
+
+    const restarted = new SellerPaymentManager(sellerIdentity, {
+      rpcUrl: 'http://127.0.0.1:8545',
+      channelsContractAddress: CONTRACT_ADDR,
+      chainId: CHAIN_ID,
+      dataDir: tempDir,
+    }, store);
+    const restartedCloseSpy = vi.spyOn(restarted.channelsClient, 'close').mockResolvedValue('0xclose-hash');
+
+    await restarted.checkTimeouts();
+
+    expect(restarted.hasSession(buyerIdentity.peerId)).toBe(false);
+    expect(restartedCloseSpy).not.toHaveBeenCalled();
   });
 
   it('checkTimeouts closes zombie channels on-chain without a SpendingAuth', async () => {


### PR DESCRIPTION
## Summary

Fixes two related seller-side payment channel close bugs that together caused a permanent `close()` retry loop:

1. **ReserveAuth persisted as SpendingAuth** — when a channel opens, the buyer's initial signature is a ReserveAuth, but it was stored in the `latestSpendingAuthSig` column. After a seller restart, hydration restored it as if it were a SpendingAuth, so every `close()` attempt reverted with `InvalidSignature` (wrong EIP-712 type). The column is now left `null` at channel creation; only real SpendingAuths are persisted there.

2. **Infinite close retries** — when `close()` exhausted `MAX_CLOSE_RETRIES`, the channel remained `ACTIVE` in the store, so `checkTimeouts()` and every seller restart replayed the same doomed signed close forever. The channel is now persisted as `TIMEOUT` once retries are exhausted (both at the pre-check and when the final attempt fails), so it falls back to the timeout path. Intermediate failures also clean up `_activeBuyers` so the buyer session doesn't leak.

## Changes

- `packages/node/src/payments/seller-payment-manager.ts` — don't persist ReserveAuth sig as SpendingAuth; persist `TIMEOUT` status when close retries are exhausted; clean up `_activeBuyers` on intermediate close failures.
- `packages/node/tests/seller-payment-manager.test.ts` — new test covering retry exhaustion → persisted `TIMEOUT` → restart does not retry the signed close; updated the disconnect-close-failure test for the corrected persistence semantics.
- `CHANGELOG.md` — two entries under Unreleased → Fixed (user-facing seller behavior change in `@antseed/node`).

## Testing

- `vitest run tests/seller-payment-manager.test.ts` — 53/53 pass on this branch.
- `packages/node` builds clean (`tsc`).
