### PR TITLE
blog: You Don't Need a VPN for AI. You Need a VPR.

### DIFF
--- a/apps/website/blog/2026-08-04-virtual-private-router-vpr.md
+++ b/apps/website/blog/2026-08-04-virtual-private-router-vpr.md
@@ -1,10 +1,10 @@
 ---
 slug: virtual-private-router-vpr
-title: "You Don't Need a VPN for AI. You Need a VPR."
+title: "What Is a VPR? The Private Alternative to a VPN for AI"
 authors: [antseed]
-tags: [privacy, VPN for AI, VPR, private AI, P2P, AI infrastructure]
-description: "A VPN for AI hides your traffic from your ISP, not your prompt from the AI provider. A VPR routes the request itself so no single company sees you."
-keywords: [private AI, VPN for AI, AI VPN alternative, virtual private router, anonymous AI routing, private AI without a provider]
+tags: [VPR, virtual private router, VPN for AI, private AI, privacy, AI infrastructure]
+description: "A VPR (Virtual Private Router) does for your AI what a VPN does for browsing, and more. It routes each prompt so no single AI provider ever sees you."
+keywords: [virtual private router for AI, VPR, what is a VPR, VPN for AI, AI VPN alternative, private AI without a provider]
 image: /og-image.jpg
 date: 2026-08-04
 ---

--- a/apps/website/blog/2026-08-04-virtual-private-router-vpr.md
+++ b/apps/website/blog/2026-08-04-virtual-private-router-vpr.md
@@ -1,0 +1,71 @@
+---
+slug: virtual-private-router-vpr
+title: "You Don't Need a VPN for AI. You Need a VPR."
+authors: [antseed]
+tags: [privacy, VPN for AI, VPR, private AI, P2P, AI infrastructure]
+description: "A VPN for AI hides your traffic from your ISP, not your prompt from the AI provider. A VPR routes the request itself so no single company sees you."
+keywords: [private AI, VPN for AI, AI VPN alternative, virtual private router, anonymous AI routing, private AI without a provider]
+image: /og-image.jpg
+date: 2026-08-04
+---
+
+If you want to use AI privately, your first instinct is probably a VPN. It is the wrong tool, and the gap is bigger than it looks.
+
+A VPN for AI encrypts the connection between you and the AI service. Useful, but the AI provider on the other end still receives your prompt in full, still reads it, and still knows exactly which paying account sent it. The tunnel is private. The destination is not. What actually protects a private AI conversation is a VPR (Virtual Private Router): something that routes the request itself across independent providers, so no single company ever sees both who you are and what you asked.
+
+That distinction is the whole point of this post.
+
+<!-- truncate -->
+
+## What is a VPR (Virtual Private Router)?
+
+A VPR is a local router that sits between your app and the AI models and spreads your requests across many independent providers, instead of funneling everything to one company's servers. The analogy is exact: a VPN is to your network traffic what a VPR is to your AI requests. One protects the pipe your packets travel through. The other protects the request itself, and who can be seen making it.
+
+The name is deliberate. People already understand what a VPN does for browsing, so "virtual private router for AI" tells you the shape of the thing in four words. VPR is the routing layer. It decides which provider serves each call, and it does so without registering you, logging you into anything, or tying the request to a billing identity.
+
+## Why a VPN does not make your AI private
+
+This is the part that trips people up, so here it is plainly. A VPN changes where your traffic appears to come from and encrypts it in transit. That defends you against your ISP, against someone sniffing public wifi, and against region blocks. It does nothing about the company at the end of the tunnel.
+
+When you send a prompt to a hosted model through a VPN, the model provider still receives the plaintext prompt, because it has to in order to answer. It still sees an API key or a logged-in session, so it still knows the account. The VPN moved the problem one hop upstream and then stopped. Your ISP no longer sees the prompt. The AI company sees all of it, exactly as before.
+
+## The "AI VPN" wave solves the wrong half
+
+In 2026 the big VPN brands noticed people wanted AI privacy and shipped products for it. ExpressVPN built [a local bridge that lets AI assistants manage VPN routing](https://www.expressvpn.com/blog/mcp-server-ai-vpn/) through the Model Context Protocol. Norton launched per-agent VPN tunnels that give each agent its own temporary identity. Both are genuinely useful engineering.
+
+Neither changes the thing that matters here. A per-agent tunnel still terminates at a single AI provider that reads the prompt and knows the account behind the tunnel. Rotating the region or isolating the connection protects the transport and the network identity. It does not remove the one company sitting at the destination with full view of your input. That is the half a VPR is built for, and the half a VPN structurally cannot reach.
+
+## VPN vs VPR, side by side
+
+| | VPN (including "AI VPN") | VPR |
+|---|---|---|
+| Encrypts your traffic in transit | Yes | Yes, requests are encrypted by default |
+| Hides your prompt from your ISP | Yes | Yes |
+| Hides your prompt from the AI provider | No | Yes, no single provider sees the whole picture |
+| Removes the single company watching you | No | Yes, requests spread across independent providers |
+| Ties every request to an account | Yes | No account exists to tie it to |
+| Changes your apparent region | Yes | Not its job |
+
+Read the table as two different jobs, not two competitors. A VPN answers "who can watch my connection." A VPR answers "who can read my prompt and prove it was mine." Most people asking for "a VPN for AI" actually wanted the second answer and did not have a word for it.
+
+## Where a plain VPN is still the right tool
+
+A comparison that only flatters one side is an advertisement, so here is the honest boundary. If your problem is that a model is blocked in your country, you want a VPN, not a VPR. If you are on hostile wifi and want your whole device encrypted, that is a VPN too. If you need your traffic to appear to originate somewhere specific, again, VPN. A VPR does none of that, and it is not trying to.
+
+The two even stack. You can run a VPN underneath a VPR: the VPN hides the connection from your network, and the VPR hides the request from any single AI company. Different layers, different jobs, no conflict.
+
+## How a VPR actually works
+
+AntSeed is a working VPR. You run a small local proxy at `localhost:8377`. It discovers providers across a peer-to-peer network, scores them on price and reliability, and routes each request over an encrypted connection to whichever one fits. The interface is OpenAI and Anthropic compatible, so pointing an existing tool at it is usually a one-line base-URL change rather than a rewrite.
+
+Because there is no account, there is nothing to log in to and no billing profile attaching your prompts to your name. Because requests are spread across independent providers rather than one endpoint, no single operator accumulates a history of everything you have asked. The scoring step matters here too: the router picks on price and reliability each time, so you are never quietly pinned to one provider that slowly learns your patterns. The privacy is a property of the routing, not a promise in a policy document that can change next quarter. If you want the hands-on version, we wrote a walkthrough of how to [run Claude, DeepSeek, and Llama with no account or identity attached](/blog/use-claude-deepseek-llama-privately), and the fastest start is to [install the local proxy](/docs/install).
+
+## Private and anonymous are not the same guarantee
+
+One caution before you assume a VPR gives you everything. Routing your request privately and being anonymous are two separate properties, and a tool can deliver one without the other. A provider serving your request may still read the content of that single call even when it cannot tie the call to you. We pulled this apart in detail in [anonymous AI vs private AI](/blog/anonymous-vs-private-ai), and it is worth reading before you decide which guarantee your situation actually needs.
+
+## Do you need a VPR?
+
+Name your risk in one sentence. If it is "the AI company should not be able to read, keep, or attribute my prompts," or "I do not want to be locked to a single vendor who sees everything," a VPR fits, and a VPN alone will not get you there. If it is "the model is blocked where I am" or "encrypt my connection on this network," reach for a VPN. If it is both, run one under the other.
+
+The reason the word matters is that the wrong tool fails silently. Nobody discovers that their VPN left the prompt fully readable at the other end until the day that readability costs them something. A VPR is the tool that closes the gap the VPN was never built to reach.


### PR DESCRIPTION
Adds one file: `apps/website/blog/2026-08-04-virtual-private-router-vpr.md`. No other changes.

Introduces **VPR (Virtual Private Router)** as the product term and explains why a VPN does not make AI private. VPR is used as the brand name throughout; first-mention rule followed.

**Lint:** 0 errors, 0 warnings (1223 words, 8 H2, 3 internal links). Title and description within limits.

**Internal links:** `/blog/anonymous-vs-private-ai`, `/blog/use-claude-deepseek-llama-privately`, `/docs/install`.
**Outbound source:** ExpressVPN's AI VPN announcement.

**Please check before merge:**
- OK to publish VPR-branded copy now, given press still says AntStation? This post never mentions AntStation.
- `/docs/install` resolves on the built site.