### PR TITLE
website: link the navbar download CTA to the detected installer

### DIFF
--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -254,7 +254,10 @@ const config: Config = {
           className: 'header-telegram-link',
         },
         {
-          href: 'https://github.com/AntSeed/antseed/releases/latest',
+          // Custom item (src/theme/NavbarItem/DownloadNavbarItem.tsx): links
+          // straight to the installer for the visitor's OS/arch, falling back
+          // to the releases page when detection fails.
+          type: 'custom-download',
           label: 'Download VPR',
           position: 'right',
           className: 'header-download-link',

--- a/apps/website/src/lib/useLatestDesktopDownload.ts
+++ b/apps/website/src/lib/useLatestDesktopDownload.ts
@@ -121,6 +121,20 @@ function matchAsset(
   return null;
 }
 
+// The hook is mounted by several CTAs at once (hero, pricing, footer CTA, and
+// the navbar item on every page), so the release lookup is memoized at module
+// level — one GitHub API request per full page load, shared by all instances.
+// A failed fetch caches `null` rather than retrying: if GitHub is down or
+// rate-limiting, hammering it on every SPA navigation only makes it worse.
+let latestReleasePromise: Promise<GitHubRelease | null> | null = null;
+
+function fetchLatestRelease(): Promise<GitHubRelease | null> {
+  latestReleasePromise ??= fetch(GH_API_LATEST)
+    .then(r => (r.ok ? (r.json() as Promise<GitHubRelease>) : null))
+    .catch(() => null);
+  return latestReleasePromise;
+}
+
 function labelFor(platform: DesktopPlatform): string {
   switch (platform) {
     case 'mac':
@@ -167,14 +181,11 @@ export function useLatestDesktopDownload(): DesktopDownload {
     // who will be sent to the releases page anyway.
     if (platform !== 'mac' && platform !== 'win') return;
     let cancelled = false;
-    fetch(GH_API_LATEST)
-      .then(r => (r.ok ? r.json() : null))
-      .then((data: GitHubRelease | null) => {
-        if (cancelled || !data) return;
-        if (data.tag_name) setTag(data.tag_name);
-        if (Array.isArray(data.assets)) setAssets(data.assets);
-      })
-      .catch(() => { /* network / rate-limit / offline — silently fall back */ });
+    fetchLatestRelease().then((data: GitHubRelease | null) => {
+      if (cancelled || !data) return;
+      if (data.tag_name) setTag(data.tag_name);
+      if (Array.isArray(data.assets)) setAssets(data.assets);
+    });
     return () => { cancelled = true; };
   }, [platform]);
 

--- a/apps/website/src/theme/NavbarItem/ComponentTypes.tsx
+++ b/apps/website/src/theme/NavbarItem/ComponentTypes.tsx
@@ -1,0 +1,7 @@
+import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
+import DownloadNavbarItem from '@site/src/theme/NavbarItem/DownloadNavbarItem';
+
+export default {
+  ...ComponentTypes,
+  'custom-download': DownloadNavbarItem,
+};

--- a/apps/website/src/theme/NavbarItem/DownloadNavbarItem.tsx
+++ b/apps/website/src/theme/NavbarItem/DownloadNavbarItem.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import DefaultNavbarItem, {type Props as DefaultNavbarItemProps} from '@theme/NavbarItem/DefaultNavbarItem';
+import {useLatestDesktopDownload} from '@site/src/lib/useLatestDesktopDownload';
+
+/**
+ * Navbar "Download VPR" item (`type: 'custom-download'` in docusaurus.config).
+ * Same rendering as a plain link navbar item, but the href is resolved at
+ * runtime to the direct installer for the visitor's OS/arch, falling back to
+ * the releases page when no installer matches (Linux, unknown platforms, or
+ * before the release lookup resolves).
+ */
+export default function DownloadNavbarItem(
+  props: Omit<DefaultNavbarItemProps, 'href' | 'to'>,
+): React.ReactNode {
+  const {href} = useLatestDesktopDownload();
+  return <DefaultNavbarItem {...props} href={href} />;
+}


### PR DESCRIPTION
## Description

All website download links now resolve to the specific installer for the visitor's OS/arch instead of the GitHub releases page. The page CTAs already did this via `useLatestDesktopDownload`; the one remaining offender was the navbar **Download VPR** item, which was a static config link.

- New `custom-download` navbar item type (swizzled `NavbarItem/ComponentTypes`) that renders identically to a plain link item but resolves its href through the detection hook. Falls back to the releases page for SSR/first paint, Linux/unknown platforms, or when the GitHub API call fails — same fallback behavior the page CTAs already had.
- The GitHub release lookup in `useLatestDesktopDownload` is now memoized at module level. The navbar mounts the hook on every page (and the homepage mounts it four times), so previously each instance fired its own request against GitHub's 60/hour unauthenticated rate limit; now all instances share one request per page load.

Left alone on purpose: the JSON-LD `downloadUrl` (schema.org metadata, not a clickable link) and the `install.md` link, whose surrounding prose is about picking an installer manually.

## Changelog

No published-package change — website only, so no `CHANGELOG.md` entry.

## Testing

- `pnpm typecheck` and full `pnpm build` pass in `apps/website`.
- Built HTML verified: the navbar item renders with the same `header-download-link` classes and the releases-page fallback href for SSR.