### PR TITLE
blog: Trust Without a Middleman — How AntSeed Security and Anonymity Work

### DIFF
--- a/apps/website/blog/2026-07-31-trust-without-a-middleman.md
+++ b/apps/website/blog/2026-07-31-trust-without-a-middleman.md
@@ -1,0 +1,88 @@
+---
+slug: trust-without-a-middleman
+title: "Trust Without a Middleman: How AntSeed's Security and Anonymity Actually Work"
+authors: [antseed]
+tags: [security, privacy, anonymous AI, P2P, TEE, reputation, ANTS]
+description: "How AntSeed's security architecture works and what anonymous by design actually means in practice — including where the boundaries are."
+keywords: [AntSeed security, anonymous AI, AI privacy architecture, P2P AI network, TEE inference, on-chain reputation, recognized usage, payment channels, model verification]
+image: /og-image.jpg
+date: 2026-07-31
+---
+
+Every centralized AI platform asks you for the same things: an account, a payment card, and blind trust that whatever you send through their servers is handled well. AntSeed is built on a different premise — that you shouldn't have to trust a company, because there is no company sitting between you and the AI you're using.
+
+That's a strong claim, and strong claims deserve scrutiny. This post walks through how AntSeed's security architecture works and what "anonymous by design" actually means in practice — including where the boundaries are. If you want the full technical detail, every section links to the protocol documentation.
+
+<!-- truncate -->
+
+## No account is not a feature. It's the architecture.
+
+On a centralized platform, your identity is a row in a database: email, payment method, request history, all tied together. Anonymity on such a platform is a policy — something the operator promises, and can change.
+
+AntSeed has no such database because there is nothing to put one in. There is no sign-up, no central account, and no platform-issued API key. Your identity on the network is simply a cryptographic keypair generated on your own machine. The address derived from that key is how peers recognize you — and it's connected to nothing else: no name, no email, no card.
+
+When you want AI inference, your node finds providers through a distributed hash table (the same class of decentralized directory that powers BitTorrent), picks one based on price, speed, reputation, or privacy preferences, and connects to it directly. Your request travels over an encrypted, direct peer-to-peer connection — WebRTC, the same encrypted transport used for secure video calling — from your machine to the provider's. There is no platform in the middle to read it, log it, or build a profile from it.
+
+This is the key distinction: on AntSeed, privacy is *structural*, not promised. A centralized aggregator sees every request from every user, and you must trust its retention policy. On AntSeed, there is no position in the network from which anyone could collect all requests, because requests never converge on a single point.
+
+Details: [Peer Discovery](/docs/discovery) · [Transport](/docs/transport)
+
+## Paying without identifying yourself
+
+Payments are usually where anonymity dies — cards and bank accounts are identity. AntSeed replaces them with USDC (a dollar-pegged stablecoin) settled on-chain, per request, directly to the provider's wallet. No card, no billing account, no payment processor holding your details.
+
+The payment design is also where the security thinking shows most clearly:
+
+**Your money and your identity are kept apart.** The key your node uses to sign messages never holds your funds. Instead, a separate wallet you control — which can be a hardware wallet — deposits USDC into an on-chain escrow contract, then steps out of the picture entirely. If your node were ever compromised, the attacker's maximum reach is the balance you chose to deposit — never the wallet behind it. Your node also never needs to hold gas or submit transactions itself.
+
+**Sessions are budgeted and time-boxed.** Before a provider can charge you anything, you sign an authorization that names that specific provider, caps the maximum amount, and expires at a deadline. First-time sessions with an unknown provider are hard-capped at $1, so neither side risks much on a stranger.
+
+**You approve spending step by step.** As requests flow, you sign cumulative spending authorizations — cryptographic vouchers that say "I approve up to this total." The provider can only ever collect what you've actually signed for. If a provider disappears mid-session, a built-in timeout lets you reclaim your locked funds after a short grace period.
+
+**Both sides keep receipts.** Usage is measured independently by buyer and provider, with signed receipts exchanged after each request. If the two measurements diverge by more than a set threshold, the transaction is flagged as disputed and the buyer is protected.
+
+Details: [Payments](/docs/payments) · [Security](/docs/security)
+
+## Trusting a stranger's hardware: reputation and TEEs
+
+An open network means anyone can become a provider — which raises the obvious question: why would you trust one?
+
+Two mechanisms answer it. The first is **an on-chain track record that can't be faked** — what the protocol calls *recognized usage*. Every payment a provider collects is backed by a buyer-signed spending authorization, and every settlement is recorded on-chain against the provider's identity: completed sessions, settled volume, and "ghost" sessions where the provider took a reservation and never delivered. Providers also put real weight behind their identity: each one backs a pool of staked ANTS, the network's token — their own stake plus ANTS that supporters lock behind them — and usage only counts as recognized when genuine stake stands behind the provider serving it. The network's weekly ANTS emissions are then distributed against this recognized usage, so a provider's income and standing both trace back to the same thing: a history of real, paid, buyer-authorized work. None of it can be self-reported, inflated, or erased. Buyers and routers read these on-chain records to score and select providers automatically.
+
+The second is **hardware-level privacy for sensitive work**. Some providers run inside Trusted Execution Environments (TEEs) — secure hardware enclaves that can cryptographically prove what code they're running and shield the data being processed even from the machine's own operator. When your work is sensitive, you can route only to TEE-attested providers, reducing what even the provider themselves can see of your request.
+
+Details: [Reputation](/docs/reputation) · [Seller Pools: The Trust Layer for AntSeed](/blog/seller-pools-reputation-tokenomics)
+
+## Is it really the model you paid for? Signed responses and black-box fingerprints
+
+There's a quieter fraud problem in the AI market that most platforms don't talk about: an API that says "premium frontier model" on the label can silently serve you something cheaper — a quantized substitute, a different model entirely — and pocket the difference. Independent audits of shadow APIs have shown this is happening in the wild. On a centralized platform, your only recourse is trusting the brand. On an open network, that's not good enough — so AntSeed is building a verification layer to replace trust with evidence.
+
+The first piece is already shipped: **ResponseAuth**, signed response provenance. On supported connections, the provider cryptographically signs each response — committing to the exact request, the exact response bytes, the service advertised, and timing. Your node verifies the signature and keeps a sample of the evidence locally. This doesn't yet prove *which model* answered, but it proves something crucial: the provider can never deny having served those exact bytes. It turns a complaint into evidence.
+
+On top of that attribution layer comes **black-box model fingerprinting**. Every model family has behavioral tells — where its knowledge ends, how it responds to unusual tokens, how its answers shift under small input changes. A suite of independent fingerprint tests, drawn from published academic research, can probe a provider's endpoint and flag when the responses don't match the claimed model. No single test is a verdict, but signals compound: a strong mismatch, backed by signed response evidence, is something your node can act on — automatically routing away from providers that don't deliver what they advertise.
+
+And in keeping with the rest of the architecture, public fingerprint packs will be distributed like torrents — signed, content-addressed bundles that any peer can mirror and verify — rather than through a central database someone would have to trust or could tamper with.
+
+Details: [Model Verification Needs More Than a Label](/blog/model-verification-fingerprint-swarm) · [Model-verification spec](https://github.com/AntSeed/antseed/blob/main/docs/protocol/spec/07-model-verification.md)
+
+## What anonymity here does — and doesn't — mean
+
+Trust requires honesty about limits, so here are AntSeed's, stated plainly — the same way the [light paper](/docs/lightpaper) states them.
+
+AntSeed's anonymity is *architectural*: no central account, no platform API key, no centralized chat database, and no aggregator reading your traffic. What it is not is a promise that every piece of data is invisible to every participant:
+
+- **The provider serving your request processes your request.** That's inherent to inference anywhere. The difference is that you choose the provider — including TEE-attested ones — rather than having one imposed on you. Providers are independent operators with their own data practices.
+- **On-chain activity is public.** Settlements are visible on the blockchain, tied to your pseudonymous address. That address links to your real identity only if you connect it yourself — but blockchain analysis is a real discipline, and users with strong anonymity needs should treat their funding path accordingly.
+- **Network-level metadata exists.** Direct peer-to-peer connections mean the provider you connect to can see your IP address, as with any direct internet connection.
+
+The practical guidance is simple: match the route to the sensitivity of the work. For everyday use, no account and no central log is already a major step up from centralized platforms. For sensitive work — the law firms, healthcare teams, and journalists the network is partly built for — prefer TEE-attested providers and be deliberate about your wallet hygiene.
+
+## Why the openness matters
+
+Everything described above is inspectable. The protocol implementation is [open source on GitHub](https://github.com/AntSeed/antseed), the smart contracts are deployed and verified on Base (addresses published in the [payments documentation](/docs/payments)), and the full protocol specification is public. You don't have to take any of this post on faith — and that's precisely the point.
+
+Centralized platforms ask you to trust their intentions. AntSeed asks you to verify its architecture. In the long run, that's the only kind of trust that scales.
+
+---
+
+*Want to go deeper? Start with the [protocol overview](/docs/overview), read the [light paper](/docs/lightpaper), or browse the [code](https://github.com/AntSeed/antseed).*


### PR DESCRIPTION
Adds one file: `apps/website/blog/2026-07-31-trust-without-a-middleman.md`. No other changes; no changelog entry (blog content only, matching #754).

Top-of-funnel architecture post: walks through the security/anonymity design (keypair identity, DHT discovery, direct WebRTC transport, escrowed USDC payments with ReserveAuth/SpendingAuth, reputation + TEEs, ResponseAuth + fingerprinting) and states the anonymity boundaries plainly (provider sees plaintext, chain is public, provider sees IP).

**Technical content updated for the recognized-usage stack (PR #632 / #742):** the trust section no longer claims providers stake USDC. It now describes *recognized usage* — every settlement backed by a buyer-signed spending authorization and recorded on-chain against the provider's identity; providers back their identity with a pool of staked ANTS (own stake + supporters' locked ANTS); usage counts as recognized only when real stake stands behind the serving provider; weekly ANTS emissions are distributed against recognized usage. The payments section is untouched — Channels/Deposits and the ReserveAuth/SpendingAuth flow don't change in that PR.

**Internal links** (all root-relative, matching existing posts): `/docs/discovery`, `/docs/transport`, `/docs/payments`, `/docs/security`, `/docs/reputation`, `/docs/overview`, `/docs/lightpaper`, `/blog/seller-pools-reputation-tokenomics`, `/blog/model-verification-fingerprint-swarm`.

**Verified:** full `docusaurus build` passes (broken internal links would fail the build); post renders at `/blog/trust-without-a-middleman`.

Note: since the recognized-usage PR is not merged yet, this post describes the target state slightly ahead of the deployed contracts — intentional, flagging in case you want to hold merge until #632 lands.