### PR TITLE
chore: weekly blog automation

### DIFF
--- a/.claude/skills/blog-writer/SKILL.md
+++ b/.claude/skills/blog-writer/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: blog-writer
+description: Write a post for the AntSeed blog from an entry in content/blog-queue.yml. Use when the weekly blog workflow runs, or when someone asks to draft, write, or revise an AntSeed blog post. Covers voice, SEO requirements, frontmatter format, internal linking, and the checks a post must pass before it opens a PR.
+---
+
+# AntSeed Blog Writer
+
+Write one post. Make it good enough that a reader who has never heard of AntSeed
+would still bookmark it.
+
+The failure mode this skill exists to prevent is competent, forgettable filler:
+correct facts, neutral tone, nothing anyone would ever link to. Sections
+"Research first" and "Voice" are the whole point. Do not skip them.
+
+---
+
+## Company context (fixed)
+
+AntSeed is a peer-to-peer AI services network. Providers offer inference, agents,
+routers, or TEE-backed environments. Buyers run a local proxy at `localhost:8377`
+that discovers providers over a BitTorrent DHT, scores them, and routes requests
+over encrypted WebRTC connections. No accounts, no signup, no central gatekeeper.
+The API surface is OpenAI and Anthropic compatible, so a base URL swap is usually
+the entire integration.
+
+Audience: English-speaking developers and technical builders. They have shipped
+things. They can smell a pitch.
+
+**Framing rule, non-negotiable.** Payments settle in USDC on Base. That is plumbing,
+not the pitch. Never lead with it. Never mention tokens, tickers, or price. Never
+frame AntSeed as a crypto project. The story is always cost, access, independence
+from a single provider, and open models. If an angle only works as a crypto angle,
+find a different angle.
+
+**Compliance boundary.** AntSeed is for providers building differentiated services.
+Raw resale of API keys or subscription credentials is not permitted and violates
+upstream terms. Never write anything that reads as encouragement to resell a Claude
+Pro or Team subscription. If a post touches provider economics, state the boundary.
+
+---
+
+## Step 0: Load context
+
+Every run, before writing a word.
+
+1. Read the queue entry you were given in `content/blog-queue.yml`. All of it.
+2. `ls apps/website/blog/` and read the frontmatter of the three most recent posts.
+3. Read every post listed in the entry's `must_link`, or at least its opening and
+   its headings. You are going to link to it, so know what it says.
+4. Grep the blog directory for the entry's `primary_keyword`. If an existing post
+   already targets it, stop and say so in the PR description instead of shipping
+   a duplicate. Two pages fighting for one keyword is worse than one page.
+
+---
+
+## Step 1: Research first
+
+Do not write from memory. Model knowledge on pricing, rate limits, model names,
+and protocol status goes stale in weeks, and this space moves faster than most.
+
+- Web search the primary keyword. Read the top three results properly. You are
+  looking for what they all say, so you can say something else.
+- Verify every number you plan to publish against a primary source. Provider
+  pricing pages, official docs, the repo itself, `PRICING.md`,
+  `https://network.antseed.com/stats`.
+- For anything about AntSeed's own behaviour, read the code or the docs. Do not
+  guess at a CLI flag. Run `grep` and find it.
+- If a claim cannot be verified, cut it. Do not hedge it into the post.
+
+Date-sensitive facts get a visible "Verified [Month Year]" note near the claim.
+
+---
+
+## Step 2: Structure
+
+Non-negotiable structure rules, in severity order.
+
+**Answer the query in the first 100 words.** No preamble, no brand throat clearing.
+State the direct answer or the core claim, then elaborate below. Google pulls the
+opening for snippets and so do AI search engines.
+
+**Primary keyword appears in the first paragraph and in at least one H2.** Natural
+placement, once or twice. Keyword stuffing reads as spam to both humans and crawlers.
+
+**No H1 in the body.** Docusaurus renders the frontmatter title as the H1. Start
+the body at H2.
+
+**`<!-- truncate -->` after the intro.** Two to four paragraphs in. This is the
+blog list excerpt, so it must stand alone and make someone click.
+
+**Self-contained paragraphs of 40 to 80 words.** AI search cites passages, not pages.
+Each paragraph should survive being quoted on its own.
+
+**Definition then elaboration.** For every key concept: one crisp sentence defining
+it, then the detail. "[Term] is [definition]. [Elaboration]."
+
+**Structured data as structure.** Comparisons go in tables. Processes go in
+numbered lists. Features go in bullets. Never bury a comparison in prose.
+
+**Questions as headings.** Where a real question exists, make it an H2 or H3 and
+answer it in 40 to 60 words directly underneath. That is the shape a featured
+snippet takes.
+
+**Minimum two internal links**, using the entry's `must_link` list, with descriptive
+anchor text. Never "click here" or "read more". The anchor should describe the
+destination.
+
+**At least one outbound link to a primary source.** Trust signal, and it keeps you
+honest.
+
+---
+
+## Step 3: Voice
+
+Short sentences next to long ones. Break the rhythm on purpose.
+
+- No em dashes. Use `--` if you need a break, or restructure the sentence. This is
+  a house rule, follow it.
+- Banned openers: "In today's world", "In the fast-paced world of", "As we all know".
+- Banned adjectives: game-changing, revolutionary, seamless, cutting-edge, robust,
+  powerful (as a standalone claim).
+- No "In conclusion". End on a thought, not a label.
+- First person plural is fine and encouraged. We built this, we got this wrong once,
+  we think this.
+- Say the uncomfortable thing. Where AntSeed is the wrong tool, write that sentence.
+  A comparison post that finds no case for the competitor is not a comparison post,
+  it is an ad, and readers can tell instantly.
+- Concrete over abstract. "A 70B model needs about 40GB of VRAM at 4-bit" beats
+  "significant hardware requirements".
+
+The strongest post shape found so far: state the thing everyone believes, then show
+where it stops being true. Reach for it when the topic allows.
+
+---
+
+## Step 4: Frontmatter
+
+Exact format. Copy this, fill it in.
+
+```yaml
+---
+slug: <slug from the queue entry, unchanged>
+title: "<50 to 60 characters, primary keyword near the front>"
+authors: [antseed]
+tags: [<4 to 7 tags, reuse existing tags from other posts where they fit>]
+description: <120 to 155 characters, written to earn a click, keyword included>
+keywords: [<primary keyword, then 4 to 6 secondaries from the queue entry>]
+image: /og-image.jpg
+date: <YYYY-MM-DD, today>
+---
+```
+
+Filename: `apps/website/blog/YYYY-MM-DD-<slug>.md`
+
+Character counts are hard limits, not suggestions. Count them. A 170 character
+description gets truncated in results and wastes the click.
+
+---
+
+## Step 5: Self-check before opening the PR
+
+Run `node scripts/blog-lint.mjs apps/website/blog/<filename>` and fix everything
+it flags. If it passes, read the post once more and ask three questions:
+
+1. Would I send this to a developer I respect? If not, what is the boring part?
+2. Is there one sentence in here that no competitor would write? If not, add it.
+3. Did I make a claim I did not verify? Cut it or verify it.
+
+Then update the queue entry's `status` from `queued` to `drafted`.
+
+---
+
+## Step 6: Open the PR
+
+Branch: `blog/<slug>`
+
+PR title: `blog: <title>`
+
+PR body, in this order:
+
+- **Target keyword** and why this angle over the obvious one.
+- **Sources verified**, as a list of URLs, with any number you published and where
+  it came from.
+- **Internal links added**, and any existing post that now deserves a link back to
+  this one. List those as a suggested follow-up, do not edit other posts yourself.
+- **Uncertain**, a short list of anything a human should check before merging.
+  If this section is empty you probably did not look hard enough.
+
+Never merge. Never push to `main`. A human reads it first.

--- a/.github/workflows/blog-autopost.yml
+++ b/.github/workflows/blog-autopost.yml
@@ -1,0 +1,140 @@
+name: Weekly Blog Post
+
+on:
+  schedule:
+    # Tuesdays 07:00 UTC. Gives a human the rest of the week to review and merge.
+    - cron: '0 7 * * 2'
+  workflow_dispatch:
+    inputs:
+      slug:
+        description: 'Force a specific slug from content/blog-queue.yml (optional)'
+        required: false
+        type: string
+  pull_request:
+    paths:
+      - 'apps/website/blog/**'
+
+concurrency:
+  group: weekly-blog-post
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------
+  # Runs on every PR that touches the blog, human-authored or not.
+  # ---------------------------------------------------------------
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm install js-yaml@4 --no-save
+
+      # Only lint what this PR touched. Older posts predate these rules and
+      # would otherwise turn every blog PR red for someone else's mistakes.
+      - name: Lint changed posts
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          FILES=$(git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}"...HEAD \
+                  | grep -E '^apps/website/blog/.*\.mdx?$' || true)
+          if [ -z "$FILES" ]; then
+            echo "no blog posts changed"
+            exit 0
+          fi
+          echo "$FILES"
+          node scripts/blog-lint.mjs $FILES
+
+  # ---------------------------------------------------------------
+  # The weekly writer.
+  # ---------------------------------------------------------------
+  write:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - run: npm install js-yaml@4 --no-save
+
+      - name: Pick the next topic
+        id: pick
+        env:
+          FORCE_SLUG: ${{ inputs.slug }}
+        run: node scripts/blog-next.mjs >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Queue is empty
+        if: steps.pick.outputs.slug == ''
+        run: echo "::warning::content/blog-queue.yml has nothing left with status queued. Add topics."
+
+      - name: Configure git
+        if: steps.pick.outputs.slug != ''
+        run: |
+          git config user.name  "antseed-blog-bot"
+          git config user.email "noreply@antseed.com"
+          git checkout -b "blog/${{ steps.pick.outputs.slug }}"
+
+      - name: Write the post
+        if: steps.pick.outputs.slug != ''
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: >-
+            --max-turns 60
+            --allowed-tools "Read,Write,Edit,Glob,Grep,WebSearch,WebFetch,Bash(node scripts/blog-lint.mjs*),Bash(git add*),Bash(git commit*),Bash(git push*),Bash(gh pr create*),Bash(ls*),Bash(cat*)"
+          prompt: |
+            You are writing this week's AntSeed blog post.
+
+            First, read `.claude/skills/blog-writer/SKILL.md` in full and follow it
+            exactly. It is the specification for this task. Every rule in it applies.
+
+            The queue entry you are writing:
+
+            ```yaml
+            ${{ steps.pick.outputs.entry_yaml }}
+            ```
+
+            Write the post to:
+              apps/website/blog/${{ steps.pick.outputs.filename }}
+
+            Then, in this order:
+
+            1. Run `node scripts/blog-lint.mjs apps/website/blog/${{ steps.pick.outputs.filename }}`
+               and fix every ERROR it reports. Re-run until it exits clean. Address the
+               WARNs too unless you have a specific reason not to, and say what that
+               reason was in the PR body.
+            2. Edit `content/blog-queue.yml` and change the status of the
+               `${{ steps.pick.outputs.slug }}` entry from `queued` to `drafted`.
+               Change nothing else in that file.
+            3. Commit both files on the current branch `blog/${{ steps.pick.outputs.slug }}`
+               and push it.
+            4. Open a draft PR against `main` with `gh pr create --draft`, using the PR
+               body format in Step 6 of the skill.
+
+            Hard rules for this run:
+            - Do not push to `main`. Do not merge anything.
+            - Do not edit any file other than the new post and the queue entry.
+            - Do not invent numbers. Every figure gets verified against a primary
+              source, or it does not get published.
+            - If the lint still fails after a genuine effort, push what you have and
+              say so plainly at the top of the PR body. A visibly broken draft beats
+              a quietly wrong published page.
+
+      - name: Report
+        if: always() && steps.pick.outputs.slug != ''
+        run: |
+          echo "### Weekly blog run" >> "$GITHUB_STEP_SUMMARY"
+          echo "Slug: \`${{ steps.pick.outputs.slug }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Keyword: ${{ steps.pick.outputs.primary_keyword }}" >> "$GITHUB_STEP_SUMMARY"

--- a/content/blog-queue.yml
+++ b/content/blog-queue.yml
@@ -1,0 +1,586 @@
+# AntSeed blog queue
+#
+# The weekly workflow picks the FIRST item with status: queued, writes it,
+# opens a PR, and flips status to drafted. A human merges and sets published.
+#
+# status: queued | drafted | published | skip
+#
+# Clusters:
+#   access      Permissionless / anonymous access        (pillar: anonymous-ai-complete-guide)
+#   cost        Price and model selection                (pillar: cheapest-claude-gpt-api-access)
+#   compare     Competitor comparisons
+#   agents      Agent payments and agentic commerce      (pillar: ai-agent-payments-explained)
+#   supply      Earning as a provider                    (pillar: earn-money-with-gpu-2026)
+#   howto       Integration and practice
+
+posts:
+  # ---------------------------------------------------------------
+  # Deliberately not written. Kept here so nobody adds it back.
+  # ---------------------------------------------------------------
+  - slug: antseed-vs-openrouter
+    status: skip
+    cluster: compare
+    skip_reason: >
+      Two assets already target this keyword: the /vs/openrouter landing page and the
+      blog post "The Permissionless OpenRouter Alternative". A third would split the
+      signal three ways and rank all three worse. If this keyword needs more work,
+      strengthen /vs/openrouter instead. That is the page with commercial intent.
+
+  - slug: anonymous-vs-private-ai
+    status: queued
+    cluster: access
+    pillar: false
+    intent: informational
+    primary_keyword: "anonymous AI vs private AI"
+    secondary_keywords:
+      - "difference between anonymous and private AI"
+      - "what is anonymous AI"
+      - "private AI meaning"
+    title_draft: "Anonymous AI vs Private AI: They Are Not the Same Thing"
+    angle: >
+      Definitional post. Private means nobody reads your prompts. Anonymous means
+      nobody knows they were yours. Most vendors sell the first and imply the second.
+      Build a clean 2x2: identity known/unknown vs content readable/unreadable, and
+      place real categories in it (hosted API, zero-retention API, TEE provider,
+      local model, P2P). This is the definition every other post in the cluster links back to.
+    target_words: 1200
+    must_link:
+      - /blog/use-claude-deepseek-llama-privately
+      - /docs/
+
+  - slug: anonymous-ai-complete-guide
+    status: queued
+    cluster: access
+    pillar: true
+    intent: informational
+    primary_keyword: "anonymous AI"
+    secondary_keywords:
+      - "anonymous AI guide"
+      - "use AI anonymously"
+      - "AI without identity"
+    title_draft: "Anonymous AI: The Complete Guide"
+    angle: >
+      The cluster pillar. Threat models first (who are you hiding from, and why),
+      then every practical option ranked honestly, including the ones where AntSeed
+      is the wrong answer. Local models win on paranoia, lose on capability.
+      Must include a comparison table and a decision tree. This page will get
+      linked from every other access post, so it has to earn it.
+    target_words: 2200
+    must_link:
+      - /blog/anonymous-vs-private-ai
+      - /blog/use-claude-deepseek-llama-privately
+
+  - slug: llm-api-without-kyc
+    status: queued
+    cluster: access
+    pillar: false
+    intent: informational
+    primary_keyword: "LLM API without KYC"
+    secondary_keywords:
+      - "AI API no verification"
+      - "API without identity verification"
+      - "no signup LLM API"
+    title_draft: "How to Use LLM APIs Without KYC"
+    angle: >
+      Why KYC crept into AI APIs at all (fraud, export controls, abuse), which
+      providers require what today, and the legitimate reasons people need to skip it.
+      Be concrete about the tradeoffs of each no-KYC route: free anonymous tiers are
+      rate limited into uselessness, local needs hardware, P2P needs a funded balance.
+    target_words: 1600
+    must_link:
+      - /blog/anonymous-ai-complete-guide
+      - /docs/
+
+  - slug: no-logs-ai-apis-compared
+    status: queued
+    cluster: access
+    pillar: false
+    intent: commercial
+    primary_keyword: "no logs AI API"
+    secondary_keywords:
+      - "zero retention LLM API"
+      - "AI API that does not store prompts"
+      - "no logging inference provider"
+    title_draft: "No-Logs AI APIs Compared: What the Policies Actually Say"
+    angle: >
+      Read the actual retention policies, not the marketing. Table of provider,
+      stated retention window, what survives it (abuse flags, metadata, billing records),
+      and whether the claim is verifiable or just a promise. The honest punchline is that
+      almost none of it is verifiable, which is the argument for architecture over policy.
+    target_words: 1800
+    must_link:
+      - /blog/anonymous-vs-private-ai
+      - /blog/model-verification-fingerprint-swarm
+
+  - slug: cheapest-claude-gpt-api-access
+    status: queued
+    cluster: cost
+    pillar: true
+    intent: commercial
+    primary_keyword: "cheapest way to access Claude and GPT APIs"
+    secondary_keywords:
+      - "cheap Claude API"
+      - "reduce LLM API costs"
+      - "GPT API cheaper alternative"
+    title_draft: "The Cheapest Way to Access Claude and GPT APIs in 2026"
+    angle: >
+      Cost pillar. Break the bill into its parts: base token price, gateway markup,
+      credit purchase fees, wasted tokens from picking an oversized model, retries.
+      Most teams overpay on the last two, not the first. Include a worked example with
+      real numbers from PRICING.md and the public stats endpoint.
+    target_words: 2000
+    must_link:
+      - /blog/which-model-for-which-task
+      - https://antseedstats.com/network
+
+  - slug: which-model-for-which-task
+    status: queued
+    cluster: cost
+    pillar: false
+    intent: informational
+    primary_keyword: "which AI model for which task"
+    secondary_keywords:
+      - "best model for coding"
+      - "best LLM for summarization"
+      - "model selection guide"
+    title_draft: "Which Model for Which Task: A Practical Routing Guide"
+    angle: >
+      Task-to-model table that a person can actually use. Cheap small model for
+      classification and extraction, mid tier for drafting, frontier only for
+      multi step reasoning and hard code. Include the cost delta per task type,
+      because the whole point is that most requests do not need the expensive model.
+    target_words: 1800
+    must_link:
+      - /blog/cheapest-claude-gpt-api-access
+      - /docs/
+
+  - slug: antseed-vs-together-ai
+    status: queued
+    cluster: compare
+    pillar: false
+    intent: commercial
+    primary_keyword: "AntSeed vs Together AI"
+    secondary_keywords:
+      - "Together AI alternative"
+      - "Together AI vs P2P inference"
+    title_draft: "AntSeed vs Together AI: Different Answers to Different Problems"
+    angle: >
+      Together is a hosted inference provider with its own GPUs and an account model.
+      AntSeed is a market with no account. Be genuinely fair, say clearly where Together
+      wins (dedicated endpoints, predictable SLA, enterprise procurement) and where the
+      open market wins (no signup, price competition, no single point of failure).
+    target_words: 1500
+    must_link:
+      - /vs/openrouter
+      - /docs/
+
+  - slug: antseed-vs-venice-ai
+    status: queued
+    cluster: compare
+    pillar: false
+    intent: commercial
+    primary_keyword: "AntSeed vs Venice AI"
+    secondary_keywords:
+      - "Venice AI alternative"
+      - "Venice AI API comparison"
+    title_draft: "AntSeed vs Venice AI: Product Versus Protocol"
+    angle: >
+      Follow up to the existing Venice post, not a rewrite of it. Venice built a
+      polished private AI product with a curated model list. AntSeed is the rails
+      underneath, which means more setup and more control. Respectful throughout,
+      Venice proved the market exists.
+    target_words: 1400
+    must_link:
+      - /blog/the-infrastructure-layer-for-private-ai
+
+  - slug: antseed-vs-litellm
+    status: queued
+    cluster: compare
+    pillar: false
+    intent: commercial
+    primary_keyword: "AntSeed vs LiteLLM"
+    secondary_keywords:
+      - "LiteLLM alternative"
+      - "self hosted LLM gateway vs P2P"
+    title_domain_note: "closest technical comparison, treat carefully"
+    title_draft: "AntSeed vs LiteLLM: Your Own Gateway or an Open Market"
+    angle: >
+      LiteLLM is a proxy you run over keys you already own. AntSeed removes the need
+      to own the keys at all. These solve adjacent problems and can even coexist,
+      so say that. Include the "run both" architecture diagram.
+    target_words: 1500
+    must_link:
+      - /docs/
+      - /vs/openrouter
+
+  - slug: ai-agent-payments-explained
+    status: queued
+    cluster: agents
+    pillar: true
+    intent: informational
+    primary_keyword: "AI agent payments"
+    secondary_keywords:
+      - "how do AI agents pay for compute"
+      - "autonomous agent payments"
+      - "agent payment protocol"
+    title_draft: "AI Agent Payments: How Autonomous Agents Pay for Compute"
+    angle: >
+      Agents cluster pillar. The problem is structural, an agent cannot sign up for an
+      account or hold a credit card. Walk the request lifecycle end to end. Keep the
+      settlement layer as plumbing, the story is autonomy and cost control.
+    target_words: 2000
+    must_link:
+      - /blog/the-402-flow
+      - /blog/ai-infrastructure-bittorrent-not-spotify
+
+  - slug: agents-that-manage-their-own-budgets
+    status: queued
+    cluster: agents
+    pillar: false
+    intent: informational
+    primary_keyword: "AI agent budget management"
+    secondary_keywords:
+      - "agent spending limits"
+      - "AI agent cost control"
+      - "build agent with own budget"
+    title_draft: "Building Agents That Manage Their Own API Budgets"
+    angle: >
+      Practical build post with code. Give the agent a capped balance, per task ceilings,
+      a downgrade path when the budget runs low, and a hard stop. Show the actual config
+      and a small worked agent loop. This one should be genuinely copy pasteable.
+    target_words: 1800
+    must_link:
+      - /blog/ai-agent-payments-explained
+      - /docs/
+
+  - slug: machine-to-machine-payments-stablecoins
+    status: queued
+    cluster: agents
+    pillar: false
+    intent: informational
+    primary_keyword: "machine to machine payments"
+    secondary_keywords:
+      - "M2M payments stablecoins"
+      - "software paying software"
+      - "micropayments for APIs"
+    title_draft: "Machine to Machine Payments: Why Cards Never Worked for Software"
+    angle: >
+      Card rails assume a human, a dispute window, and a minimum viable transaction size.
+      Sub cent per request breaks all three. Explain the economics, not the chain.
+      Frame stablecoins as the settlement detail, never as the headline.
+    target_words: 1600
+    must_link:
+      - /blog/the-402-flow
+      - /blog/ai-agent-payments-explained
+
+  - slug: what-is-agentic-commerce
+    status: queued
+    cluster: agents
+    pillar: false
+    intent: informational
+    primary_keyword: "what is agentic commerce"
+    secondary_keywords:
+      - "agentic commerce definition"
+      - "agent economy"
+      - "agent to agent transactions"
+    title_draft: "What Is Agentic Commerce?"
+    angle: >
+      Straight definitional explainer built for featured snippets and AI citation.
+      One crisp definition in the first 60 words, then the four layers of the stack,
+      then what actually ships today versus what is still a deck slide. Include the
+      honest note that a chunk of current volume is testing, not commerce.
+    target_words: 1400
+    must_link:
+      - /blog/ai-agent-payments-explained
+
+  - slug: agent-payment-protocols-compared
+    status: queued
+    cluster: agents
+    pillar: false
+    intent: commercial
+    primary_keyword: "x402 vs AP2 vs MPP"
+    secondary_keywords:
+      - "agent payment protocols compared"
+      - "x402 alternative"
+      - "agent payment standard"
+    title_draft: "Agent Payment Protocols Compared: x402, AP2, MPP, and What Sits Between Peers"
+    angle: >
+      Comparison table across who the intermediary is, whether a facilitator is required,
+      chain assumptions, and maturity. AntSeed's angle is the facilitator free path, which
+      the existing 402 Flow post already argues, so link there rather than repeating it.
+    target_words: 1800
+    must_link:
+      - /blog/the-402-flow
+
+  - slug: earn-money-with-gpu-2026
+    status: queued
+    cluster: supply
+    pillar: true
+    intent: commercial
+    primary_keyword: "earn money with GPU"
+    secondary_keywords:
+      - "make money with idle GPU"
+      - "rent out GPU for AI"
+      - "GPU passive income 2026"
+    title_draft: "How to Earn Money With Your GPU in 2026"
+    angle: >
+      Supply side pillar. Realistic numbers, no hype. Electricity cost, utilization rate,
+      which cards are actually worth running, and the blunt truth that a single consumer
+      GPU is a side income and not a business. Cover selling frontier API access with
+      added value as the higher margin path, per the compliance rules.
+    target_words: 2000
+    must_link:
+      - /docs/
+      - /providers
+
+  - slug: gpu-mining-vs-ai-inference
+    status: queued
+    cluster: supply
+    pillar: false
+    intent: commercial
+    primary_keyword: "GPU mining vs AI inference"
+    secondary_keywords:
+      - "is AI inference more profitable than mining"
+      - "repurpose mining rig for AI"
+    title_draft: "Idle GPUs: Mining Versus AI Inference"
+    angle: >
+      For the crowd sitting on mining hardware. Different workload shape entirely,
+      inference is bursty and latency sensitive, mining is steady and latency blind.
+      Cover what a mining rig can and cannot serve, VRAM being the usual wall.
+    target_words: 1600
+    must_link:
+      - /blog/earn-money-with-gpu-2026
+
+  - slug: become-a-provider-guide
+    status: queued
+    cluster: supply
+    pillar: false
+    intent: transactional
+    primary_keyword: "sell AI inference"
+    secondary_keywords:
+      - "become an AI inference provider"
+      - "sell GPU compute for AI"
+    title_draft: "Selling Inference on AntSeed: A Setup Walkthrough"
+    angle: >
+      Step by step from install to first payment. Every command verified against the
+      current CLI. Include the pricing decision, the compliance boundary around
+      subscription resale, and what to expect in week one.
+    target_words: 1800
+    must_link:
+      - /docs/commands
+      - /blog/earn-money-with-gpu-2026
+
+  - slug: antseed-best-practices
+    status: queued
+    cluster: howto
+    pillar: false
+    intent: informational
+    primary_keyword: "AntSeed best practices"
+    secondary_keywords:
+      - "AntSeed setup guide"
+      - "AntSeed with Claude Code"
+      - "open source AI tools with AntSeed"
+    title_draft: "AntSeed Best Practices: Getting the Most Out of the Network"
+    angle: >
+      The post existing users will actually thank you for. Provider scoring, fallback
+      behaviour, which open source tools it slots into cleanly, how to debug a slow peer,
+      what to do when a request fails. Written for someone already running the proxy.
+    target_words: 1800
+    must_link:
+      - /docs/
+      - /integrations
+
+  - slug: openai-compatible-api-explained
+    status: queued
+    cluster: howto
+    pillar: false
+    intent: informational
+    primary_keyword: "OpenAI compatible API"
+    secondary_keywords:
+      - "what does OpenAI compatible mean"
+      - "swap base URL LLM"
+      - "drop in OpenAI replacement"
+    title_draft: "What OpenAI-Compatible Actually Means (and Where It Breaks)"
+    angle: >
+      Everyone claims compatibility. Compatibility usually covers chat completions and
+      stops there. Map what commonly breaks, streaming quirks, tool calling shape,
+      system prompt handling, token counting. Useful to anyone, regardless of AntSeed.
+    target_words: 1500
+    must_link:
+      - /docs/
+      - /integrations
+
+  - slug: run-claude-code-without-an-account
+    status: queued
+    cluster: howto
+    pillar: false
+    intent: transactional
+    primary_keyword: "use Claude Code without account"
+    secondary_keywords:
+      - "Claude Code alternative backend"
+      - "point Claude Code at another API"
+      - "ANTHROPIC_BASE_URL"
+    title_draft: "Pointing Claude Code Somewhere Else: A Base URL Walkthrough"
+    angle: >
+      High intent how to. One environment variable, one local proxy, done. Show the
+      before and after, cover the failure modes, and be straight about the compliance
+      boundary. Keep every command copy pasteable and verified.
+    target_words: 1400
+    must_link:
+      - /docs/
+      - /integrations
+
+  - slug: llm-rate-limits-compared
+    status: queued
+    cluster: cost
+    pillar: false
+    intent: commercial
+    primary_keyword: "LLM API rate limits compared"
+    secondary_keywords:
+      - "OpenAI rate limits 2026"
+      - "Anthropic rate limits"
+      - "API rate limit comparison table"
+    title_draft: "LLM API Rate Limits Compared"
+    angle: >
+      Pure reference table, built to get cited by AI search. Provider, tier, RPM, TPM,
+      what unlocks the next tier, and the date the number was checked. Add a dated
+      "last verified" line because this ages fast. Keep opinion minimal.
+    target_words: 1400
+    must_link:
+      - /blog/cheapest-claude-gpt-api-access
+
+  - slug: model-deprecation-survival-guide
+    status: queued
+    cluster: howto
+    pillar: false
+    intent: informational
+    primary_keyword: "AI model deprecation"
+    secondary_keywords:
+      - "model sunset migration"
+      - "what happens when a model is deprecated"
+    title_draft: "Your Model Is Getting Deprecated. Now What?"
+    angle: >
+      Every provider retires models on their own schedule and your prompts were tuned
+      for the old one. Cover the migration checklist, eval before you swap, why pinning
+      a version is a false comfort, and how a multi seller market changes the deadline
+      pressure.
+    target_words: 1500
+    must_link:
+      - /blog/which-model-for-which-task
+
+  - slug: vendor-lock-in-ai-real-cost
+    status: queued
+    cluster: cost
+    pillar: false
+    intent: informational
+    primary_keyword: "AI vendor lock-in"
+    secondary_keywords:
+      - "LLM provider lock in"
+      - "avoid AI vendor lock in"
+      - "cost of switching AI provider"
+    title_draft: "The Real Cost of AI Vendor Lock-In"
+    angle: >
+      Lock in is not the API surface, that part is easy to swap. It is the prompts you
+      tuned, the evals you built, the quirks you worked around, and the pricing you
+      planned around. Quantify it, then talk about what actually reduces it.
+    target_words: 1600
+    must_link:
+      - /blog/the-permissionless-openrouter-alternative
+
+  - slug: tee-inference-explained
+    status: queued
+    cluster: access
+    pillar: false
+    intent: informational
+    primary_keyword: "TEE inference"
+    secondary_keywords:
+      - "confidential computing AI"
+      - "trusted execution environment LLM"
+      - "attestation AI inference"
+    title_draft: "TEE Inference Explained: Trust That Does Not Require Trust"
+    angle: >
+      What a trusted execution environment actually proves, what it does not, and why
+      attestation matters more than the marketing badge. Honest about the limits,
+      side channels exist and the hardware vendor is still in your trust boundary.
+    target_words: 1600
+    must_link:
+      - /blog/anonymous-vs-private-ai
+      - /blog/model-verification-fingerprint-swarm
+
+  - slug: verify-the-model-you-paid-for
+    status: queued
+    cluster: howto
+    pillar: false
+    intent: informational
+    primary_keyword: "verify AI model identity"
+    secondary_keywords:
+      - "is my API serving the model it claims"
+      - "model substitution detection"
+      - "quantized model swap"
+    title_draft: "How to Check You Got the Model You Paid For"
+    angle: >
+      Practical companion to the existing verification post. Give readers actual probes
+      they can run themselves, fingerprint prompts, latency signatures, token
+      distribution checks. Then explain why a network level solution beats DIY.
+    target_words: 1500
+    must_link:
+      - /blog/model-verification-fingerprint-swarm
+
+  - slug: self-hosted-vs-gateway-vs-p2p
+    status: queued
+    cluster: compare
+    pillar: false
+    intent: commercial
+    primary_keyword: "self hosted vs managed LLM gateway"
+    secondary_keywords:
+      - "AI gateway architecture comparison"
+      - "LLM routing architecture"
+    title_draft: "Self-Hosted, Managed Gateway, or Open Market: Picking an Inference Architecture"
+    angle: >
+      Decision framework rather than a pitch. Four columns, who holds the keys, who
+      sees the traffic, who is the single point of failure, what breaks at scale.
+      Say plainly which situations do not call for AntSeed.
+    target_words: 1800
+    must_link:
+      - /blog/antseed-vs-litellm
+      - /vs/openrouter
+
+  - slug: ai-access-geo-restrictions
+    status: queued
+    cluster: access
+    pillar: false
+    intent: informational
+    primary_keyword: "AI API blocked country"
+    secondary_keywords:
+      - "OpenAI not available in my country"
+      - "AI geo restrictions"
+      - "access LLM API from restricted region"
+    title_draft: "When the AI API Is Not Available in Your Country"
+    angle: >
+      Why geo blocking exists (export controls, sanctions, payment processing, licensing),
+      which regions are affected, and what the legitimate options are. Careful, factual
+      tone. Do not give sanctions evasion advice, do explain the developer reality.
+    target_words: 1600
+    must_link:
+      - /blog/llm-api-without-kyc
+      - /blog/anonymous-ai-complete-guide
+
+  - slug: private-llm-api-options-2026
+    status: queued
+    cluster: access
+    pillar: false
+    intent: commercial
+    primary_keyword: "private LLM API"
+    secondary_keywords:
+      - "private AI API 2026"
+      - "confidential LLM API options"
+    title_draft: "Private LLM API Options in 2026"
+    angle: >
+      Roundup with a clear rubric applied consistently to every option. Publish the
+      rubric before the list so it does not read as a rigged scorecard. Heavy overlap
+      risk with the no-logs post, so this one leans on architecture categories while
+      that one leans on policy text. Check the published no-logs post before writing.
+    target_words: 1800
+    must_link:
+      - /blog/no-logs-ai-apis-compared
+      - /blog/anonymous-ai-complete-guide

--- a/scripts/blog-lint.mjs
+++ b/scripts/blog-lint.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * SEO and house-style linter for AntSeed blog posts.
+ *
+ * Usage:
+ *   node scripts/blog-lint.mjs apps/website/blog/2026-08-04-some-post.md
+ *   node scripts/blog-lint.mjs            # lints every post in the blog dir
+ *
+ * Exit 1 on any ERROR. WARNs are printed and do not fail the build.
+ *
+ * This is the guard between an AI draft and a live page. Keep it strict.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import yaml from 'js-yaml';
+
+const BLOG_DIR = join(process.cwd(), 'apps', 'website', 'blog');
+
+const BANNED_PHRASES = [
+  'in today\'s world',
+  'in the fast-paced world',
+  'in conclusion',
+  'as we all know',
+  'game-changing',
+  'game changer',
+  'revolutionary',
+  'cutting-edge',
+  'seamlessly',
+  'it is important to note',
+  'delve into',
+  'in the realm of',
+  'unlock the power',
+];
+
+const REQUIRED_FM = ['slug', 'title', 'authors', 'tags', 'description', 'keywords', 'image', 'date'];
+
+let errors = 0;
+let warnings = 0;
+
+const err = (file, msg) => { console.error(`ERROR  ${basename(file)}: ${msg}`); errors++; };
+const warn = (file, msg) => { console.warn(`WARN   ${basename(file)}: ${msg}`); warnings++; };
+
+function parse(file) {
+  const raw = readFileSync(file, 'utf8');
+  const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  if (!m) return null;
+  return { fm: yaml.load(m[1]), body: m[2], raw };
+}
+
+function wordsOf(text) {
+  return text
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/[#>*_`|-]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function lint(file) {
+  const parsed = parse(file);
+  if (!parsed) { err(file, 'no valid YAML frontmatter block'); return; }
+  const { fm, body } = parsed;
+
+  // --- frontmatter ---
+  for (const key of REQUIRED_FM) {
+    if (fm[key] === undefined || fm[key] === null || fm[key] === '') {
+      err(file, `frontmatter missing "${key}"`);
+    }
+  }
+
+  if (fm.title) {
+    const len = String(fm.title).length;
+    if (len > 60) err(file, `title is ${len} chars, max 60 (gets truncated in results)`);
+    else if (len < 30) warn(file, `title is only ${len} chars, aim for 50 to 60`);
+  }
+
+  if (fm.description) {
+    const len = String(fm.description).length;
+    if (len > 155 || len < 120) {
+      err(file, `description is ${len} chars, must be 120 to 155`);
+    }
+  }
+
+  if (Array.isArray(fm.keywords) && fm.keywords.length < 3) {
+    warn(file, `only ${fm.keywords.length} keywords, aim for 5 to 7`);
+  }
+  if (Array.isArray(fm.tags) && (fm.tags.length < 3 || fm.tags.length > 8)) {
+    warn(file, `${fm.tags.length} tags, aim for 4 to 7`);
+  }
+
+  // filename must agree with slug and date
+  const fname = basename(file);
+  if (fm.slug && !fname.includes(fm.slug)) {
+    err(file, `filename does not contain the slug "${fm.slug}"`);
+  }
+  if (fm.date) {
+    // js-yaml turns an unquoted YYYY-MM-DD into a Date object, so normalise both cases
+    const d = fm.date instanceof Date
+      ? fm.date.toISOString().slice(0, 10)
+      : String(fm.date).slice(0, 10);
+    if (!fname.startsWith(d)) err(file, `filename date does not match frontmatter date ${d}`);
+  }
+
+  // --- body structure ---
+  if (!body.includes('<!-- truncate -->')) {
+    err(file, 'missing <!-- truncate --> marker');
+  } else {
+    const intro = body.split('<!-- truncate -->')[0];
+    const introWords = wordsOf(intro).length;
+    if (introWords < 40) warn(file, `intro before truncate is only ${introWords} words`);
+    if (introWords > 220) warn(file, `intro before truncate is ${introWords} words, that is a lot for an excerpt`);
+
+    // primary keyword should show up early
+    const first100 = wordsOf(intro).slice(0, 100).join(' ').toLowerCase();
+    const kw = Array.isArray(fm.keywords) ? String(fm.keywords[0] || '').toLowerCase() : '';
+    if (kw) {
+      const kwWords = kw.split(/\s+/).filter((w) => w.length > 3);
+      const hit = kwWords.length > 0 && kwWords.every((w) => first100.includes(w));
+      if (!hit) warn(file, `primary keyword "${kw}" not clearly in the first 100 words`);
+    }
+  }
+
+  if (/^# /m.test(body)) {
+    err(file, 'body contains an H1, Docusaurus renders the frontmatter title as H1');
+  }
+
+  const h2s = body.match(/^## /gm) || [];
+  if (h2s.length < 3) warn(file, `only ${h2s.length} H2 sections, thin structure`);
+
+  // heading level skips
+  const levels = [...body.matchAll(/^(#{2,6}) /gm)].map((m) => m[1].length);
+  for (let i = 1; i < levels.length; i++) {
+    if (levels[i] - levels[i - 1] > 1) {
+      warn(file, 'heading levels skip a level somewhere, H2 then H4');
+      break;
+    }
+  }
+
+  // --- links ---
+  const links = [...body.matchAll(/\[([^\]]+)\]\(([^)]+)\)/g)];
+  const internal = links.filter((l) => l[2].startsWith('/') || l[2].includes('antseed.com'));
+  const external = links.filter((l) => l[2].startsWith('http') && !l[2].includes('antseed.com'));
+
+  if (internal.length < 2) err(file, `only ${internal.length} internal links, minimum 2`);
+  if (external.length < 1) warn(file, 'no outbound links to a primary source');
+
+  for (const l of links) {
+    if (/^(click here|read more|here|this|link|this article)$/i.test(l[1].trim())) {
+      err(file, `non-descriptive anchor text: "${l[1]}"`);
+    }
+  }
+
+  // --- house style ---
+  if (body.includes('\u2014')) {
+    err(file, 'em dash found, house style uses -- or a restructured sentence');
+  }
+
+  const lower = body.toLowerCase();
+  for (const phrase of BANNED_PHRASES) {
+    if (lower.includes(phrase)) err(file, `banned phrase: "${phrase}"`);
+  }
+
+  // crypto framing guard
+  const cryptoHits = ['tokenomics', 'to the moon', 'hodl', 'airdrop', 'price action', 'market cap']
+    .filter((t) => lower.includes(t));
+  if (cryptoHits.length) {
+    warn(file, `crypto framing detected (${cryptoHits.join(', ')}), confirm this is intentional`);
+  }
+
+  // --- length ---
+  const count = wordsOf(body).length;
+  if (count < 800) err(file, `${count} words, minimum 800`);
+  else if (count < 1200) warn(file, `${count} words, most cluster posts should clear 1200`);
+
+  if (errors === 0) console.log(`ok     ${basename(file)}  (${count} words, ${h2s.length} H2, ${internal.length} internal links)`);
+}
+
+// --- duplicate slug / keyword check across the whole blog ---
+function crossCheck(files) {
+  const slugs = new Map();
+  const kws = new Map();
+  for (const f of files) {
+    const p = parse(f);
+    if (!p) continue;
+    const { fm } = p;
+    if (fm.slug) {
+      if (slugs.has(fm.slug)) err(f, `duplicate slug, also used by ${basename(slugs.get(fm.slug))}`);
+      slugs.set(fm.slug, f);
+    }
+    const kw = Array.isArray(fm.keywords) ? String(fm.keywords[0] || '').toLowerCase().trim() : '';
+    if (kw) {
+      if (kws.has(kw)) {
+        warn(f, `primary keyword "${kw}" also targeted by ${basename(kws.get(kw))}, possible cannibalization`);
+      }
+      kws.set(kw, f);
+    }
+  }
+}
+
+const args = process.argv.slice(2);
+let files;
+
+if (args.length) {
+  files = args;
+} else {
+  if (!existsSync(BLOG_DIR)) { console.error(`no blog dir at ${BLOG_DIR}`); process.exit(1); }
+  files = readdirSync(BLOG_DIR)
+    .filter((f) => f.endsWith('.md') || f.endsWith('.mdx'))
+    .map((f) => join(BLOG_DIR, f));
+}
+
+for (const f of files) lint(f);
+
+// cross-check always runs against the full directory
+if (existsSync(BLOG_DIR)) {
+  crossCheck(
+    readdirSync(BLOG_DIR)
+      .filter((f) => f.endsWith('.md') || f.endsWith('.mdx'))
+      .map((f) => join(BLOG_DIR, f))
+  );
+}
+
+console.log(`\n${errors} error(s), ${warnings} warning(s)`);
+process.exit(errors > 0 ? 1 : 0);

--- a/scripts/blog-next.mjs
+++ b/scripts/blog-next.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Picks the next post to write from content/blog-queue.yml.
+ *
+ * Order: FORCE_SLUG if set, otherwise the first entry with status: queued.
+ * Emits GitHub Actions outputs. Exits 0 with an empty slug if nothing is queued,
+ * so an empty queue is a no-op rather than a red build.
+ *
+ * Usage: node scripts/blog-next.mjs
+ */
+
+import { readFileSync, appendFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import yaml from 'js-yaml';
+
+const QUEUE_PATH = join(process.cwd(), 'content', 'blog-queue.yml');
+const BLOG_DIR = join(process.cwd(), 'apps', 'website', 'blog');
+
+function out(key, value) {
+  const file = process.env.GITHUB_OUTPUT;
+  const str = String(value ?? '');
+  if (file) {
+    // multiline-safe heredoc form
+    const delim = `EOF_${key}_${Math.random().toString(36).slice(2)}`;
+    appendFileSync(file, `${key}<<${delim}\n${str}\n${delim}\n`);
+  }
+  console.log(`${key} = ${str.split('\n')[0].slice(0, 120)}`);
+}
+
+if (!existsSync(QUEUE_PATH)) {
+  console.error(`queue not found at ${QUEUE_PATH}`);
+  process.exit(1);
+}
+
+const queue = yaml.load(readFileSync(QUEUE_PATH, 'utf8'));
+const posts = queue?.posts ?? [];
+
+if (!Array.isArray(posts) || posts.length === 0) {
+  console.log('queue is empty');
+  out('slug', '');
+  process.exit(0);
+}
+
+const force = (process.env.FORCE_SLUG || '').trim();
+let entry;
+
+if (force) {
+  entry = posts.find((p) => p.slug === force);
+  if (!entry) {
+    console.error(`slug "${force}" is not in the queue`);
+    process.exit(1);
+  }
+} else {
+  entry = posts.find((p) => p.status === 'queued');
+}
+
+if (!entry) {
+  console.log('nothing with status: queued left in the queue');
+  out('slug', '');
+  process.exit(0);
+}
+
+// Guard: refuse to write over an existing post with the same slug.
+if (existsSync(BLOG_DIR)) {
+  const { readdirSync } = await import('node:fs');
+  const clash = readdirSync(BLOG_DIR).some((f) => f.includes(entry.slug));
+  if (clash && !force) {
+    console.error(`a post for "${entry.slug}" already exists in ${BLOG_DIR}`);
+    console.error('set its queue status to published, or use workflow_dispatch with a forced slug');
+    process.exit(1);
+  }
+}
+
+const today = new Date().toISOString().slice(0, 10);
+
+out('slug', entry.slug);
+out('filename', `${today}-${entry.slug}.md`);
+out('date', today);
+out('primary_keyword', entry.primary_keyword ?? '');
+out('title_draft', entry.title_draft ?? '');
+out('entry_yaml', yaml.dump(entry, { lineWidth: 100 }));


### PR DESCRIPTION
Weekly blog automation: a scheduled workflow picks the next topic from a YAML queue, drafts a Docusaurus post via `claude-code-action`, lints it for SEO and house style, and opens a PR for a human to merge.

Runs Tuesdays at 07:00 UTC (`cron: 0 7 * * 2`), plus `workflow_dispatch` and `pull_request`.

## Files added (5)

| File | Purpose |
| --- | --- |
| `.github/workflows/blog-autopost.yml` | Scheduled workflow; two jobs, `lint` and `write` |
| `.claude/skills/blog-writer/SKILL.md` | House style + SEO rules, read by the workflow at runtime |
| `content/blog-queue.yml` | Topic queue; ordering and the single skip entry are deliberate |
| `scripts/blog-next.mjs` | Picks the next `status: queued` entry, emits Actions outputs |
| `scripts/blog-lint.mjs` | SEO and house-style linter; exits non-zero on errors |

`content/` is a **new top-level directory** in this repo. `scripts/` already exists and gains two files.

This PR adds five files and modifies nothing. `package.json` and `pnpm-lock.yaml` are untouched — `js-yaml` was installed with `--no-save` for local verification only.

## Verification

**Picker** (`node scripts/blog-next.mjs`) selects `anonymous-vs-private-ai` → `2026-07-29-anonymous-vs-private-ai.md`, and emits the full multi-line `entry_yaml` to `GITHUB_OUTPUT` via the heredoc form.

**Linter** (`node scripts/blog-lint.mjs`) exits **1** against the existing blog. This is expected and is the point: it is flagging genuine problems in posts that already shipped, which proves the linter reads real files rather than passing vacuously. Full output:

```
WARN   2026-03-02-the-infrastructure-layer-for-private-ai.md: primary keyword "private ai network" not clearly in the first 100 words
WARN   2026-03-02-the-infrastructure-layer-for-private-ai.md: no outbound links to a primary source
ERROR  2026-03-02-the-infrastructure-layer-for-private-ai.md: 798 words, minimum 800
ERROR  2026-03-03-use-claude-deepseek-llama-privately.md: title is 66 chars, max 60 (gets truncated in results)
ERROR  2026-03-03-use-claude-deepseek-llama-privately.md: description is 203 chars, must be 120 to 155
WARN   2026-03-03-use-claude-deepseek-llama-privately.md: primary keyword "use claude without account" not clearly in the first 100 words
WARN   2026-03-03-use-claude-deepseek-llama-privately.md: no outbound links to a primary source
WARN   2026-03-03-use-claude-deepseek-llama-privately.md: 1196 words, most cluster posts should clear 1200
WARN   2026-07-17-announcing-antseed-non-profit-foundation.md: only 2 keywords, aim for 5 to 7
ERROR  2026-07-17-announcing-antseed-non-profit-foundation.md: only 1 internal links, minimum 2
WARN   2026-07-17-announcing-antseed-non-profit-foundation.md: no outbound links to a primary source
ERROR  2026-07-17-announcing-antseed-non-profit-foundation.md: 676 words, minimum 800

5 error(s), 7 warning(s)
```

These pre-existing SEO issues are **not** fixed here — that is a separate follow-up PR.

## Before the first run

- `CLAUDE_CODE_OAUTH_TOKEN` is present as a **repo-level** secret (set 2026-05-06), already used by `claude.yml`.
- Workflow permissions could not be read with the current token (HTTP 403 on the Actions permissions API). A maintainer should confirm **Settings → Actions → General → Workflow permissions** is set to *Read and write permissions* with *Allow GitHub Actions to create and approve pull requests* enabled, or the `write` job cannot open its PR.

The workflow has not been triggered; the first run is intended to be started manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
