### PR TITLE
fix(desktop): Bake the Fun API key into release builds

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -108,6 +108,8 @@ jobs:
         working-directory: apps/desktop
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Baked into the renderer bundle by vite.config.ts (Fun deposit CTA).
+          ANTSEED_FUNKIT_API_KEY: ${{ secrets.ANTSEED_FUNKIT_API_KEY }}
           # electron-builder accepts base64-encoded content directly in CSC_LINK.
           CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MAC_CSC_KEY_PASSWORD }}
@@ -171,6 +173,8 @@ jobs:
         working-directory: apps/desktop
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Baked into the renderer bundle by vite.config.ts (Fun deposit CTA).
+          ANTSEED_FUNKIT_API_KEY: ${{ secrets.ANTSEED_FUNKIT_API_KEY }}
           CSC_LINK: ${{ secrets.WIN_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.WIN_CSC_KEY_PASSWORD }}
         run: |
@@ -251,6 +255,8 @@ jobs:
         working-directory: apps/desktop
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Baked into the renderer bundle by vite.config.ts (Fun deposit CTA).
+          ANTSEED_FUNKIT_API_KEY: ${{ secrets.ANTSEED_FUNKIT_API_KEY }}
           USE_SYSTEM_FPM: ${{ matrix.arch == 'arm64' }}
         run: |
           if [ "${{ inputs.dry_run }}" = "true" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
-- The desktop now shows deposit progress as a fixed banner from any view — received → depositing → credited (with a transaction link), on top of every overlay including the Fun checkout modal — instead of only inside the deposit page. The main-process deposit watcher also keeps running for a while after the deposit page closes (slow background polling, ~30 min, re-armed by activity), so a card/Fun delivery landing after you navigate away is still swept into credits automatically.
-
 - Sellers now run periodic model health self-checks (a 1-token probe per advertised service, every 5 minutes by default) and unadvertise services that keep failing, restoring them automatically when they recover. Configurable via `seller.healthCheck` (`enabled`, `intervalMs`, `failureThreshold`); sellers announcing this behavior advertise the `seller.model-health.v1` capability in discovery metadata. Exposed as `ModelHealthChecker` in `@antseed/node`, alongside `AntseedNode.refreshSellerMetadata()` for runtime service-list changes.
 - The buyer proxy now treats `model_not_found` responses as routing failures (instead of successes) and refreshes peer discovery metadata in the background, so a stale cached model list recovers quickly after a seller unadvertises a model.
 
@@ -17,10 +15,6 @@ This project uses selective package publishing. Each release entry lists the pub
 - The buyer attaches its latest SpendingAuth by default; the seller closes at whichever cumulative is higher (its own or the buyer's), so a seller that lost the last authorization can still be paid in full, and a buyer cannot use this path to settle below what it owes.
 - Added `antseed buyer channels close <channelId>` (with `--no-auth` and `--json`), which runs the request through a running `antseed buyer start` daemon's live seller connection via the new `/_antseed/channels/close` control-plane endpoint.
 - Added `AntseedNode.requestChannelClose(peerId, opts)` to `@antseed/node`, plus the `payments.cooperative-close.v1` capability advertised in discovery metadata and the connection handshake.
-
-### Changed
-
-- The desktop Balance page's two deposit buttons (Credit Card / USDC on Base) are now a single full-width "Add Credits" button opening the Add-credits chooser, and the separate "Pay with card" options page (including the embedded Crossmint checkout) is removed — the Fun-led chooser is the deposit flow. Dropping Crossmint also cuts the renderer bundle roughly in half.
 
 ### Fixed
 
@@ -35,6 +29,24 @@ This project uses selective package publishing. Each release entry lists the pub
 - Fixed seller crashes when sending `PaymentRequired` to a buyer that disconnected before the payment terms could be delivered.
 - Fixed the buyer's Responses→Chat Completions request adapter to group parallel tool calls into a single assistant `tool_calls` message. Previously each call became its own assistant message, so strict chat-completions upstreams rejected multi-tool turns with `an assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'`.
 - Fixed the Responses request normalizer to drop non-message input items with no renderable text (e.g. Codex `reasoning` items) instead of converting them into empty user messages mid-history.
+
+## 2026-08-06 — Desktop 0.2.3
+
+### Desktop
+
+- `@antseed/desktop@0.2.3`
+
+### Added
+
+- The desktop now shows deposit progress as a fixed banner from any view — received → depositing → credited (with a transaction link), on top of every overlay including the Fun checkout modal — instead of only inside the deposit page. The main-process deposit watcher also keeps running for a while after the deposit page closes (slow background polling, ~30 min, re-armed by activity), so a card/Fun delivery landing after you navigate away is still swept into credits automatically.
+
+### Changed
+
+- The desktop Balance page's two deposit buttons (Credit Card / USDC on Base) are now a single full-width "Add Credits" button opening the Add-credits chooser, and the separate "Pay with card" options page (including the embedded Crossmint checkout) is removed — the Fun-led chooser is the deposit flow. Dropping Crossmint also cuts the renderer bundle roughly in half.
+
+### Fixed
+
+- Packaged desktop builds now ship with the Fun deposit checkout enabled — 0.2.2 resolved the Fun API key only from user config or a runtime environment variable, so the primary Deposit button never appeared for end users.
 
 ## 2026-08-06 — Desktop 0.2.2
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed VPR",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
@@ -21,6 +21,9 @@ import styles from './VprDepositView.module.scss';
 // as its own chunk the first time the deposit chooser renders the CTA.
 const FunkitDeposit = lazy(() => import('./FunkitDeposit'));
 
+/** Build-time Fun API key (empty when the build had none) — vite.config.ts. */
+declare const __FUNKIT_API_KEY__: string;
+
 const AMOUNT_PRESETS = ['5', '10', '25'];
 
 type Props = { onSelectView?: (view: import('../../types').ViewName) => void };
@@ -379,8 +382,10 @@ export function VprDepositView({ onSelectView }: Props) {
     });
   }, [amount]);
 
-  // The Fun API key is resolved by the main process (config or environment)
-  // and is never in the source tree. null = still fetching, '' = not
+  // The Fun API key: the main process resolves overrides (user config, then
+  // runtime environment); release builds fall back to the key baked in at
+  // build time (see vite.config.ts) so packaged installs work out of the
+  // box. Never in the source tree. null = still fetching, '' = not
   // configured (CTA hidden).
   const [funkitApiKey, setFunkitApiKey] = useState<string | null>(null);
   useEffect(() => {
@@ -389,9 +394,9 @@ export function VprDepositView({ onSelectView }: Props) {
     // the CTA is live, not just visible, by the time they resolve.
     void import('./FunkitDeposit');
     void window.antseedDesktop?.paymentsFunkitConfig?.().then((result) => {
-      if (!cancelled) setFunkitApiKey((result.ok && result.data?.apiKey) || '');
+      if (!cancelled) setFunkitApiKey((result.ok && result.data?.apiKey) || __FUNKIT_API_KEY__);
     }).catch(() => {
-      if (!cancelled) setFunkitApiKey('');
+      if (!cancelled) setFunkitApiKey(__FUNKIT_API_KEY__);
     });
     return () => { cancelled = true; };
   }, []);

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { readFileSync } from 'node:fs';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 
 const rendererRoot = path.resolve(__dirname, 'src/renderer');
 const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'utf-8'));
@@ -22,7 +22,17 @@ const stubbedWalletSdks = [
   'porto',
 ];
 
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  // Fun (fun.xyz) API key baked into the renderer at build time so packaged
+  // installs ship with the deposit CTA enabled. Deliberately NOT in the
+  // source tree: release builds get it from the ANTSEED_FUNKIT_API_KEY
+  // environment variable (CI: repo secret; local: apps/desktop/.env, which
+  // loadEnv reads). Empty when absent — the CTA then hides, and a runtime
+  // key in config.payments.funkit.apiKey still overrides the baked one.
+  const fileEnv = loadEnv(mode, __dirname, '');
+  const funkitApiKey = process.env.ANTSEED_FUNKIT_API_KEY ?? fileEnv.ANTSEED_FUNKIT_API_KEY ?? '';
+
+  return {
   plugins: [react()],
   base: './',
   root: rendererRoot,
@@ -51,10 +61,12 @@ export default defineConfig({
   },
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    __FUNKIT_API_KEY__: JSON.stringify(funkitApiKey),
   },
   server: {
     host: '127.0.0.1',
     port: 5174,
     strictPort: true,
   },
+  };
 });


### PR DESCRIPTION
## Description

The 0.2.2 release shipped without the Fun deposit CTA: packaged installs resolve the key only from user config or a runtime env var, and end users have neither. The renderer build now bakes `ANTSEED_FUNKIT_API_KEY` in as a Vite define — CI release builds get it from the repo secret (wired into all three OS jobs in `release-desktop.yml`), local release builds from `apps/desktop/.env`. A runtime key in `config.payments.funkit.apiKey` still overrides the baked one, and a build with no key behaves as before (CTA hidden).

Also bumps the desktop to **0.2.3** (0.2.2 is already published) and moves the desktop entries from Unreleased into the 0.2.3 changelog section, including this fix.

Verified locally that a key set via the env var lands in the built renderer bundle.

## Changelog

Updated `CHANGELOG.md` — new `2026-08-06 — Desktop 0.2.3` section.

## Testing

- Renderer typecheck + build pass; renderer test suite passes (171 tests).
- Baked-key presence in the bundle verified with a test value.