### PR TITLE
chore(desktop): Slim the Fun/Crossmint wallet stack

### DIFF
--- a/apps/desktop/src/renderer/ui/components/views/FunkitDeposit.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/FunkitDeposit.tsx
@@ -5,15 +5,14 @@ import {
   FunkitProvider,
   useFunkitCheckout,
   useActiveTheme,
-  getDefaultChains,
-  getDefaultTransports,
   darkTheme,
   lightTheme,
   type FunkitConfig,
   type FunkitCheckoutConfig,
-  type FunkitWagmiConfig,
 } from '@funkit/connect';
-import { QueryClient } from '@tanstack/react-query';
+import { WagmiProvider, createConfig, http } from 'wagmi';
+import { base } from 'wagmi/chains';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { activeThemeMode, type ThemeMode } from '../../lib/theme';
 
 /**
@@ -40,20 +39,18 @@ type Props = {
   onError?: (message: string) => void;
 };
 
-// FunkitProvider only mounts its internal WagmiProvider + QueryClientProvider
-// when handed both a wagmi config and a query client (plus an initialChain to
-// resolve the chain id) — without them the SDK's hooks throw
-// WagmiProviderNotFoundError. Module-level singletons: one config/client for
-// the lifetime of the renderer, regardless of view remounts.
+// The SDK's hooks need a WagmiProvider above them (its own is only mounted
+// when handed a full FunkitWagmiConfig, which wires up the whole wallet
+// connector stack — WalletConnect, MetaMask SDK, …). The desktop app never
+// connects a wallet (showWalletConnect is off, no extensions exist), so we
+// mount our own minimal wagmi provider instead: Base + http transport, zero
+// connectors, keeping the connector code out of the bundle. Module-level
+// singletons: one config/client for the renderer's lifetime.
 const funkitQueryClient = new QueryClient();
-const funkitWagmiConfig: FunkitWagmiConfig = {
-  chains: getDefaultChains() as FunkitWagmiConfig['chains'],
-  transports: getDefaultTransports(),
-  // WalletConnect is never offered (showWalletConnect is off and no extension
-  // wallets exist in the desktop app), so no real WalletConnect Cloud project
-  // is registered — the config just requires a non-empty id.
-  projectId: 'antseed-desktop',
-};
+const funkitWagmiConfig = createConfig({
+  chains: [base],
+  transports: { [base.id]: http() },
+});
 
 // Both schemes must be handed over as a set: with a single theme object the
 // SDK derives light/dark for its icon assets from the OS scheme, which can
@@ -129,18 +126,20 @@ export default function FunkitDeposit(props: Props) {
   }), [props.apiKey, props.recipient]);
 
   return (
-    <FunkitProvider
-      funkitConfig={funkitConfig}
-      theme={funkitTheme}
-      modalSize="medium"
-      locale="en"
-      debug={import.meta.env.DEV}
-      initialChain={8453}
-      wagmiConfig={funkitWagmiConfig}
-      queryClient={funkitQueryClient}
-    >
-      <ThemeSync mode={mode} />
-      <DepositButton {...props} />
-    </FunkitProvider>
+    <WagmiProvider config={funkitWagmiConfig}>
+      <QueryClientProvider client={funkitQueryClient}>
+        <FunkitProvider
+          funkitConfig={funkitConfig}
+          theme={funkitTheme}
+          modalSize="medium"
+          locale="en"
+          debug={import.meta.env.DEV}
+          initialChain={8453}
+        >
+          <ThemeSync mode={mode} />
+          <DepositButton {...props} />
+        </FunkitProvider>
+      </QueryClientProvider>
+    </WagmiProvider>
   );
 }

--- a/apps/desktop/src/renderer/wallet-sdk-stub.ts
+++ b/apps/desktop/src/renderer/wallet-sdk-stub.ts
@@ -1,0 +1,22 @@
+/**
+ * Build-time stub for browser-wallet SDKs.
+ *
+ * The Fun checkout SDK statically imports wagmi's connector factories, whose
+ * bodies lazily `import()` the actual wallet SDKs (MetaMask, WalletConnect,
+ * Coinbase, …) — ~7 MB of chunks for wallet UI the desktop app never shows
+ * (`showWalletConnect: false`, zero connectors in the wagmi config, no
+ * extension wallets in Electron). Aliasing those packages here (see
+ * vite.config.ts) drops the chunks from the bundle. The factories that would
+ * consume these modules are never invoked, so this stub is never executed.
+ */
+export default {};
+
+/** Named exports demanded statically by @dynamic-labs/ethereum (Crossmint's
+    embedded-wallet layer) and @wagmi/connectors — all inside never-loaded
+    lazy chunks or never-invoked connector factories. Values are inert. */
+export class CoinbaseWalletSDK {}
+export class MetaMaskSDK {}
+export const ProviderInterface = undefined;
+export const SDKProvider = undefined;
+export const RpcSchema = undefined;
+export const z = undefined;

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -6,10 +6,33 @@ import { defineConfig } from 'vite';
 const rendererRoot = path.resolve(__dirname, 'src/renderer');
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'));
 
+// Browser-wallet SDKs lazily imported by wagmi's connector factories. The
+// desktop app never connects a browser wallet (the Fun checkout runs with
+// zero connectors), so these resolve to an empty stub — dropping ~7 MB of
+// never-loaded chunks from the renderer bundle. See wallet-sdk-stub.ts.
+const walletSdkStub = path.resolve(rendererRoot, 'wallet-sdk-stub.ts');
+const stubbedWalletSdks = [
+  '@base-org/account',
+  '@coinbase/wallet-sdk',
+  '@metamask/sdk',
+  '@safe-global/safe-apps-provider',
+  '@safe-global/safe-apps-sdk',
+  '@walletconnect/ethereum-provider',
+  'cbw-sdk',
+  'porto',
+];
+
 export default defineConfig({
   plugins: [react()],
   base: './',
   root: rendererRoot,
+  resolve: {
+    // Regex form so package subpath imports (e.g. porto/internal) stub too.
+    alias: stubbedWalletSdks.map((sdk) => ({
+      find: new RegExp(`^${sdk.replace(/[/\\^$.*+?()[\]{}|]/g, '\\$&')}(/.*)?$`),
+      replacement: walletSdkStub,
+    })),
+  },
   build: {
     outDir: path.resolve(__dirname, 'dist/renderer'),
     emptyOutDir: true,


### PR DESCRIPTION
## Description

The desktop app never connects a browser wallet, but both checkout SDKs drag the wallet ecosystem into the renderer bundle. Two changes:

- **Zero-connector wagmi config**: the Fun checkout mounted the SDK-built wagmi config, which instantiates the full wallet-connector stack (WalletConnect core with a placeholder projectId, MetaMask SDK scaffolding) for UI that `showWalletConnect: false` never shows. We now mount our own minimal outer WagmiProvider (Base + http, no connectors).
- **Wallet SDK build stubs**: with zero connectors and Crossmint crypto disabled, the wallet SDK payloads (MetaMask, WalletConnect, Coinbase, porto, Safe) are only reachable via never-invoked connector factories and never-rendered lazy components. Vite aliases them to an inert stub.

Renderer JS drops **10.9 MB → 7.8 MB** (147 → 56 chunks) and the build shrinks by ~5,700 modules, which also eases the heap pressure behind #784.

## Changelog

No user-facing change.

## Testing

- Renderer typecheck + build pass; renderer test suite passes (171 tests).
- Deposit modal manually verified after the wagmi change (methods load, card form reachable).