### PR TITLE
desktop: add Linux builds to CI and website download links

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,18 +1,21 @@
 name: Release Desktop
 
-# Builds and publishes the AntSeed Desktop Electron app for macOS and
-# Windows in parallel, attaching artifacts to the same GitHub Release
-# (tagged v<version> where <version> is read from apps/desktop/package.json).
+# Builds and publishes the AntSeed Desktop Electron app for macOS,
+# Windows, and Linux in parallel, attaching artifacts to the same GitHub
+# Release (tagged v<version>, read from apps/desktop/package.json).
 #
 # macOS: DMG + zip, arm64 + x64, code-signed with Developer ID and
 #        notarized via Apple App Store Connect API key.
 # Windows: NSIS installer, x64 + arm64. Optional code signing if the
 #          WIN_CSC_* secrets are set.
+# Linux: AppImage + deb, x64 + arm64, unsigned. Each arch builds on a
+#        native runner (ubuntu-latest / ubuntu-24.04-arm) so native
+#        modules never need cross-compilation.
 #
 # Triggers:
 #   - Manual dispatch from the Actions tab (or `gh workflow run`). Choose
 #     which platforms to build via the `platforms` input.
-#   - Push of a `desktop-v*` tag builds both platforms.
+#   - Push of a `desktop-v*` tag builds all platforms.
 #
 # Required repo secrets:
 #   macOS:
@@ -39,11 +42,12 @@ on:
       platforms:
         description: 'Which platforms to build'
         type: choice
-        default: both
+        default: all
         options:
-          - both
+          - all
           - mac
           - win
+          - linux
       dry_run:
         description: 'Build only, do not publish to GitHub Releases'
         type: boolean
@@ -58,8 +62,8 @@ permissions:
 jobs:
   mac:
     name: Build & publish macOS
-    # Skip if user explicitly chose win-only. Tag-push always runs both.
-    if: github.event_name != 'workflow_dispatch' || inputs.platforms != 'win'
+    # Tag-push always runs every platform.
+    if: github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || inputs.platforms == 'mac'
     runs-on: macos-14  # Apple Silicon; electron-builder cross-builds x64
     timeout-minutes: 60
 
@@ -133,7 +137,7 @@ jobs:
 
   win:
     name: Build & publish Windows
-    if: github.event_name != 'workflow_dispatch' || inputs.platforms != 'mac'
+    if: github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || inputs.platforms == 'win'
     runs-on: windows-latest
     timeout-minutes: 45
 
@@ -189,6 +193,70 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  linux:
+    name: Build & publish Linux (${{ matrix.arch }})
+    if: github.event_name != 'workflow_dispatch' || inputs.platforms == 'all' || inputs.platforms == 'linux'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # One native runner per arch — prepare-dist then fetches/builds
+          # native modules (better-sqlite3 etc.) for the host arch, so no
+          # cross-compilation is ever needed. x64 publishes latest-linux.yml,
+          # arm64 publishes latest-linux-arm64.yml, so the two jobs never
+          # clobber each other's updater metadata.
+          - runner: ubuntu-latest
+            arch: x64
+          - runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build monorepo (tiers 0-3)
+        run: |
+          pnpm run build:tier0
+          pnpm run build:tier1
+          pnpm run build:tier2
+          pnpm run build:tier3
+
+      - name: Build & publish desktop (Linux ${{ matrix.arch }})
+        working-directory: apps/desktop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            npm run dist:linux
+          else
+            npm run release:linux
+          fi
+
+      - name: Upload installers as workflow artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: antseed-desktop-linux-${{ matrix.arch }}
+          path: |
+            apps/desktop/release/*.AppImage
+            apps/desktop/release/*.deb
+            apps/desktop/release/latest*.yml
+          if-no-files-found: warn
+          retention-days: 14
+
   # Keep the rolling `alpha` release pointing at the newest prerelease build,
   # under fixed asset names, so a single shareable link
   # (releases/download/alpha/AntSeed-VPR-alpha-arm64.dmg) always serves the
@@ -199,7 +267,7 @@ jobs:
   # disappear from disk), the release assets are.
   mirror-alpha:
     name: Mirror to rolling alpha release
-    needs: [mac, win]
+    needs: [mac, win, linux]
     # Run when nothing failed, at least one platform published, and this is a
     # real publish (not a dry run). A platform skipped via the `platforms`
     # input must not block the mirror.
@@ -208,7 +276,8 @@ jobs:
       inputs.dry_run != true &&
       needs.mac.result != 'failure' &&
       needs.win.result != 'failure' &&
-      (needs.mac.result == 'success' || needs.win.result == 'success')
+      needs.linux.result != 'failure' &&
+      (needs.mac.result == 'success' || needs.win.result == 'success' || needs.linux.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -230,7 +299,11 @@ jobs:
           for pair in \
             "AntSeed-VPR-${version}-arm64.dmg:AntSeed-VPR-alpha-arm64.dmg" \
             "AntSeed-VPR-${version}.dmg:AntSeed-VPR-alpha.dmg" \
-            "AntSeed-VPR-Setup-${version}.exe:AntSeed-VPR-Setup-alpha.exe"; do
+            "AntSeed-VPR-Setup-${version}.exe:AntSeed-VPR-Setup-alpha.exe" \
+            "AntSeed-VPR-${version}-x64.AppImage:AntSeed-VPR-alpha-x64.AppImage" \
+            "AntSeed-VPR-${version}-arm64.AppImage:AntSeed-VPR-alpha-arm64.AppImage" \
+            "AntSeed-VPR-${version}-x64.deb:AntSeed-VPR-alpha-x64.deb" \
+            "AntSeed-VPR-${version}-arm64.deb:AntSeed-VPR-alpha-arm64.deb"; do
             src="${pair%%:*}"; dst="${pair##*:}"
             if gh release download "v${version}" -p "$src" --dir alpha --clobber; then
               mv "alpha/$src" "alpha/$dst"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project uses selective package publishing. Each release entry lists the pub
 - Added `antseed buyer channels close <channelId>` (with `--no-auth` and `--json`), which runs the request through a running `antseed buyer start` daemon's live seller connection via the new `/_antseed/channels/close` control-plane endpoint.
 - Added `AntseedNode.requestChannelClose(peerId, opts)` to `@antseed/node`, plus the `payments.cooperative-close.v1` capability advertised in discovery metadata and the connection handshake.
 
+- The desktop release workflow now builds and publishes Linux installers (AppImage + deb, x64 + arm64, each arch on a native runner) alongside macOS and Windows, mirrors them to the rolling alpha release, and the website download CTAs now offer Linux visitors a direct AppImage download for their CPU arch instead of only linking to the releases page.
+
 ### Fixed
 
 - Fixed seller health checks leaving unavailable upstreams advertised: HTTP 402 responses now count as failures, every failing service can be removed, and a provider with no healthy services is omitted from signed discovery metadata until a probe succeeds.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -116,15 +116,17 @@ nsis:
 linux:
   icon: assets/antseed-dock-icon.png
   category: Development
+  # Deterministic names (default deb naming uses the package name + amd64):
+  # AntSeed-VPR-<version>-<x64|arm64>.<AppImage|deb>. The website download
+  # matcher and the alpha mirror both rely on this shape.
+  artifactName: "${productName}-${version}-${arch}.${ext}"
+  # NOTE: arch is intentionally NOT pinned here (same reasoning as mac above).
+  # CI builds each arch on a matching native runner (ubuntu-latest /
+  # ubuntu-24.04-arm), so the default current-arch build always packs
+  # prepare-dist's matching-arch native modules.
   target:
     - target: AppImage
-      arch:
-        - x64
-        - arm64
     - target: deb
-      arch:
-        - x64
-        - arm64
 
 publish:
   provider: github

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,7 +35,8 @@
     "release:mac": "npm run build && node scripts/release-mac.mjs",
     "dist:win": "npm run build && npm run prepare-dist && electron-builder --win",
     "release:win": "npm run build && npm run prepare-dist && node scripts/release-win.mjs",
-    "dist:linux": "npm run build && npm run prepare-dist && electron-builder --linux"
+    "dist:linux": "npm run build && npm run prepare-dist && electron-builder --linux",
+    "release:linux": "npm run build && npm run prepare-dist && electron-builder --linux --publish always"
   },
   "dependencies": {
     "@antseed/node": "workspace:*",

--- a/apps/website/src/lib/useLatestDesktopDownload.ts
+++ b/apps/website/src/lib/useLatestDesktopDownload.ts
@@ -16,8 +16,10 @@ import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
  *     relied on.
  *   - Windows arm64 / Windows x64: same high-entropy API. Windows UA also
  *     lies about arch by default.
- *   - Linux / unknown: no installer is matched; the CTA links to the
- *     releases page where the user picks.
+ *   - Linux arm64 / x64: same high-entropy API; matches the AppImage
+ *     (distro-agnostic — deb users can pick theirs on the releases page).
+ *   - Unknown (mobile, etc.): no installer is matched; the CTA links to
+ *     the releases page where the user picks.
  *
  * Asset matching is done by regex against `asset.name` rather than URL
  * construction so the hook self-corrects when electron-builder changes its
@@ -118,6 +120,15 @@ function matchAsset(
     }) ?? null;
   }
 
+  if (platform === 'linux') {
+    // AppImage runs on any distro; .deb stays a releases-page choice.
+    return assets.find(a => {
+      if (isBlockmap(a.name)) return false;
+      if (!/\.AppImage$/i.test(a.name)) return false;
+      return arch === 'arm64' ? hasArm64(a.name) : !hasArm64(a.name);
+    }) ?? null;
+  }
+
   return null;
 }
 
@@ -177,9 +188,9 @@ export function useLatestDesktopDownload(): DesktopDownload {
 
   useEffect(() => {
     // Only fetch on platforms we actually ship installers for. Avoids burning
-    // GitHub's unauthenticated API rate limit for Linux / unknown visitors
-    // who will be sent to the releases page anyway.
-    if (platform !== 'mac' && platform !== 'win') return;
+    // GitHub's unauthenticated API rate limit for unknown (mobile, etc.)
+    // visitors who will be sent to the releases page anyway.
+    if (platform === 'unknown') return;
     let cancelled = false;
     fetchLatestRelease().then((data: GitHubRelease | null) => {
       if (cancelled || !data) return;


### PR DESCRIPTION
## Description

Adds Linux (AppImage + deb, x64 + arm64) to the desktop release workflow, built on native runners and mirrored to the rolling alpha release. The website download CTAs now give Linux visitors a direct AppImage download for their arch instead of only linking to the releases page.

## Changes

- New `linux` job in `release-desktop.yml` with an x64 (`ubuntu-latest`) and arm64 (`ubuntu-24.04-arm`) matrix; `platforms` input gains `linux` and its default is now `all`
- `release:linux` script and deterministic Linux artifact names in electron-builder config
- Website `useLatestDesktopDownload` matches AppImage assets for Linux
- Changelog entry