### PR TITLE
fix(node): Retry initial reserve backpressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed bursty buyer startups causing initial payment-channel reserves to fail when delegated seller accounts reject excess in-flight transactions. Sellers now retry transient transaction backpressure before acknowledging the channel.
 - Fixed seller health checks leaving unavailable upstreams advertised: HTTP 402 responses now count as failures, every failing service can be removed, and a provider with no healthy services is omitted from signed discovery metadata until a probe succeeds.
 - Fixed OpenAI Responses model health probes using a scalar `input` value that strict providers rejected with HTTP 400, leaving every health result inconclusive and preventing automatic model unadvertising.
 - Fixed payment negotiation getting stuck when a buyer lost its local channel state while an older channel remained active on-chain. Sellers now close the superseded channel from durable seller state before accepting the buyer's replacement ReserveAuth.

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -60,6 +60,8 @@ const CLOSE_RETRY_AFTER_MS = 2_000;
 const TOP_UP_THRESHOLD_NOT_MET_SELECTOR = '0x1ea4506b';
 const INSUFFICIENT_BALANCE_SELECTOR = '0xf4d678b8';
 const IN_FLIGHT_TX_LIMIT_PHRASE = 'in-flight transaction limit';
+/** Backoff stays well inside the buyer's 30-second AuthAck timeout. */
+const RESERVE_BACKPRESSURE_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000] as const;
 
 type TopUpFailureKind = 'retryable-threshold' | 'retryable-tx-backpressure' | 'insufficient-balance' | 'non-retryable';
 /** `amount`/`txHash` describe the close actually submitted on-chain, which may
@@ -531,16 +533,15 @@ export class SellerPaymentManager {
           }
         }
 
-        debugLog(`[SellerPayment] Reserving channel ${channelId.slice(0, 18)}... on-chain`);
         const reserveSalt = payload.reserveSalt ?? channelId;
-        await this._channelsClient.reserve(
+        await this._reserveWithBackpressureRetry(channelId, () => this._channelsClient.reserve(
           this._signer,
           buyerEvmAddr,
           reserveSalt,
           reserveMaxAmount,
           BigInt(reserveDeadline),
           payload.spendingAuthSig,
-        );
+        ));
 
         // Store new session (sessionId field stores channelId for backward compat)
         const now = Date.now();
@@ -765,6 +766,37 @@ export class SellerPaymentManager {
     } catch (err) {
       debugWarn(`[SellerPayment] Failed to process SpendingAuth: ${err instanceof Error ? err.message : err}`);
       return 'rejected';
+    }
+  }
+
+  /**
+   * Retry initial reserves rejected by delegated-account transaction
+   * backpressure. BaseEvmClient already assigns distinct nonces across buyers;
+   * retries let a rejected submission land as soon as the provider's account
+   * queue has room, without holding unrelated buyers until a receipt is mined.
+   */
+  private async _reserveWithBackpressureRetry(
+    channelId: string,
+    submit: () => Promise<string>,
+  ): Promise<string> {
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        debugLog(
+          `[SellerPayment] Reserving channel ${channelId.slice(0, 18)}... on-chain` +
+          `${attempt > 0 ? ` (retry ${attempt}/${RESERVE_BACKPRESSURE_RETRY_DELAYS_MS.length})` : ''}`,
+        );
+        return await submit();
+      } catch (err) {
+        const delayMs = RESERVE_BACKPRESSURE_RETRY_DELAYS_MS[attempt];
+        if (!this._isRetryableTxSubmissionFailure(err) || delayMs === undefined) {
+          throw err;
+        }
+        debugWarn(
+          `[SellerPayment] Reserve hit transaction backpressure for ${channelId.slice(0, 18)}... ` +
+          `— retrying in ${delayMs}ms: ${this._formatError(err)}`,
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+      }
     }
   }
 

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -189,6 +189,75 @@ describe('SellerPaymentManager', () => {
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
   });
 
+  it('retries overlapping initial reserves after delegated account transaction backpressure', async () => {
+    vi.useFakeTimers();
+    try {
+      const otherBuyer = createTestIdentity();
+      const channelId = makeChannelId(123);
+      const otherChannelId = makeChannelId(124);
+      const [payload, otherPayload] = await Promise.all([
+        buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { isReserve: true }),
+        buildSpendingAuth(otherBuyer, sellerIdentity, otherChannelId, { isReserve: true }),
+      ]);
+      const attemptsByBuyer = new Map<string, number>();
+      vi.mocked(manager.channelsClient.reserve).mockImplementation(async (_signer, buyerAddress) => {
+        const attempts = (attemptsByBuyer.get(buyerAddress) ?? 0) + 1;
+        attemptsByBuyer.set(buyerAddress, attempts);
+        if (attempts === 1) throw makeInFlightTxLimitError();
+        return '0xreserve-hash';
+      });
+
+      const resultsPromise = Promise.all([
+        manager.handleSpendingAuth(buyerIdentity.peerId, payload, mux),
+        manager.handleSpendingAuth(otherBuyer.peerId, otherPayload, mux),
+      ]);
+      await vi.waitFor(() => expect(manager.channelsClient.reserve).toHaveBeenCalledTimes(2));
+      expect(mux.sentAuthAcks).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(250);
+      await expect(resultsPromise).resolves.toEqual(['reserved', 'reserved']);
+
+      expect(manager.channelsClient.reserve).toHaveBeenCalledTimes(4);
+      expect(mux.sentAuthAcks).toHaveLength(2);
+      expect(store.getChannel(channelId)?.status).toBe(CHANNEL_STATUS.ACTIVE);
+      expect(store.getChannel(otherChannelId)?.status).toBe(CHANNEL_STATUS.ACTIVE);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects an initial reserve after transaction backpressure retries are exhausted', async () => {
+    vi.useFakeTimers();
+    try {
+      const channelId = makeChannelId(125);
+      const payload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { isReserve: true });
+      vi.mocked(manager.channelsClient.reserve).mockRejectedValue(makeInFlightTxLimitError());
+
+      const resultPromise = manager.handleSpendingAuth(buyerIdentity.peerId, payload, mux);
+      await vi.waitFor(() => expect(manager.channelsClient.reserve).toHaveBeenCalledOnce());
+      await vi.runAllTimersAsync();
+
+      await expect(resultPromise).resolves.toBe('rejected');
+      expect(manager.channelsClient.reserve).toHaveBeenCalledTimes(6);
+      expect(mux.sentAuthAcks).toHaveLength(0);
+      expect(store.getChannel(channelId)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not retry a permanent initial reserve failure', async () => {
+    const channelId = makeChannelId(124);
+    const payload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { isReserve: true });
+    vi.mocked(manager.channelsClient.reserve).mockRejectedValueOnce(new Error('execution reverted: InsufficientBalance'));
+
+    await expect(manager.handleSpendingAuth(buyerIdentity.peerId, payload, mux)).resolves.toBe('rejected');
+
+    expect(manager.channelsClient.reserve).toHaveBeenCalledOnce();
+    expect(mux.sentAuthAcks).toHaveLength(0);
+    expect(store.getChannel(channelId)).toBeNull();
+  });
+
   it('closes a prior signed channel before reserving a replacement channel', async () => {
     const priorChannelId = makeChannelId(110);
     const replacementChannelId = makeChannelId(111);


### PR DESCRIPTION
## Description

Retries initial payment-channel reserve submissions when delegated seller accounts temporarily reject excess in-flight transactions. Retries use bounded backoff within the buyer’s AuthAck timeout, while permanent failures still reject immediately.

## Release Notes

- Fixed payment-channel setup failures during bursty buyer startups caused by delegated-account transaction backpressure.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
