### PR TITLE
feat(payments): Buyer-requested cooperative channel close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ## Unreleased
 
+### Added
+
+- Added buyer-initiated cooperative channel close (`CloseChannelRequest`/`CloseChannelResult`, message types 0x59/0x5A), so a buyer can get its reserved USDC released immediately instead of waiting out the on-chain `request-close` → 15-minute grace → `withdraw` flow. The seller closes on-chain and returns the transaction hash. It refuses while it is still mid-accumulation with that buyer — a billable request in flight (`busy`), or served work the buyer hasn't signed for yet (`pending_auth`, sent alongside a `NeedAuth` for the outstanding amount) — leaving the channel untouched so the buyer can retry or fall back to the timeout path.
+- The buyer attaches its latest SpendingAuth by default; the seller closes at whichever cumulative is higher (its own or the buyer's), so a seller that lost the last authorization can still be paid in full, and a buyer cannot use this path to settle below what it owes.
+- Added `antseed buyer channels close <channelId>` (with `--no-auth` and `--json`), which runs the request through a running `antseed buyer start` daemon's live seller connection via the new `/_antseed/channels/close` control-plane endpoint.
+- Added `AntseedNode.requestChannelClose(peerId, opts)` to `@antseed/node`, plus the `payments.cooperative-close.v1` capability advertised in discovery metadata and the connection handshake.
+
 ### Fixed
 
 - Fixed the seller persisting the initial ReserveAuth signature in the SpendingAuth column, so restart hydration restored it under the wrong EIP-712 type and every subsequent `close()` reverted with `InvalidSignature`.

--- a/apps/cli/src/cli/commands/buyer/channel-withdraw.ts
+++ b/apps/cli/src/cli/commands/buyer/channel-withdraw.ts
@@ -147,7 +147,13 @@ export function registerBuyerChannelWithdrawCommands(channelsCmd: Command, buyer
       try {
         result = await daemonRequestClose(config.buyer.proxyPort, localChannel.peerId, options.auth);
       } catch (err) {
+        // An unreachable seller lands here, and that is the likeliest reason to
+        // be running this command at all — so give the same actionable fallback
+        // the decline path gives, not just the raw error.
         spinner.fail(chalk.red(`Close request failed: ${(err as Error).message}`));
+        console.log(chalk.dim('The channel is unchanged. To release the reserve without the seller:'));
+        console.log(chalk.cyan(`  antseed buyer channels request-close ${localChannel.sessionId}`));
+        console.log(chalk.dim(`  ...then after ${formatWait(CHANNEL_CLOSE_GRACE_PERIOD_SECONDS)}: antseed buyer channels withdraw ${localChannel.sessionId}`));
         process.exit(1);
       }
 

--- a/apps/cli/src/cli/commands/buyer/channel-withdraw.ts
+++ b/apps/cli/src/cli/commands/buyer/channel-withdraw.ts
@@ -1,7 +1,7 @@
 import type { Command } from 'commander';
 import chalk from 'chalk';
 import ora from 'ora';
-import type { StoredChannel } from '@antseed/node';
+import type { CloseChannelResultPayload, StoredChannel } from '@antseed/node';
 import { CHANNEL_STATUS } from '@antseed/node/payments';
 import { getGlobalOptions } from '../types.js';
 import { loadConfig } from '../../../config/loader.js';
@@ -71,7 +71,109 @@ function openChannelStoreOrExit(dataDir: string): ReturnType<typeof openChannelS
   }
 }
 
+/**
+ * Human-readable guidance per seller rejection code. The seller declining is a
+ * normal outcome — it means the channel is still accumulating — so we explain
+ * what to do rather than treating it as a failure of the command.
+ */
+const REJECT_HINTS: Record<string, string> = {
+  busy: 'The seller is still serving a request on this channel. Retry in a few seconds.',
+  pending_auth: 'The seller has served work you have not signed for yet. The catch-up authorization was just requested — retry in a few seconds.',
+  no_channel: 'The seller has no active channel with you. It may already be closed on-chain — check `antseed buyer channels list`.',
+  invalid_auth: 'The seller rejected the attached authorization. Retry with --no-auth to let the seller close using the signature it already holds.',
+  close_failed: 'The seller could not submit the on-chain close.',
+  unsupported: 'This peer does not support cooperative close. Use `antseed buyer channels request-close` instead.',
+};
+
+async function daemonRequestClose(
+  port: number,
+  peerId: string,
+  includeAuth: boolean,
+): Promise<CloseChannelResultPayload> {
+  let res: Response;
+  try {
+    res = await fetch(`http://127.0.0.1:${port}/_antseed/channels/close`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ peerId, includeAuth }),
+      signal: AbortSignal.timeout(90_000),
+    });
+  } catch {
+    throw new Error(
+      `No buyer daemon is listening on port ${port}. A cooperative close runs over the daemon's live `
+      + 'connection to the seller — start it with `antseed buyer start`, or fall back to '
+      + '`antseed buyer channels request-close <channelId>`.',
+    );
+  }
+  const body = await res.json().catch(() => null) as {
+    ok?: boolean; result?: CloseChannelResultPayload; error?: string;
+  } | null;
+  if (!res.ok || !body?.ok || !body.result) {
+    throw new Error(body?.error ?? `Daemon returned HTTP ${res.status}`);
+  }
+  return body.result;
+}
+
 export function registerBuyerChannelWithdrawCommands(channelsCmd: Command, buyerCmd: Command): void {
+  channelsCmd
+    .command('close <channelId>')
+    .description('Ask the seller to close an active channel now, skipping the request-close grace period')
+    .option('--no-auth', 'do not attach your latest spending authorization; let the seller use the one it holds')
+    .option('--json', 'output as JSON', false)
+    .action(async (channelId: string, options: { auth: boolean; json: boolean }) => {
+      const globalOpts = getGlobalOptions(buyerCmd);
+      const config = await loadConfig(globalOpts.config);
+      const { address } = await loadCryptoContext(globalOpts.dataDir);
+
+      let localChannel: StoredChannel;
+      const store = openChannelStoreOrExit(globalOpts.dataDir);
+      try {
+        localChannel = resolveBuyerChannelById(
+          store.getAllChannelsByBuyer('buyer', address),
+          channelId,
+        );
+      } finally {
+        store.close();
+      }
+
+      if (localChannel.status !== CHANNEL_STATUS.ACTIVE) {
+        console.error(chalk.red(`Error: Local channel ${shortId(localChannel.sessionId, 18)} is ${localChannel.status}, not active.`));
+        console.error(chalk.dim('Only active channels can be closed.'));
+        process.exit(1);
+      }
+
+      const spinner = ora(`Asking seller ${shortId(localChannel.peerId, 12)} to close ${shortId(localChannel.sessionId, 18)}...`).start();
+      let result: CloseChannelResultPayload;
+      try {
+        result = await daemonRequestClose(config.buyer.proxyPort, localChannel.peerId, options.auth);
+      } catch (err) {
+        spinner.fail(chalk.red(`Close request failed: ${(err as Error).message}`));
+        process.exit(1);
+      }
+
+      if (options.json) {
+        spinner.stop();
+        console.log(JSON.stringify(result, null, 2));
+        if (result.status !== 'closed') process.exit(1);
+        return;
+      }
+
+      if (result.status === 'closed') {
+        spinner.succeed(chalk.green(`Seller closed ${shortId(result.channelId, 18)}`));
+        console.log(chalk.dim(`Transaction: ${result.txHash}`));
+        console.log(chalk.dim(`Settled at: ${formatUsdc(BigInt(result.finalAmount ?? '0'))} USDC`));
+        console.log(chalk.dim('Your remaining reserve is released — no grace period to wait out.'));
+        return;
+      }
+
+      spinner.warn(chalk.yellow(`Seller declined to close ${shortId(result.channelId, 18)}: ${result.code ?? 'unknown'}`));
+      if (result.reason) console.log(chalk.dim(result.reason));
+      const hint = result.code ? REJECT_HINTS[result.code] : undefined;
+      if (hint) console.log(hint);
+      console.log(chalk.dim(`Fallback: antseed buyer channels request-close ${localChannel.sessionId}`));
+      process.exit(1);
+    });
+
   channelsCmd
     .command('request-close <channelId>')
     .description('Request timeout close for an active buyer payment channel so reserved funds can be withdrawn after the grace period')

--- a/apps/cli/src/cli/commands/buyer/channels.ts
+++ b/apps/cli/src/cli/commands/buyer/channels.ts
@@ -80,7 +80,7 @@ async function listBuyerChannels(buyerCmd: Command, options: { status?: string; 
 export function registerBuyerChannelsCommand(buyerCmd: Command): void {
   const channelsCmd = buyerCmd
     .command('channels')
-    .description('List, request-close, and withdraw buyer payment channels');
+    .description('List, close, request-close, and withdraw buyer payment channels');
 
   channelsCmd
     .command('list')

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -998,6 +998,53 @@ export class BuyerProxy {
       return
     }
 
+    // Ask a seller to cooperatively close a payment channel, skipping the
+    // on-chain request-close → grace → withdraw flow. Needs the daemon's live
+    // seller connection, so it can only run here.
+    if (path === '/_antseed/channels/close' && method === 'POST') {
+      const chunks: Buffer[] = []
+      let totalSize = 0
+      for await (const chunk of req) {
+        totalSize += (chunk as Buffer).length
+        if (totalSize > 8192) {
+          res.writeHead(413, { 'content-type': 'application/json' })
+          res.end(JSON.stringify({ ok: false, error: 'Request body too large' }))
+          return
+        }
+        chunks.push(chunk as Buffer)
+      }
+      let peerId: string
+      let includeAuth = true
+      try {
+        const body = JSON.parse(Buffer.concat(chunks).toString())
+        peerId = String(body.peerId ?? '')
+        if (body.includeAuth === false) includeAuth = false
+      } catch {
+        res.writeHead(400, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: 'Invalid JSON body' }))
+        return
+      }
+      if (!peerId) {
+        res.writeHead(400, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: 'Missing peerId' }))
+        return
+      }
+      try {
+        const result = await this._node.requestChannelClose(peerId, { includeAuth })
+        log(
+          `Cooperative close of ${result.channelId.slice(0, 18)}... with ${peerId.slice(0, 12)}...: ` +
+          `${result.status}${result.code ? ` (${result.code})` : ''}`,
+        )
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: true, result }))
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        res.writeHead(502, { 'content-type': 'application/json' })
+        res.end(JSON.stringify({ ok: false, error: message }))
+      }
+      return
+    }
+
     const sweepReceiptMatch = path.match(/^\/_antseed\/sweep\/(0x[0-9a-fA-F]{64})$/)
     if (sweepReceiptMatch && method === 'GET') {
       const receipt = this._sweepReceipts.get(sweepReceiptMatch[1]!.toLowerCase()) ?? null

--- a/docs/protocol/spec/04-payments.md
+++ b/docs/protocol/spec/04-payments.md
@@ -54,6 +54,52 @@ The seller calls `settle()` with the latest SpendingAuth to charge the cumulativ
 
 If the seller disappears after the deadline, anyone can call `requestTimeout()`. After a 15-minute grace period, `withdraw()` releases the locked funds back to the buyer's deposit.
 
+### Cooperative close (buyer-requested)
+
+Close is normally seller-initiated. A buyer that wants its reserve back **now** —
+without waiting out the 15-minute timeout grace period — asks the seller to
+close instead, over `CloseChannelRequest` / `CloseChannelResult` (§11).
+
+```
+BUYER                              SELLER                           ON-CHAIN
+  │ ─ CloseChannelRequest ────────► │                                │
+  │   {channelId, [SpendingAuth]}   │  no request in flight?         │
+  │                                  │  no unsigned spend?            │
+  │                                  │  amount = max(own, buyer's)    │
+  │                                  │ ── close(SpendingAuth) ───────►│
+  │ ◄── CloseChannelResult ───────── │                                │
+  │   {status: closed, txHash}       │                                │
+```
+
+The buyer MAY attach its latest SpendingAuth. Attaching costs it nothing — the
+cumulative is unchanged, so it authorizes no more than the seller could already
+claim — but it lets a seller that never received the last auth (lost frame,
+crash before persist) still close at the full amount owed. The seller settles at
+`max(own last-accepted, buyer-supplied)`, so neither party can use this path to
+settle below what is actually owed. A supplied auth must recover to the on-chain
+channel buyer and its `metadataHash` must match its `metadata`, or the request is
+rejected as `invalid_auth`.
+
+The seller agrees only when it is **not mid-accumulation** with that buyer:
+
+- No billable request is in flight. The seller holds the channel open for the
+  whole billable span — provider call, spend recording, and the follow-up
+  NeedAuth — so a close cannot land between serving a request and claiming its
+  cost. Otherwise: `busy`.
+- No served work is unsigned. If `spent` exceeds the highest signed cumulative,
+  the seller waits briefly for a catch-up auth already on the wire; failing
+  that it emits a `NeedAuth` for the outstanding amount and rejects with
+  `pending_auth` plus `requiredCumulativeAmount`. The buyer signs and retries.
+
+Rejections are normal outcomes, not errors — the channel is left untouched and
+the buyer can retry or fall back to `requestTimeout()`. When neither side holds
+a usable auth the seller closes at the current on-chain `settled` amount with an
+empty signature, which the contract accepts without signature verification
+(`finalAmount == settled`) and which claims no unproven spend.
+
+Sellers advertise support with the `payments.cooperative-close.v1` capability in
+discovery metadata and in the connection handshake.
+
 ## 2. EIP-712 Signed Messages
 
 EIP-712 domain for both message types:
@@ -273,12 +319,25 @@ Contracts reference each other by address (set at deployment, updateable by owne
 
 ## 11. P2P Messages
 
+Payment messages occupy `0x50-0x5F`. Payloads are UTF-8 JSON capped at 64 KiB;
+uint256 values are decimal strings, and receivers MUST validate every field —
+payloads are untrusted peer input.
+
 | Type | Name | Direction | Description |
 |---|---|---|---|
-| 0x50 | `ReserveAuth` | Buyer → Seller | EIP-712 signed reserve authorization |
+| 0x50 | `SpendingAuth` | Buyer → Seller | EIP-712 signed cumulative spending authorization (carries the opening ReserveAuth on the first send) |
 | 0x51 | `AuthAck` | Seller → Buyer | Reservation confirmed |
-| 0x53 | `SellerReceipt` | Seller → Buyer | Running-total receipt after each request |
-| 0x54 | `SpendingAuth` | Buyer → Seller | EIP-712 signed cumulative spending authorization |
+| 0x52 | `FreeUsageOpen` | Buyer → Seller | Open a zero-price usage channel |
+| 0x53 | `FreeUsageAuth` | Buyer → Seller | Signed cumulative zero-price usage record |
+| 0x54 | `FreeUsageAck` | Seller → Buyer | Zero-price open/record accepted |
+| 0x55 | `NeedFreeUsageAuth` | Seller → Buyer | Request a zero-price usage signature |
+| 0x56 | `PaymentRequired` | Seller → Buyer | Payment terms accompanying an HTTP 402 |
+| 0x58 | `NeedAuth` | Seller → Buyer | Per-request cost report + required cumulative |
+| 0x59 | `CloseChannelRequest` | Buyer → Seller | Ask the seller to close the channel now (§1) |
+| 0x5A | `CloseChannelResult` | Seller → Buyer | Close verdict: `closed` + txHash, or `rejected` + code |
+
+`CloseChannelResult` rejection codes: `busy`, `pending_auth`, `no_channel`,
+`invalid_auth`, `close_failed`, `unsupported`.
 
 ## 12. Session Persistence
 

--- a/docs/protocol/spec/04-payments.md
+++ b/docs/protocol/spec/04-payments.md
@@ -98,7 +98,14 @@ empty signature, which the contract accepts without signature verification
 (`finalAmount == settled`) and which claims no unproven spend.
 
 Sellers advertise support with the `payments.cooperative-close.v1` capability in
-discovery metadata and in the connection handshake.
+discovery metadata and in the connection handshake. A seller predating this
+protocol drops the unrecognized `0x59` frame silently, so buyers MUST check the
+capability before sending and fail fast rather than waiting out the response
+timeout. The check reads the peer's **discovery metadata**; the connection
+handshake's remote-capability set is only populated for inbound connections and
+so is empty on the buyer's own outbound connection. A buyer that has no
+capability data for a peer at all SHOULD attempt the close anyway — absence of
+data is not evidence of non-support.
 
 ## 2. EIP-712 Signed Messages
 

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -32,6 +32,7 @@ import type { DHTHealthMonitor } from "./dht-health.js";
 import {
   CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1,
   CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+  CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1,
 } from "../types/protocol.js";
 
 export interface SellerContractConfig {
@@ -278,7 +279,10 @@ export class PeerAnnouncer {
       return providerAnnouncement;
     });
 
-    const capabilities: string[] = [CONNECTION_CAPABILITY_RESPONSE_AUTH_V1];
+    const capabilities: string[] = [
+      CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+      CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1,
+    ];
     if (this.config.relaysSweeps) {
       capabilities.push(CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1);
     }

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -52,6 +52,8 @@ import { VerificationMux } from "./verification/verification-mux.js";
 import { DepositRelayer } from "./payments/deposit-relayer.js";
 import {
   CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1,
+  CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1,
+  peerSupportsCooperativeClose,
   type SweepRequestPayload,
   type SweepReceiptPayload,
   type CloseChannelResultPayload,
@@ -1017,6 +1019,23 @@ export class AntseedNode extends EventEmitter {
       if (!conn) {
         throw new Error(`Failed to establish a connection to seller ${sellerPeerId.slice(0, 12)}...`);
       }
+    }
+
+    // A seller that predates this feature drops the 0x59 frame silently, so
+    // without this the buyer would wait out the full 60s response timeout and
+    // get a vague "did not answer". Note the capability must come from the
+    // peer's discovery metadata (`_peerCapabilities`), not
+    // `conn.hasRemoteCapability` — the latter is only populated for *inbound*
+    // connections, so on the buyer's own outbound connection it is always
+    // empty and would reject every close.
+    const capabilities = this._peerCapabilities.get(peerId);
+    if (capabilities && capabilities.size > 0
+      && !peerSupportsCooperativeClose({ capabilities: [...capabilities] })) {
+      throw new Error(
+        `Seller ${sellerPeerId.slice(0, 12)}... does not support cooperative close ` +
+        `(missing ${CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1}). ` +
+        `Use the on-chain request-close flow instead.`,
+      );
     }
 
     return negotiator.requestChannelClose(peerId, conn, opts);

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -54,6 +54,7 @@ import {
   CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1,
   type SweepRequestPayload,
   type SweepReceiptPayload,
+  type CloseChannelResultPayload,
 } from "./types/protocol.js";
 import { VerificationStorage } from "./verification/storage.js";
 import { VerificationSampler } from "./verification/samples.js";
@@ -976,6 +977,52 @@ export class AntseedNode extends EventEmitter {
   }
 
   /**
+   * Ask a seller to close our payment channel with it right now, releasing the
+   * reserved deposit without the on-chain `requestClose()` → 15-minute grace →
+   * `withdraw()` round trip.
+   *
+   * The seller refuses while it is still serving (or still owed for) requests
+   * on that channel; those refusals come back as `{ status: 'rejected', code }`
+   * rather than as exceptions. Only a missing session, a peer we can't reach,
+   * or an unanswered request throws.
+   *
+   * By default the buyer attaches its latest SpendingAuth so a seller that lost
+   * the last one can still close at the full amount owed; the seller settles at
+   * whichever cumulative is higher.
+   */
+  async requestChannelClose(
+    sellerPeerId: string,
+    opts: { includeAuth?: boolean; timeoutMs?: number } = {},
+  ): Promise<CloseChannelResultPayload> {
+    const negotiator = this._buyerNegotiator;
+    if (!negotiator) {
+      throw new Error('Buyer payments are not configured on this node');
+    }
+    if (!this._connectionManager) {
+      throw new Error('Node not started');
+    }
+
+    const peerId = sellerPeerId as PeerId;
+    let conn = this._connectionManager.getConnection(peerId);
+    if (!conn || (conn.state !== ConnectionState.Open && conn.state !== ConnectionState.Authenticated)) {
+      const peer = await this.findPeer(sellerPeerId);
+      if (!peer) {
+        throw new Error(
+          `Seller ${sellerPeerId.slice(0, 12)}... is not connected and could not be found on the network. ` +
+          `A cooperative close needs the seller online — otherwise use the on-chain request-close flow.`,
+        );
+      }
+      await this.connectToPeer(peer);
+      conn = this._connectionManager.getConnection(peer.peerId);
+      if (!conn) {
+        throw new Error(`Failed to establish a connection to seller ${sellerPeerId.slice(0, 12)}...`);
+      }
+    }
+
+    return negotiator.requestChannelClose(peerId, conn, opts);
+  }
+
+  /**
    * Query session stats for a specific seller peer.
    * Combines channel store data (authoritative payment/session info) with
    * metering events when available.
@@ -1605,9 +1652,43 @@ export class AntseedNode extends EventEmitter {
             debugWarn(`[Node] SpendingAuth handler error for ${buyerPeerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
           });
       });
+      paymentMux.onCloseChannelRequest((payload) => {
+        void spm.handleCloseChannelRequest(buyerPeerId, payload, paymentMux)
+          .then((result) => {
+            paymentMux.sendCloseChannelResult(result);
+            if (result.status === 'closed') {
+              this.emit('payment:channel-closed', {
+                buyerPeerId,
+                channelId: result.channelId,
+                txHash: result.txHash,
+                finalAmount: result.finalAmount,
+              });
+            }
+          })
+          .catch((err) => {
+            const message = err instanceof Error ? err.message : String(err);
+            debugWarn(`[Node] CloseChannelRequest handler error for ${buyerPeerId.slice(0, 12)}...: ${message}`);
+            paymentMux.sendCloseChannelResult({
+              version: 1,
+              channelId: payload.channelId,
+              status: 'rejected',
+              code: 'close_failed',
+              reason: message,
+            });
+          });
+      });
     } else {
       paymentMux.onSpendingAuth(() => {
         debugWarn(`[Node] SpendingAuth rejected — SellerPaymentManager not configured`);
+      });
+      paymentMux.onCloseChannelRequest((payload) => {
+        paymentMux.sendCloseChannelResult({
+          version: 1,
+          channelId: payload.channelId,
+          status: 'rejected',
+          code: 'unsupported',
+          reason: 'This peer has no payment manager configured',
+        });
       });
     }
     if (this._sellerFreeUsageManager) {

--- a/packages/node/src/p2p/connection-manager.ts
+++ b/packages/node/src/p2p/connection-manager.ts
@@ -7,7 +7,10 @@ import type {
 } from "node-datachannel";
 import { type PeerId } from "../types/peer.js";
 import { ConnectionState, type ConnectionConfig } from "../types/connection.js";
-import { CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 } from "../types/protocol.js";
+import {
+  CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+  CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1,
+} from "../types/protocol.js";
 import { type IceConfig, getDefaultIceConfig } from "./ice-config.js";
 import type { Wallet } from "ethers";
 import {
@@ -65,7 +68,10 @@ const LINE_SEPARATOR = "\n";
 const INITIAL_LINE_TIMEOUT_MS = 10_000;
 const MAX_INITIAL_LINE_BYTES = 8 * 1024;
 const TCP_KEEPALIVE_INITIAL_DELAY_MS = 10_000;
-const LOCAL_CONNECTION_CAPABILITIES = [CONNECTION_CAPABILITY_RESPONSE_AUTH_V1] as const;
+const LOCAL_CONNECTION_CAPABILITIES = [
+  CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+  CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1,
+] as const;
 
 /** Represents a single P2P connection. */
 export class PeerConnection extends EventEmitter {

--- a/packages/node/src/p2p/payment-codec.ts
+++ b/packages/node/src/p2p/payment-codec.ts
@@ -1,5 +1,6 @@
 import {
   PAYMENT_CODE_CHANNEL_EXHAUSTED,
+  CLOSE_CHANNEL_REJECT_CODES,
   type SpendingAuthPayload,
   type AuthAckPayload,
   type FreeUsageOpenPayload,
@@ -8,6 +9,9 @@ import {
   type NeedFreeUsageAuthPayload,
   type PaymentRequiredPayload,
   type NeedAuthPayload,
+  type CloseChannelRequestPayload,
+  type CloseChannelResultPayload,
+  type CloseChannelRejectCode,
 } from '../types/protocol.js';
 import { parseJsonObject, requireStringField } from '../utils/json-codec.js';
 
@@ -63,6 +67,14 @@ export function encodePaymentRequired(payload: PaymentRequiredPayload): Uint8Arr
 }
 
 export function encodeNeedAuth(payload: NeedAuthPayload): Uint8Array {
+  return encoder.encode(JSON.stringify(payload));
+}
+
+export function encodeCloseChannelRequest(payload: CloseChannelRequestPayload): Uint8Array {
+  return encoder.encode(JSON.stringify(payload));
+}
+
+export function encodeCloseChannelResult(payload: CloseChannelResultPayload): Uint8Array {
   return encoder.encode(JSON.stringify(payload));
 }
 
@@ -172,5 +184,53 @@ export function decodeNeedAuth(data: Uint8Array): NeedAuthPayload {
   if (typeof obj.cachedInputTokens === 'string') result.cachedInputTokens = obj.cachedInputTokens;
   if (typeof obj.freshInputTokens === 'string') result.freshInputTokens = obj.freshInputTokens;
   if (typeof obj.service === 'string') result.service = obj.service;
+  return result;
+}
+
+export function decodeCloseChannelRequest(data: Uint8Array): CloseChannelRequestPayload {
+  const obj = parsePaymentJson(data);
+  const result: CloseChannelRequestPayload = {
+    version: 1,
+    channelId: requireStringField(obj, 'channelId'),
+  };
+  // The four auth fields are only meaningful together — a partial set would
+  // leave the seller unable to verify the signature, so drop it wholesale.
+  if (
+    typeof obj.cumulativeAmount === 'string'
+    && typeof obj.metadataHash === 'string'
+    && typeof obj.metadata === 'string'
+    && typeof obj.spendingAuthSig === 'string'
+  ) {
+    result.cumulativeAmount = obj.cumulativeAmount;
+    result.metadataHash = obj.metadataHash;
+    result.metadata = obj.metadata;
+    result.spendingAuthSig = obj.spendingAuthSig;
+  }
+  return result;
+}
+
+export function decodeCloseChannelResult(data: Uint8Array): CloseChannelResultPayload {
+  const obj = parsePaymentJson(data);
+  const status = requireStringField(obj, 'status');
+  if (status !== 'closed' && status !== 'rejected') {
+    throw new Error(`Payment payload field "status" must be "closed" or "rejected"`);
+  }
+  const result: CloseChannelResultPayload = {
+    version: 1,
+    channelId: requireStringField(obj, 'channelId'),
+    status,
+  };
+  if (typeof obj.txHash === 'string') result.txHash = obj.txHash;
+  if (typeof obj.finalAmount === 'string') result.finalAmount = obj.finalAmount;
+  if (typeof obj.code === 'string' && (CLOSE_CHANNEL_REJECT_CODES as readonly string[]).includes(obj.code)) {
+    result.code = obj.code as CloseChannelRejectCode;
+  }
+  if (typeof obj.reason === 'string') result.reason = obj.reason;
+  if (typeof obj.retryAfterMs === 'number' && Number.isFinite(obj.retryAfterMs)) {
+    result.retryAfterMs = obj.retryAfterMs;
+  }
+  if (typeof obj.requiredCumulativeAmount === 'string') {
+    result.requiredCumulativeAmount = obj.requiredCumulativeAmount;
+  }
   return result;
 }

--- a/packages/node/src/p2p/payment-mux.ts
+++ b/packages/node/src/p2p/payment-mux.ts
@@ -9,6 +9,8 @@ import type {
   NeedFreeUsageAuthPayload,
   PaymentRequiredPayload,
   NeedAuthPayload,
+  CloseChannelRequestPayload,
+  CloseChannelResultPayload,
 } from '../types/protocol.js';
 import { encodeFrame } from './message-protocol.js';
 import type { FramedMessage } from '../types/protocol.js';
@@ -24,6 +26,8 @@ const MESSAGE_TYPE_NAME: Record<number, string> = {
   [MessageType.NeedFreeUsageAuth]: 'NeedFreeUsageAuth',
   [MessageType.PaymentRequired]: 'PaymentRequired',
   [MessageType.NeedAuth]: 'NeedAuth',
+  [MessageType.CloseChannelRequest]: 'CloseChannelRequest',
+  [MessageType.CloseChannelResult]: 'CloseChannelResult',
 };
 
 export type PaymentMessageHandler<T> = (payload: T) => void | Promise<void>;
@@ -46,6 +50,8 @@ export class PaymentMux {
   private _onNeedFreeUsageAuth?: PaymentMessageHandler<NeedFreeUsageAuthPayload>;
   private _onPaymentRequired?: PaymentMessageHandler<PaymentRequiredPayload>;
   private _onNeedAuth?: PaymentMessageHandler<NeedAuthPayload>;
+  private _onCloseChannelRequest?: PaymentMessageHandler<CloseChannelRequestPayload>;
+  private _onCloseChannelResult?: PaymentMessageHandler<CloseChannelResultPayload>;
 
   constructor(connection: PeerConnection) {
     this._connection = connection;
@@ -76,6 +82,12 @@ export class PaymentMux {
   onNeedAuth(handler: PaymentMessageHandler<NeedAuthPayload>): void {
     this._onNeedAuth = handler;
   }
+  onCloseChannelRequest(handler: PaymentMessageHandler<CloseChannelRequestPayload>): void {
+    this._onCloseChannelRequest = handler;
+  }
+  onCloseChannelResult(handler: PaymentMessageHandler<CloseChannelResultPayload>): void {
+    this._onCloseChannelResult = handler;
+  }
 
   // --- Sending ---
   sendSpendingAuth(payload: SpendingAuthPayload): void {
@@ -101,6 +113,12 @@ export class PaymentMux {
   }
   sendNeedAuth(payload: NeedAuthPayload): void {
     this._send(MessageType.NeedAuth, codec.encodeNeedAuth(payload));
+  }
+  sendCloseChannelRequest(payload: CloseChannelRequestPayload): void {
+    this._send(MessageType.CloseChannelRequest, codec.encodeCloseChannelRequest(payload));
+  }
+  sendCloseChannelResult(payload: CloseChannelResultPayload): void {
+    this._send(MessageType.CloseChannelResult, codec.encodeCloseChannelResult(payload));
   }
 
   // --- Receiving ---
@@ -135,6 +153,12 @@ export class PaymentMux {
         return true;
       case MessageType.NeedAuth:
         await this._onNeedAuth?.(codec.decodeNeedAuth(frame.payload));
+        return true;
+      case MessageType.CloseChannelRequest:
+        await this._onCloseChannelRequest?.(codec.decodeCloseChannelRequest(frame.payload));
+        return true;
+      case MessageType.CloseChannelResult:
+        await this._onCloseChannelResult?.(codec.decodeCloseChannelResult(frame.payload));
         return true;
       default:
         return false;

--- a/packages/node/src/payments/buyer-payment-manager.ts
+++ b/packages/node/src/payments/buyer-payment-manager.ts
@@ -6,6 +6,7 @@ import type {
   SpendingAuthPayload,
   AuthAckPayload,
   NeedAuthPayload,
+  CloseChannelRequestPayload,
 } from '../types/protocol.js';
 import { DepositsClient } from './evm/deposits-client.js';
 import {
@@ -327,6 +328,48 @@ export class BuyerPaymentManager {
     }
 
     return session.sessionId;
+  }
+
+  /**
+   * Build a CloseChannelRequest for an active session.
+   *
+   * With `includeAuth` (the default) the buyer signs its current cumulative so
+   * a seller that lost the last SpendingAuth can still close at the full
+   * amount owed. Signing costs nothing extra: the cumulative is unchanged, so
+   * this authorizes no more than the seller could already claim. Pass
+   * `includeAuth: false` to send a bare request and let the seller close using
+   * whatever auth it already holds.
+   */
+  async buildCloseChannelRequest(
+    sellerPeerId: string,
+    { includeAuth = true }: { includeAuth?: boolean } = {},
+  ): Promise<CloseChannelRequestPayload> {
+    const session = this.getActiveSession(sellerPeerId);
+    if (!session) {
+      throw new Error(`[BuyerPayment] No active session for seller ${sellerPeerId.slice(0, 12)}...`);
+    }
+
+    const cumulativeAmount = this._cumulativeAmount.get(sellerPeerId) ?? BigInt(session.authMax);
+    if (!includeAuth || cumulativeAmount <= 0n) {
+      return { version: 1, channelId: session.sessionId };
+    }
+
+    const currentMeta = this._sanitizeMetadata(this._metadata.get(sellerPeerId));
+    const metadataHash = computeMetadataHash(currentMeta);
+    const metadataMsg: SpendingAuthMessage = {
+      channelId: session.sessionId,
+      cumulativeAmount,
+      metadataHash,
+    };
+
+    return {
+      version: 1,
+      channelId: session.sessionId,
+      cumulativeAmount: cumulativeAmount.toString(),
+      metadataHash,
+      metadata: encodeMetadata(currentMeta),
+      spendingAuthSig: await signSpendingAuth(this._signer, this._channelsDomain, metadataMsg),
+    };
   }
 
   async resendReserveAuth(

--- a/packages/node/src/payments/buyer-payment-negotiator.ts
+++ b/packages/node/src/payments/buyer-payment-negotiator.ts
@@ -3,7 +3,11 @@ import type { PeerConnection } from '../p2p/connection-manager.js';
 import { PaymentMux } from '../p2p/payment-mux.js';
 import type { PeerInfo, PeerId } from '../types/peer.js';
 import type { SerializedHttpRequest, SerializedHttpResponse } from '../types/http.js';
-import { PAYMENT_CODE_CHANNEL_EXHAUSTED, type PaymentRequiredPayload } from '../types/protocol.js';
+import {
+  PAYMENT_CODE_CHANNEL_EXHAUSTED,
+  type PaymentRequiredPayload,
+  type CloseChannelResultPayload,
+} from '../types/protocol.js';
 import type { BuyerPaymentManager } from './buyer-payment-manager.js';
 import type { BuyerFreeUsageManager } from './buyer-free-usage-manager.js';
 import type { DepositsClient } from './evm/deposits-client.js';
@@ -20,6 +24,9 @@ import { formatUsdc } from './usdc-utils.js';
 import { parseJsonObject, tryParseJsonObject } from '../utils/json-codec.js';
 
 export interface BuyerNegotiatorConfig {}
+
+/** How long to wait for a seller's CloseChannelResult before giving up. */
+const CLOSE_REQUEST_TIMEOUT_MS = 60_000;
 
 /** Emitter interface — subset of EventEmitter used by the negotiator. */
 export interface NegotiationEmitter {
@@ -94,6 +101,13 @@ export class BuyerPaymentNegotiator {
   private readonly _muxes = new Map<PeerId, PaymentMux>();
   /** In-flight NeedAuth handlers keyed by seller peerId. */
   private readonly _pendingNeedAuth = new Map<string, Promise<void>>();
+  /** In-flight cooperative-close requests keyed by seller peerId. */
+  private readonly _pendingCloseRequests = new Map<string, {
+    channelId: string;
+    resolve: (payload: CloseChannelResultPayload) => void;
+    reject: (err: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }>();
 
   constructor(
     identity: Identity,
@@ -165,6 +179,24 @@ export class BuyerPaymentNegotiator {
       });
     });
 
+    pmux.onCloseChannelResult((payload) => {
+      const pending = this._pendingCloseRequests.get(peerId);
+      if (!pending) {
+        debugWarn(`[BuyerNegotiator] Unsolicited CloseChannelResult from ${peerId.slice(0, 12)}... — ignoring`);
+        return;
+      }
+      if (pending.channelId.toLowerCase() !== payload.channelId.toLowerCase()) {
+        debugWarn(
+          `[BuyerNegotiator] CloseChannelResult from ${peerId.slice(0, 12)}... is for ` +
+          `${payload.channelId.slice(0, 18)}..., expected ${pending.channelId.slice(0, 18)}... — ignoring`,
+        );
+        return;
+      }
+      clearTimeout(pending.timer);
+      this._pendingCloseRequests.delete(peerId);
+      pending.resolve(payload);
+    });
+
     pmux.onPaymentRequired((payload) => {
       const pending = this._pendingPaymentRequired.get(peerId);
       if (pending) {
@@ -213,7 +245,7 @@ export class BuyerPaymentNegotiator {
     }
     // Skip if cost data was already consumed by post-response auth
     if (!this._lastResponseCost.has(peer.peerId)) return;
-    await this._sendPerRequestAuth(peer, conn);
+    await this._sendPerRequestAuth(peer.peerId, conn);
   }
 
   /**
@@ -222,12 +254,18 @@ export class BuyerPaymentNegotiator {
    * even if the buyer disconnects before the next request.
    */
   async sendPostResponseAuth(peer: PeerInfo, conn: PeerConnection): Promise<void> {
-    if (!this._lockedPeers.has(peer.peerId)) return;
-    if (!this._lastResponseCost.has(peer.peerId)) return;
-    await this._sendPerRequestAuth(peer, conn);
+    await this.sendPostResponseAuthTo(peer.peerId, conn);
   }
 
-  private async _sendPerRequestAuth(peer: PeerInfo, conn: PeerConnection): Promise<void> {
+  /** peerId-only variant of sendPostResponseAuth. */
+  async sendPostResponseAuthTo(peerId: PeerId, conn: PeerConnection): Promise<void> {
+    if (!this._lockedPeers.has(peerId)) return;
+    if (!this._lastResponseCost.has(peerId)) return;
+    await this._sendPerRequestAuth(peerId, conn);
+  }
+
+  private async _sendPerRequestAuth(peerId: PeerId, conn: PeerConnection): Promise<void> {
+    const peer = { peerId };
     const pmux = this.getOrCreatePaymentMux(peer.peerId, conn);
 
     const lastCost = this._lastResponseCost.get(peer.peerId);
@@ -257,6 +295,88 @@ export class BuyerPaymentNegotiator {
       debugWarn(`[BuyerNegotiator] Failed to send per-request SpendingAuth: ${err instanceof Error ? err.message : err}`);
       throw err;
     }
+  }
+
+  /**
+   * Ask a seller to close the buyer's payment channel now, bypassing the
+   * on-chain `requestClose()` → grace period → `withdraw()` flow.
+   *
+   * Resolves with the seller's verdict — `status: 'closed'` carries the
+   * transaction hash. A rejection is a normal outcome (the seller may still be
+   * serving requests, or be owed for work the buyer hasn't signed for), so it
+   * resolves rather than throws; only "we never got an answer" throws.
+   */
+  async requestChannelClose(
+    peerId: PeerId,
+    conn: PeerConnection,
+    { includeAuth = true, timeoutMs = CLOSE_REQUEST_TIMEOUT_MS }: {
+      includeAuth?: boolean;
+      timeoutMs?: number;
+    } = {},
+  ): Promise<CloseChannelResultPayload> {
+    if (this._pendingCloseRequests.has(peerId)) {
+      throw new Error(`A channel close request is already in flight for ${peerId.slice(0, 12)}...`);
+    }
+
+    const session = this._bpm.getActiveSession(peerId);
+    if (!session) {
+      throw new Error(`No active payment channel with seller ${peerId.slice(0, 12)}...`);
+    }
+
+    // Flush any SpendingAuth the buyer still owes for the last response first —
+    // otherwise the seller rejects with 'pending_auth' on the very first try.
+    await this.drainPendingNeedAuth();
+    await this.sendPostResponseAuthTo(peerId, conn).catch((err) => {
+      debugWarn(`[BuyerNegotiator] Pre-close auth flush failed for ${peerId.slice(0, 12)}...: ${err instanceof Error ? err.message : err}`);
+    });
+
+    const pmux = this.getOrCreatePaymentMux(peerId, conn);
+    const payload = await this._bpm.buildCloseChannelRequest(peerId, { includeAuth });
+
+    const result = await new Promise<CloseChannelResultPayload>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this._pendingCloseRequests.delete(peerId);
+        reject(new Error(
+          `Seller ${peerId.slice(0, 12)}... did not answer the channel close request within ${timeoutMs}ms. ` +
+          `The channel is unchanged — retry, or fall back to the on-chain request-close flow.`,
+        ));
+      }, timeoutMs);
+      this._pendingCloseRequests.set(peerId, { channelId: payload.channelId, resolve, reject, timer });
+
+      try {
+        pmux.sendCloseChannelRequest(payload);
+        debugLog(`[BuyerNegotiator] CloseChannelRequest sent to ${peerId.slice(0, 12)}... channel=${payload.channelId.slice(0, 18)}...`);
+      } catch (err) {
+        clearTimeout(timer);
+        this._pendingCloseRequests.delete(peerId);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
+    });
+
+    if (result.status === 'closed') {
+      const finalAmount = result.finalAmount != null ? safeBigInt(result.finalAmount) : null;
+      this._bpm.retireSession(peerId, CHANNEL_STATUS.SETTLED, finalAmount ?? undefined);
+      this._lockedPeers.delete(peerId);
+      this._firstRequestSent.delete(peerId);
+      this._lastResponseCost.delete(peerId);
+      debugLog(
+        `[BuyerNegotiator] Seller ${peerId.slice(0, 12)}... closed channel ` +
+        `${result.channelId.slice(0, 18)}... at ${result.finalAmount ?? '?'} (tx=${result.txHash ?? '?'})`,
+      );
+      this._emit.emit('payment:channel-closed', {
+        peerId,
+        channelId: result.channelId,
+        txHash: result.txHash,
+        finalAmount: result.finalAmount,
+      });
+    } else {
+      debugWarn(
+        `[BuyerNegotiator] Seller ${peerId.slice(0, 12)}... declined to close ` +
+        `${result.channelId.slice(0, 18)}...: ${result.code ?? 'unknown'} — ${result.reason ?? 'no reason given'}`,
+      );
+    }
+
+    return result;
   }
 
   async handle402(
@@ -618,6 +738,13 @@ export class BuyerPaymentNegotiator {
       pendingPR.reject(new Error(`Peer ${peerId.slice(0, 12)}... disconnected during payment negotiation`));
     }
 
+    const pendingClose = this._pendingCloseRequests.get(peerId);
+    if (pendingClose) {
+      clearTimeout(pendingClose.timer);
+      this._pendingCloseRequests.delete(peerId);
+      pendingClose.reject(new Error(`Peer ${peerId.slice(0, 12)}... disconnected before answering the channel close request`));
+    }
+
     this._lockedPeers.delete(peerId);
     this._firstRequestSent.delete(peerId);
     this._lastResponseCost.delete(peerId);
@@ -644,6 +771,12 @@ export class BuyerPaymentNegotiator {
     this._pendingPaymentRequired.clear();
     this._bufferedPaymentRequired.clear();
     this._negotiationLocks.clear();
+
+    for (const [, pending] of this._pendingCloseRequests) {
+      clearTimeout(pending.timer);
+      pending.reject(new Error('Node stopped'));
+    }
+    this._pendingCloseRequests.clear();
   }
 
   /**

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -4,6 +4,9 @@ import type { PaymentMux } from '../p2p/payment-mux.js';
 import type {
   SpendingAuthPayload,
   PaymentRequiredPayload,
+  CloseChannelRequestPayload,
+  CloseChannelResultPayload,
+  CloseChannelRejectCode,
 } from '../types/protocol.js';
 import { ChannelsClient } from './evm/channels-client.js';
 import {
@@ -43,6 +46,16 @@ const DEFAULT_MIN_BUDGET_PER_REQUEST = '500000';
 /** ~200× typical Base settle gas cost at 0.006 gwei. */
 export const DEFAULT_MIN_SETTLE_DELTA_STR = '2000';
 const DEFAULT_MIN_SETTLE_DELTA = BigInt(DEFAULT_MIN_SETTLE_DELTA_STR);
+
+/**
+ * How long a buyer-requested close waits for an in-flight SpendingAuth to land
+ * before declaring the channel still mid-accumulation. Mirrors the request
+ * path's catch-up wait: the buyer's auth for the last response may still be on
+ * the wire when the close request arrives.
+ */
+const CLOSE_CATCH_UP_WAIT_MS = 5_000;
+/** `retryAfterMs` hint returned with 'busy' / 'pending_auth' rejections. */
+const CLOSE_RETRY_AFTER_MS = 2_000;
 
 const TOP_UP_THRESHOLD_NOT_MET_SELECTOR = '0x1ea4506b';
 const INSUFFICIENT_BALANCE_SELECTOR = '0xf4d678b8';
@@ -129,6 +142,15 @@ export class SellerPaymentManager {
 
   /** channelIds with an in-flight close() tx/estimate. Prevents duplicate close submissions. */
   private readonly _closingChannels = new Set<string>();
+
+  /**
+   * buyerPeerId -> number of billable requests currently being served.
+   * Incremented before the provider call and decremented only after the
+   * request's spend has been recorded and its NeedAuth sent, so a non-zero
+   * count means "this buyer is still accumulating" and the channel must not be
+   * closed out from under it.
+   */
+  private readonly _inFlightRequests = new Map<string, number>();
 
   /** channelId -> cumulative amount last successfully settled on-chain by this
    *  process. Lets the idle-settle loop skip the `getSession` RPC when the
@@ -1084,6 +1106,14 @@ export class SellerPaymentManager {
     }
 
     // Clean up maps after successful close, zero-cumulative deferral, or exhausted retries
+    this._forgetChannel(channelId, buyerPeerId);
+  }
+
+  /**
+   * Drop all in-memory state for a channel that is no longer live. Does not
+   * touch persisted status — callers set that first (SETTLED / TIMEOUT).
+   */
+  private _forgetChannel(channelId: string, buyerPeerId: string): void {
     this._acceptedCumulative.delete(channelId);
     this._spent.delete(channelId);
     this._latestAuth.delete(channelId);
@@ -1096,6 +1126,25 @@ export class SellerPaymentManager {
     this._hydratedChannelIds.delete(channelId);
     this._releaseAcceptedWaiters(channelId);
     this._activeBuyers.delete(buyerPeerId);
+  }
+
+  // ── In-flight request tracking ────────────────────────────────
+
+  /** Mark a billable request as started for this buyer. */
+  beginBillableRequest(buyerPeerId: string): void {
+    this._inFlightRequests.set(buyerPeerId, (this._inFlightRequests.get(buyerPeerId) ?? 0) + 1);
+  }
+
+  /** Mark a billable request as fully accounted for (spend recorded, NeedAuth sent). */
+  endBillableRequest(buyerPeerId: string): void {
+    const next = (this._inFlightRequests.get(buyerPeerId) ?? 0) - 1;
+    if (next > 0) this._inFlightRequests.set(buyerPeerId, next);
+    else this._inFlightRequests.delete(buyerPeerId);
+  }
+
+  /** Whether this buyer has requests still being served and billed. */
+  hasInFlightRequests(buyerPeerId: string): boolean {
+    return (this._inFlightRequests.get(buyerPeerId) ?? 0) > 0;
   }
 
   // ── Disconnect handling ───────────────────────────────────────
@@ -1304,6 +1353,226 @@ export class SellerPaymentManager {
     };
   }
 
+  // ── Buyer-requested cooperative close ─────────────────────────
+
+  /**
+   * Handle a buyer's CloseChannelRequest: close the channel on-chain right
+   * away so the buyer's reserve is released without the `requestClose()` →
+   * 15-minute grace → `withdraw()` detour.
+   *
+   * The seller only agrees when it is not mid-accumulation with this buyer:
+   * no billable request in flight, and no served work the buyer has not signed
+   * for. It closes at `max(own last-accepted auth, buyer-supplied auth)`, so a
+   * buyer cannot use this path to settle below what it already owes, and a
+   * seller that lost the buyer's latest auth can still be paid in full by the
+   * copy the buyer attaches.
+   */
+  async handleCloseChannelRequest(
+    buyerPeerId: string,
+    payload: CloseChannelRequestPayload,
+    paymentMux: PaymentMux,
+  ): Promise<CloseChannelResultPayload> {
+    const reject = (
+      code: CloseChannelRejectCode,
+      reason: string,
+      extra: Partial<CloseChannelResultPayload> = {},
+    ): CloseChannelResultPayload => {
+      debugLog(`[SellerPayment] Declining close of ${payload.channelId.slice(0, 18)}... — ${code}: ${reason}`);
+      return { version: 1, channelId: payload.channelId, status: 'rejected', code, reason, ...extra };
+    };
+
+    let session = this._channelStore.getActiveChannelByPeer(buyerPeerId, CHANNEL_ROLE.SELLER);
+    if (!session) {
+      return reject('no_channel', 'no active channel for this buyer');
+    }
+    if (session.sessionId.toLowerCase() !== payload.channelId.toLowerCase()) {
+      return reject('no_channel', `active channel is ${session.sessionId}, not the requested channel`);
+    }
+
+    const channelId = session.sessionId;
+
+    if (this.hasInFlightRequests(buyerPeerId)) {
+      return reject('busy', 'a request is still being served on this channel', {
+        retryAfterMs: CLOSE_RETRY_AFTER_MS,
+      });
+    }
+    if (this._closingChannels.has(channelId)) {
+      return reject('busy', 'a close is already in flight for this channel', {
+        retryAfterMs: CLOSE_RETRY_AFTER_MS,
+      });
+    }
+
+    // Let any SpendingAuth already being processed finish before reading the
+    // accepted cumulative, then re-check the channel still exists.
+    await this.waitForPendingAuths(buyerPeerId);
+    session = this._channelStore.getActiveChannelByPeer(buyerPeerId, CHANNEL_ROLE.SELLER);
+    if (!session || session.sessionId !== channelId) {
+      return reject('no_channel', 'channel was retired while the close request was being processed');
+    }
+
+    // Verify the buyer's optional auth before comparing it with our own.
+    let buyerAuth: LatestAuth | null;
+    try {
+      buyerAuth = await this._verifyBuyerCloseAuth(session, payload);
+    } catch (err) {
+      return reject('invalid_auth', err instanceof Error ? err.message : String(err));
+    }
+    if (buyerAuth) {
+      this._adoptBuyerCloseAuth(channelId, buyerAuth);
+    }
+
+    // Anything served but not yet signed for is unclaimable — ask for the
+    // catch-up auth rather than closing at a loss.
+    let spent = this._spent.get(channelId) ?? 0n;
+    let best = this._getSettleParams(channelId);
+    if (spent > best.amount) {
+      await this.awaitAcceptedAtLeast(channelId, spent, CLOSE_CATCH_UP_WAIT_MS);
+      spent = this._spent.get(channelId) ?? 0n;
+      best = this._getSettleParams(channelId);
+    }
+    if (spent > best.amount) {
+      const accepted = this._acceptedCumulative.get(channelId) ?? 0n;
+      try {
+        paymentMux.sendNeedAuth({
+          channelId,
+          requiredCumulativeAmount: spent.toString(),
+          currentAcceptedCumulative: accepted.toString(),
+          deposit: session.authMax ?? '0',
+        });
+      } catch (err) {
+        debugWarn(`[SellerPayment] Failed to send catch-up NeedAuth before close: ${this._formatError(err)}`);
+      }
+      return reject('pending_auth', `unsigned spend outstanding (spent=${spent} signed=${best.amount})`, {
+        retryAfterMs: CLOSE_RETRY_AFTER_MS,
+        requiredCumulativeAmount: spent.toString(),
+      });
+    }
+
+    // The contract rejects a finalAmount at or below what is already settled
+    // (InvalidAmount) and skips signature verification when they are equal, so
+    // fall back to an unsigned close-at-settled when we have nothing better.
+    let onChainSettled: bigint;
+    try {
+      onChainSettled = (await this._channelsClient.getSession(channelId)).settled;
+    } catch (err) {
+      return reject('close_failed', `could not read on-chain channel state: ${this._formatError(err)}`);
+    }
+
+    const useSignedAuth = best.sig !== '0x' && best.amount > onChainSettled;
+    const finalAmount = useSignedAuth ? best.amount : onChainSettled;
+    const metadata = useSignedAuth ? best.metadata : '0x';
+    const sig = useSignedAuth ? best.sig : '0x';
+
+    this._closingChannels.add(channelId);
+    let txHash: string;
+    try {
+      debugLog(
+        `[SellerPayment] Buyer-requested close of ${channelId.slice(0, 18)}... ` +
+        `finalAmount=${finalAmount} (signed=${useSignedAuth})`,
+      );
+      txHash = await this._channelsClient.close(this._signer, channelId, finalAmount, metadata, sig);
+    } catch (err) {
+      debugWarn(`[SellerPayment] Buyer-requested close failed for ${channelId.slice(0, 18)}...: ${this._formatError(err)}`);
+      return reject('close_failed', this._formatError(err), {
+        ...(this._isRetryableTxSubmissionFailure(err) ? { retryAfterMs: CLOSE_RETRY_AFTER_MS } : {}),
+      });
+    } finally {
+      this._closingChannels.delete(channelId);
+    }
+
+    this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.SETTLED, finalAmount.toString());
+    this._forgetChannel(channelId, buyerPeerId);
+    debugLog(`[SellerPayment] Channel ${channelId.slice(0, 18)}... closed on buyer request (tx=${txHash})`);
+
+    return {
+      version: 1,
+      channelId,
+      status: 'closed',
+      txHash,
+      finalAmount: finalAmount.toString(),
+    };
+  }
+
+  /**
+   * Verify a SpendingAuth attached to a CloseChannelRequest. Returns null when
+   * the buyer attached nothing; throws with a caller-safe message when the
+   * attached auth does not check out.
+   */
+  private async _verifyBuyerCloseAuth(
+    session: StoredChannel,
+    payload: CloseChannelRequestPayload,
+  ): Promise<LatestAuth | null> {
+    const { cumulativeAmount, metadataHash, metadata, spendingAuthSig } = payload;
+    if (
+      cumulativeAmount === undefined || metadataHash === undefined
+      || metadata === undefined || spendingAuthSig === undefined
+    ) {
+      return null;
+    }
+
+    let amount: bigint;
+    try {
+      amount = BigInt(cumulativeAmount);
+    } catch {
+      throw new Error(`cumulativeAmount "${cumulativeAmount}" is not an integer`);
+    }
+    if (amount < 0n) throw new Error('cumulativeAmount must not be negative');
+
+    if (keccak256(metadata).toLowerCase() !== metadataHash.toLowerCase()) {
+      throw new Error('metadataHash does not match metadata');
+    }
+
+    const { channels } = await this._resolvedAddresses!;
+    const channelsDomain = makeChannelsDomain(this._config.chainId, channels);
+    const recovered = verifyTypedData(
+      channelsDomain,
+      SPENDING_AUTH_TYPES,
+      { channelId: session.sessionId, cumulativeAmount: amount, metadataHash },
+      spendingAuthSig,
+    );
+    if (recovered.toLowerCase() !== session.buyerEvmAddr.toLowerCase()) {
+      throw new Error(`signature recovers to ${recovered}, not the channel buyer`);
+    }
+
+    return { spendingAuthSig, cumulativeAmount: amount, metadataHash, metadata };
+  }
+
+  /**
+   * Take the buyer-supplied auth as our latest when it authorizes strictly more
+   * than what we already hold. Persisted so a crash between here and close()
+   * doesn't lose the higher claim.
+   */
+  private _adoptBuyerCloseAuth(channelId: string, buyerAuth: LatestAuth): void {
+    const current = this._latestAuth.get(channelId);
+    if (current && current.spendingAuthSig.length > 0 && current.cumulativeAmount >= buyerAuth.cumulativeAmount) {
+      return;
+    }
+
+    this._latestAuth.set(channelId, buyerAuth);
+    const accepted = this._acceptedCumulative.get(channelId) ?? 0n;
+    if (buyerAuth.cumulativeAmount > accepted) {
+      this._acceptedCumulative.set(channelId, buyerAuth.cumulativeAmount);
+      this._notifyAcceptedUpdate(channelId, buyerAuth.cumulativeAmount);
+    }
+
+    const stored = this._channelStore.getChannel(channelId);
+    if (stored) {
+      stored.authMax = (
+        buyerAuth.cumulativeAmount > BigInt(stored.authMax || '0') ? buyerAuth.cumulativeAmount : BigInt(stored.authMax)
+      ).toString();
+      stored.latestBuyerSig = buyerAuth.spendingAuthSig;
+      stored.latestSpendingAuthSig = buyerAuth.spendingAuthSig;
+      stored.latestMetadata = buyerAuth.metadata;
+      stored.updatedAt = Date.now();
+      this._channelStore.upsertChannel(stored);
+    }
+
+    debugLog(
+      `[SellerPayment] Adopted buyer-supplied close auth for ${channelId.slice(0, 18)}... ` +
+      `cumulative=${buyerAuth.cumulativeAmount} (was ${current?.cumulativeAmount ?? 0n})`,
+    );
+  }
+
   // ── CloseRequested handling ───────────────────────────────────
 
   /**
@@ -1332,24 +1601,8 @@ export class SellerPaymentManager {
       this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.TIMEOUT);
     }
 
-    // Clean up in-memory state
-    this._acceptedCumulative.delete(channelId);
-    this._spent.delete(channelId);
-    this._latestAuth.delete(channelId);
-    this._closeRetryCount.delete(channelId);
-    this._closingChannels.delete(channelId);
-    this._reserveMax.delete(channelId);
-    this._pendingTopUp.delete(channelId);
-    this._blockedChannels.delete(channelId);
-    this._lastSettledCumulative.delete(channelId);
-    this._hydratedChannelIds.delete(channelId);
-    this._releaseAcceptedWaiters(channelId);
-
-    // Find and remove buyer from active set
-    const channel = this._channelStore.getChannel(channelId);
-    if (channel) {
-      this._activeBuyers.delete(channel.peerId);
-    }
+    // Clean up in-memory state, including removing the buyer from the active set
+    this._forgetChannel(channelId, this._channelStore.getChannel(channelId)?.peerId ?? '');
   }
 
   /**

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -424,6 +424,11 @@ export class SellerRequestHandler {
       let streamAuthStatusCode = 0;
       let streamAuthHeaders: Record<string, string> | null = null;
       let responseUsage: import('./utils/response-usage.js').ResponseUsage = { inputTokens: 0, outputTokens: 0, freshInputTokens: 0, cachedInputTokens: 0 };
+      // Hold the channel open for the whole billable span — provider call,
+      // spend recording, and NeedAuth — so a buyer-requested close can't land
+      // between serving the request and claiming its cost.
+      const isBillable = !isFreeService && (spm?.hasSession(buyerPeerId) ?? false);
+      if (isBillable) spm!.beginBillableRequest(buyerPeerId);
       this.adjustProviderLoad(provider.name, 1);
       try {
         try {
@@ -579,6 +584,7 @@ export class SellerRequestHandler {
         }
       } finally {
         this.adjustProviderLoad(provider.name, -1);
+        if (isBillable) spm!.endBillableRequest(buyerPeerId);
       }
     });
 

--- a/packages/node/src/types/protocol.ts
+++ b/packages/node/src/types/protocol.ts
@@ -21,6 +21,8 @@ export enum MessageType {
   NeedFreeUsageAuth = 0x55,
   PaymentRequired = 0x56,
   NeedAuth = 0x58,
+  CloseChannelRequest = 0x59,
+  CloseChannelResult = 0x5A,
 
   // Report message types
   PeerReport = 0x60,
@@ -46,10 +48,19 @@ export enum MessageType {
 
 export const CONNECTION_CAPABILITY_RESPONSE_AUTH_V1 = 'verification.response-auth.v1' as const;
 export const CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1 = 'payments.relays-sweeps.v1' as const;
+/** Seller honours buyer-initiated cooperative channel close (0x59 / 0x5A). */
+export const CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1 = 'payments.cooperative-close.v1' as const;
 
 export function peerRelaysSweeps(peer: { capabilities?: string[]; metadata?: { capabilities?: string[] } }): boolean {
   return peer.capabilities?.includes(CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1) === true
     || peer.metadata?.capabilities?.includes(CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1) === true;
+}
+
+export function peerSupportsCooperativeClose(
+  peer: { capabilities?: string[]; metadata?: { capabilities?: string[] } },
+): boolean {
+  return peer.capabilities?.includes(CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1) === true
+    || peer.metadata?.capabilities?.includes(CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1) === true;
 }
 
 export interface FramedMessage {
@@ -204,6 +215,76 @@ export interface NeedAuthPayload {
   freshInputTokens?: string;
   /** Service/model name for service-specific pricing validation. */
   service?: string;
+}
+
+// ─── Cooperative Channel Close Messages ─────────────────────────
+
+/**
+ * Buyer asks the seller to close a payment channel now, skipping the on-chain
+ * `requestClose()` → 15-minute grace → `withdraw()` path.
+ *
+ * The buyer MAY attach its latest SpendingAuth so the seller can close at that
+ * cumulative even if the seller never received it (e.g. the frame was lost on
+ * disconnect). The seller closes at whichever cumulative is higher — its own
+ * last-accepted auth or the one attached here — so neither side can use this
+ * message to under-report spend.
+ *
+ * All four auth fields travel together: either all are present or none are.
+ */
+export interface CloseChannelRequestPayload {
+  version: 1;
+  /** Channel the buyer wants closed. Must match the seller's active channel. */
+  channelId: string;
+  /** Cumulative USDC (base units) the attached signature authorizes. */
+  cumulativeAmount?: string;
+  /** bytes32 keccak256 of `metadata`. */
+  metadataHash?: string;
+  /** Hex-encoded abi.encode(...) usage metadata covered by the signature. */
+  metadata?: string;
+  /** EIP-712 SpendingAuth signature over (channelId, cumulativeAmount, metadataHash). */
+  spendingAuthSig?: string;
+}
+
+/** Why a seller declined to close a channel on request. */
+export const CLOSE_CHANNEL_REJECT_CODES = [
+  /** Seller is still serving requests for this buyer — retry shortly. */
+  'busy',
+  /** Seller has served work the buyer has not signed for yet. A NeedAuth was
+   *  sent alongside this result; sign `requiredCumulativeAmount` and retry. */
+  'pending_auth',
+  /** No active channel for this buyer, or `channelId` does not match it. */
+  'no_channel',
+  /** The attached SpendingAuth failed verification. */
+  'invalid_auth',
+  /** The on-chain close() call failed. `reason` carries the revert text. */
+  'close_failed',
+  /** Seller has no payment manager configured. */
+  'unsupported',
+] as const;
+
+export type CloseChannelRejectCode = typeof CLOSE_CHANNEL_REJECT_CODES[number];
+
+/**
+ * Seller's answer to a CloseChannelRequest. On success it carries the
+ * transaction hash of the on-chain `close()`; on refusal, a stable code the
+ * buyer can switch on.
+ */
+export interface CloseChannelResultPayload {
+  version: 1;
+  channelId: string;
+  status: 'closed' | 'rejected';
+  /** Present when status === 'closed'. */
+  txHash?: string;
+  /** Cumulative the channel was closed at (base units). Present on success. */
+  finalAmount?: string;
+  /** Present when status === 'rejected'. */
+  code?: CloseChannelRejectCode;
+  /** Human-readable detail. Never load-bearing — switch on `code`. */
+  reason?: string;
+  /** Hint for 'busy' / 'pending_auth': wait this long before retrying. */
+  retryAfterMs?: number;
+  /** For 'pending_auth': the cumulative the buyer must sign before retrying. */
+  requiredCumulativeAmount?: string;
 }
 
 // ─── Deposit Sweep Messages ─────────────────────────────────────

--- a/packages/node/tests/announcer.test.ts
+++ b/packages/node/tests/announcer.test.ts
@@ -7,6 +7,7 @@ import { toPeerId } from '../src/types/peer.js';
 import {
   CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1,
   CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+  CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1,
 } from '../src/types/protocol.js';
 
 function makeBaseConfig(): AnnouncerConfig {
@@ -62,7 +63,10 @@ describe('PeerAnnouncer capabilities', () => {
     const announcer = new PeerAnnouncer(makeBaseConfig());
     await announcer.announce();
     const meta = announcer.getLatestMetadata();
-    expect(meta?.capabilities).toEqual([CONNECTION_CAPABILITY_RESPONSE_AUTH_V1]);
+    expect(meta?.capabilities).toEqual([
+      CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+      CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1,
+    ]);
   });
 
   it('publishes sweep relay support only when configured', async () => {
@@ -74,6 +78,7 @@ describe('PeerAnnouncer capabilities', () => {
     const meta = announcer.getLatestMetadata();
     expect(meta?.capabilities).toEqual([
       CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+      CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1,
       CONNECTION_CAPABILITY_RELAYS_SWEEPS_V1,
     ]);
   });

--- a/packages/node/tests/buyer-payment-negotiator.test.ts
+++ b/packages/node/tests/buyer-payment-negotiator.test.ts
@@ -790,6 +790,110 @@ describe('BuyerPaymentNegotiator', () => {
       expect(mux1).not.toBe(mux2);
     });
   });
+
+  describe('requestChannelClose', () => {
+    const CHANNEL_ID = '0x' + 'ab'.repeat(32);
+
+    beforeEach(() => {
+      (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(makeActiveSession(SELLER_PEER_ID));
+      (bpm as Record<string, unknown>).buildCloseChannelRequest = vi.fn().mockResolvedValue({
+        version: 1,
+        channelId: CHANNEL_ID,
+        cumulativeAmount: '750000',
+        metadataHash: '0x' + 'cc'.repeat(32),
+        metadata: '0x00',
+        spendingAuthSig: '0x' + 'ee'.repeat(65),
+      });
+    });
+
+    /** Feed a CloseChannelResult back through the buyer's mux, as the seller would. */
+    function replyWithResult(payload: Record<string, unknown>): void {
+      void negotiator.getOrCreatePaymentMux(SELLER_PEER_ID, conn).handleFrame({
+        type: 0x5A,
+        messageId: 1,
+        payload: enc.encode(JSON.stringify(payload)),
+      });
+    }
+
+    it('throws when there is no active session', async () => {
+      (bpm.getActiveSession as ReturnType<typeof vi.fn>).mockReturnValue(null);
+      await expect(negotiator.requestChannelClose(SELLER_PEER_ID, conn)).rejects.toThrow(/No active payment channel/);
+    });
+
+    it('sends the request and retires the session once the seller confirms', async () => {
+      const promise = negotiator.requestChannelClose(SELLER_PEER_ID, conn);
+      await vi.waitFor(() => expect(conn.send).toHaveBeenCalled());
+      replyWithResult({
+        version: 1,
+        channelId: CHANNEL_ID,
+        status: 'closed',
+        txHash: '0x' + 'bb'.repeat(32),
+        finalAmount: '750000',
+      });
+
+      const result = await promise;
+      expect(result.status).toBe('closed');
+      expect(result.txHash).toBe('0x' + 'bb'.repeat(32));
+      expect(bpm.retireSession).toHaveBeenCalledWith(SELLER_PEER_ID, CHANNEL_STATUS.SETTLED, 750_000n);
+      expect(emitter.emit).toHaveBeenCalledWith('payment:channel-closed', expect.objectContaining({
+        peerId: SELLER_PEER_ID,
+        channelId: CHANNEL_ID,
+      }));
+    });
+
+    it('resolves (not throws) on a rejection and leaves the session alone', async () => {
+      const promise = negotiator.requestChannelClose(SELLER_PEER_ID, conn);
+      await vi.waitFor(() => expect(conn.send).toHaveBeenCalled());
+      replyWithResult({
+        version: 1,
+        channelId: CHANNEL_ID,
+        status: 'rejected',
+        code: 'busy',
+        reason: 'still serving',
+        retryAfterMs: 2000,
+      });
+
+      const result = await promise;
+      expect(result.status).toBe('rejected');
+      expect(result.code).toBe('busy');
+      expect(bpm.retireSession).not.toHaveBeenCalled();
+    });
+
+    it('honours includeAuth: false', async () => {
+      const promise = negotiator.requestChannelClose(SELLER_PEER_ID, conn, { includeAuth: false });
+      await vi.waitFor(() => expect(conn.send).toHaveBeenCalled());
+      expect((bpm as Record<string, unknown>).buildCloseChannelRequest)
+        .toHaveBeenCalledWith(SELLER_PEER_ID, { includeAuth: false });
+
+      replyWithResult({ version: 1, channelId: CHANNEL_ID, status: 'closed', finalAmount: '0' });
+      await promise;
+    });
+
+    it('ignores a result naming a different channel', async () => {
+      const promise = negotiator.requestChannelClose(SELLER_PEER_ID, conn, { timeoutMs: 300 });
+      await vi.waitFor(() => expect(conn.send).toHaveBeenCalled());
+      replyWithResult({ version: 1, channelId: '0x' + 'ff'.repeat(32), status: 'closed' });
+
+      await expect(promise).rejects.toThrow(/did not answer/);
+      expect(bpm.retireSession).not.toHaveBeenCalled();
+    });
+
+    it('rejects the pending request when the peer disconnects', async () => {
+      const promise = negotiator.requestChannelClose(SELLER_PEER_ID, conn);
+      await vi.waitFor(() => expect(conn.send).toHaveBeenCalled());
+      negotiator.onPeerDisconnect(SELLER_PEER_ID);
+      await expect(promise).rejects.toThrow(/disconnected/);
+    });
+
+    it('refuses to start a second close while one is in flight', async () => {
+      const first = negotiator.requestChannelClose(SELLER_PEER_ID, conn);
+      await vi.waitFor(() => expect(conn.send).toHaveBeenCalled());
+      await expect(negotiator.requestChannelClose(SELLER_PEER_ID, conn)).rejects.toThrow(/already in flight/);
+
+      replyWithResult({ version: 1, channelId: CHANNEL_ID, status: 'closed', finalAmount: '750000' });
+      await first;
+    });
+  });
 });
 
 // ── Helpers ──────────────────────────────────────────────────────

--- a/packages/node/tests/cooperative-close-capability.test.ts
+++ b/packages/node/tests/cooperative-close-capability.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AntseedNode } from '../src/node.js';
+import { ConnectionState } from '../src/types/connection.js';
+import {
+  CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1,
+  CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+} from '../src/types/protocol.js';
+import { toPeerId } from '../src/types/peer.js';
+
+const SELLER = toPeerId('a'.repeat(40));
+
+/**
+ * Wire up just enough of a started buyer node for requestChannelClose:
+ * a live connection to SELLER, a negotiator, and a capability set.
+ */
+function makeNode(capabilities: Set<string> | undefined) {
+  const node = new AntseedNode({ role: 'buyer' });
+  const requestChannelClose = vi.fn().mockResolvedValue({
+    version: 1, channelId: '0x' + 'cd'.repeat(32), status: 'closed', txHash: '0xtx', finalAmount: '1',
+  });
+
+  const internals = node as unknown as {
+    _connectionManager: unknown;
+    _buyerNegotiator: unknown;
+    _peerCapabilities: Map<string, Set<string>>;
+  };
+  internals._connectionManager = {
+    getConnection: (peerId: string) =>
+      peerId === SELLER ? { state: ConnectionState.Open } : undefined,
+  };
+  internals._buyerNegotiator = { requestChannelClose };
+  internals._peerCapabilities = capabilities ? new Map([[SELLER, capabilities]]) : new Map();
+
+  return { node, requestChannelClose };
+}
+
+describe('AntseedNode.requestChannelClose capability gating', () => {
+  it('sends the request when the seller advertises cooperative close', async () => {
+    const { node, requestChannelClose } = makeNode(new Set([
+      CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,
+      CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1,
+    ]));
+
+    await expect(node.requestChannelClose(SELLER)).resolves.toMatchObject({ status: 'closed' });
+    expect(requestChannelClose).toHaveBeenCalledOnce();
+  });
+
+  it('fails fast instead of waiting out the response timeout on a seller that lacks it', async () => {
+    // An older seller still advertises response-auth, so the set is non-empty —
+    // positive evidence that it speaks capabilities but not this one.
+    const { node, requestChannelClose } = makeNode(new Set([CONNECTION_CAPABILITY_RESPONSE_AUTH_V1]));
+
+    await expect(node.requestChannelClose(SELLER)).rejects.toThrow(/does not support cooperative close/);
+    expect(requestChannelClose).not.toHaveBeenCalled();
+  });
+
+  it('attempts anyway when capabilities are unknown, rather than blocking a close that would work', async () => {
+    // Partial discovery data must not be read as "unsupported" — that would be
+    // a false negative on a seller that does support it.
+    for (const caps of [undefined, new Set<string>()]) {
+      const { node, requestChannelClose } = makeNode(caps);
+      await expect(node.requestChannelClose(SELLER)).resolves.toMatchObject({ status: 'closed' });
+      expect(requestChannelClose).toHaveBeenCalledOnce();
+    }
+  });
+});

--- a/packages/node/tests/node-payment-pricing.test.ts
+++ b/packages/node/tests/node-payment-pricing.test.ts
@@ -53,6 +53,9 @@ function makeSpmMock(overrides: Record<string, unknown> = {}): any {
     waitForPendingAuths: async () => {},
     awaitAcceptedAtLeast: async () => false,
     settleSession: vi.fn(async () => {}),
+    beginBillableRequest: vi.fn(),
+    endBillableRequest: vi.fn(),
+    hasInFlightRequests: () => false,
     ...overrides,
   };
 }

--- a/packages/node/tests/payment-codec.test.ts
+++ b/packages/node/tests/payment-codec.test.ts
@@ -8,6 +8,8 @@ import {
   encodeNeedFreeUsageAuth, decodeNeedFreeUsageAuth,
   encodePaymentRequired, decodePaymentRequired,
   encodeNeedAuth, decodeNeedAuth,
+  encodeCloseChannelRequest, decodeCloseChannelRequest,
+  encodeCloseChannelResult, decodeCloseChannelResult,
 } from '../src/p2p/payment-codec.js';
 
 describe('payment codec round-trips', () => {
@@ -167,5 +169,78 @@ describe('payment codec round-trips', () => {
     const encoded = encodeNeedAuth(payload);
     const decoded = decodeNeedAuth(encoded);
     expect(decoded).toEqual(payload);
+  });
+
+  it('CloseChannelRequest without an attached auth', () => {
+    const payload = { version: 1 as const, channelId: '0x' + 'aa'.repeat(32) };
+    expect(decodeCloseChannelRequest(encodeCloseChannelRequest(payload))).toEqual(payload);
+  });
+
+  it('CloseChannelRequest with an attached auth', () => {
+    const payload = {
+      version: 1 as const,
+      channelId: '0x' + 'aa'.repeat(32),
+      cumulativeAmount: '750000',
+      metadataHash: '0x' + 'cc'.repeat(32),
+      metadata: '0x' + 'dd'.repeat(128),
+      spendingAuthSig: '0x' + 'ee'.repeat(65),
+    };
+    expect(decodeCloseChannelRequest(encodeCloseChannelRequest(payload))).toEqual(payload);
+  });
+
+  it('CloseChannelRequest drops a partial auth rather than passing it on unverifiable', () => {
+    const wire = new TextEncoder().encode(JSON.stringify({
+      version: 1,
+      channelId: '0x' + 'aa'.repeat(32),
+      cumulativeAmount: '750000',
+      spendingAuthSig: '0x' + 'ee'.repeat(65),
+      // metadata / metadataHash missing
+    }));
+    const decoded = decodeCloseChannelRequest(wire);
+    expect(decoded.cumulativeAmount).toBeUndefined();
+    expect(decoded.spendingAuthSig).toBeUndefined();
+  });
+
+  it('CloseChannelResult success', () => {
+    const payload = {
+      version: 1 as const,
+      channelId: '0x' + 'aa'.repeat(32),
+      status: 'closed' as const,
+      txHash: '0x' + 'bb'.repeat(32),
+      finalAmount: '750000',
+    };
+    expect(decodeCloseChannelResult(encodeCloseChannelResult(payload))).toEqual(payload);
+  });
+
+  it('CloseChannelResult rejection', () => {
+    const payload = {
+      version: 1 as const,
+      channelId: '0x' + 'aa'.repeat(32),
+      status: 'rejected' as const,
+      code: 'pending_auth' as const,
+      reason: 'unsigned spend outstanding',
+      retryAfterMs: 2000,
+      requiredCumulativeAmount: '750000',
+    };
+    expect(decodeCloseChannelResult(encodeCloseChannelResult(payload))).toEqual(payload);
+  });
+
+  it('CloseChannelResult drops an unrecognized reject code', () => {
+    const wire = new TextEncoder().encode(JSON.stringify({
+      version: 1,
+      channelId: '0x' + 'aa'.repeat(32),
+      status: 'rejected',
+      code: 'not_a_real_code',
+    }));
+    expect(decodeCloseChannelResult(wire).code).toBeUndefined();
+  });
+
+  it('CloseChannelResult rejects an unknown status', () => {
+    const wire = new TextEncoder().encode(JSON.stringify({
+      version: 1,
+      channelId: '0x' + 'aa'.repeat(32),
+      status: 'maybe',
+    }));
+    expect(() => decodeCloseChannelResult(wire)).toThrow(/status/);
   });
 });

--- a/packages/node/tests/seller-cooperative-close.test.ts
+++ b/packages/node/tests/seller-cooperative-close.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
+import { Wallet } from 'ethers';
+import { SellerPaymentManager, type SellerPaymentConfig } from '../src/payments/seller-payment-manager.js';
+import { ChannelStore, CHANNEL_STATUS } from '../src/payments/channel-store.js';
+import type { PaymentMux } from '../src/p2p/payment-mux.js';
+import type { Identity } from '../src/p2p/identity.js';
+import type { CloseChannelRequestPayload, SpendingAuthPayload } from '../src/types/protocol.js';
+import { bytesToHex } from '../src/utils/hex.js';
+import { toPeerId } from '../src/types/peer.js';
+import {
+  signSpendingAuth,
+  signReserveAuth,
+  makeChannelsDomain,
+  computeMetadataHash,
+  encodeMetadata,
+  ZERO_METADATA_HASH,
+} from '../src/payments/evm/signatures.js';
+import type { SpendingAuthMessage, ReserveAuthMessage, SpendingAuthMetadata } from '../src/payments/evm/signatures.js';
+
+const CHAIN_ID = 31337;
+const CONTRACT_ADDR = '0x' + 'dd'.repeat(20);
+const CHANNEL_ID = '0x' + 'ab'.repeat(32);
+
+function createTestIdentity(): Identity {
+  const privateKey = randomBytes(32);
+  const wallet = new Wallet('0x' + bytesToHex(privateKey));
+  return { peerId: toPeerId(wallet.address.slice(2).toLowerCase()), privateKey, wallet };
+}
+
+function createMockPaymentMux(): PaymentMux & { sentNeedAuths: unknown[] } {
+  const mux = {
+    sentNeedAuths: [] as unknown[],
+    sendSpendingAuth() {},
+    sendAuthAck() {},
+    sendPaymentRequired() {},
+    sendNeedAuth(payload: unknown) { mux.sentNeedAuths.push(payload); },
+    sendCloseChannelResult() {},
+    onSpendingAuth() {},
+    onAuthAck() {},
+    onPaymentRequired() {},
+    onNeedAuth() {},
+    onCloseChannelRequest() {},
+    onCloseChannelResult() {},
+    handleFrame: vi.fn(),
+  };
+  return mux as unknown as PaymentMux & { sentNeedAuths: unknown[] };
+}
+
+function metadataFor(inputTokens: bigint): SpendingAuthMetadata {
+  return {
+    cumulativeInputTokens: inputTokens,
+    cumulativeOutputTokens: 0n,
+    cumulativeRequestCount: 0n,
+  };
+}
+
+/** Buyer's opening ReserveAuth — establishes the channel on the seller. */
+async function buildReserveAuth(buyer: Identity, reserveMaxAmount = 10_000_000n): Promise<SpendingAuthPayload> {
+  const deadline = Math.floor(Date.now() / 1000) + 3600;
+  const meta = metadataFor(0n);
+  const domain = makeChannelsDomain(CHAIN_ID, CONTRACT_ADDR);
+  const reserveMsg: ReserveAuthMessage = {
+    channelId: CHANNEL_ID,
+    maxAmount: reserveMaxAmount,
+    deadline: BigInt(deadline),
+  };
+  return {
+    channelId: CHANNEL_ID,
+    cumulativeAmount: '0',
+    metadataHash: computeMetadataHash(meta),
+    metadata: encodeMetadata(meta),
+    spendingAuthSig: await signReserveAuth(buyer.wallet, domain, reserveMsg),
+    reserveSalt: '0x' + '01'.repeat(32),
+    reserveMaxAmount: reserveMaxAmount.toString(),
+    reserveDeadline: deadline,
+  };
+}
+
+async function buildSpendingAuth(buyer: Identity, cumulativeAmount: bigint): Promise<SpendingAuthPayload> {
+  const meta = metadataFor(cumulativeAmount);
+  const metadataHash = computeMetadataHash(meta);
+  const msg: SpendingAuthMessage = { channelId: CHANNEL_ID, cumulativeAmount, metadataHash };
+  return {
+    channelId: CHANNEL_ID,
+    cumulativeAmount: cumulativeAmount.toString(),
+    metadataHash,
+    metadata: encodeMetadata(meta),
+    spendingAuthSig: await signSpendingAuth(buyer.wallet, makeChannelsDomain(CHAIN_ID, CONTRACT_ADDR), msg),
+  };
+}
+
+/** A CloseChannelRequest carrying a valid buyer SpendingAuth at `cumulativeAmount`. */
+async function buildCloseRequest(
+  buyer: Identity,
+  cumulativeAmount: bigint,
+): Promise<CloseChannelRequestPayload> {
+  const auth = await buildSpendingAuth(buyer, cumulativeAmount);
+  return {
+    version: 1,
+    channelId: CHANNEL_ID,
+    cumulativeAmount: auth.cumulativeAmount,
+    metadataHash: auth.metadataHash,
+    metadata: auth.metadata,
+    spendingAuthSig: auth.spendingAuthSig,
+  };
+}
+
+function onChainChannel(buyer: Identity, seller: Identity, settled: bigint) {
+  return {
+    buyer: buyer.wallet.address,
+    seller: seller.wallet.address,
+    deposit: 10_000_000n,
+    settled,
+    metadataHash: ZERO_METADATA_HASH,
+    deadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
+    settledAt: 0n,
+    closeRequestedAt: 0n,
+    status: 1,
+  };
+}
+
+describe('SellerPaymentManager.handleCloseChannelRequest', () => {
+  let tempDir: string;
+  let store: ChannelStore;
+  let seller: Identity;
+  let buyer: Identity;
+  let manager: SellerPaymentManager;
+  let mux: ReturnType<typeof createMockPaymentMux>;
+
+  beforeEach(async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'seller-coop-close-'));
+    store = new ChannelStore(tempDir);
+    seller = createTestIdentity();
+    buyer = createTestIdentity();
+
+    const config: SellerPaymentConfig = {
+      rpcUrl: 'http://127.0.0.1:8545',
+      channelsContractAddress: CONTRACT_ADDR,
+      chainId: CHAIN_ID,
+      dataDir: tempDir,
+    };
+    manager = new SellerPaymentManager(seller, config, store);
+
+    vi.spyOn(manager.channelsClient, 'reserve').mockResolvedValue('0xreserve');
+    vi.spyOn(manager.channelsClient, 'settle').mockResolvedValue('0xsettle');
+    vi.spyOn(manager.channelsClient, 'close').mockResolvedValue('0xclosetx');
+    vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(onChainChannel(buyer, seller, 0n));
+
+    mux = createMockPaymentMux();
+
+    // Establish the channel so a close has something to act on.
+    await manager.handleSpendingAuth(buyer.peerId, await buildReserveAuth(buyer), mux);
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('closes at the seller-held cumulative when the buyer sends no signature', async () => {
+    await manager.handleSpendingAuth(buyer.peerId, await buildSpendingAuth(buyer, 400_000n), mux);
+    manager.recordSpend(CHANNEL_ID, 400_000n);
+
+    const result = await manager.handleCloseChannelRequest(
+      buyer.peerId,
+      { version: 1, channelId: CHANNEL_ID },
+      mux,
+    );
+
+    expect(result.status).toBe('closed');
+    expect(result.txHash).toBe('0xclosetx');
+    expect(result.finalAmount).toBe('400000');
+    expect(manager.channelsClient.close).toHaveBeenCalledWith(
+      expect.anything(), CHANNEL_ID, 400_000n, expect.any(String), expect.any(String),
+    );
+    expect(store.getChannel(CHANNEL_ID)!.status).toBe(CHANNEL_STATUS.SETTLED);
+    expect(manager.hasSession(buyer.peerId)).toBe(false);
+  });
+
+  it('closes at the buyer-supplied cumulative when it exceeds the seller-held one', async () => {
+    await manager.handleSpendingAuth(buyer.peerId, await buildSpendingAuth(buyer, 400_000n), mux);
+    manager.recordSpend(CHANNEL_ID, 400_000n);
+
+    const result = await manager.handleCloseChannelRequest(
+      buyer.peerId,
+      await buildCloseRequest(buyer, 900_000n),
+      mux,
+    );
+
+    expect(result.status).toBe('closed');
+    expect(result.finalAmount).toBe('900000');
+    expect(manager.channelsClient.close).toHaveBeenCalledWith(
+      expect.anything(), CHANNEL_ID, 900_000n, expect.any(String), expect.any(String),
+    );
+  });
+
+  it('keeps the seller-held cumulative when the buyer offers a lower one', async () => {
+    await manager.handleSpendingAuth(buyer.peerId, await buildSpendingAuth(buyer, 900_000n), mux);
+    manager.recordSpend(CHANNEL_ID, 900_000n);
+
+    const result = await manager.handleCloseChannelRequest(
+      buyer.peerId,
+      await buildCloseRequest(buyer, 100_000n),
+      mux,
+    );
+
+    expect(result.status).toBe('closed');
+    expect(result.finalAmount).toBe('900000');
+  });
+
+  it('refuses while a billable request is still in flight', async () => {
+    await manager.handleSpendingAuth(buyer.peerId, await buildSpendingAuth(buyer, 400_000n), mux);
+    manager.beginBillableRequest(buyer.peerId);
+
+    const result = await manager.handleCloseChannelRequest(
+      buyer.peerId,
+      { version: 1, channelId: CHANNEL_ID },
+      mux,
+    );
+
+    expect(result.status).toBe('rejected');
+    expect(result.code).toBe('busy');
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+    expect(manager.channelsClient.close).not.toHaveBeenCalled();
+    expect(manager.hasSession(buyer.peerId)).toBe(true);
+
+    manager.endBillableRequest(buyer.peerId);
+    expect(manager.hasInFlightRequests(buyer.peerId)).toBe(false);
+  });
+
+  it('refuses with pending_auth and a NeedAuth when spend outruns the signed amount', async () => {
+    await manager.handleSpendingAuth(buyer.peerId, await buildSpendingAuth(buyer, 400_000n), mux);
+    manager.recordSpend(CHANNEL_ID, 750_000n);
+
+    const result = await manager.handleCloseChannelRequest(
+      buyer.peerId,
+      { version: 1, channelId: CHANNEL_ID },
+      mux,
+      // The catch-up wait resolves immediately: no auth will arrive in a unit test.
+    );
+
+    expect(result.status).toBe('rejected');
+    expect(result.code).toBe('pending_auth');
+    expect(result.requiredCumulativeAmount).toBe('750000');
+    expect(manager.channelsClient.close).not.toHaveBeenCalled();
+
+    const needAuth = mux.sentNeedAuths.at(-1) as Record<string, unknown>;
+    expect(needAuth.channelId).toBe(CHANNEL_ID);
+    expect(needAuth.requiredCumulativeAmount).toBe('750000');
+  }, 10_000);
+
+  it('accepts a buyer signature that covers the outstanding spend', async () => {
+    await manager.handleSpendingAuth(buyer.peerId, await buildSpendingAuth(buyer, 400_000n), mux);
+    manager.recordSpend(CHANNEL_ID, 750_000n);
+
+    const result = await manager.handleCloseChannelRequest(
+      buyer.peerId,
+      await buildCloseRequest(buyer, 750_000n),
+      mux,
+    );
+
+    expect(result.status).toBe('closed');
+    expect(result.finalAmount).toBe('750000');
+  });
+
+  it('rejects a signature signed by someone other than the channel buyer', async () => {
+    await manager.handleSpendingAuth(buyer.peerId, await buildSpendingAuth(buyer, 400_000n), mux);
+    const impostor = createTestIdentity();
+
+    const result = await manager.handleCloseChannelRequest(
+      buyer.peerId,
+      await buildCloseRequest(impostor, 900_000n),
+      mux,
+    );
+
+    expect(result.status).toBe('rejected');
+    expect(result.code).toBe('invalid_auth');
+    expect(manager.channelsClient.close).not.toHaveBeenCalled();
+  });
+
+  it('rejects a signature whose metadata does not match its hash', async () => {
+    await manager.handleSpendingAuth(buyer.peerId, await buildSpendingAuth(buyer, 400_000n), mux);
+    const request = await buildCloseRequest(buyer, 900_000n);
+    request.metadata = encodeMetadata(metadataFor(12345n));
+
+    const result = await manager.handleCloseChannelRequest(buyer.peerId, request, mux);
+
+    expect(result.status).toBe('rejected');
+    expect(result.code).toBe('invalid_auth');
+  });
+
+  it('rejects a request naming a different channel', async () => {
+    const result = await manager.handleCloseChannelRequest(
+      buyer.peerId,
+      { version: 1, channelId: '0x' + 'ee'.repeat(32) },
+      mux,
+    );
+
+    expect(result.status).toBe('rejected');
+    expect(result.code).toBe('no_channel');
+  });
+
+  it('rejects when the buyer has no active channel', async () => {
+    const stranger = createTestIdentity();
+    const result = await manager.handleCloseChannelRequest(
+      stranger.peerId,
+      { version: 1, channelId: CHANNEL_ID },
+      mux,
+    );
+
+    expect(result.status).toBe('rejected');
+    expect(result.code).toBe('no_channel');
+  });
+
+  it('closes unsigned at the on-chain settled amount when no auth exists on either side', async () => {
+    vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(onChainChannel(buyer, seller, 250_000n));
+
+    const result = await manager.handleCloseChannelRequest(
+      buyer.peerId,
+      { version: 1, channelId: CHANNEL_ID },
+      mux,
+    );
+
+    expect(result.status).toBe('closed');
+    expect(result.finalAmount).toBe('250000');
+    // finalAmount == settled makes the contract skip signature verification.
+    expect(manager.channelsClient.close).toHaveBeenCalledWith(
+      expect.anything(), CHANNEL_ID, 250_000n, '0x', '0x',
+    );
+  });
+
+  it('reports close_failed and keeps the channel when the on-chain call reverts', async () => {
+    await manager.handleSpendingAuth(buyer.peerId, await buildSpendingAuth(buyer, 400_000n), mux);
+    vi.spyOn(manager.channelsClient, 'close').mockRejectedValue(new Error('execution reverted: InvalidAmount'));
+
+    const result = await manager.handleCloseChannelRequest(
+      buyer.peerId,
+      { version: 1, channelId: CHANNEL_ID },
+      mux,
+    );
+
+    expect(result.status).toBe('rejected');
+    expect(result.code).toBe('close_failed');
+    expect(result.reason).toContain('InvalidAmount');
+    expect(store.getChannel(CHANNEL_ID)!.status).toBe(CHANNEL_STATUS.ACTIVE);
+    expect(manager.hasSession(buyer.peerId)).toBe(true);
+  });
+
+  it('persists an adopted buyer auth so a later close can still use it', async () => {
+    await manager.handleSpendingAuth(buyer.peerId, await buildSpendingAuth(buyer, 400_000n), mux);
+    manager.recordSpend(CHANNEL_ID, 400_000n);
+    vi.spyOn(manager.channelsClient, 'close').mockRejectedValueOnce(new Error('boom'));
+
+    const failed = await manager.handleCloseChannelRequest(
+      buyer.peerId,
+      await buildCloseRequest(buyer, 900_000n),
+      mux,
+    );
+    expect(failed.status).toBe('rejected');
+
+    expect(store.getChannel(CHANNEL_ID)!.authMax).toBe('900000');
+    expect(manager.getAcceptedCumulative(CHANNEL_ID)).toBe(900_000n);
+
+    const retried = await manager.handleCloseChannelRequest(
+      buyer.peerId,
+      { version: 1, channelId: CHANNEL_ID },
+      mux,
+    );
+    expect(retried.status).toBe('closed');
+    expect(retried.finalAmount).toBe('900000');
+  });
+});


### PR DESCRIPTION
## Description

Lets a buyer ask its seller to close a payment channel on the spot, releasing the reserved USDC without the on-chain `requestClose()` → 15-minute grace → `withdraw()` detour. Adds `CloseChannelRequest` (0x59) / `CloseChannelResult` (0x5A) to the existing PaymentMux, gated on the seller not being mid-accumulation with that buyer.

## How the seller decides

It agrees only when both hold:

- **No billable request in flight.** A new per-buyer in-flight counter spans the whole billable span — provider call, spend recording, and the follow-up `NeedAuth` — so a close cannot land between serving a request and claiming its cost. Otherwise `busy`.
- **No unsigned spend.** If `spent` exceeds the highest signed cumulative, the seller waits briefly for a catch-up auth already on the wire, then emits `NeedAuth` and rejects with `pending_auth` + `requiredCumulativeAmount` so the buyer signs and retries.

Rejections resolve normally rather than throwing, and leave the channel untouched — the buyer retries or falls back to the timeout path.

## Whose signature wins

The buyer may attach its latest SpendingAuth, and does by default. Attaching costs nothing — the cumulative is unchanged, so it authorizes no more than the seller could already claim — but it lets a seller that never received the last auth still close at the full amount owed. The seller settles at `max(own last-accepted, buyer-supplied)`, so neither side can settle below what is actually owed. A supplied auth must recover to the on-chain channel buyer and its `metadataHash` must match its `metadata`, else `invalid_auth`.

When neither side holds a usable auth, the seller closes at the current on-chain `settled` amount with an empty signature — the contract skips verification when `finalAmount == settled`, and this claims no unproven spend.

## Release Notes

- Added buyer-initiated cooperative channel close, so a buyer gets its reserved USDC released immediately instead of waiting out the on-chain `request-close` → 15-minute grace → `withdraw` flow. The seller closes on-chain and returns the transaction hash.
- The seller refuses while still mid-accumulation — a request in flight (`busy`) or work the buyer hasn't signed for (`pending_auth`) — leaving the channel untouched for a retry.
- Added `antseed buyer channels close <channelId>` (`--no-auth`, `--json`), which runs through a running `antseed buyer start` daemon's live seller connection.
- Added `AntseedNode.requestChannelClose(peerId, opts)` and the `payments.cooperative-close.v1` capability.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (payments spec §1 + §11, CHANGELOG)
- [x] I have added tests (13 seller-close, 6 negotiator round-trip, 6 codec)
- [x] Lint and unit tests pass locally with my changes (801/801 node, 201/201 CLI)

## Note

This also corrects the stale P2P message table in `docs/protocol/spec/04-payments.md`, which listed `0x50` as `ReserveAuth` and `0x54` as `SpendingAuth` — neither has matched `protocol.ts` for some time. Happy to split that out if you'd rather keep this PR to the feature.
