### PR TITLE
fix(desktop): Raise Node heap for the renderer build

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -18,7 +18,7 @@
     "prestart": "npm run ensure:cli-dist && npm run brand:electron-dev && npm run ensure:native",
     "build": "npm run build:main && npm run build:renderer",
     "build:main": "tsc -p tsconfig.main.json",
-    "build:renderer": "vite build",
+    "build:renderer": "cross-env NODE_OPTIONS=--max-old-space-size=4096 vite build",
     "test": "pnpm run build:main && node --test $(find dist/main -name '*.test.js') && pnpm run test:renderer",
     "test:renderer": "vitest run --dir src/renderer",
     "typecheck:renderer": "tsc -p tsconfig.renderer.json --noEmit",


### PR DESCRIPTION
## Description

The mac release job died with a JS heap OOM (exit 134) during the Vite renderer build — the Fun SDK's wagmi/walletconnect dependency graph pushes Rollup past Node's default ~2GB heap on the runner. Sets `--max-old-space-size=4096` on `build:renderer` via cross-env so every environment builds with headroom.

The `keccak`/`bigint-buffer` distutils warnings earlier in the same log are non-fatal (optional native builds with JS fallbacks).

## Changelog

No user-facing change — build infrastructure only.

## Testing

- Renderer build passes locally through the updated script.