### PR TITLE
blog: TEE verification post + run/verify TEE seller guides

### DIFF
--- a/apps/website/blog/2026-07-31-dont-trust-the-tee-label.md
+++ b/apps/website/blog/2026-07-31-dont-trust-the-tee-label.md
@@ -1,0 +1,78 @@
+---
+slug: dont-trust-the-tee-label
+title: "Don't Trust the TEE Label: How AntSeed Verifies Confidential AI"
+authors: [antseed]
+tags: [privacy, TEE, security, verification, confidential computing, P2P]
+description: "TEE inference is only as private as your ability to verify it. How AntSeed lets buyers cryptographically check a seller's secure hardware before routing a single paid request."
+keywords: [TEE inference, confidential AI, Intel TDX attestation, verify TEE, private AI, remote attestation, NVIDIA confidential computing, AntSeed verifier]
+image: /og-image.jpg
+date: 2026-07-31
+---
+
+Every provider of confidential AI makes the same promise: your prompts are processed inside secure hardware that nobody — not even the operator — can look into. It's a real technology and a strong promise. But on almost every platform, it arrives the same way every other privacy promise does: as a claim on a website, checked by the same company that made it.
+
+AntSeed takes a different position — a promise you can't verify yourself is just a policy. So the network now ships the verification: before routing a single paid request, your own node can cryptographically check that the machine on the other end really is the secure hardware it claims to be. This post explains what that hardware protects, why the checking matters as much as the hardware, and how the check actually works — with links to the documentation if you want to go deeper.
+
+<!-- truncate -->
+
+## What a TEE protects
+
+In [Anonymous AI vs Private AI](/blog/anonymous-vs-private-ai) we split privacy into two separate questions: does anyone know a request was *yours*, and can anyone *read* it. AntSeed's architecture answers the first question structurally — no accounts, no platform in the middle, [payments that don't identify you](/blog/trust-without-a-middleman).
+
+The second question is harder, because whoever runs the model has to process your prompt — that's inherent to inference anywhere. The strongest available answer is a Trusted Execution Environment (TEE): a mode of modern server hardware that runs a workload inside a sealed compartment, encrypted in memory, that the machine's own operating system and administrators cannot see into. Intel's version, called TDX, seals the processor side; NVIDIA's Confidential Computing extends the seal to the GPUs where the model actually runs.
+
+Put the two axes together and you reach the corner of the privacy map that centralized platforms can't offer: nobody knows the request is yours, and the operator serving it can't read it. A platform can promise not to look. A sealed compartment can't look.
+
+## A claim of secure hardware is not secure hardware
+
+From the outside, a server running in a TEE and a server merely claiming to run in one look identical. The responses are the same bytes. If "TEE-secured" is just a label on a service listing, it protects nothing.
+
+What makes the claim checkable is a hardware feature called remote attestation. The chip itself can produce a *quote* — a signed statement, traceable to the chip maker's published root keys, that says: this exact software is running inside a genuine sealed compartment on genuine hardware. Anyone can check that signature against Intel's public certificates, without trusting the machine's operator at all.
+
+Here is the part most confidential-AI products get wrong. They do run attestation — and then check it for you, on their own servers, behind the same dashboard you were already trusting. The proof exists, but the checking is centralized, which quietly restores the exact trust the hardware was meant to remove.
+
+On AntSeed, your node does the checking. It challenges the seller directly, receives the evidence over the same encrypted peer-to-peer connection the request would travel on, and verifies it locally against Intel's certificates — before any payment happens. There is no one between you and the proof.
+
+## How verification works on the network
+
+The mechanism is deliberately small. A *verifier* is a package with two halves: one half runs on the seller and answers challenges; the other runs on the buyer and checks the answers. Sellers announce which verifiers they can answer the same way they announce prices and models, so your node learns who can prove what during normal discovery.
+
+When your node picks a seller that advertises verification, it runs the check before anything is paid or metered — verification is free by construction, and it happens on a reserved path that never touches the seller's billing. By default the check is advisory: your node verifies whoever it can and records the result. Add one flag — `--require-verifier` — and it becomes a hard rule: no verified hardware, no traffic.
+
+One more boundary matters. Verification code is security-critical, so your node only ever runs verifiers from a curated list, pinned to an exact version. A seller can advertise anything it likes; code outside your pinned list is never downloaded or run, and nobody upstream can silently change what checks run on your machine.
+
+Details: [Verify a seller's TEE](/docs/guides/verify-tee) · [The protocol specification (AIP-3)](https://github.com/AntSeed/AIPs/blob/main/AIPS/aip-3.md)
+
+## What the first verifier proves
+
+The first verifier SDK, [antseed-verifier](https://github.com/AntSeed/antseed-verifier), checks Intel TDX. A passing verdict rests on two proofs, both required:
+
+**The hardware is genuine, and the proof is fresh.** Your node sends the seller a random challenge number, used once. The seller's hardware mints a quote bound to that exact number, and your node verifies the quote's signature chain up to Intel's root certificates — confirming a genuine TDX machine, with its security patches at an acceptable level and debugging switched off. A recorded quote from an earlier session, a machine faking it in software, or an enclave borrowed from someone else all fail.
+
+**The hardware belongs to the seller you're paying.** The seller signs the whole evidence bundle with the same identity key it uses on the network, so the proof is tied to the exact peer you selected — not relayed from some other machine that happens to be genuine.
+
+Together, the two proofs say: *the node you are about to pay is a genuine Intel TDX machine, attested fresh for this exchange, under the identity you chose.* Not a label — a proof.
+
+Beyond those two, the verifier reports additional evidence your node can use in its routing decisions: whether the seller's downstream inference provider also runs in genuine sealed hardware, whether that provider's GPUs run NVIDIA Confidential Computing (checked against NVIDIA's own attestation service), and whether the software inside the compartment matches a list of measurements you approve. And none of it is tied to one vendor — pointing a seller at a different confidential-computing provider is a configuration change, not new code. The whole chain has been validated end-to-end on real Intel TDX hardware, including against a live third-party provider.
+
+Details: [Run a TEE-attested seller](/docs/guides/tee-provider)
+
+## What attestation does — and doesn't — prove
+
+Trust requires honesty about limits, so here are this feature's, stated plainly.
+
+A passing verdict proves the seller was genuine, sealed hardware, freshly attested, under the identity you chose — *at the moment of attestation*. What it does not yet do is cryptographically tie every response byte that follows to that same sealed compartment: today the proof gates where your traffic goes, and is refreshed as you keep routing, but the responses themselves are not individually signed by a key held inside the hardware. That stronger binding — a signing key created inside the compartment, attested along with it, signing every response — is the [agreed next milestone](https://github.com/AntSeed/antseed-verifier/blob/main/docs/milestone-a2-channel-binding.md) for the verifier, with a working reference implementation already running.
+
+It's also worth being precise about what question attestation answers. It proves the *environment* — sealed, genuine, yours-to-verify. Whether the *model* behind the service is the one advertised is a different question, answered by different evidence: [reputation and recognized usage](/blog/trust-without-a-middleman) tell you a seller has a history of delivering, and [model fingerprinting](/blog/model-verification-fingerprint-swarm) probes what's actually answering. Different questions, different proofs — attestation adds the missing one.
+
+## Try it
+
+Any buyer can demand verified hardware today with one flag:
+
+```bash
+antseed buyer start --verifiers antseed-verifier --require-verifier
+```
+
+Two new guides walk through both sides: [running a TEE-attested seller](/docs/guides/tee-provider) — provisioning the hardware, loading the prover, wiring a confidential inference provider behind it — and [verifying a seller's TEE](/docs/guides/verify-tee) — the policy flags, what each check means, and how to read a verdict.
+
+The claim underneath all of this is the same one the rest of AntSeed makes. Confidential AI that asks you to trust the operator's dashboard isn't confidential — it's outsourced. Here, the hardware's proof, Intel's certificates, the verifier code your node runs, and the protocol that carries the challenge are all public and inspectable. You don't have to take the label on faith — and that's precisely the point.

--- a/apps/website/docs/guides/tee-provider.md
+++ b/apps/website/docs/guides/tee-provider.md
@@ -1,0 +1,144 @@
+---
+sidebar_position: 2
+slug: /guides/tee-provider
+title: Run a TEE-Attested Seller
+hide_title: true
+---
+
+# Run a TEE-Attested Seller
+
+A seller running on Intel TDX hardware can prove it — cryptographically, to every buyer, before any payment. This guide takes an existing seller (see [Become a Provider](/docs/guides/become-a-provider)) and adds TEE attestation via the [`antseed-verifier`](https://github.com/AntSeed/antseed-verifier) SDK, so buyers running `--require-verifier` will route to you.
+
+:::info Availability
+Verifier SDK support landed in the CLI with [PR #713](https://github.com/AntSeed/antseed/pull/713) (July 2026). Check that your `antseed seller start --help` lists a `--verifiers` option; older releases don't have it.
+:::
+
+## How it works
+
+- Your seller loads the SDK's **prover** at startup and advertises the capability `verifier.antseed-verifier` in its discovery metadata.
+- A buyer challenges you on the reserved route `/_antseed/attest/antseed-verifier` with a fresh nonce. The prover mints an Intel TDX quote **bound to that nonce and your peer id**, signs the evidence bundle with your identity key, and returns it.
+- The buyer verifies the quote against Intel's DCAP certificate chain locally. Attestation runs before provider matching, payment, and metering — it is free and unmetered, and rate-limited to 10 attestations per buyer per minute.
+
+If the prover fails to load at startup, the seller exits rather than advertising a capability it can't answer.
+
+## Prerequisites
+
+- A genuine **Intel TDX** VM — e.g. a GCP `c3` confidential VM (Ubuntu 24.04) with TDX enabled. The prover mints quotes through `configfs-tsm` (`/sys/kernel/config/tsm/report`), which only exists on real TDX hardware and requires **root**.
+- A working seller (`antseed seller start` serving requests) on that VM.
+- Node.js 20+.
+
+## 1. Install the verifier SDK
+
+The CLI resolves the id `antseed-verifier` to the npm package `@antseed/antseed-verifier`, version-pinned, and auto-installs it into `~/.antseed/plugins` on first use (`npm install --ignore-scripts` under the hood).
+
+Until the package is published to npm, install it into the plugins directory from source:
+
+```bash
+git clone https://github.com/AntSeed/antseed-verifier
+cd antseed-verifier
+npm install && npm run build && npm pack
+npm install --prefix ~/.antseed/plugins ./antseed-antseed-verifier-*.tgz
+```
+
+The loader expects the package at `~/.antseed/plugins/node_modules/@antseed/antseed-verifier`.
+
+## 2. Configure the prover
+
+The prover reads its configuration from the environment only — never from buyer-supplied values:
+
+```bash
+# Required: your peer id (EVM address, without 0x)
+export ANTSEED_TEE_PEER_ID=<your-peer-id>
+
+# Recommended: your seller identity key (hex). Enables the seller-bound
+# capability — the evidence bundle is signed so buyers can recover your peerId.
+# Disabled automatically if the key's address doesn't match ANTSEED_TEE_PEER_ID.
+export ANTSEED_VERIFIER_SIGNING_KEY=<hex-private-key>
+
+# Node quote source. Defaults to configfs; leave unset on a standard TDX VM.
+# export ANTSEED_VERIFIER_NODE_TEE=configfs
+```
+
+## 3. Start the seller with the verifier
+
+```bash
+sudo -E antseed seller start --verifiers antseed-verifier
+```
+
+(`sudo` because `configfs` quote minting needs root; `-E` preserves the environment.)
+
+Three equivalent ways to enable it, in precedence order:
+
+1. `--verifiers antseed-verifier` on the command line
+2. `ANTSEED_VERIFIER_SDKS=antseed-verifier` in the environment
+3. `"verifiers": ["antseed-verifier"]` under `seller` in `~/.antseed/config.json` (the `antseed seller setup` wizard can write this)
+
+The first id in the list becomes your advertised default. On success you'll see:
+
+```
+Verifier prover embedded: antseed-verifier
+Verifiers advertised: antseed-verifier
+```
+
+## 4. Confirm you're advertising
+
+From any other machine:
+
+```bash
+antseed network peer <your-peer-id>
+# → Verifiers:       antseed-verifier (default)
+```
+
+`antseed network browse` also shows a `Verifier` column once any peer advertises one.
+
+## 5. Attest your inference provider too (optional)
+
+The two gating capabilities (`seller-node-tee-genuine`, `seller-bound`) cover your **node**. If your downstream inference provider also runs confidential hardware, the prover can relay its evidence so buyers see it — `seller-provider-tee-genuine`, `seller-provider-gpu-cc` (NVIDIA Confidential Computing), and `seller-provider-measured-image` are reported for buyer policy:
+
+```bash
+# An endpoint that returns the provider's evidence for a nonce ({nonce} → hex)
+export ANTSEED_VERIFIER_PROVIDER_EVIDENCE_URL='http://127.0.0.1:9000/evidence?nonce={nonce}'
+export ANTSEED_VERIFIER_PROVIDER_TEE_FIELD=quote
+
+# The frozen report_data binding scheme the provider's quote uses:
+#   antseed-rd-v1            — AntSeed's canonical scheme
+#   nonce-pubkey-sha256-v1   — used by e.g. Chutes
+export ANTSEED_VERIFIER_PROVIDER_BINDING_SCHEME=antseed-rd-v1
+export ANTSEED_VERIFIER_PROVIDER_BINDING_PUBKEY_FIELD=e2e_pubkey
+
+# Optional: per-GPU NVIDIA CC evidence field → enables seller-provider-gpu-cc
+# export ANTSEED_VERIFIER_PROVIDER_GPU_FIELD=gpu_evidence
+```
+
+The SDK is provider-agnostic — no vendor hosts or schemas are baked in. Pointing at a different confidential-inference backend is configuration only. For a worked example against a live third-party TDX provider (Chutes), including the small auth shim it needs, see the [SDK's e2e guide](https://github.com/AntSeed/antseed-verifier/blob/main/docs/e2e-report-data-schemes.md).
+
+## 6. Test the full loop as a buyer
+
+From a second machine (no special hardware needed):
+
+```bash
+antseed buyer start --verifiers antseed-verifier --require-verifier --peer <your-peer-id>
+```
+
+Send any request through the proxy. The buyer log should show:
+
+```
+Verified <your-peer-id>... via antseed-verifier
+```
+
+If attestation fails under `--require-verifier`, the request is refused with a 502 naming the failed claims — which is exactly the guarantee your buyers are paying for.
+
+## Troubleshooting
+
+| Symptom | Cause |
+|---|---|
+| Seller exits at startup with a verifier load error | SDK not installed in `~/.antseed/plugins`, or its version doesn't match the CLI's pinned version |
+| `seller-node-tee-genuine` fails locally | Not a genuine TDX VM, not running as root, or `configfs-tsm` unavailable |
+| `seller-bound` missing from verdicts | `ANTSEED_VERIFIER_SIGNING_KEY` unset, or its address doesn't match `ANTSEED_TEE_PEER_ID` |
+| Buyer reports TCB failures | Host platform needs microcode/TCB updates; buyers running `ANTSEED_VERIFIER_STRICT_TCB=true` accept only `UpToDate` |
+
+## See also
+
+- [Verify a seller's TEE](/docs/guides/verify-tee) — the buyer side of this handshake
+- [AIP-3: Pluggable Verifier SDKs](https://github.com/AntSeed/AIPs/blob/main/AIPS/aip-3.md) — the protocol specification
+- [Don't Trust the TEE Label](/blog/dont-trust-the-tee-label) — why this exists

--- a/apps/website/docs/guides/verify-tee.md
+++ b/apps/website/docs/guides/verify-tee.md
@@ -1,0 +1,105 @@
+---
+sidebar_position: 3
+slug: /guides/verify-tee
+title: Verify a Seller's TEE
+hide_title: true
+---
+
+# Verify a Seller's TEE
+
+Before routing a paid request to a seller, your buyer node can cryptographically verify that the seller runs inside a genuine Intel TDX enclave — checked locally on your machine, against Intel's own certificate chain, with no third party in between. This guide covers turning verification on, making it mandatory, and reading a verdict.
+
+:::info Availability
+Verifier SDK support landed in the CLI with [PR #713](https://github.com/AntSeed/antseed/pull/713) (July 2026). Check that your `antseed buyer start --help` lists `--verifiers`; older releases don't have it. No special hardware is needed on the buyer side.
+:::
+
+## The three flags
+
+```bash
+# Default (no flags): verification is ON, best-effort.
+# Sellers that advertise a trusted verifier are checked; the verdict is
+# logged, but requests route either way.
+antseed buyer start
+
+# Strict: refuse to route unless the seller passes verification.
+antseed buyer start --verifiers antseed-verifier --require-verifier
+
+# Off: skip verification entirely.
+antseed buyer start --no-verifier
+```
+
+- `--verifiers <a,b,c>` — an ordered preference list of verifier ids. Without it, the buyer uses the seller's advertised default — if that id is in the curated trust set.
+- `--require-verifier` — a failed **or missing** verification becomes a hard block: the request is answered with a `502` naming the failed claims instead of being routed. The peer is not silently swapped for another.
+- `--no-verifier` — disables verification. Combining it with either other flag is rejected as contradictory.
+
+The startup banner confirms the active policy, e.g. `Verifier: antseed-verifier (required)`.
+
+## Finding TEE sellers
+
+```bash
+antseed network browse            # shows a "Verifier" column when peers advertise one
+antseed network peer <peer-id>    # → Verifiers:       antseed-verifier (default)
+```
+
+Sellers advertise verifier support as capabilities (`verifier.<id>`) in ordinary discovery metadata — what you see there is *advertised support*, not a verdict. The verdict is produced by your own node at request time.
+
+## What a passing verdict proves
+
+With the [`antseed-verifier`](https://github.com/AntSeed/antseed-verifier) SDK, the verdict gates on two required capabilities:
+
+| Capability | Proves |
+|---|---|
+| `seller-node-tee-genuine` | The seller node runs in a **genuine Intel TDX enclave**: quote verified against Intel's DCAP certificate chain, acceptable TCB, debug off — and minted fresh for *your* nonce, bound to the seller's peer id. Replayed quotes and non-TDX machines fail. |
+| `seller-bound` | The seller's identity key signed the whole evidence bundle for this round — the enclave is tied to the exact peer you're paying, not borrowed from elsewhere. |
+
+Four more capabilities are reported as evidence for your own policy but don't gate the verdict:
+
+| Capability | Reports |
+|---|---|
+| `seller-provider-tee-genuine` | The downstream inference **provider's** TEE quote is genuine TDX, and round-bound when the provider declares a binding scheme |
+| `seller-provider-gpu-cc` | The provider's GPUs run **NVIDIA Confidential Computing**, verified against NVIDIA's attestation service (NRAS), nonce-bound |
+| `seller-provider-measured-image` | The provider quote's measurements (MRTD/RTMR) match an allow-list **you** control |
+| `seller-provider-claims` | Named provider claims, each marked self-vouched or TEE-attested |
+
+## Policy knobs
+
+```bash
+# Accept only TCB status "UpToDate" (default also accepts SWHardeningNeeded)
+export ANTSEED_VERIFIER_STRICT_TCB=true
+
+# Approved-measurement allow-list for seller-provider-measured-image
+# (inline JSON or @/path/to/policy.json)
+export ANTSEED_VERIFIER_MEASURED_IMAGE_POLICY=@~/measured-images.json
+
+# Override NVIDIA NRAS endpoints for gpu-cc
+# export ANTSEED_VERIFIER_NRAS_URL=... ANTSEED_VERIFIER_NRAS_JWKS_URL=...
+```
+
+## What happens at request time
+
+1. After a peer is selected and matched — and **before** any payment negotiation — the buyer challenges it on the reserved route `/_antseed/attest/<verifier-id>` over the existing encrypted connection. Attestation is free: it never passes through pricing or metering.
+2. The verifier runs with a 30-second timeout, composed with your request's abort signal.
+3. Verdicts are cached per `(peer, advertised-verifier-set)` for the peer-cache TTL (minutes), so attestation doesn't rerun on every request. Transient failures — network hiccups, timeouts — are never cached as negative verdicts.
+4. On failure: in default mode the request routes anyway and the log shows `Verification (antseed-verifier) did not pass ... (optional — routing anyway)`; with `--require-verifier` the request fails with `502` and the failed claims, e.g. `seller-node-tee-genuine: report_data does not match scheme "antseed-rd-v1"`.
+
+## The trust boundary
+
+Your node only ever runs verifier code from a **curated, version-pinned trust set** — a built-in map from verifier id to an exact npm package and version (`antseed-verifier` → `@antseed/antseed-verifier`, pinned). The pinned version is enforced on every load; a version mismatch is an error, and there is no auto-upgrade to a floating "latest". A seller can advertise any id it likes — an id outside your trust set is simply never loaded or run. The trust decision is yours alone: which SDK to run, and whether its verdict gates routing.
+
+## Limits worth knowing
+
+- A passing verdict proves the enclave was genuine and fresh **at attestation time**, and the cached verdict covers the following minutes. Binding every response byte to an enclave-held signing key is the [next milestone](https://github.com/AntSeed/antseed-verifier/blob/main/docs/milestone-a2-channel-binding.md) in the verifier SDK.
+- Attestation proves the *environment*, not the *model*. For whether the model is what the seller claims, see [model verification](/blog/model-verification-fingerprint-swarm).
+
+:::note Three different "verifications"
+AntSeed has three unrelated features that all involve the word "verify" — don't conflate them:
+1. **Verifier SDKs** (this guide) — cryptographic TEE attestation of a seller, run by your node.
+2. The **`Verified` column** in `network browse` — domain/GitHub ownership proofs a seller publishes about its identity.
+3. **Model verification** — black-box fingerprint probing of the model behind a service.
+:::
+
+## See also
+
+- [Run a TEE-attested seller](/docs/guides/tee-provider) — the seller side
+- [AIP-3: Pluggable Verifier SDKs](https://github.com/AntSeed/AIPs/blob/main/AIPS/aip-3.md) — the protocol specification
+- [Security](/docs/security) — the wider security model

--- a/apps/website/sidebars.ts
+++ b/apps/website/sidebars.ts
@@ -19,6 +19,8 @@ const sidebars: SidebarsConfig = {
       items: [
         'guides/using-the-api',
         'guides/become-a-provider',
+        'guides/tee-provider',
+        'guides/verify-tee',
         'guides/payments',
         'guides/pricing',
         'guides/metrics',


### PR DESCRIPTION
Adds a blog post and two docs guides covering the pluggable verifier SDKs (PR #713, AIP-3) and the first verifier, [`antseed-verifier`](https://github.com/AntSeed/antseed-verifier) (Intel TDX). Four files: the post, two guides, and the sidebar entry. No changelog entry (website content only, matching #754/#756).

**Blog** — `/blog/dont-trust-the-tee-label` ("Don't Trust the TEE Label: How AntSeed Verifies Confidential AI"). The argument: a TEE claim is only as good as your ability to check it, and most confidential-AI products verify attestation server-side behind their own dashboard — re-centralizing the trust the hardware was meant to remove. On AntSeed the buyer's node verifies the quote locally against Intel's certificates, pre-payment. Written in the same register as the no-middleman post: technical terms glossed in plain language, "Details:" link pattern, honest-limits section (verdict proves the enclave at attestation time; per-response signing by an enclave-held key is the agreed A2 milestone, linked).

**Guides** (added under Guides in the sidebar):
- `/docs/guides/tee-provider` — Run a TEE-Attested Seller: TDX VM prerequisites (configfs-tsm needs root), SDK install into `~/.antseed/plugins` (from-source path included since `@antseed/antseed-verifier` isn't on npm yet), prover env vars, the three enable paths (`--verifiers` → `ANTSEED_VERIFIER_SDKS` → `seller.verifiers` config, verified against the code), advertising checks, optional downstream-provider evidence wiring (binding schemes incl. the Chutes flow), e2e buyer test, troubleshooting table.
- `/docs/guides/verify-tee` — Verify a Seller's TEE: the three buyer flags and exact semantics (default best-effort; `--require-verifier` → 502 with failed claims, no silent re-route; `--no-verifier` contradiction check), gating vs informational capabilities, policy env knobs, request-time behavior (30s timeout, verdict cache, transients never cached), version-pinned trust set, and a note disambiguating verifier SDKs from the `Verified` ownership column and from model verification.

All CLI flags, env vars, config keys, log lines, and failure behaviors were checked against the merged #713 code (`apps/cli/src/plugins/{verifier,loader,registry}.ts`, `buyer-proxy.ts`, `seller-request-handler.ts`).

**Verified:** full `docusaurus build` passes (`onBrokenLinks: throw`); all three pages render locally.

**Timing notes for merge:**
- No *released* CLI includes #713 yet (latest published is 0.1.136 from 2026-07-20; the merge was 2026-07-21). Both guides carry an availability note; consider deploying alongside the next CLI release.
- `@antseed/antseed-verifier` isn't published to npm yet — the seller guide documents the from-source install until it is.