### PR TITLE
fix(payments): Recover superseded channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed payment negotiation getting stuck when a buyer lost its local channel state while an older channel remained active on-chain. Sellers now close the superseded channel from durable seller state before accepting the buyer's replacement ReserveAuth.
 - Fixed the seller persisting the initial ReserveAuth signature in the SpendingAuth column, so restart hydration restored it under the wrong EIP-712 type and every subsequent `close()` reverted with `InvalidSignature`.
 - Fixed sellers retrying a failing signed `close()` forever: once the retry limit is exhausted the channel is now persisted as timed out, so `checkTimeouts()` and restarts fall back to the timeout path instead of replaying the same doomed close.
 - Fixed seller crashes when sending `PaymentRequired` to a buyer that disconnected before the payment terms could be delivered.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project uses selective package publishing. Each release entry lists the pub
 ### Fixed
 
 - Fixed payment negotiation getting stuck when a buyer lost its local channel state while an older channel remained active on-chain. Sellers now close the superseded channel from durable seller state before accepting the buyer's replacement ReserveAuth.
+- Fixed the seller recording an inaccurate settled amount when two close paths raced on the same channel. Only one `close()` is submitted, and every path that joins it now persists the amount that transaction actually settled.
 - Fixed the seller persisting the initial ReserveAuth signature in the SpendingAuth column, so restart hydration restored it under the wrong EIP-712 type and every subsequent `close()` reverted with `InvalidSignature`.
 - Fixed sellers retrying a failing signed `close()` forever: once the retry limit is exhausted the channel is now persisted as timed out, so `checkTimeouts()` and restarts fall back to the timeout path instead of replaying the same doomed close.
 - Fixed seller crashes when sending `PaymentRequired` to a buyer that disconnected before the payment terms could be delivered.

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -458,6 +458,19 @@ export class SellerPaymentManager {
           return 'rejected';
         }
         debugLog(`[SellerPayment] ReserveAuth verified for buyer ${buyerPeerId.slice(0, 12)}...`);
+
+        const superseded = this._channelStore.getActiveChannelByPeer(buyerPeerId, CHANNEL_ROLE.SELLER);
+        if (superseded && superseded.sessionId !== channelId) {
+          const closed = await this._closeSupersededChannel(superseded);
+          if (!closed) {
+            debugWarn(
+              `[SellerPayment] Cannot reserve replacement channel ${channelId.slice(0, 18)}... ` +
+              `while prior channel ${superseded.sessionId.slice(0, 18)}... remains active`,
+            );
+            return 'rejected';
+          }
+        }
+
         debugLog(`[SellerPayment] Reserving channel ${channelId.slice(0, 18)}... on-chain`);
         const reserveSalt = payload.reserveSalt ?? channelId;
         await this._channelsClient.reserve(
@@ -1188,6 +1201,64 @@ export class SellerPaymentManager {
       } catch (err) {
         debugWarn(`[SellerPayment] Failed to process channel ${channel.sessionId.slice(0, 18)}...: ${err instanceof Error ? err.message : err}`);
       }
+    }
+  }
+
+  /**
+   * Close the seller's previous channel before accepting a replacement
+   * ReserveAuth from the same buyer. Buyers may lose local channel state and
+   * generate a new channel ID while the previous reserve remains active
+   * on-chain. The contract rejects a second active channel for the same pair,
+   * so recover synchronously using the seller's durable state instead of
+   * leaving both peers in an unrecoverable negotiation loop.
+   */
+  private async _closeSupersededChannel(channel: StoredChannel): Promise<boolean> {
+    const channelId = channel.sessionId;
+    const accepted = this._acceptedCumulative.get(channelId)
+      ?? this._restorePersistedSpendingAuth(channel)
+      ?? 0n;
+
+    try {
+      if (accepted > 0n) {
+        const { amount, metadata, sig } = this._getSettleParams(channelId);
+        await this._channelsClient.close(this._signer, channelId, amount, metadata, sig);
+        this._evictStaleChannel(
+          channelId,
+          channel.peerId,
+          'closed before replacement reserve',
+          CHANNEL_STATUS.SETTLED,
+        );
+      } else {
+        const onChainState = classifyOnChainChannel(await this._channelsClient.getSession(channelId));
+        if (!onChainState.exists || onChainState.status !== 'active') {
+          this._evictStaleChannel(
+            channelId,
+            channel.peerId,
+            `replacement reserve: on-chain status=${onChainState.exists ? onChainState.status : 'missing'}`,
+          );
+        } else {
+          await this._channelsClient.close(
+            this._signer,
+            channelId,
+            onChainState.channel.settled,
+            '0x',
+            '0x',
+          );
+          this._evictStaleChannel(
+            channelId,
+            channel.peerId,
+            'zero-auth channel closed before replacement reserve',
+            CHANNEL_STATUS.SETTLED,
+          );
+        }
+      }
+      return true;
+    } catch (err) {
+      debugWarn(
+        `[SellerPayment] Failed to close superseded channel ${channelId.slice(0, 18)}...: ` +
+        `${err instanceof Error ? err.message : err}`,
+      );
+      return false;
     }
   }
 

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -49,6 +49,7 @@ const INSUFFICIENT_BALANCE_SELECTOR = '0xf4d678b8';
 const IN_FLIGHT_TX_LIMIT_PHRASE = 'in-flight transaction limit';
 
 type TopUpFailureKind = 'retryable-threshold' | 'retryable-tx-backpressure' | 'insufficient-balance' | 'non-retryable';
+type CloseResult = { closed: true } | { closed: false; error: unknown };
 
 /** Stored auth entry for buyer's SpendingAuth signature. */
 interface LatestAuth {
@@ -127,8 +128,12 @@ export class SellerPaymentManager {
   /** Channels that must not serve more paid work until closed/renegotiated. */
   private readonly _blockedChannels = new Set<string>();
 
-  /** channelIds with an in-flight close() tx/estimate. Prevents duplicate close submissions. */
-  private readonly _closingChannels = new Set<string>();
+  /**
+   * channelId -> in-flight close() result. Every close path shares this map so
+   * replacement negotiation can await an existing close instead of submitting
+   * a duplicate transaction.
+   */
+  private readonly _closingChannels = new Map<string, Promise<CloseResult>>();
 
   /** channelId -> cumulative amount last successfully settled on-chain by this
    *  process. Lets the idle-settle loop skip the `getSession` RPC when the
@@ -259,15 +264,40 @@ export class SellerPaymentManager {
     this._spent.delete(channelId);
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
-    this._closingChannels.delete(channelId);
     this._hydratedChannelIds.delete(channelId);
     this._reserveMax.delete(channelId);
     this._pendingTopUp.delete(channelId);
     this._blockedChannels.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
     this._releaseAcceptedWaiters(channelId);
-    this._activeBuyers.delete(peerId);
+    this._deactivateBuyerForChannel(peerId, channelId);
     debugLog(`[SellerPayment] Evicted stale channel ${channelId.slice(0, 18)}... — ${reason}`);
+  }
+
+  /** Remove connectivity only if it still belongs to the channel being cleaned up. */
+  private _deactivateBuyerForChannel(peerId: string, channelId: string): void {
+    const current = this._channelStore.getActiveChannelByPeer(peerId, CHANNEL_ROLE.SELLER);
+    if (!current || current.sessionId === channelId) {
+      this._activeBuyers.delete(peerId);
+    }
+  }
+
+  /** Submit at most one close transaction per channel and share its outcome. */
+  private _submitClose(channelId: string, submit: () => Promise<string>): Promise<CloseResult> {
+    const existing = this._closingChannels.get(channelId);
+    if (existing) return existing;
+
+    const operation: Promise<CloseResult> = submit().then(
+      () => ({ closed: true }),
+      (error: unknown) => ({ closed: false, error }),
+    );
+    this._closingChannels.set(channelId, operation);
+    void operation.finally(() => {
+      if (this._closingChannels.get(channelId) === operation) {
+        this._closingChannels.delete(channelId);
+      }
+    });
+    return operation;
   }
 
   /**
@@ -1007,10 +1037,6 @@ export class SellerPaymentManager {
 
   // ── Settlement ──────────────────────────────────────────────
 
-  /**
-   * Close a completed session on-chain using the latest buyer-signed dual signatures.
-   * Uses close() for final settlement (releases remaining deposit to buyer).
-   */
   /** Get the latest SpendingAuth params for a channel, or zero-auth if none exists. */
   private _getSettleParams(channelId: string): { amount: bigint; metadata: string; sig: string } {
     const latestAuth = this._latestAuth.get(channelId);
@@ -1049,49 +1075,44 @@ export class SellerPaymentManager {
       await this._settleLatestAuth(channelId, 'idle settle', { respectMinSettleDelta: true });
       return;
     } else {
-      if (this._closingChannels.has(channelId)) {
-        debugLog(`[SellerPayment] Close already in flight for ${channelId.slice(0, 18)}... — skipping duplicate request`);
-        return;
-      }
-
       const retries = this._closeRetryCount.get(channelId) ?? 0;
       if (retries >= SellerPaymentManager.MAX_CLOSE_RETRIES) {
         debugWarn(`[SellerPayment] close() failed ${retries} times for ${channelId.slice(0, 18)}... — falling back to timeout path`);
         this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.TIMEOUT);
       } else {
         debugLog(`[SellerPayment] Closing channel ${channelId.slice(0, 18)}... cumulative=${amount} (attempt ${retries + 1}/${SellerPaymentManager.MAX_CLOSE_RETRIES})`);
-        this._closingChannels.add(channelId);
-        try {
-          await this._channelsClient.close(this._signer, channelId, amount, metadata, sig);
+        const closeResult = await this._submitClose(
+          channelId,
+          () => this._channelsClient.close(this._signer, channelId, amount, metadata, sig),
+        );
+        if (closeResult.closed) {
           this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.SETTLED, amount.toString());
           this._closeRetryCount.delete(channelId);
-        } catch (err) {
-          if (this._isRetryableTxSubmissionFailure(err)) {
+        } else {
+          if (this._isRetryableTxSubmissionFailure(closeResult.error)) {
             debugWarn(
               `[SellerPayment] Close hit transaction backpressure for ${channelId.slice(0, 18)}... ` +
-              `— keeping channel state for retry: ${this._formatError(err)}`,
+              `— keeping channel state for retry: ${this._formatError(closeResult.error)}`,
             );
             if (cleanupOnFailure) {
-              this._activeBuyers.delete(buyerPeerId);
+              this._deactivateBuyerForChannel(buyerPeerId, channelId);
             }
             return;
           }
 
           const failedAttempts = retries + 1;
-          debugWarn(`[SellerPayment] Failed to close channel (attempt ${failedAttempts}): ${err instanceof Error ? err.message : err}`);
+          debugWarn(`[SellerPayment] Failed to close channel (attempt ${failedAttempts}): ${this._formatError(closeResult.error)}`);
           this._closeRetryCount.set(channelId, failedAttempts);
 
           if (failedAttempts < SellerPaymentManager.MAX_CLOSE_RETRIES) {
             if (cleanupOnFailure) {
-              this._activeBuyers.delete(buyerPeerId);
+              this._deactivateBuyerForChannel(buyerPeerId, channelId);
             }
             return;
           }
 
           debugWarn(`[SellerPayment] close() failed ${failedAttempts} times for ${channelId.slice(0, 18)}... — falling back to timeout path`);
           this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.TIMEOUT);
-        } finally {
-          this._closingChannels.delete(channelId);
         }
       }
     }
@@ -1101,14 +1122,13 @@ export class SellerPaymentManager {
     this._spent.delete(channelId);
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
-    this._closingChannels.delete(channelId);
     this._reserveMax.delete(channelId);
     this._pendingTopUp.delete(channelId);
     this._blockedChannels.delete(channelId);
     this._lastSettledCumulative.delete(channelId);
     this._hydratedChannelIds.delete(channelId);
     this._releaseAcceptedWaiters(channelId);
-    this._activeBuyers.delete(buyerPeerId);
+    this._deactivateBuyerForChannel(buyerPeerId, channelId);
   }
 
   // ── Disconnect handling ───────────────────────────────────────
@@ -1221,7 +1241,11 @@ export class SellerPaymentManager {
     try {
       if (accepted > 0n) {
         const { amount, metadata, sig } = this._getSettleParams(channelId);
-        await this._channelsClient.close(this._signer, channelId, amount, metadata, sig);
+        const closeResult = await this._submitClose(
+          channelId,
+          () => this._channelsClient.close(this._signer, channelId, amount, metadata, sig),
+        );
+        if (!closeResult.closed) return false;
         this._evictStaleChannel(
           channelId,
           channel.peerId,
@@ -1237,13 +1261,17 @@ export class SellerPaymentManager {
             `replacement reserve: on-chain status=${onChainState.exists ? onChainState.status : 'missing'}`,
           );
         } else {
-          await this._channelsClient.close(
-            this._signer,
+          const closeResult = await this._submitClose(
             channelId,
-            onChainState.channel.settled,
-            '0x',
-            '0x',
+            () => this._channelsClient.close(
+              this._signer,
+              channelId,
+              onChainState.channel.settled,
+              '0x',
+              '0x',
+            ),
           );
+          if (!closeResult.closed) return false;
           this._evictStaleChannel(
             channelId,
             channel.peerId,
@@ -1269,11 +1297,6 @@ export class SellerPaymentManager {
    * remaining reserved deposit back to the buyer.
    */
   private async _closeWithoutAuth(channelId: string, peerId: string, onChainSettled: bigint): Promise<void> {
-    if (this._closingChannels.has(channelId)) {
-      debugLog(`[SellerPayment] Close already in flight for ${channelId.slice(0, 18)}... — skipping zombie close`);
-      return;
-    }
-
     const retries = this._closeRetryCount.get(channelId) ?? 0;
     if (retries >= SellerPaymentManager.MAX_CLOSE_RETRIES) {
       debugWarn(`[SellerPayment] Zombie close failed ${retries} times for ${channelId.slice(0, 18)}... — falling back to local eviction`);
@@ -1281,24 +1304,22 @@ export class SellerPaymentManager {
       return;
     }
 
-    this._closingChannels.add(channelId);
     debugLog(`[SellerPayment] Closing zombie channel ${channelId.slice(0, 18)}... finalAmount=${onChainSettled} (attempt ${retries + 1}/${SellerPaymentManager.MAX_CLOSE_RETRIES})`);
-    try {
-      await this._channelsClient.close(this._signer, channelId, onChainSettled, '0x', '0x');
+    const closeResult = await this._submitClose(
+      channelId,
+      () => this._channelsClient.close(this._signer, channelId, onChainSettled, '0x', '0x'),
+    );
+    if (closeResult.closed) {
       this._closeRetryCount.delete(channelId);
       this._evictStaleChannel(channelId, peerId, 'zombie closed on-chain', CHANNEL_STATUS.SETTLED);
-    } catch (err) {
-      if (this._isRetryableTxSubmissionFailure(err)) {
-        debugWarn(
-          `[SellerPayment] Zombie close hit transaction backpressure for ${channelId.slice(0, 18)}... ` +
-          `— keeping channel for retry: ${this._formatError(err)}`,
-        );
-      } else {
-        this._closeRetryCount.set(channelId, retries + 1);
-        debugWarn(`[SellerPayment] Zombie close failed (attempt ${retries + 1}): ${err instanceof Error ? err.message : err}`);
-      }
-    } finally {
-      this._closingChannels.delete(channelId);
+    } else if (this._isRetryableTxSubmissionFailure(closeResult.error)) {
+      debugWarn(
+        `[SellerPayment] Zombie close hit transaction backpressure for ${channelId.slice(0, 18)}... ` +
+        `— keeping channel for retry: ${this._formatError(closeResult.error)}`,
+      );
+    } else {
+      this._closeRetryCount.set(channelId, retries + 1);
+      debugWarn(`[SellerPayment] Zombie close failed (attempt ${retries + 1}): ${this._formatError(closeResult.error)}`);
     }
   }
 
@@ -1388,14 +1409,19 @@ export class SellerPaymentManager {
     if (accepted > 0n) {
       const { amount, metadata, sig } = this._getSettleParams(channelId);
       debugLog(`[SellerPayment] CloseRequested for channel ${channelId.slice(0, 18)}... — closing with cumulative=${amount}`);
-      try {
-        await this._channelsClient.close(this._signer, channelId, amount, metadata, sig);
-        this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.SETTLED, amount.toString());
-        debugLog(`[SellerPayment] Channel ${channelId.slice(0, 18)}... closed successfully after CloseRequested`);
-      } catch (err) {
-        debugWarn(`[SellerPayment] Failed to close channel ${channelId.slice(0, 18)}... after CloseRequested: ${err instanceof Error ? err.message : err}`);
+      const closeResult = await this._submitClose(
+        channelId,
+        () => this._channelsClient.close(this._signer, channelId, amount, metadata, sig),
+      );
+      if (!closeResult.closed) {
+        debugWarn(
+          `[SellerPayment] Failed to close channel ${channelId.slice(0, 18)}... ` +
+          `after CloseRequested: ${this._formatError(closeResult.error)}`,
+        );
         return;
       }
+      this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.SETTLED, amount.toString());
+      debugLog(`[SellerPayment] Channel ${channelId.slice(0, 18)}... closed successfully after CloseRequested`);
     } else {
       // No voucher — seller can't claim anything. Clean up locally;
       // buyer will withdraw after grace period.
@@ -1408,7 +1434,6 @@ export class SellerPaymentManager {
     this._spent.delete(channelId);
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
-    this._closingChannels.delete(channelId);
     this._reserveMax.delete(channelId);
     this._pendingTopUp.delete(channelId);
     this._blockedChannels.delete(channelId);
@@ -1419,7 +1444,7 @@ export class SellerPaymentManager {
     // Find and remove buyer from active set
     const channel = this._channelStore.getChannel(channelId);
     if (channel) {
-      this._activeBuyers.delete(channel.peerId);
+      this._deactivateBuyerForChannel(channel.peerId, channelId);
     }
   }
 

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -49,7 +49,9 @@ const INSUFFICIENT_BALANCE_SELECTOR = '0xf4d678b8';
 const IN_FLIGHT_TX_LIMIT_PHRASE = 'in-flight transaction limit';
 
 type TopUpFailureKind = 'retryable-threshold' | 'retryable-tx-backpressure' | 'insufficient-balance' | 'non-retryable';
-type CloseResult = { closed: true } | { closed: false; error: unknown };
+/** `amount` is the finalAmount actually submitted on-chain, which may differ
+ *  from what a caller that joined an in-flight close intended to submit. */
+type CloseResult = { closed: true; amount: bigint } | { closed: false; error: unknown };
 
 /** Stored auth entry for buyer's SpendingAuth signature. */
 interface LatestAuth {
@@ -282,13 +284,17 @@ export class SellerPaymentManager {
     }
   }
 
-  /** Submit at most one close transaction per channel and share its outcome. */
-  private _submitClose(channelId: string, submit: () => Promise<string>): Promise<CloseResult> {
+  /**
+   * Submit at most one close transaction per channel and share its outcome.
+   * Callers that join an in-flight close receive the amount that close actually
+   * submitted, not the one they asked for — persist that, not `amount`.
+   */
+  private _submitClose(channelId: string, amount: bigint, submit: () => Promise<string>): Promise<CloseResult> {
     const existing = this._closingChannels.get(channelId);
     if (existing) return existing;
 
     const operation: Promise<CloseResult> = submit().then(
-      () => ({ closed: true }),
+      () => ({ closed: true, amount }),
       (error: unknown) => ({ closed: false, error }),
     );
     this._closingChannels.set(channelId, operation);
@@ -1083,10 +1089,11 @@ export class SellerPaymentManager {
         debugLog(`[SellerPayment] Closing channel ${channelId.slice(0, 18)}... cumulative=${amount} (attempt ${retries + 1}/${SellerPaymentManager.MAX_CLOSE_RETRIES})`);
         const closeResult = await this._submitClose(
           channelId,
+          amount,
           () => this._channelsClient.close(this._signer, channelId, amount, metadata, sig),
         );
         if (closeResult.closed) {
-          this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.SETTLED, amount.toString());
+          this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.SETTLED, closeResult.amount.toString());
           this._closeRetryCount.delete(channelId);
         } else {
           if (this._isRetryableTxSubmissionFailure(closeResult.error)) {
@@ -1243,6 +1250,7 @@ export class SellerPaymentManager {
         const { amount, metadata, sig } = this._getSettleParams(channelId);
         const closeResult = await this._submitClose(
           channelId,
+          amount,
           () => this._channelsClient.close(this._signer, channelId, amount, metadata, sig),
         );
         if (!closeResult.closed) return false;
@@ -1263,6 +1271,7 @@ export class SellerPaymentManager {
         } else {
           const closeResult = await this._submitClose(
             channelId,
+            onChainState.channel.settled,
             () => this._channelsClient.close(
               this._signer,
               channelId,
@@ -1307,6 +1316,7 @@ export class SellerPaymentManager {
     debugLog(`[SellerPayment] Closing zombie channel ${channelId.slice(0, 18)}... finalAmount=${onChainSettled} (attempt ${retries + 1}/${SellerPaymentManager.MAX_CLOSE_RETRIES})`);
     const closeResult = await this._submitClose(
       channelId,
+      onChainSettled,
       () => this._channelsClient.close(this._signer, channelId, onChainSettled, '0x', '0x'),
     );
     if (closeResult.closed) {
@@ -1411,6 +1421,7 @@ export class SellerPaymentManager {
       debugLog(`[SellerPayment] CloseRequested for channel ${channelId.slice(0, 18)}... — closing with cumulative=${amount}`);
       const closeResult = await this._submitClose(
         channelId,
+        amount,
         () => this._channelsClient.close(this._signer, channelId, amount, metadata, sig),
       );
       if (!closeResult.closed) {
@@ -1420,7 +1431,7 @@ export class SellerPaymentManager {
         );
         return;
       }
-      this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.SETTLED, amount.toString());
+      this._channelStore.updateChannelStatus(channelId, CHANNEL_STATUS.SETTLED, closeResult.amount.toString());
       debugLog(`[SellerPayment] Channel ${channelId.slice(0, 18)}... closed successfully after CloseRequested`);
     } else {
       // No voucher — seller can't claim anything. Clean up locally;

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -189,6 +189,121 @@ describe('SellerPaymentManager', () => {
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
   });
 
+  it('closes a prior signed channel before reserving a replacement channel', async () => {
+    const priorChannelId = makeChannelId(110);
+    const replacementChannelId = makeChannelId(111);
+
+    const priorReserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, priorChannelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, priorReserve, mux);
+    const priorAuth = await buildSpendingAuth(buyerIdentity, sellerIdentity, priorChannelId, {
+      cumulativeAmount: 200_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, priorAuth, mux);
+
+    vi.mocked(manager.channelsClient.close)
+      .mockRejectedValueOnce(new Error('temporary RPC failure'))
+      .mockResolvedValue('0xclose-hash');
+    manager.onBuyerDisconnect(buyerIdentity.peerId);
+    await vi.waitFor(() => {
+      expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    });
+
+    // The seller retains the durable active record after a close submission
+    // failure while the buyer loses its local channel ID and presents a fresh
+    // ReserveAuth.
+    expect(store.getChannel(priorChannelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
+    vi.mocked(manager.channelsClient.close).mockClear();
+
+    const replacement = await buildSpendingAuth(buyerIdentity, sellerIdentity, replacementChannelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    const result = await manager.handleSpendingAuth(buyerIdentity.peerId, replacement, mux);
+
+    expect(result).toBe('reserved');
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    expect(manager.channelsClient.close).toHaveBeenCalledWith(
+      expect.anything(),
+      priorChannelId,
+      200_000n,
+      priorAuth.metadata,
+      priorAuth.spendingAuthSig,
+    );
+    expect(manager.channelsClient.reserve).toHaveBeenCalledTimes(2);
+    expect(store.getChannel(priorChannelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
+    expect(store.getChannel(replacementChannelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
+  });
+
+  it('closes a zero-spend prior channel before reserving a replacement channel', async () => {
+    const priorChannelId = makeChannelId(112);
+    const replacementChannelId = makeChannelId(113);
+
+    const priorReserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, priorChannelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, priorReserve, mux);
+    manager.onBuyerDisconnect(buyerIdentity.peerId);
+
+    vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(
+      makeOnChainChannel(buyerIdentity, sellerIdentity, {
+        deposit: 1_000_000n,
+        settled: 0n,
+        status: 1,
+      }),
+    );
+
+    const replacement = await buildSpendingAuth(buyerIdentity, sellerIdentity, replacementChannelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    const result = await manager.handleSpendingAuth(buyerIdentity.peerId, replacement, mux);
+
+    expect(result).toBe('reserved');
+    expect(manager.channelsClient.close).toHaveBeenCalledWith(
+      expect.anything(), priorChannelId, 0n, '0x', '0x',
+    );
+    expect(manager.channelsClient.reserve).toHaveBeenCalledTimes(2);
+    expect(store.getChannel(priorChannelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
+    expect(store.getChannel(replacementChannelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
+  });
+
+  it('keeps the prior channel active and rejects replacement reserve when close fails', async () => {
+    const priorChannelId = makeChannelId(114);
+    const replacementChannelId = makeChannelId(115);
+
+    const priorReserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, priorChannelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, priorReserve, mux);
+    manager.onBuyerDisconnect(buyerIdentity.peerId);
+
+    vi.spyOn(manager.channelsClient, 'getSession').mockResolvedValue(
+      makeOnChainChannel(buyerIdentity, sellerIdentity, {
+        deposit: 1_000_000n,
+        settled: 0n,
+        status: 1,
+      }),
+    );
+    vi.mocked(manager.channelsClient.close).mockRejectedValue(new Error('temporary RPC failure'));
+
+    const replacement = await buildSpendingAuth(buyerIdentity, sellerIdentity, replacementChannelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    const result = await manager.handleSpendingAuth(buyerIdentity.peerId, replacement, mux);
+
+    expect(result).toBe('rejected');
+    expect(manager.channelsClient.reserve).toHaveBeenCalledOnce();
+    expect(store.getChannel(priorChannelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
+    expect(store.getChannel(replacementChannelId)).toBeNull();
+  });
+
   it('test_handleSpendingAuth_subsequent: validates monotonic increase', async () => {
 
     const channelId = makeChannelId(2);

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -1157,6 +1157,46 @@ describe('SellerPaymentManager', () => {
     await Promise.all([first, second]);
   });
 
+  it('records the amount actually submitted when joining an in-flight close', async () => {
+    const channelId = makeChannelId(120);
+
+    const reserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, reserve, mux);
+    const firstAuth = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 200_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, firstAuth, mux);
+
+    let resolveClose!: (value: string) => void;
+    const closePromise = new Promise<string>((resolve) => { resolveClose = resolve; });
+    vi.mocked(manager.channelsClient.close).mockReturnValue(closePromise);
+
+    const first = manager.settleSession(buyerIdentity.peerId);
+    expect(manager.channelsClient.close).toHaveBeenCalledWith(
+      expect.anything(), channelId, 200_000n, expect.anything(), expect.anything(),
+    );
+
+    // A later auth raises the local cumulative while the close is still in flight.
+    const laterAuth = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, {
+      cumulativeAmount: 400_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, laterAuth, mux);
+
+    const second = manager.settleSession(buyerIdentity.peerId);
+    resolveClose('0xclose-hash');
+    await Promise.all([first, second]);
+
+    // The joiner must not claim its own (higher) cumulative was settled — only
+    // 200_000 was ever submitted on-chain.
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    expect(store.getChannel(channelId)!.settledAmount).toBe('200000');
+  });
+
   it('rejects SpendingAuth when cumulative exceeds on-chain deposit', async () => {
     const channelId = makeChannelId(40);
 

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -283,6 +283,49 @@ describe('SellerPaymentManager', () => {
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
   });
 
+  it('keeps the replacement session active when a superseded channel is evicted afterwards', async () => {
+    const priorChannelId = makeChannelId(118);
+    const replacementChannelId = makeChannelId(119);
+
+    const priorReserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, priorChannelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, priorReserve, mux);
+    const priorAuth = await buildSpendingAuth(buyerIdentity, sellerIdentity, priorChannelId, {
+      cumulativeAmount: 200_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, priorAuth, mux);
+
+    const replacement = await buildSpendingAuth(buyerIdentity, sellerIdentity, replacementChannelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+
+    // checkTimeouts snapshots the active channels before it awaits getSession.
+    // Negotiate the replacement inside that await so the eviction below runs
+    // against a channel the buyer has already moved off of.
+    let negotiated = false;
+    vi.spyOn(manager.channelsClient, 'getSession').mockImplementation(async () => {
+      if (!negotiated) {
+        negotiated = true;
+        await manager.handleSpendingAuth(buyerIdentity.peerId, replacement, mux);
+      }
+      // Prior channel is already closed on-chain — checkTimeouts evicts it locally.
+      return makeOnChainChannel(buyerIdentity, sellerIdentity, { status: 2 });
+    });
+
+    await manager.checkTimeouts();
+
+    // Evicting the superseded channel must not deactivate the buyer, who now
+    // belongs to the replacement channel.
+    expect(store.getChannel(priorChannelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
+    expect(store.getChannel(replacementChannelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
+    expect(manager.getChannelByPeer(buyerIdentity.peerId)?.sessionId).toBe(replacementChannelId);
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
+  });
+
   it('closes a zero-spend prior channel before reserving a replacement channel', async () => {
     const priorChannelId = makeChannelId(112);
     const replacementChannelId = makeChannelId(113);

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -238,6 +238,51 @@ describe('SellerPaymentManager', () => {
     expect(store.getChannel(replacementChannelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
   });
 
+  it('shares an in-flight disconnect close and preserves the replacement session', async () => {
+    const priorChannelId = makeChannelId(116);
+    const replacementChannelId = makeChannelId(117);
+
+    const priorReserve = await buildSpendingAuth(buyerIdentity, sellerIdentity, priorChannelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, priorReserve, mux);
+    const priorAuth = await buildSpendingAuth(buyerIdentity, sellerIdentity, priorChannelId, {
+      cumulativeAmount: 200_000n,
+      reserveMaxAmount: '1000000',
+    });
+    await manager.handleSpendingAuth(buyerIdentity.peerId, priorAuth, mux);
+
+    let resolveClose!: (value: string) => void;
+    const closePromise = new Promise<string>((resolve) => { resolveClose = resolve; });
+    vi.mocked(manager.channelsClient.close).mockReturnValue(closePromise);
+
+    manager.onBuyerDisconnect(buyerIdentity.peerId);
+    await vi.waitFor(() => {
+      expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    });
+
+    const replacement = await buildSpendingAuth(buyerIdentity, sellerIdentity, replacementChannelId, {
+      isReserve: true,
+      reserveMaxAmount: '1000000',
+    });
+    const replacementPromise = manager.handleSpendingAuth(buyerIdentity.peerId, replacement, mux);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    expect(manager.channelsClient.reserve).toHaveBeenCalledOnce();
+
+    resolveClose('0xclose-hash');
+    await expect(replacementPromise).resolves.toBe('reserved');
+
+    expect(manager.channelsClient.close).toHaveBeenCalledOnce();
+    expect(manager.channelsClient.reserve).toHaveBeenCalledTimes(2);
+    expect(store.getChannel(priorChannelId)!.status).toBe(CHANNEL_STATUS.SETTLED);
+    expect(store.getChannel(replacementChannelId)!.status).toBe(CHANNEL_STATUS.ACTIVE);
+    expect(manager.getChannelByPeer(buyerIdentity.peerId)?.sessionId).toBe(replacementChannelId);
+    expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
+  });
+
   it('closes a zero-spend prior channel before reserving a replacement channel', async () => {
     const priorChannelId = makeChannelId(112);
     const replacementChannelId = makeChannelId(113);


### PR DESCRIPTION
## Description

Closes a seller's durable prior payment channel before accepting a replacement ReserveAuth from the same buyer. This recovers buyers that lost their local channel state without leaving payment negotiation stuck behind an active on-chain channel.

## Release Notes

- Fixed payment negotiation getting stuck when a buyer lost its local channel state while an older channel remained active on-chain.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
