### PR TITLE
blog: Anonymous AI vs Private AI: Not the Same Thing

### DIFF
--- a/apps/website/blog/2026-07-29-anonymous-vs-private-ai.md
+++ b/apps/website/blog/2026-07-29-anonymous-vs-private-ai.md
@@ -1,0 +1,78 @@
+---
+slug: anonymous-vs-private-ai
+title: "Anonymous AI vs Private AI: Not the Same Thing"
+authors: [antseed]
+tags: [privacy, anonymous AI, private AI, P2P, TEE, AI infrastructure]
+description: "Private AI means nobody can read your prompts. Anonymous AI means nobody knows they were yours. Most vendors sell one and quietly imply the other."
+keywords: [anonymous AI vs private AI, difference between anonymous and private AI, what is anonymous AI, private AI meaning, private vs anonymous AI, AI privacy]
+image: /og-image.jpg
+date: 2026-07-29
+---
+
+Private and anonymous are not the same property, and the difference decides whether a tool actually protects you.
+
+Anonymous AI vs private AI comes down to two separate questions. Private means nobody can read the content of your prompts. Anonymous means nobody can tie those prompts back to you. A service can be one without the other. Most vendors sell the first and let you assume the second, which is how people end up trusting a product that never promised the thing they cared about.
+
+So before you pick a tool, it helps to know which of the two you are actually buying.
+
+<!-- truncate -->
+
+## The two questions that actually matter
+
+Every AI privacy claim collapses into two independent axes. The first: can whoever runs the model read what you sent? The second: do they know it was you who sent it? Content and identity. They vary independently, and almost every confused privacy debate is really two people arguing about different axes without noticing.
+
+Private AI is about the content axis. A private service cannot read the plaintext of your prompt, or contractually will not, or technically is prevented from doing so. Anonymous AI is about the identity axis. An anonymous service may read your prompt in full but has no idea whose prompt it is. Neither property implies the other.
+
+## A 2x2 that sorts the whole market
+
+Put content on one axis and identity on the other, and every real product lands in one of four boxes. This is the map worth keeping in your head.
+
+| | Content readable by provider | Content unreadable by provider |
+|---|---|---|
+| **Identity known** | Hosted consumer chatbot | Enterprise deployment in your own cloud |
+| **Identity unknown** | P2P inference, standard provider | TEE provider, or a local model on your own machine |
+
+A hosted consumer chatbot knows your account and can read every message. That is the top-left, and it is where most people spend their time. A local model on your own hardware is the opposite corner: nobody else sees the content and nobody else knows you ran it. Everything interesting happens in the two off-diagonal boxes, because that is where a product gives you one property and it is easy to assume you got both.
+
+## What "private AI" usually means
+
+When a vendor says private AI, they almost always mean the content axis, and usually in the enterprise sense: your data is not used for training, retention is short, and access is controlled. That is a real and useful guarantee. It is also fully compatible with knowing exactly who you are.
+
+Take a standard hosted API. By default OpenAI retains API inputs and outputs for up to 30 days for abuse monitoring, then deletes them, and does not train on API data. Zero-retention is available, but only on approval for qualifying enterprise use cases and eligible endpoints. OpenAI documents this in its [data controls guide](https://developers.openai.com/api/docs/guides/your-data). That is private in a meaningful sense. It is not anonymous in any sense: every request is tied to a billing account, which is tied to you.
+
+## What "anonymous AI" means
+
+Anonymous AI is about the identity axis. The service processes your request without knowing, or being able to prove, that the request came from you specifically. No account, no email, no billing record that links a prompt to a person.
+
+Here is the part vendors gloss over. Anonymous does not mean the content is protected. A provider serving an anonymous request can still read every word of the prompt. They just cannot attach a name to it. For a lot of threat models that is exactly enough. For a journalist protecting a source, being unlinkable matters more than the provider theoretically seeing the text. For someone pasting a database schema, it is the reverse.
+
+## Where the two come apart
+
+The uncomfortable truth is that you frequently get one and not the other, and the marketing rarely tells you which.
+
+- A **zero-retention API** protects content reasonably well and leaves identity fully exposed. Good for a company that trusts the vendor but has a data-handling policy. Useless if the risk is that anyone can prove you asked the question.
+- An **anonymous relay** in front of a normal model protects identity and does nothing for content. The relay operator, or the model host, still reads the prompt.
+- A **local model** gives you both, and costs you the ability to run frontier models you cannot fit on your own hardware. A 70B model needs roughly 40GB of VRAM at 4-bit, and the strongest closed models you cannot run locally at all.
+- A **TEE provider** aims for both over the network: the request runs inside a hardware enclave that even the operator cannot read into, with cryptographic attestation instead of a promise.
+
+This is also where we will say the unglamorous thing. If your actual requirement is a signed data-processing agreement, audit logs, and a named vendor your compliance team can subpoena, an anonymous network is the wrong tool. Anonymity and accountability trade against each other on purpose. A private enterprise deployment beats an anonymous one when what you need is a paper trail.
+
+## Where AntSeed sits on the map
+
+AntSeed is a peer-to-peer network, so anonymity is structural rather than a policy. There is no account, no signup, and requests reach providers without carrying your identity. That puts the default experience in the bottom-left box: identity unknown, content readable by whichever provider serves the request.
+
+To move up into the "content unreadable" row, the network supports TEE providers, where inference runs inside an attested enclave the operator cannot read. That combination, unlinkable and unreadable over the network, is the corner that is hard to reach any other way. If you want the practical walkthrough, we covered how to [run frontier models with no account or identity attached](/blog/use-claude-deepseek-llama-privately), and the fastest path is to [install the local proxy](/docs/install) and route through it.
+
+## How to check which one a vendor actually gives you
+
+Do not take the word on the landing page. Each axis has a concrete test you can apply in a few minutes.
+
+For the content axis, read the retention terms, not the tagline. Look for a specific number and a specific default: how long inputs are kept, whether that applies to your plan or only to enterprise agreements, and whether "we don't train on your data" is quietly separate from "we don't store it." Those are two different promises and vendors often keep one while implying both.
+
+For the identity axis, look at what the signup demands. If it needs an email, a phone number, or a card before the first request, your prompts are linkable to you by construction, no matter how strong the content guarantees are. Real anonymity shows up as the absence of an account, not as a privacy policy that says nice things about the account you had to create.
+
+## Which one do you actually need?
+
+Decide by naming your risk in one sentence. If it is "someone could read what I asked," you need the content axis: a local model, a TEE provider, or at minimum a zero-retention agreement. If it is "someone could prove I asked it," you need the identity axis: an anonymous path with no account behind it. If it is both, you are looking for the unreadable-and-unlinkable corner, and you should not settle for a product that only ships one of them.
+
+The vocabulary matters because the failure is silent. Nobody discovers they bought anonymity when they needed privacy until the moment the content leaks, and by then the distinction they skipped over is the whole story.


### PR DESCRIPTION
Adds one file: `apps/website/blog/2026-07-29-anonymous-vs-private-ai.md`. No other changes.

Definitional post separating "private" (nobody can read your prompts) from "anonymous" (nobody knows they were yours), with a 2x2 placing hosted API, zero-retention API, TEE, local model, and P2P.

**Lint:** 0 errors, 0 warnings (1279 words, 8 H2, 2 internal links).
**Internal links:** `/blog/use-claude-deepseek-llama-privately`, `/docs/install`.
**Outbound source:** OpenAI data controls guide.