### PR TITLE
fix(node): Unadvertise upstreams on HTTP 402

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed seller health checks leaving unavailable upstreams advertised: HTTP 402 responses now count as failures, every failing service can be removed, and a provider with no healthy services is omitted from signed discovery metadata until a probe succeeds.
 - Fixed OpenAI Responses model health probes using a scalar `input` value that strict providers rejected with HTTP 400, leaving every health result inconclusive and preventing automatic model unadvertising.
 - Fixed payment negotiation getting stuck when a buyer lost its local channel state while an older channel remained active on-chain. Sellers now close the superseded channel from durable seller state before accepting the buyer's replacement ReserveAuth.
 - Fixed the seller recording an inaccurate settled amount when two close paths raced on the same channel. Only one `close()` is submitted, and every path that joins it now persists the amount that transaction actually settled.

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -54,6 +54,8 @@ export interface AnnouncerConfig {
     serviceCategories?: Record<string, string[]>;
     serviceApiProtocols?: Record<string, ServiceApiProtocol[]>;
     maxConcurrency: number;
+    /** Runtime availability predicate. Unavailable providers are omitted. */
+    isAvailable?: () => boolean;
     /** Per-instance pricing. Takes precedence over the shared pricing Map. */
     pricing?: {
       defaults: { inputUsdPerMillion: number; outputUsdPerMillion: number };
@@ -251,33 +253,35 @@ export class PeerAnnouncer {
   }
 
   private async _buildSignedMetadata(includeOnChainReputation = true): Promise<PeerMetadata> {
-    const providers: ProviderAnnouncement[] = this.config.providers.map((p) => {
-      const pricing = p.pricing ?? this.config.pricing.get(p.provider) ?? {
-        defaults: {
-          inputUsdPerMillion: 0,
-          outputUsdPerMillion: 0,
-        },
-      };
-      const providerAnnouncement: ProviderAnnouncement = {
-        provider: p.provider,
-        services: p.services,
-        defaultPricing: pricing.defaults,
-        maxConcurrency: p.maxConcurrency,
-        currentLoad: this.loadMap.get(p.provider) ?? 0,
-      };
-      if (pricing.services) {
-        providerAnnouncement.servicePricing = pricing.services;
-      }
-      const normalizedServiceCategories = this._normalizeServiceCategories(p.serviceCategories, p.services);
-      if (normalizedServiceCategories) {
-        providerAnnouncement.serviceCategories = normalizedServiceCategories;
-      }
-      const normalizedServiceApiProtocols = this._normalizeServiceApiProtocols(p.serviceApiProtocols, p.services);
-      if (normalizedServiceApiProtocols) {
-        providerAnnouncement.serviceApiProtocols = normalizedServiceApiProtocols;
-      }
-      return providerAnnouncement;
-    });
+    const providers: ProviderAnnouncement[] = this.config.providers
+      .filter((provider) => provider.isAvailable?.() !== false)
+      .map((p) => {
+        const pricing = p.pricing ?? this.config.pricing.get(p.provider) ?? {
+          defaults: {
+            inputUsdPerMillion: 0,
+            outputUsdPerMillion: 0,
+          },
+        };
+        const providerAnnouncement: ProviderAnnouncement = {
+          provider: p.provider,
+          services: p.services,
+          defaultPricing: pricing.defaults,
+          maxConcurrency: p.maxConcurrency,
+          currentLoad: this.loadMap.get(p.provider) ?? 0,
+        };
+        if (pricing.services) {
+          providerAnnouncement.servicePricing = pricing.services;
+        }
+        const normalizedServiceCategories = this._normalizeServiceCategories(p.serviceCategories, p.services);
+        if (normalizedServiceCategories) {
+          providerAnnouncement.serviceCategories = normalizedServiceCategories;
+        }
+        const normalizedServiceApiProtocols = this._normalizeServiceApiProtocols(p.serviceApiProtocols, p.services);
+        if (normalizedServiceApiProtocols) {
+          providerAnnouncement.serviceApiProtocols = normalizedServiceApiProtocols;
+        }
+        return providerAnnouncement;
+      });
 
     const capabilities: string[] = [
       CONNECTION_CAPABILITY_RESPONSE_AUTH_V1,

--- a/packages/node/src/discovery/metadata-validator.ts
+++ b/packages/node/src/discovery/metadata-validator.ts
@@ -315,13 +315,10 @@ export function validateMetadata(metadata: PeerMetadata): ValidationError[] {
     });
   }
 
-  // providers count
-  if (metadata.providers.length === 0) {
-    errors.push({
-      field: "providers",
-      message: "Must have at least one provider",
-    });
-  } else if (metadata.providers.length > MAX_PROVIDERS) {
+  // A health-checked seller may temporarily have zero available providers.
+  // It remains discoverable so buyers can observe recovery, but advertises no
+  // inference route until at least one service becomes healthy again.
+  if (metadata.providers.length > MAX_PROVIDERS) {
     errors.push({
       field: "providers",
       message: `Provider count ${metadata.providers.length} exceeds max ${MAX_PROVIDERS}`,

--- a/packages/node/src/health/model-health-checker.ts
+++ b/packages/node/src/health/model-health-checker.ts
@@ -78,8 +78,9 @@ interface ServiceHealthState {
  *
  * Removal mutates `provider.services` in place — the same array reference the
  * announcer and the seller request handler read live — so it takes effect on
- * the next `/metadata` fetch and the next incoming request without extra
- * plumbing.
+ * the next `/metadata` fetch and the next incoming request. If every service
+ * is removed, `provider.healthCheckAvailable` becomes false so discovery omits
+ * the provider instead of treating its empty service list as a wildcard.
  */
 export class ModelHealthChecker {
   private readonly _targets: ModelHealthTarget[];
@@ -250,21 +251,17 @@ export class ModelHealthChecker {
     if (index < 0) {
       // Already gone (removed externally) — track it as removed so it can recover.
       state.removed = true;
-      return;
-    }
-    // Metadata semantics treat an empty services list as a wildcard ("serves
-    // anything"), so never unadvertise a provider's last service — that would
-    // advertise MORE, not less.
-    if (services.length <= 1) {
-      debugWarn(
-        `[ModelHealth] ${provider.name}/${state.service} keeps failing but is the provider's `
-        + 'last advertised service — leaving it advertised (empty services would mean wildcard)',
-      );
+      if (services.length === 0) {
+        provider.healthCheckAvailable = false;
+      }
       return;
     }
     services.splice(index, 1);
     state.removed = true;
     state.removedAtIndex = index;
+    if (services.length === 0) {
+      provider.healthCheckAvailable = false;
+    }
     this._emitChange({
       provider: provider.name,
       service: state.service,
@@ -280,6 +277,7 @@ export class ModelHealthChecker {
     if (!services.includes(state.service)) {
       services.splice(Math.min(state.removedAtIndex, services.length), 0, state.service);
     }
+    provider.healthCheckAvailable = true;
     this._emitChange({
       provider: provider.name,
       service: state.service,
@@ -362,15 +360,16 @@ export function buildHealthProbeRequest(service: string, protocol: ServiceApiPro
  * Classify a probe response status.
  *
  * - 2xx/3xx — the model answered: healthy.
- * - 401/403/404 and 5xx — credentials broken, model gone, or upstream down:
- *   unhealthy. (The relay collapses upstream network errors/timeouts to 502.)
- * - Everything else (400, 402, 422, 429, ...) — the endpoint is alive but the
- *   probe itself was rejected (unsupported parameter, rate limit, busy):
- *   inconclusive, so a working model is never unadvertised over a probe quirk.
+ * - 401/402/403/404 and 5xx — credentials broken, billing unavailable, model
+ *   gone, or upstream down: unhealthy. (The relay collapses upstream network
+ *   errors/timeouts to 502.)
+ * - Everything else (400, 422, 429, ...) — the endpoint is alive but the probe
+ *   itself was rejected (unsupported parameter, rate limit, busy): inconclusive,
+ *   so a working model is never unadvertised over a probe quirk.
  */
 export function classifyProbeStatus(statusCode: number): ProbeOutcome {
   if (statusCode >= 200 && statusCode < 400) return 'healthy';
-  if (statusCode === 401 || statusCode === 403 || statusCode === 404) return 'unhealthy';
+  if (statusCode === 401 || statusCode === 402 || statusCode === 403 || statusCode === 404) return 'unhealthy';
   if (statusCode >= 500) return 'unhealthy';
   return 'inconclusive';
 }

--- a/packages/node/src/interfaces/seller-provider.ts
+++ b/packages/node/src/interfaces/seller-provider.ts
@@ -27,6 +27,14 @@ export interface Provider {
   /** Service IDs this provider supports (e.g., ['claude-sonnet-4-5-20250929', 'claude-opus-4-0-20250514']) */
   services: string[];
 
+  /**
+   * Runtime health availability. The model health checker sets this to false
+   * when every configured service has been removed, allowing discovery to
+   * omit the provider instead of interpreting an empty service list as a
+   * wildcard. Undefined means available for providers without health checks.
+   */
+  healthCheckAvailable?: boolean;
+
   /** Seller pricing in USD per 1M tokens (defaults + optional per-service overrides). */
   pricing: ProviderPricing;
 

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1545,6 +1545,7 @@ export class AntseedNode extends EventEmitter {
           ...(p.serviceCategories ? { serviceCategories: { ...p.serviceCategories } } : {}),
           ...(p.serviceApiProtocols ? { serviceApiProtocols: { ...p.serviceApiProtocols } } : {}),
           maxConcurrency: p.maxConcurrency,
+          isAvailable: () => p.healthCheckAvailable !== false,
           pricing: {
             defaults: {
               inputUsdPerMillion: p.pricing.defaults.inputUsdPerMillion,

--- a/packages/node/tests/announcer.test.ts
+++ b/packages/node/tests/announcer.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { randomBytes } from 'node:crypto';
 import { Wallet } from 'ethers';
 import { PeerAnnouncer, type AnnouncerConfig } from '../src/discovery/announcer.js';
+import { validateMetadata } from '../src/discovery/metadata-validator.js';
 import { bytesToHex } from '../src/p2p/identity.js';
 import { toPeerId } from '../src/types/peer.js';
 import {
@@ -35,6 +36,34 @@ function makeBaseConfig(): AnnouncerConfig {
     signalingPort: 0,
   };
 }
+
+describe('PeerAnnouncer provider availability', () => {
+  it('omits unavailable providers and restores them when they recover', async () => {
+    let available = true;
+    const announcer = new PeerAnnouncer({
+      ...makeBaseConfig(),
+      providers: [{
+        provider: 'openai',
+        services: ['model-a'],
+        maxConcurrency: 4,
+        isAvailable: () => available,
+      }],
+    });
+
+    await announcer.announce();
+    expect(announcer.getLatestMetadata()?.providers.map((provider) => provider.provider)).toEqual(['openai']);
+
+    available = false;
+    await announcer.refreshMetadata();
+    const unavailableMetadata = announcer.getLatestMetadata();
+    expect(unavailableMetadata?.providers).toEqual([]);
+    expect(validateMetadata(unavailableMetadata!)).toEqual([]);
+
+    available = true;
+    await announcer.refreshMetadata();
+    expect(announcer.getLatestMetadata()?.providers.map((provider) => provider.provider)).toEqual(['openai']);
+  });
+});
 
 describe('PeerAnnouncer sellerContract', () => {
   it('publishes sellerContract in metadata as lowercase 40-hex', async () => {

--- a/packages/node/tests/metadata-validator.test.ts
+++ b/packages/node/tests/metadata-validator.test.ts
@@ -81,9 +81,9 @@ describe('validateMetadata', () => {
     expect(errors.some((e) => e.field === 'timestamp')).toBe(true);
   });
 
-  it('should reject zero providers', () => {
+  it('should accept zero providers while a health-checked seller is unavailable', () => {
     const errors = validateMetadata(validMetadata({ providers: [] }));
-    expect(errors.some((e) => e.field === 'providers')).toBe(true);
+    expect(errors).toEqual([]);
   });
 
   it('should reject too many providers', () => {

--- a/packages/node/tests/model-health-checker.test.ts
+++ b/packages/node/tests/model-health-checker.test.ts
@@ -46,13 +46,13 @@ describe('classifyProbeStatus', () => {
     expect(classifyProbeStatus(200)).toBe('healthy');
     expect(classifyProbeStatus(304)).toBe('healthy');
     expect(classifyProbeStatus(401)).toBe('unhealthy');
+    expect(classifyProbeStatus(402)).toBe('unhealthy');
     expect(classifyProbeStatus(403)).toBe('unhealthy');
     expect(classifyProbeStatus(404)).toBe('unhealthy');
     expect(classifyProbeStatus(500)).toBe('unhealthy');
     expect(classifyProbeStatus(502)).toBe('unhealthy');
     // Endpoint alive but probe rejected — must never unadvertise over these.
     expect(classifyProbeStatus(400)).toBe('inconclusive');
-    expect(classifyProbeStatus(402)).toBe('inconclusive');
     expect(classifyProbeStatus(422)).toBe('inconclusive');
     expect(classifyProbeStatus(429)).toBe('inconclusive');
   });
@@ -157,10 +157,10 @@ describe('ModelHealthChecker', () => {
     expect(provider.services).toEqual(['model-a', 'model-b']);
   });
 
-  it('never removes the last advertised service (empty list would mean wildcard)', async () => {
+  it('removes the final service, marks the provider unavailable, and restores both', async () => {
     const provider = makeProvider({
       services: ['only-model'],
-      onRequest: async (req) => jsonResponse(req.requestId, 500),
+      onRequest: statusSequence({ 'only-model': [402, 200] }),
     });
     const events: ModelHealthEvent[] = [];
     const checker = new ModelHealthChecker({
@@ -170,9 +170,31 @@ describe('ModelHealthChecker', () => {
     });
 
     await checker.runSweep();
+    expect(provider.services).toEqual([]);
+    expect(provider.healthCheckAvailable).toBe(false);
+
     await checker.runSweep();
     expect(provider.services).toEqual(['only-model']);
-    expect(events).toEqual([]);
+    expect(provider.healthCheckAvailable).toBe(true);
+    expect(events.map((event) => event.status)).toEqual(['removed', 'restored']);
+  });
+
+  it('removes every service when the whole upstream is unavailable', async () => {
+    const provider = makeProvider({
+      onRequest: async (req) => jsonResponse(req.requestId, 402),
+    });
+    const checker = new ModelHealthChecker({
+      targets: [{ provider }],
+      failureThreshold: 1,
+    });
+
+    await checker.runSweep();
+    expect(provider.services).toEqual([]);
+    expect(provider.healthCheckAvailable).toBe(false);
+    expect(checker.getSnapshot()).toEqual([
+      expect.objectContaining({ service: 'model-a', advertised: false, lastStatusCode: 402 }),
+      expect.objectContaining({ service: 'model-b', advertised: false, lastStatusCode: 402 }),
+    ]);
   });
 
   it('treats a thrown probe as unhealthy', async () => {
@@ -229,7 +251,7 @@ describe('ModelHealthChecker', () => {
     });
     const probeProvider = makeProvider({
       services,
-      onRequest: async (req) => jsonResponse(req.requestId, 500),
+      onRequest: statusSequence({ 'model-a': [500], 'model-b': [200] }),
     });
     const checker = new ModelHealthChecker({
       targets: [{ provider: advertised, probeProvider }],


### PR DESCRIPTION
## Description

Fixes seller health handling when an upstream returns HTTP 402 or all of its models become unavailable. Unhealthy services are removed from discovery, and providers with no healthy services remain omitted until a recovery probe succeeds.

## Release Notes

- Fixed sellers continuing to advertise models when an upstream account returns HTTP 402 or has no healthy services.
- Restored provider advertisements automatically when an unavailable model recovers.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation
- [x] I have added tests
- [x] Lint and unit tests pass locally with my changes
