### PR TITLE
feat(desktop): add VPR deposit history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- The desktop app's deposit screen now has a "View deposit history" link showing every past USDC deposit (amount, date, and a link to the transaction on Basescan), read directly from the Deposits contract's `Deposited` events. Previously the only deposit-related record in the app was a live in-flight status while a deposit was being swept — there was no way to see past deposits. Exposed as `DepositsClient.getDepositHistory()` in `@antseed/node`, which scans `eth_getLogs` in adaptively-sized chunks so it works regardless of a given RPC provider's block-range cap.
 - Sellers now run periodic model health self-checks (a 1-token probe per advertised service, every 5 minutes by default) and unadvertise services that keep failing, restoring them automatically when they recover. Configurable via `seller.healthCheck` (`enabled`, `intervalMs`, `failureThreshold`); sellers announcing this behavior advertise the `seller.model-health.v1` capability in discovery metadata. Exposed as `ModelHealthChecker` in `@antseed/node`, alongside `AntseedNode.refreshSellerMetadata()` for runtime service-list changes.
 - The buyer proxy now treats `model_not_found` responses as routing failures (instead of successes) and refreshes peer discovery metadata in the background, so a stale cached model list recovers quickly after a seller unadvertises a model.
 

--- a/apps/desktop/src/main/ipc/payments.ts
+++ b/apps/desktop/src/main/ipc/payments.ts
@@ -45,6 +45,10 @@ import {
   sweepIncomingUsdc,
 } from '../payments/deposit-sweep.js';
 import {
+  type DepositHistoryEntry,
+  loadDepositHistory,
+} from '../payments/deposit-history.js';
+import {
   DEFAULT_CARD_PROVIDERS,
   PAYMENTS_PORT,
   PAY_PAGE_KINDS,
@@ -250,6 +254,12 @@ export function registerPaymentsIpc(): void {
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
+  });
+
+  ipcMain.handle('deposits:get-history', async (): Promise<{ ok: boolean; data: DepositHistoryEntry[] | null; chainId: number | null; error: string | null }> => {
+    const result = await loadDepositHistory();
+    if (!result.ok) return { ok: false, data: null, chainId: null, error: result.error ?? 'Unknown error' };
+    return { ok: true, data: result.data ?? [], chainId: result.chainId ?? null, error: null };
   });
 
   ipcMain.handle('deposits:watch-stop', () => {

--- a/apps/desktop/src/main/payments/credits.ts
+++ b/apps/desktop/src/main/payments/credits.ts
@@ -65,6 +65,7 @@ let cachedCryptoConfig: {
   emissionsAddress?: string;
   antsTokenAddress?: string;
   depositRelayAddress?: string;
+  depositsDeployBlock?: number;
 } | null = null;
 
 // Cached on-chain clients for the rewards summary — invalidated together with
@@ -98,6 +99,7 @@ export async function loadCachedCryptoConfig(): Promise<typeof cachedCryptoConfi
     ...(cc.emissionsContractAddress ? { emissionsAddress: cc.emissionsContractAddress } : {}),
     ...(cc.antsTokenAddress ? { antsTokenAddress: cc.antsTokenAddress } : {}),
     ...(cc.depositRelayAddress ? { depositRelayAddress: cc.depositRelayAddress } : {}),
+    ...(cc.depositsDeployBlock !== undefined ? { depositsDeployBlock: cc.depositsDeployBlock } : {}),
   };
   return cachedCryptoConfig;
 }

--- a/apps/desktop/src/main/payments/deposit-history.ts
+++ b/apps/desktop/src/main/payments/deposit-history.ts
@@ -1,0 +1,68 @@
+/**
+ * Past on-chain deposits for the signed-in buyer, read from the Deposits
+ * contract's `Deposited` events. A full scan from the contract's deploy
+ * block is expensive on mainnet (millions of blocks), so results are cached
+ * in memory for the session and each subsequent call only scans the blocks
+ * produced since the last one.
+ */
+import { getSecureIdentity } from '../identity.js';
+import { loadCachedCryptoConfig } from './credits.js';
+import { makeDepositsClient } from './deposit-sweep.js';
+
+export type DepositHistoryEntry = {
+  blockNumber: number;
+  txHash: string;
+  /** USDC base units (6 decimals), bigint string. */
+  amountBaseUnits: string;
+  /** Block timestamp, unix seconds. */
+  timestamp: number;
+};
+
+let cachedBuyer: string | null = null;
+let cachedChainId: number | null = null;
+let cachedEntries: DepositHistoryEntry[] = [];
+let cachedThroughBlock = -1;
+
+export async function loadDepositHistory(): Promise<{ ok: boolean; data?: DepositHistoryEntry[]; chainId?: number; error?: string }> {
+  const identity = getSecureIdentity();
+  if (!identity) return { ok: false, error: 'Identity not available' };
+  const cc = await loadCachedCryptoConfig();
+  if (!cc) return { ok: false, error: 'No payment chain configured' };
+
+  const buyer = identity.wallet.address;
+  if (buyer !== cachedBuyer || cc.chainId !== cachedChainId) {
+    cachedBuyer = buyer;
+    cachedChainId = cc.chainId;
+    cachedEntries = [];
+    cachedThroughBlock = -1;
+  }
+
+  const client = makeDepositsClient(cc);
+  try {
+    const toBlock = await client.getBlockNumber();
+    const fromBlock = cachedThroughBlock >= 0 ? cachedThroughBlock + 1 : (cc.depositsDeployBlock ?? 0);
+    if (fromBlock <= toBlock) {
+      const events = await client.getDepositHistory(buyer, { fromBlock, toBlock });
+      const additions = events.map((e) => ({
+        blockNumber: e.blockNumber,
+        txHash: e.txHash,
+        amountBaseUnits: e.amount.toString(),
+        timestamp: e.timestamp,
+      }));
+      cachedEntries = [...cachedEntries, ...additions];
+      cachedThroughBlock = toBlock;
+    }
+    // Newest first for display.
+    return { ok: true, data: [...cachedEntries].reverse(), chainId: cc.chainId };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/** Drop the cached history — call when the signing identity changes. */
+export function invalidateDepositHistoryCache(): void {
+  cachedBuyer = null;
+  cachedChainId = null;
+  cachedEntries = [];
+  cachedThroughBlock = -1;
+}

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -549,6 +549,7 @@ const api = {
   },
   depositsWatchStart: () => ipcRenderer.invoke('deposits:watch-start'),
   depositsWatchStop: () => ipcRenderer.invoke('deposits:watch-stop'),
+  depositsGetHistory: () => ipcRenderer.invoke('deposits:get-history'),
   onDepositsWatchStatus(handler: (data: unknown) => void): () => void {
     const listener = (_: unknown, data: unknown) => handler(data);
     ipcRenderer.on('deposits:watch-status', listener);

--- a/apps/desktop/src/renderer/core/format.ts
+++ b/apps/desktop/src/renderer/core/format.ts
@@ -213,6 +213,13 @@ export function formatCompactUsd(value: number): string {
   return `$${trimmed}`;
 }
 
+/** Block-explorer transaction URL for a chain we know about, or null. */
+export function explorerTxUrl(chainId: number | undefined, txHash: string): string | null {
+  if (chainId === 8453) return `https://basescan.org/tx/${txHash}`;
+  if (chainId === 84532) return `https://sepolia.basescan.org/tx/${txHash}`;
+  return null;
+}
+
 export function shortAddress(value: string | null): string {
   if (!value) return 'Not configured';
   return value.length > 14 ? `${value.slice(0, 6)}...${value.slice(-4)}` : value;

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -86,6 +86,15 @@ export type DesktopRewardsSummary = {
   error: string | null;
 };
 
+export type DepositHistoryEntry = {
+  blockNumber: number;
+  txHash: string;
+  /** USDC base units (6 decimals), bigint string. */
+  amountBaseUnits: string;
+  /** Block timestamp, unix seconds. */
+  timestamp: number;
+};
+
 export type DepositWatchStatus = {
   phase: 'received' | 'sweeping' | 'credited' | 'error';
   /** USDC base units (6 decimals), bigint string. */
@@ -411,6 +420,7 @@ export type DesktopBridge = {
   depositsWatchStart?: () => Promise<{ ok: boolean; data?: { address: string; walletUsdcBaseUnits: string; usdcAddress: string; chainId: number }; error?: string }>;
   depositsWatchStop?: () => Promise<{ ok: boolean }>;
   onDepositsWatchStatus?: (handler: (data: DepositWatchStatus) => void) => () => void;
+  depositsGetHistory?: () => Promise<{ ok: boolean; data: DepositHistoryEntry[] | null; chainId: number | null; error: string | null }>;
 
   systemProxyStart?: (opts: { peerId: string; port?: number; profiles?: string[]; defaultModel?: string; servedModels?: string[]; toolRoutes?: Record<string, { peerId: string; model: string }>; profileSwitch?: boolean }) => Promise<{ ok: boolean; state?: RuntimeProcessState; error?: string }>;
   systemProxyListProfiles?: () => Promise<SystemProxyProfileSummary[]>;

--- a/apps/desktop/src/renderer/ui/components/viewRegistry.ts
+++ b/apps/desktop/src/renderer/ui/components/viewRegistry.ts
@@ -134,6 +134,12 @@ export const VIEW_REGISTRY = {
     async () => (await import('./views/VprDepositView')).VprDepositView as ComponentType<RoutedViewProps>,
     { receivesOnSelectView: true, slideIndex: 6, preloadPriority: 'idle' },
   ),
+  'deposit-history': createViewEntry(
+    async () => (await import('./views/VprDepositHistoryView')).VprDepositHistoryView as ComponentType<RoutedViewProps>,
+    // Drill-in from the deposit chooser — slides in from its right, same
+    // idiom as `chats` (3.5) between `tools` (3) and `preferences` (4).
+    { receivesOnSelectView: true, slideIndex: 6.5, preloadPriority: 'none' },
+  ),
   activity: createViewEntry(
     async () => (await import('./views/VprActivityView')).VprActivityView as ComponentType<RoutedViewProps>,
     { receivesOnSelectView: true, slideIndex: 7, preloadPriority: 'idle' },

--- a/apps/desktop/src/renderer/ui/components/views/VprDepositHistoryView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositHistoryView.module.scss
@@ -1,0 +1,121 @@
+.view {
+  height: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: clip;
+  padding: 8px 16px 24px;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  max-width: 392px;
+  margin: 0 auto;
+  min-width: 0;
+}
+
+/* ---------- Empty / error states ---------- */
+
+.emptyCard {
+  display: grid;
+  gap: 4px;
+  padding: 20px 16px;
+  text-align: center;
+}
+
+.emptyTitle {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 18px;
+}
+
+.emptyHint {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.errorCard {
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent-red, #d64545) 12%, transparent);
+  color: var(--accent-red, #d64545);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+/* ---------- Deposit list ---------- */
+
+.listCard {
+  display: grid;
+  padding: 4px 16px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+}
+
+.row + .row {
+  border-top: 1px solid var(--border);
+}
+
+.rowMain {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.rowAmount {
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 17px;
+}
+
+.rowMeta {
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 15px;
+}
+
+.rowSide {
+  display: grid;
+  gap: 2px;
+  justify-items: end;
+  flex: 0 0 auto;
+}
+
+.txLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--accent-green);
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 15px;
+  cursor: pointer;
+}
+
+.txLink:hover {
+  color: var(--brand);
+}
+
+/* ---------- Footnote ---------- */
+
+.footnote {
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 15px;
+  text-align: center;
+  padding: 0 8px;
+}

--- a/apps/desktop/src/renderer/ui/components/views/VprDepositHistoryView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositHistoryView.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useState } from 'react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArrowUpRight01Icon } from '@hugeicons/core-free-icons';
+import { explorerTxUrl, formatShortId } from '../../../core/format';
+import { VprCard, VprPage } from '../vpr/VprKit';
+import type { DepositHistoryEntry } from '../../../types/bridge';
+import styles from './VprDepositHistoryView.module.scss';
+
+function baseUnitsToUsd(value: string | undefined): string {
+  try {
+    const units = BigInt(value ?? '0');
+    const whole = units / 1_000_000n;
+    const cents = (units % 1_000_000n) / 10_000n;
+    return `${whole}.${cents.toString().padStart(2, '0')}`;
+  } catch {
+    return '0.00';
+  }
+}
+
+function formatDate(tsSeconds: number): string {
+  if (!tsSeconds) return '';
+  return new Date(tsSeconds * 1000).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+type Props = { onSelectView?: (view: import('../../types').ViewName) => void };
+
+/**
+ * Past on-chain deposits: amount, date and a link to the transaction on the
+ * chain explorer. Read-only — deposits are recorded on-chain via the QR/card
+ * flow in VprDepositView, this just lists what already happened.
+ */
+export function VprDepositHistoryView({ onSelectView: _onSelectView }: Props) {
+  const [entries, setEntries] = useState<DepositHistoryEntry[] | null>(null);
+  const [chainId, setChainId] = useState<number | undefined>(undefined);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void window.antseedDesktop?.depositsGetHistory?.().then((result) => {
+      if (cancelled) return;
+      if (result.ok) {
+        setEntries(result.data ?? []);
+        setChainId(result.chainId ?? undefined);
+      } else {
+        setError(result.error ?? 'Could not load deposit history');
+        setEntries([]);
+      }
+    }).catch((err: unknown) => {
+      if (cancelled) return;
+      setError(err instanceof Error ? err.message : String(err));
+      setEntries([]);
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  const loading = entries === null;
+
+  return (
+    <section className={`view view-vpr-deposit-history view-pinned-header ${styles.view}`} role="tabpanel">
+      <VprPage title="Deposit history" backFallback="deposit">
+      <div className={styles.stack}>
+
+        {error && <div className={styles.errorCard} role="alert">{error}</div>}
+
+        {loading ? (
+          <VprCard className={styles.emptyCard}>
+            <span className={styles.emptyTitle}>Loading deposits...</span>
+          </VprCard>
+        ) : entries!.length === 0 ? (
+          <VprCard className={styles.emptyCard}>
+            <span className={styles.emptyTitle}>No deposits yet</span>
+            <span className={styles.emptyHint}>
+              USDC you add to your balance shows up here once it lands on-chain.
+            </span>
+          </VprCard>
+        ) : (
+          <VprCard className={styles.listCard}>
+            {entries!.map((entry) => {
+              const txUrl = explorerTxUrl(chainId, entry.txHash);
+              return (
+                <div key={`${entry.txHash}-${entry.blockNumber}`} className={styles.row}>
+                  <div className={styles.rowMain}>
+                    <span className={styles.rowAmount}>${baseUnitsToUsd(entry.amountBaseUnits)}</span>
+                    <span className={styles.rowMeta}>{formatDate(entry.timestamp)}</span>
+                  </div>
+                  <div className={styles.rowSide}>
+                    {txUrl ? (
+                      <button
+                        type="button"
+                        className={styles.txLink}
+                        onClick={() => void window.antseedDesktop?.openExternalUrl?.(txUrl)}
+                      >
+                        <span>{formatShortId(entry.txHash, 6, 4)}</span>
+                        <HugeiconsIcon icon={ArrowUpRight01Icon} size={12} strokeWidth={2} />
+                      </button>
+                    ) : (
+                      <span className={styles.rowMeta}>{formatShortId(entry.txHash, 6, 4)}</span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </VprCard>
+        )}
+
+        <span className={styles.footnote}>
+          Deposits are credited automatically once they confirm on Base — this list is
+          read directly from the AntSeed Deposits contract.
+        </span>
+      </div>
+      </VprPage>
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/ui/components/views/VprDepositView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositView.module.scss
@@ -485,6 +485,25 @@
   color: var(--brand);
 }
 
+.historyLink {
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 16px;
+  cursor: pointer;
+}
+
+.historyLink:hover {
+  color: var(--text-primary);
+}
+
 .cardPayButton {
   width: 100%;
   min-height: 44px;

--- a/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
@@ -13,7 +13,7 @@ import {
 } from '@hugeicons/core-free-icons';
 import { shallowEqual, useUiSelector } from '../../hooks/useUiSelector';
 import { useActions } from '../../hooks/useActions';
-import { formatCredits, shortAddress } from '../../../core/format';
+import { explorerTxUrl, formatCredits, shortAddress } from '../../../core/format';
 import { VprCard, VprPage } from '../vpr/VprKit';
 import { takeDepositIntent, type DepositMethod } from '../../lib/depositIntent';
 import type { DepositWatchStatus } from '../../../types/bridge';
@@ -254,12 +254,6 @@ function StripeMark({ size = 22 }: { size?: number }) {
       <path fillRule="evenodd" clipRule="evenodd" d="M120 392L392 334.317V120L120 178.357V392Z" fill="#fff" />
     </svg>
   );
-}
-
-function explorerTxUrl(chainId: number | undefined, txHash: string): string | null {
-  if (chainId === 8453) return `https://basescan.org/tx/${txHash}`;
-  if (chainId === 84532) return `https://sepolia.basescan.org/tx/${txHash}`;
-  return null;
 }
 
 /** A selectable card option: hosted URL providers (Coinbase, etc.) plus the
@@ -516,6 +510,15 @@ export function VprDepositView({ onSelectView }: Props) {
               what you use, and unused credits can be withdrawn anytime.
             </span>
           </VprCard>
+
+          <button
+            type="button"
+            className={styles.historyLink}
+            onClick={() => onSelectView?.('deposit-history')}
+          >
+            <span>View deposit history</span>
+            <HugeiconsIcon icon={ArrowRight01Icon} size={14} strokeWidth={2} />
+          </button>
 
           {/* Primary path: deposit through Fun (fun.xyz). The Fun checkout
               only runs on the web; until our hosted integration is live this

--- a/apps/desktop/src/renderer/ui/types.ts
+++ b/apps/desktop/src/renderer/ui/types.ts
@@ -1,4 +1,4 @@
-export const VPR_VIEW_NAMES = ['home', 'explore', 'model', 'tools', 'chats', 'preferences', 'credits', 'deposit', 'activity', 'rewards', 'chat', 'help'] as const;
+export const VPR_VIEW_NAMES = ['home', 'explore', 'model', 'tools', 'chats', 'preferences', 'credits', 'deposit', 'deposit-history', 'activity', 'rewards', 'chat', 'help'] as const;
 export const DEV_VIEW_NAMES = ['peers', 'connection', 'desktop', 'config'] as const;
 
 export const VIEW_NAMES = [...VPR_VIEW_NAMES, ...DEV_VIEW_NAMES] as const;

--- a/apps/desktop/src/shared/view-windows.ts
+++ b/apps/desktop/src/shared/view-windows.ts
@@ -15,6 +15,7 @@ export const VIEW_WINDOW_PRESETS = {
   preferences: 'compact',
   credits: 'compact',
   deposit: 'compact',
+  'deposit-history': 'compact',
   activity: 'compact',
   rewards: 'compact',
   help: 'compact',

--- a/packages/node/src/payments/chain-config.ts
+++ b/packages/node/src/payments/chain-config.ts
@@ -23,6 +23,8 @@ export interface ChainConfig {
   antsTokenAddress?: string;
   /** Block when Channels contract was deployed. Floor for event log scans. */
   channelsDeployBlock?: number;
+  /** Block when Deposits contract was deployed. Floor for deposit-history event log scans. */
+  depositsDeployBlock?: number;
   /** AntseedStats contract address. Populated only where an indexer aggregates it. */
   statsContractAddress?: string;
   /** Deployment block of AntseedStats for cold-start indexer backfill. */
@@ -58,6 +60,7 @@ const CHAIN_CONFIGS: Record<ChainId, ChainConfig> = {
     antsTokenAddress: '0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263',
     identityRegistryAddress: '0x8004A169FB4a3325136EB29fA0ceB6D2e539a432',
     channelsDeployBlock: 44469557,
+    depositsDeployBlock: 44469557,
     statsContractAddress: '0x15649ff076bfa5e37e24ee3154a00503149954fd',
     statsDeployBlock: 44469557,
     networkStatsUrl: 'https://network.antseed.com',

--- a/packages/node/src/payments/evm/deposits-client.test.ts
+++ b/packages/node/src/payments/evm/deposits-client.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { ethers } from 'ethers';
+import { DepositsClient } from './deposits-client.js';
+
+const DEPOSITED_ABI = [
+  'event Deposited(address indexed buyer, uint256 amount)',
+] as const;
+
+const CONTRACT_ADDRESS = '0x0000000000000000000000000000000000000001';
+const USDC_ADDRESS = '0x0000000000000000000000000000000000000002';
+
+function makeClient(): DepositsClient {
+  return new DepositsClient({ rpcUrl: 'http://localhost:8545', contractAddress: CONTRACT_ADDRESS, usdcAddress: USDC_ADDRESS });
+}
+
+function buildLog(params: {
+  buyer: string;
+  amount: bigint;
+  blockNumber: number;
+  transactionHash: string;
+  index: number;
+}) {
+  const iface = new ethers.Interface(DEPOSITED_ABI);
+  const encoded = iface.encodeEventLog('Deposited', [params.buyer, params.amount]);
+  return {
+    topics: encoded.topics,
+    data: encoded.data,
+    blockNumber: params.blockNumber,
+    transactionHash: params.transactionHash,
+    index: params.index,
+    address: CONTRACT_ADDRESS,
+  };
+}
+
+describe('DepositsClient.getDepositHistory', () => {
+  it('decodes Deposited logs and resolves block timestamps', async () => {
+    const buyer = ethers.getAddress('0xabcdef1234567890abcdef1234567890abcdef12');
+    const amount = 5_000_000n;
+    const blockNumber = 1000;
+    const transactionHash = '0x' + 'ff'.repeat(32);
+
+    const cannedLog = buildLog({ buyer, amount, blockNumber, transactionHash, index: 2 });
+
+    const client = makeClient();
+    (client as any)._provider.getLogs = async () => [cannedLog];
+    (client as any)._provider.getBlock = async () => ({ timestamp: 1_700_000_000 });
+
+    const events = await client.getDepositHistory(buyer, { fromBlock: 0, toBlock: 2000 });
+
+    expect(events).toHaveLength(1);
+    const evt = events[0]!;
+    expect(evt.buyer).toBe(buyer.toLowerCase());
+    expect(evt.amount).toBe(amount);
+    expect(evt.blockNumber).toBe(blockNumber);
+    expect(evt.txHash).toBe(transactionHash);
+    expect(evt.logIndex).toBe(2);
+    expect(evt.timestamp).toBe(1_700_000_000);
+  });
+
+  it('sorts events ascending by (blockNumber, logIndex)', async () => {
+    const buyer = '0x0000000000000000000000000000000000000003';
+    const base = { buyer, amount: 1_000_000n, transactionHash: '0x' + '00'.repeat(32) };
+
+    const log1 = buildLog({ ...base, blockNumber: 5, index: 0 });
+    const log2 = buildLog({ ...base, blockNumber: 3, index: 1 });
+    const log3 = buildLog({ ...base, blockNumber: 3, index: 0 });
+
+    const client = makeClient();
+    (client as any)._provider.getLogs = async () => [log1, log2, log3];
+    (client as any)._provider.getBlock = async () => ({ timestamp: 1_700_000_000 });
+
+    const events = await client.getDepositHistory(buyer, { fromBlock: 0, toBlock: 10 });
+
+    expect(events).toHaveLength(3);
+    expect(events[0]!.blockNumber).toBe(3);
+    expect(events[0]!.logIndex).toBe(0);
+    expect(events[1]!.blockNumber).toBe(3);
+    expect(events[1]!.logIndex).toBe(1);
+    expect(events[2]!.blockNumber).toBe(5);
+    expect(events[2]!.logIndex).toBe(0);
+  });
+
+  it('halves the block range and retries when the RPC rejects a wide getLogs call', async () => {
+    const buyer = ethers.getAddress('0xabcdef1234567890abcdef1234567890abcdef12');
+    const amount = 2_000_000n;
+    const transactionHash = '0x' + 'ab'.repeat(32);
+    const cannedLog = buildLog({ buyer, amount, blockNumber: 750, transactionHash, index: 0 });
+
+    const client = makeClient();
+    const calls: Array<{ fromBlock: number; toBlock: number }> = [];
+    (client as any)._provider.getLogs = async (params: { fromBlock: number; toBlock: number }) => {
+      calls.push({ fromBlock: params.fromBlock, toBlock: params.toBlock });
+      const span = params.toBlock - params.fromBlock + 1;
+      if (span > 600) {
+        throw new Error('block range exceeds the maximum allowed');
+      }
+      return params.fromBlock <= 750 && 750 <= params.toBlock ? [cannedLog] : [];
+    };
+    (client as any)._provider.getBlock = async () => ({ timestamp: 1_700_000_000 });
+
+    const events = await client.getDepositHistory(buyer, { fromBlock: 0, toBlock: 999, chunkSize: 1000 });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.blockNumber).toBe(750);
+    // The initial full-range call failed and was split into narrower retries.
+    expect(calls.some((c) => c.toBlock - c.fromBlock + 1 > 600)).toBe(true);
+    expect(calls.some((c) => c.toBlock - c.fromBlock + 1 <= 600)).toBe(true);
+  });
+
+  it('gives up once the adaptive range hits the minimum chunk floor', async () => {
+    const buyer = '0x0000000000000000000000000000000000000004';
+    const client = makeClient();
+    (client as any)._provider.getLogs = async () => {
+      throw new Error('persistently rejected');
+    };
+
+    await expect(client.getDepositHistory(buyer, { fromBlock: 0, toBlock: 999, chunkSize: 1000 }))
+      .rejects.toThrow('persistently rejected');
+  });
+
+  it('returns an empty list without querying when fromBlock is after toBlock', async () => {
+    const buyer = '0x0000000000000000000000000000000000000005';
+    const client = makeClient();
+    let called = false;
+    (client as any)._provider.getLogs = async () => { called = true; return []; };
+
+    const events = await client.getDepositHistory(buyer, { fromBlock: 100, toBlock: 50 });
+
+    expect(events).toEqual([]);
+    expect(called).toBe(false);
+  });
+});

--- a/packages/node/src/payments/evm/deposits-client.ts
+++ b/packages/node/src/payments/evm/deposits-client.ts
@@ -1,5 +1,5 @@
-import { Contract } from 'ethers';
-import type { AbstractSigner } from 'ethers';
+import { Contract, ethers } from 'ethers';
+import type { AbstractSigner, Log } from 'ethers';
 import { BaseEvmClient, ERC20_ABI } from './base-evm-client.js';
 
 export interface DepositsClientConfig {
@@ -16,6 +16,16 @@ export interface BuyerBalanceInfo {
   lastActivityAt: bigint;
 }
 
+export interface DecodedDeposited {
+  blockNumber: number;
+  txHash: string;
+  logIndex: number;
+  buyer: string;
+  amount: bigint;
+  /** Block timestamp, unix seconds. */
+  timestamp: number;
+}
+
 const DEPOSITS_ABI = [
   'function deposit(address buyer, uint256 amount) external',
   'function withdraw(address buyer, uint256 amount) external',
@@ -27,7 +37,16 @@ const DEPOSITS_ABI = [
   'function setOperator(address buyer, address operator, uint256 nonce, bytes buyerSig) external',
   'function transferOperator(address buyer, address newOperator) external',
   'function domainSeparator() external view returns (bytes32)',
+  'event Deposited(address indexed buyer, uint256 amount)',
 ] as const;
+
+// Public RPC providers cap eth_getLogs to widely varying block ranges (and
+// signal it in provider-specific error shapes), so a fixed chunk size can't
+// be trusted. Start at a generous span and, on any error, halve the range
+// and retry until either it succeeds or hits the floor (where the error is
+// no longer a range problem and should surface to the caller).
+const DEFAULT_LOG_CHUNK_BLOCKS = 50_000;
+const MIN_LOG_CHUNK_BLOCKS = 500;
 
 export class DepositsClient extends BaseEvmClient {
   private readonly _usdcAddress: string;
@@ -96,5 +115,86 @@ export class DepositsClient extends BaseEvmClient {
   async getUSDCBalance(ownerAddr: string): Promise<bigint> {
     const usdc = new Contract(this._usdcAddress, ERC20_ABI, this._provider);
     return usdc.getFunction('balanceOf')(ownerAddr) as Promise<bigint>;
+  }
+
+  // ─── Deposit History ────────────────────────────────────────────
+
+  async getBlockNumber(): Promise<number> {
+    return this._provider.getBlockNumber();
+  }
+
+  /**
+   * Fetch this buyer's past Deposited events between fromBlock and toBlock
+   * (inclusive, defaults to the full chain history through the latest
+   * block). Scans in chunks with adaptive range-halving so it works against
+   * public RPCs regardless of their eth_getLogs block-range cap, and
+   * resolves each event's block timestamp. Returns events sorted by
+   * (blockNumber, logIndex) ascending.
+   */
+  async getDepositHistory(buyerAddr: string, opts?: {
+    fromBlock?: number;
+    toBlock?: number;
+    chunkSize?: number;
+  }): Promise<DecodedDeposited[]> {
+    const toBlock = opts?.toBlock ?? await this.getBlockNumber();
+    const fromBlock = opts?.fromBlock ?? 0;
+    if (fromBlock > toBlock) return [];
+    const chunkSize = opts?.chunkSize ?? DEFAULT_LOG_CHUNK_BLOCKS;
+
+    const iface = new ethers.Interface(DEPOSITS_ABI);
+    const topic = iface.getEvent('Deposited')!.topicHash;
+    const buyerTopic = ethers.zeroPadValue(ethers.getAddress(buyerAddr), 32);
+
+    const decoded: DecodedDeposited[] = [];
+    for (let start = fromBlock; start <= toBlock; start += chunkSize) {
+      const end = Math.min(start + chunkSize - 1, toBlock);
+      const logs = await this._getLogsAdaptive(topic, buyerTopic, start, end);
+      for (const log of logs) {
+        const parsed = iface.parseLog({ topics: [...log.topics], data: log.data });
+        if (!parsed || parsed.name !== 'Deposited') continue;
+        decoded.push({
+          blockNumber: log.blockNumber,
+          txHash: log.transactionHash,
+          logIndex: log.index,
+          buyer: (parsed.args[0] as string).toLowerCase(),
+          amount: parsed.args[1] as bigint,
+          timestamp: 0,
+        });
+      }
+    }
+
+    // Resolve block timestamps — one lookup per unique block, not per event.
+    const uniqueBlocks = [...new Set(decoded.map((e) => e.blockNumber))];
+    const timestamps = new Map<number, number>();
+    await Promise.all(uniqueBlocks.map(async (blockNumber) => {
+      const block = await this._provider.getBlock(blockNumber);
+      timestamps.set(blockNumber, block?.timestamp ?? 0);
+    }));
+    for (const event of decoded) event.timestamp = timestamps.get(event.blockNumber) ?? 0;
+
+    decoded.sort((a, b) =>
+      a.blockNumber !== b.blockNumber ? a.blockNumber - b.blockNumber : a.logIndex - b.logIndex,
+    );
+    return decoded;
+  }
+
+  private async _getLogsAdaptive(topic: string, buyerTopic: string, fromBlock: number, toBlock: number): Promise<Log[]> {
+    try {
+      return await this._provider.getLogs({
+        address: this._contractAddress,
+        fromBlock,
+        toBlock,
+        topics: [topic, buyerTopic],
+      });
+    } catch (err) {
+      const span = toBlock - fromBlock + 1;
+      if (span <= MIN_LOG_CHUNK_BLOCKS) throw err;
+      const mid = fromBlock + Math.floor(span / 2) - 1;
+      const [left, right] = await Promise.all([
+        this._getLogsAdaptive(topic, buyerTopic, fromBlock, mid),
+        this._getLogsAdaptive(topic, buyerTopic, mid + 1, toBlock),
+      ]);
+      return [...left, ...right];
+    }
   }
 }

--- a/packages/node/src/payments/index.ts
+++ b/packages/node/src/payments/index.ts
@@ -18,7 +18,7 @@ export { BaseEvmClient } from './evm/base-evm-client.js';
 
 // Deposits client (buyer deposits + seller payouts)
 export { DepositsClient } from './evm/deposits-client.js';
-export type { DepositsClientConfig, BuyerBalanceInfo } from './evm/deposits-client.js';
+export type { DepositsClientConfig, BuyerBalanceInfo, DecodedDeposited } from './evm/deposits-client.js';
 
 // Channels client (reserve, settle, timeout)
 export { ChannelsClient } from './evm/channels-client.js';


### PR DESCRIPTION


## What

Adds a "deposit history" screen to the desktop app so users can see past USDC deposits — previously there was no way to see them anywhere, since the Activity tab only shows payment-channel spending, not deposits.

Implementation: DepositsClient.getDepositHistory() in @antseed/node reads Deposited events from the AntseedDeposits contract, wired through the desktop main process (cached per session) → IPC → preload → a new "View deposit history" screen off the deposit view.



## Why

there's no way for users to see their deposit history in the app, which makes it hard to reconcile balance changes or confirm a deposit actually landed. This closes that gap by reading deposit history directly from the on-chain Deposits contract, so it can't drift from what's actually true on-chain.


## Testing

- Added unit tests for the new event-scanning/chunking logic in `deposits-client.test.ts` (covers decoding, sorting, and the adaptive retry when an RPC rejects a wide block range)
- `pnpm run build` passes across the whole monorepo
- `pnpm run typecheck` passes (including the desktop renderer, which isn't covered by the root script, so I ran it separately)
- `pnpm run test` passes — 844 tests in @antseed/node, 171 in the desktop renderer, everything else green
- Did not manually test in the running Electron app — this needs a live wallet + local chain (the anvil setup in CLAUDE.md), which I didn't spin up for this change


## Checklist

- [ X] `pnpm run build` passes
- [ X] `pnpm run test` passes
- [ ] Breaking changes documented
