### PR TITLE
feat(node): announce per-service model capabilities in v11 metadata

### DIFF
--- a/packages/node/src/buyer-request-handler.ts
+++ b/packages/node/src/buyer-request-handler.ts
@@ -17,6 +17,7 @@ import type { VerificationStorage } from "./verification/storage.js";
 import type { VerificationSampler } from "./verification/samples.js";
 import type { BuyerFreeUsageManager } from "./payments/buyer-free-usage-manager.js";
 import { verifyResponseAuth } from "./verification/response-auth.js";
+import { isFreeUnitBillingModel } from "./billing/unit.js";
 import type { ServiceApiProtocol } from "./types/service-api.js";
 import {
   detectRequestServiceApiProtocol,
@@ -565,6 +566,15 @@ function shouldExpectResponseAuth(
 }
 
 function isPeerServiceFree(peer: PeerInfo, service: string): boolean {
+  // Unit-billed services (e.g. images) can have zero token pricing but still
+  // charge per unit — mirror the seller's isFreeService gate.
+  for (const providerModels of Object.values(peer.providerServiceUnitBillingModels ?? {})) {
+    const serviceModels = providerModels.services[service];
+    if (!serviceModels) continue;
+    for (const model of Object.values(serviceModels)) {
+      if (model && !isFreeUnitBillingModel(model)) return false;
+    }
+  }
   const servicePricing = findPeerServicePricing(peer, service);
   if (!servicePricing) return false;
   return (servicePricing.inputUsdPerMillion ?? 0) === 0

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -10,7 +10,7 @@ import {
   topicToInfoHash,
 } from "./dht-node.js";
 import type { PeerOffering } from "../types/capability.js";
-import type { DomainVerificationClaim, DomainVerificationMethod, GithubVerificationClaim, PeerMetadata, PeerVerifications, ProviderAnnouncement } from "./peer-metadata.js";
+import type { DomainVerificationClaim, DomainVerificationMethod, GithubVerificationClaim, PeerMetadata, PeerVerifications, ProviderAnnouncement, ServiceCapabilities } from "./peer-metadata.js";
 import { METADATA_VERSION } from "./peer-metadata.js";
 import {
   MAX_DOMAIN_LENGTH,
@@ -56,6 +56,7 @@ export interface AnnouncerConfig {
     serviceCategories?: Record<string, string[]>;
     serviceApiProtocols?: Record<string, ServiceApiProtocol[]>;
     serviceUnitBillingModels?: ServiceUnitBillingModelsV1;
+    serviceCapabilities?: Record<string, ServiceCapabilities>;
     maxConcurrency: number;
     /** Runtime availability predicate. Unavailable providers are omitted. */
     isAvailable?: () => boolean;
@@ -285,6 +286,10 @@ export class PeerAnnouncer {
         const normalizedServiceUnitBillingModels = this._normalizeServiceUnitBillingModels(p.serviceUnitBillingModels, p.services);
         if (normalizedServiceUnitBillingModels) {
           providerAnnouncement.serviceUnitBillingModels = normalizedServiceUnitBillingModels;
+        }
+        const normalizedServiceCapabilities = this._normalizeServiceCapabilities(p.serviceCapabilities, p.services);
+        if (normalizedServiceCapabilities) {
+          providerAnnouncement.serviceCapabilities = normalizedServiceCapabilities;
         }
         return providerAnnouncement;
       });
@@ -519,6 +524,30 @@ export class PeerAnnouncer {
         continue;
       }
       normalized[service] = Object.fromEntries(entries) as ServiceUnitBillingModelsV1[string];
+    }
+
+    return Object.keys(normalized).length > 0 ? normalized : undefined;
+  }
+
+  private _normalizeServiceCapabilities(
+    serviceCapabilities: Record<string, ServiceCapabilities> | undefined,
+    supportedServices: string[],
+  ): Record<string, ServiceCapabilities> | undefined {
+    if (!serviceCapabilities) {
+      return undefined;
+    }
+
+    const hasWildcardServices = supportedServices.length === 0;
+    const supportedServiceSet = new Set(supportedServices);
+    const normalized: Record<string, ServiceCapabilities> = {};
+    for (const [service, caps] of Object.entries(serviceCapabilities)) {
+      if (!hasWildcardServices && !supportedServiceSet.has(service)) {
+        continue;
+      }
+      if (!caps || typeof caps !== "object" || Object.keys(caps).length === 0) {
+        continue;
+      }
+      normalized[service] = caps;
     }
 
     return Object.keys(normalized).length > 0 ? normalized : undefined;

--- a/packages/node/src/discovery/metadata-codec.ts
+++ b/packages/node/src/discovery/metadata-codec.ts
@@ -1,4 +1,5 @@
-import type { DomainVerificationClaim, DomainVerificationMethod, GithubVerificationClaim, PeerMetadata } from "./peer-metadata.js";
+import type { DomainVerificationClaim, DomainVerificationMethod, GithubVerificationClaim, PeerMetadata, ServiceCapabilities, ServiceCapabilityInput } from "./peer-metadata.js";
+import { SERVICE_CAPABILITY_INPUTS } from "./peer-metadata.js";
 import type { PeerOffering } from "../types/capability.js";
 import { hexToBytes, bytesToHex } from "../utils/hex.js";
 import { toPeerId } from "../types/peer.js";
@@ -217,6 +218,7 @@ function encodeBody(metadata: PeerMetadata): Uint8Array {
 
     if (metadata.version >= SERVICE_UNIT_BILLING_METADATA_VERSION) {
       encodeServiceUnitBillingModels(parts, p.serviceUnitBillingModels);
+      encodeServiceCapabilities(parts, p.serviceCapabilities);
     }
 
     // maxConcurrency: 2 bytes (uint16)
@@ -447,6 +449,108 @@ function encodeServiceUnitBillingModels(
       }
     }
   }
+}
+
+// Presence bits for the per-service capability entry. A set bit means the
+// field was announced (booleans distinguish "known false" from "unknown").
+const CAP_HAS_CONTEXT_WINDOW = 1 << 0;
+const CAP_HAS_MAX_OUTPUT_TOKENS = 1 << 1;
+const CAP_HAS_INPUTS = 1 << 2;
+const CAP_HAS_REASONING = 1 << 3;
+const CAP_HAS_TOOL_USE = 1 << 4;
+const CAP_HAS_STRUCTURED_OUTPUT = 1 << 5;
+
+function encodeServiceCapabilities(
+  parts: Uint8Array[],
+  serviceCapabilities: PeerMetadata["providers"][number]["serviceCapabilities"],
+): void {
+  const entries = Object.entries(serviceCapabilities ?? {})
+    .sort(([a], [b]) => a.localeCompare(b));
+  parts.push(new Uint8Array([entries.length]));
+  for (const [serviceName, caps] of entries) {
+    pushUtf8(parts, serviceName);
+    let presence = 0;
+    if (caps.contextWindow !== undefined) presence |= CAP_HAS_CONTEXT_WINDOW;
+    if (caps.maxOutputTokens !== undefined) presence |= CAP_HAS_MAX_OUTPUT_TOKENS;
+    if (caps.inputs !== undefined) presence |= CAP_HAS_INPUTS;
+    if (caps.reasoning !== undefined) presence |= CAP_HAS_REASONING;
+    if (caps.toolUse !== undefined) presence |= CAP_HAS_TOOL_USE;
+    if (caps.structuredOutput !== undefined) presence |= CAP_HAS_STRUCTURED_OUTPUT;
+    parts.push(new Uint8Array([presence]));
+    if (caps.contextWindow !== undefined) {
+      const buf = new ArrayBuffer(4);
+      new DataView(buf).setUint32(0, caps.contextWindow, false);
+      parts.push(new Uint8Array(buf));
+    }
+    if (caps.maxOutputTokens !== undefined) {
+      const buf = new ArrayBuffer(4);
+      new DataView(buf).setUint32(0, caps.maxOutputTokens, false);
+      parts.push(new Uint8Array(buf));
+    }
+    if (caps.inputs !== undefined) {
+      let inputBits = 0;
+      for (const input of caps.inputs) {
+        const id = SERVICE_CAPABILITY_INPUTS.indexOf(input);
+        if (id >= 0) inputBits |= 1 << id;
+      }
+      parts.push(new Uint8Array([inputBits]));
+    }
+    let boolBits = 0;
+    if (caps.reasoning === true) boolBits |= CAP_HAS_REASONING;
+    if (caps.toolUse === true) boolBits |= CAP_HAS_TOOL_USE;
+    if (caps.structuredOutput === true) boolBits |= CAP_HAS_STRUCTURED_OUTPUT;
+    parts.push(new Uint8Array([boolBits]));
+  }
+}
+
+function decodeServiceCapabilities(
+  data: Uint8Array,
+  getOffset: () => number,
+  setOffset: (offset: number) => void,
+  checkBounds: (offset: number, needed: number, total: number) => void,
+): PeerMetadata["providers"][number]["serviceCapabilities"] | undefined {
+  let offset = getOffset();
+  checkBounds(offset, 1, data.length);
+  const entryCount = data[offset]!;
+  offset += 1;
+  const serviceCapabilities: NonNullable<PeerMetadata["providers"][number]["serviceCapabilities"]> = {};
+  for (let i = 0; i < entryCount; i += 1) {
+    const [serviceName, serviceOffset] = readUtf8(data, offset, checkBounds);
+    offset = serviceOffset;
+    checkBounds(offset, 1, data.length);
+    const presence = data[offset]!;
+    offset += 1;
+    const caps: ServiceCapabilities = {};
+    if (presence & CAP_HAS_CONTEXT_WINDOW) {
+      checkBounds(offset, 4, data.length);
+      caps.contextWindow = new DataView(data.buffer, data.byteOffset + offset, 4).getUint32(0, false);
+      offset += 4;
+    }
+    if (presence & CAP_HAS_MAX_OUTPUT_TOKENS) {
+      checkBounds(offset, 4, data.length);
+      caps.maxOutputTokens = new DataView(data.buffer, data.byteOffset + offset, 4).getUint32(0, false);
+      offset += 4;
+    }
+    if (presence & CAP_HAS_INPUTS) {
+      checkBounds(offset, 1, data.length);
+      const inputBits = data[offset]!;
+      offset += 1;
+      const inputs: ServiceCapabilityInput[] = [];
+      for (let id = 0; id < SERVICE_CAPABILITY_INPUTS.length; id += 1) {
+        if (inputBits & (1 << id)) inputs.push(SERVICE_CAPABILITY_INPUTS[id]!);
+      }
+      caps.inputs = inputs;
+    }
+    checkBounds(offset, 1, data.length);
+    const boolBits = data[offset]!;
+    offset += 1;
+    if (presence & CAP_HAS_REASONING) caps.reasoning = (boolBits & CAP_HAS_REASONING) !== 0;
+    if (presence & CAP_HAS_TOOL_USE) caps.toolUse = (boolBits & CAP_HAS_TOOL_USE) !== 0;
+    if (presence & CAP_HAS_STRUCTURED_OUTPUT) caps.structuredOutput = (boolBits & CAP_HAS_STRUCTURED_OUTPUT) !== 0;
+    serviceCapabilities[serviceName] = caps;
+  }
+  setOffset(offset);
+  return Object.keys(serviceCapabilities).length > 0 ? serviceCapabilities : undefined;
 }
 
 function pushUtf8(parts: Uint8Array[], value: string): void {
@@ -730,6 +834,9 @@ export function decodeMetadata(data: Uint8Array): PeerMetadata {
     const serviceUnitBillingModels = version >= SERVICE_UNIT_BILLING_METADATA_VERSION
       ? decodeServiceUnitBillingModels(data, () => offset, (next) => { offset = next; }, checkBounds)
       : undefined;
+    const serviceCapabilities = version >= SERVICE_UNIT_BILLING_METADATA_VERSION
+      ? decodeServiceCapabilities(data, () => offset, (next) => { offset = next; }, checkBounds)
+      : undefined;
 
     // maxConcurrency: 2 bytes uint16
     checkBounds(offset, 2, data.length);
@@ -755,6 +862,7 @@ export function decodeMetadata(data: Uint8Array): PeerMetadata {
       ...(serviceCategories && Object.keys(serviceCategories).length > 0 ? { serviceCategories } : {}),
       ...(serviceApiProtocols && Object.keys(serviceApiProtocols).length > 0 ? { serviceApiProtocols } : {}),
       ...(serviceUnitBillingModels && Object.keys(serviceUnitBillingModels).length > 0 ? { serviceUnitBillingModels } : {}),
+      ...(serviceCapabilities && Object.keys(serviceCapabilities).length > 0 ? { serviceCapabilities } : {}),
       maxConcurrency,
       currentLoad,
     });

--- a/packages/node/src/discovery/metadata-validator.ts
+++ b/packages/node/src/discovery/metadata-validator.ts
@@ -1,5 +1,5 @@
 import type { DomainVerificationMethod, PeerMetadata } from "./peer-metadata.js";
-import { METADATA_VERSION, MIN_SUPPORTED_METADATA_VERSION, SERVICE_UNIT_BILLING_METADATA_VERSION, WELL_KNOWN_SERVICE_API_PROTOCOLS } from "./peer-metadata.js";
+import { METADATA_VERSION, MIN_SUPPORTED_METADATA_VERSION, SERVICE_CAPABILITY_INPUTS, SERVICE_UNIT_BILLING_METADATA_VERSION, WELL_KNOWN_SERVICE_API_PROTOCOLS } from "./peer-metadata.js";
 import { encodeMetadata } from "./metadata-codec.js";
 import { MAX_PUBLIC_ADDRESS_LENGTH, parsePublicAddress } from "./public-address.js";
 import { validateUnitBillingModelV1 } from "../billing/unit.js";
@@ -25,6 +25,9 @@ export const MAX_BILLING_MATCH_ENTRIES_PER_COMPONENT = 3;
 export const MAX_BILLING_MATCH_VALUE_BYTES = 32;
 export const MAX_PEER_CAPABILITIES = 16;
 export const MAX_PEER_CAPABILITY_LENGTH = 64;
+/** Ceiling for announced contextWindow / maxOutputTokens (fits the u32 wire field). */
+export const MAX_CAPABILITY_TOKEN_COUNT = 1_000_000_000;
+const SERVICE_CAPABILITY_INPUT_SET = new Set<string>(SERVICE_CAPABILITY_INPUTS);
 const SERVICE_CATEGORY_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const DOMAIN_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const DOMAIN_VERIFICATION_METHODS = new Set<DomainVerificationMethod>(["dns-txt", "https-well-known"]);
@@ -592,6 +595,72 @@ export function validateMetadata(metadata: PeerMetadata): ValidationError[] {
           field: `providers[${i}].serviceUnitBillingModels`,
           message: `Expanded billing model count ${expandedBillingModelCount} exceeds max ${MAX_SERVICES_PER_PROVIDER}`,
         });
+      }
+    }
+
+    if (p.serviceCapabilities !== undefined) {
+      if (metadata.version < SERVICE_UNIT_BILLING_METADATA_VERSION) {
+        errors.push({
+          field: `providers[${i}].serviceCapabilities`,
+          message: `Service capabilities require metadata version ${SERVICE_UNIT_BILLING_METADATA_VERSION}`,
+        });
+      }
+      const capabilityEntries = Object.entries(p.serviceCapabilities);
+      if (capabilityEntries.length > MAX_SERVICES_PER_PROVIDER) {
+        errors.push({
+          field: `providers[${i}].serviceCapabilities`,
+          message: `Service capability entry count ${capabilityEntries.length} exceeds max ${MAX_SERVICES_PER_PROVIDER}`,
+        });
+      }
+      for (const [serviceName, caps] of capabilityEntries) {
+        const field = `providers[${i}].serviceCapabilities.${serviceName}`;
+        if (serviceName.length > MAX_SERVICE_NAME_LENGTH) {
+          errors.push({
+            field,
+            message: `Service name length ${serviceName.length} exceeds max ${MAX_SERVICE_NAME_LENGTH}`,
+          });
+        }
+        if (!hasWildcardServices && !p.services.includes(serviceName)) {
+          errors.push({
+            field,
+            message: "Service capabilities must reference a service listed in providers[].services",
+          });
+        }
+        if (!caps || typeof caps !== "object" || Array.isArray(caps)) {
+          errors.push({ field, message: "Service capability entry must be an object" });
+          continue;
+        }
+        for (const key of ["contextWindow", "maxOutputTokens"] as const) {
+          const value = caps[key];
+          if (value === undefined) continue;
+          if (!Number.isSafeInteger(value) || value <= 0 || value > MAX_CAPABILITY_TOKEN_COUNT) {
+            errors.push({
+              field: `${field}.${key}`,
+              message: `${key} must be a positive integer <= ${MAX_CAPABILITY_TOKEN_COUNT}`,
+            });
+          }
+        }
+        if (caps.inputs !== undefined) {
+          if (!Array.isArray(caps.inputs)) {
+            errors.push({ field: `${field}.inputs`, message: "inputs must be an array" });
+          } else {
+            const seen = new Set<string>();
+            for (const input of caps.inputs) {
+              if (!SERVICE_CAPABILITY_INPUT_SET.has(input)) {
+                errors.push({ field: `${field}.inputs`, message: `Unsupported input modality "${input}"` });
+              } else if (seen.has(input)) {
+                errors.push({ field: `${field}.inputs`, message: `Duplicate input modality "${input}"` });
+              }
+              seen.add(input);
+            }
+          }
+        }
+        for (const key of ["reasoning", "toolUse", "structuredOutput"] as const) {
+          const value = caps[key];
+          if (value !== undefined && typeof value !== "boolean") {
+            errors.push({ field: `${field}.${key}`, message: `${key} must be a boolean` });
+          }
+        }
       }
     }
 

--- a/packages/node/src/discovery/peer-metadata.ts
+++ b/packages/node/src/discovery/peer-metadata.ts
@@ -25,6 +25,28 @@ export interface TokenPricingUsdPerMillion {
   cachedInputUsdPerMillion?: number;
 }
 
+export const SERVICE_CAPABILITY_INPUTS = ["text", "image", "audio", "video", "pdf"] as const;
+export type ServiceCapabilityInput = (typeof SERVICE_CAPABILITY_INPUTS)[number];
+
+/**
+ * Per-service model capability hints announced by sellers. Every field is
+ * optional: absent means unknown, so buyers fall back to their own defaults.
+ */
+export interface ServiceCapabilities {
+  /** Total context window in tokens. */
+  contextWindow?: number;
+  /** Maximum output tokens per response. */
+  maxOutputTokens?: number;
+  /** Supported input modalities. */
+  inputs?: ServiceCapabilityInput[];
+  /** Supports extended thinking / reasoning effort. */
+  reasoning?: boolean;
+  /** Supports tool use / function calling. */
+  toolUse?: boolean;
+  /** Supports structured output / JSON schema responses. */
+  structuredOutput?: boolean;
+}
+
 export interface ProviderAnnouncement {
   provider: string;
   services: string[];
@@ -33,6 +55,7 @@ export interface ProviderAnnouncement {
   serviceCategories?: Record<string, string[]>;
   serviceApiProtocols?: Record<string, ServiceApiProtocol[]>;
   serviceUnitBillingModels?: ServiceUnitBillingModelsV1;
+  serviceCapabilities?: Record<string, ServiceCapabilities>;
   maxConcurrency: number;
   currentLoad: number;
 }

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -42,10 +42,13 @@ export { OFFICIAL_BOOTSTRAP_NODES, mergeBootstrapNodes, toBootstrapConfig } from
 export {
   WELL_KNOWN_SERVICE_CATEGORIES,
   WELL_KNOWN_SERVICE_API_PROTOCOLS,
+  SERVICE_CAPABILITY_INPUTS,
   type DomainVerificationClaim,
   type DomainVerificationMethod,
   type GithubVerificationClaim,
   type ServiceApiProtocol,
+  type ServiceCapabilities,
+  type ServiceCapabilityInput,
   type PeerMetadata,
   type PeerVerifications,
   type ProviderAnnouncement,

--- a/packages/node/src/interfaces/seller-provider.ts
+++ b/packages/node/src/interfaces/seller-provider.ts
@@ -1,6 +1,7 @@
 import type { SerializedHttpRequest, SerializedHttpResponse, SerializedHttpResponseChunk } from '../types/http.js';
 import type { ServiceApiProtocol } from '../types/service-api.js';
 import type { ServiceUnitBillingModelsV1 } from '../types/billing.js';
+import type { ServiceCapabilities } from '../discovery/peer-metadata.js';
 
 export interface ProviderTokenPricingUsdPerMillion {
   inputUsdPerMillion: number;
@@ -47,6 +48,9 @@ export interface Provider {
 
   /** Optional per-service/protocol unit billing model support advertised via discovery metadata. */
   serviceUnitBillingModels?: ServiceUnitBillingModelsV1;
+
+  /** Optional per-service model capability hints advertised via discovery metadata. */
+  serviceCapabilities?: Record<string, ServiceCapabilities>;
 
   /** Maximum concurrent requests this provider can handle */
   maxConcurrency: number;

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1546,6 +1546,7 @@ export class AntseedNode extends EventEmitter {
           ...(p.serviceCategories ? { serviceCategories: { ...p.serviceCategories } } : {}),
           ...(p.serviceApiProtocols ? { serviceApiProtocols: { ...p.serviceApiProtocols } } : {}),
           ...(p.serviceUnitBillingModels ? { serviceUnitBillingModels: { ...p.serviceUnitBillingModels } } : {}),
+          ...(p.serviceCapabilities ? { serviceCapabilities: { ...p.serviceCapabilities } } : {}),
           maxConcurrency: p.maxConcurrency,
           isAvailable: () => p.healthCheckAvailable !== false,
           pricing: {
@@ -2286,6 +2287,7 @@ export class AntseedNode extends EventEmitter {
     const providerServiceCategoryEntries: NonNullable<PeerInfo["providerServiceCategories"]> = {};
     const providerServiceApiProtocolEntries: NonNullable<PeerInfo["providerServiceApiProtocols"]> = {};
     const providerServiceUnitBillingModelEntries: NonNullable<PeerInfo["providerServiceUnitBillingModels"]> = {};
+    const providerServiceCapabilityEntries: NonNullable<PeerInfo["providerServiceCapabilities"]> = {};
 
     for (const providerAnnouncement of result.metadata.providers) {
       const provName = providerAnnouncement.provider;
@@ -2350,12 +2352,23 @@ export class AntseedNode extends EventEmitter {
           providerServiceUnitBillingModelEntries[provName] = { services: newEntries };
         }
       }
+
+      if (providerAnnouncement.serviceCapabilities && Object.keys(providerAnnouncement.serviceCapabilities).length > 0) {
+        const existingCapabilities = providerServiceCapabilityEntries[provName];
+        const newEntries = { ...providerAnnouncement.serviceCapabilities };
+        if (existingCapabilities) {
+          Object.assign(existingCapabilities.services, newEntries);
+        } else {
+          providerServiceCapabilityEntries[provName] = { services: newEntries };
+        }
+      }
     }
 
     const hasProviderPricing = Object.keys(providerPricingEntries).length > 0;
     const hasProviderServiceCategories = Object.keys(providerServiceCategoryEntries).length > 0;
     const hasProviderServiceApiProtocols = Object.keys(providerServiceApiProtocolEntries).length > 0;
     const hasProviderServiceUnitBillingModels = Object.keys(providerServiceUnitBillingModelEntries).length > 0;
+    const hasProviderServiceCapabilities = Object.keys(providerServiceCapabilityEntries).length > 0;
 
     return {
       peerId: result.metadata.peerId,
@@ -2377,6 +2390,7 @@ export class AntseedNode extends EventEmitter {
       ...(hasProviderServiceCategories ? { providerServiceCategories: providerServiceCategoryEntries } : {}),
       ...(hasProviderServiceApiProtocols ? { providerServiceApiProtocols: providerServiceApiProtocolEntries } : {}),
       ...(hasProviderServiceUnitBillingModels ? { providerServiceUnitBillingModels: providerServiceUnitBillingModelEntries } : {}),
+      ...(hasProviderServiceCapabilities ? { providerServiceCapabilities: providerServiceCapabilityEntries } : {}),
       defaultInputUsdPerMillion: firstProvider?.defaultPricing.inputUsdPerMillion,
       defaultOutputUsdPerMillion: firstProvider?.defaultPricing.outputUsdPerMillion,
       defaultCachedInputUsdPerMillion: firstProvider?.defaultPricing.cachedInputUsdPerMillion,

--- a/packages/node/src/types/peer.ts
+++ b/packages/node/src/types/peer.ts
@@ -1,6 +1,6 @@
 import type { ServiceApiProtocol } from "./service-api.js";
 import type { ServiceUnitBillingModelsV1 } from "./billing.js";
-import type { PeerMetadata } from "../discovery/peer-metadata.js";
+import type { PeerMetadata, ServiceCapabilities } from "../discovery/peer-metadata.js";
 import type { DomainVerificationResult } from "../discovery/domain-verification.js";
 import type { GithubVerificationResult } from "../discovery/github-verification.js";
 
@@ -50,6 +50,10 @@ export interface ProviderServiceUnitBillingModelMatrixEntry {
   services: ServiceUnitBillingModelsV1;
 }
 
+export interface ProviderServiceCapabilityMatrixEntry {
+  services: Record<string, ServiceCapabilities>;
+}
+
 export interface PeerVerificationResults {
   /** True when every announced external claim verified successfully. */
   verified: boolean;
@@ -92,6 +96,8 @@ export interface PeerInfo {
   providerServiceApiProtocols?: Record<string, ProviderServiceApiProtocolMatrixEntry>;
   /** Provider/service/protocol unit billing models announced by seller. */
   providerServiceUnitBillingModels?: Record<string, ProviderServiceUnitBillingModelMatrixEntry>;
+  /** Provider/service model capability hints announced by seller. */
+  providerServiceCapabilities?: Record<string, ProviderServiceCapabilityMatrixEntry>;
   /** Deterministic fallback default input price (USD per 1M tokens). */
   defaultInputUsdPerMillion?: number;
   /** Deterministic fallback default output price (USD per 1M tokens). */

--- a/packages/node/tests/announcer.test.ts
+++ b/packages/node/tests/announcer.test.ts
@@ -139,6 +139,10 @@ describe('PeerAnnouncer metadata versions', () => {
               },
             },
           },
+          serviceCapabilities: {
+            'gpt-image-1': { inputs: ['text'] },
+            'unlisted-service': { contextWindow: 1000 },
+          },
           maxConcurrency: 5,
         },
       ],
@@ -151,6 +155,10 @@ describe('PeerAnnouncer metadata versions', () => {
     expect(metadata?.providers[0]?.serviceUnitBillingModels?.['gpt-image-1']?.['openai-images']).toEqual({
       version: 1,
       components: [{ unit: 'output_images', priceUsd: 0.04 }],
+    });
+    // Capabilities for services outside providers[].services are dropped.
+    expect(metadata?.providers[0]?.serviceCapabilities).toEqual({
+      'gpt-image-1': { inputs: ['text'] },
     });
   });
 

--- a/packages/node/tests/metadata-codec.test.ts
+++ b/packages/node/tests/metadata-codec.test.ts
@@ -197,6 +197,75 @@ describe('encodeMetadata / decodeMetadata', () => {
     expect(encodeMetadataForSigning(changed)).not.toEqual(encodeMetadataForSigning(original));
   });
 
+  it('round-trips v11 service capabilities and signs capability bytes', () => {
+    const original = makeMetadata({
+      version: SERVICE_UNIT_BILLING_METADATA_VERSION,
+      providers: [
+        {
+          provider: 'openai',
+          services: ['gpt-5.5', 'gpt-image-1'],
+          defaultPricing: { inputUsdPerMillion: 0, outputUsdPerMillion: 0 },
+          serviceCapabilities: {
+            'gpt-5.5': {
+              contextWindow: 200_000,
+              maxOutputTokens: 16_384,
+              inputs: ['text', 'image'],
+              reasoning: true,
+              toolUse: false,
+            },
+            'gpt-image-1': {
+              inputs: ['text'],
+            },
+          },
+          maxConcurrency: 3,
+          currentLoad: 0,
+        },
+      ],
+    });
+    const decoded = decodeMetadata(encodeMetadata(original));
+    expect(decoded.providers[0]!.serviceCapabilities?.['gpt-5.5']).toEqual({
+      contextWindow: 200_000,
+      maxOutputTokens: 16_384,
+      inputs: ['text', 'image'],
+      reasoning: true,
+      toolUse: false,
+    });
+    expect(decoded.providers[0]!.serviceCapabilities?.['gpt-5.5']?.structuredOutput).toBeUndefined();
+    expect(decoded.providers[0]!.serviceCapabilities?.['gpt-image-1']).toEqual({ inputs: ['text'] });
+
+    const changed = makeMetadata({
+      ...original,
+      providers: [{
+        ...original.providers[0]!,
+        serviceCapabilities: {
+          ...original.providers[0]!.serviceCapabilities,
+          'gpt-5.5': { contextWindow: 128_000 },
+        },
+      }],
+    });
+    expect(encodeMetadataForSigning(changed)).not.toEqual(encodeMetadataForSigning(original));
+  });
+
+  it('excludes service capabilities from v10 metadata bytes', () => {
+    const original = makeMetadata({
+      version: 10,
+      providers: [
+        {
+          provider: 'openai',
+          services: ['gpt-5.5'],
+          defaultPricing: { inputUsdPerMillion: 0, outputUsdPerMillion: 0 },
+          serviceCapabilities: { 'gpt-5.5': { contextWindow: 200_000 } },
+          maxConcurrency: 3,
+          currentLoad: 0,
+        },
+      ],
+    });
+
+    const decoded = decodeMetadata(encodeMetadata(original));
+    expect(decoded.version).toBe(10);
+    expect(decoded.providers[0]?.serviceCapabilities).toBeUndefined();
+  });
+
   it('excludes service unit billing models from v10 metadata bytes', () => {
     const original = makeMetadata({
       version: 10,

--- a/packages/node/tests/metadata-validator.test.ts
+++ b/packages/node/tests/metadata-validator.test.ts
@@ -348,6 +348,88 @@ describe('validateMetadata', () => {
     );
   });
 
+  it('accepts valid service capabilities and rejects malformed ones', () => {
+    const capsProvider = {
+      provider: 'openai',
+      services: ['gpt-5.5'],
+      defaultPricing: { inputUsdPerMillion: 1, outputUsdPerMillion: 1 },
+      serviceCapabilities: {
+        'gpt-5.5': {
+          contextWindow: 200_000,
+          maxOutputTokens: 16_384,
+          inputs: ['text', 'image'],
+          reasoning: true,
+        },
+      },
+      maxConcurrency: 1,
+      currentLoad: 0,
+    } satisfies PeerMetadata['providers'][number];
+
+    expect(validateMetadata(validMetadata({
+      version: SERVICE_UNIT_BILLING_METADATA_VERSION,
+      providers: [capsProvider],
+    }))).toEqual([]);
+
+    const badErrors = validateMetadata(validMetadata({
+      version: SERVICE_UNIT_BILLING_METADATA_VERSION,
+      providers: [
+        {
+          ...capsProvider,
+          serviceCapabilities: {
+            'gpt-5.5': {
+              contextWindow: -5,
+              inputs: ['text', 'hologram' as any, 'text'],
+            },
+            'not-announced': { contextWindow: 1000 },
+          },
+        },
+      ],
+    }));
+    expect(badErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'providers[0].serviceCapabilities.gpt-5.5.contextWindow',
+        }),
+        expect.objectContaining({
+          field: 'providers[0].serviceCapabilities.gpt-5.5.inputs',
+          message: expect.stringContaining('hologram'),
+        }),
+        expect.objectContaining({
+          field: 'providers[0].serviceCapabilities.gpt-5.5.inputs',
+          message: expect.stringContaining('Duplicate'),
+        }),
+        expect.objectContaining({
+          field: 'providers[0].serviceCapabilities.not-announced',
+          message: expect.stringContaining('must reference a service'),
+        }),
+      ]),
+    );
+  });
+
+  it('rejects service capabilities on pre-v11 metadata', () => {
+    const errors = validateMetadata(validMetadata({
+      version: 10,
+      providers: [
+        {
+          provider: 'openai',
+          services: ['gpt-5.5'],
+          defaultPricing: { inputUsdPerMillion: 1, outputUsdPerMillion: 1 },
+          serviceCapabilities: { 'gpt-5.5': { contextWindow: 1000 } },
+          maxConcurrency: 1,
+          currentLoad: 0,
+        },
+      ],
+    }));
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: 'providers[0].serviceCapabilities',
+          message: expect.stringContaining('require metadata version 11'),
+        }),
+      ]),
+    );
+  });
+
   it('should reject maxConcurrency < 1', () => {
     const errors = validateMetadata(
       validMetadata({

--- a/packages/provider-core/src/base-provider.ts
+++ b/packages/provider-core/src/base-provider.ts
@@ -15,6 +15,7 @@ export interface BaseProviderConfig {
   pricing: Provider['pricing'];
   serviceApiProtocols?: Record<string, ServiceApiProtocol[]>;
   serviceUnitBillingModels?: Provider['serviceUnitBillingModels'];
+  serviceCapabilities?: Provider['serviceCapabilities'];
   relay: RelayConfig;
 }
 
@@ -28,6 +29,7 @@ export class BaseProvider implements Provider {
   readonly pricing: Provider['pricing'];
   readonly serviceApiProtocols?: Record<string, ServiceApiProtocol[]>;
   readonly serviceUnitBillingModels?: Provider['serviceUnitBillingModels'];
+  readonly serviceCapabilities?: Provider['serviceCapabilities'];
   readonly maxConcurrency: number;
 
   private readonly _relay: HttpRelay;
@@ -41,6 +43,7 @@ export class BaseProvider implements Provider {
     this.pricing = config.pricing;
     this.serviceApiProtocols = config.serviceApiProtocols;
     this.serviceUnitBillingModels = config.serviceUnitBillingModels;
+    this.serviceCapabilities = config.serviceCapabilities;
     this.maxConcurrency = config.relay.maxConcurrency;
 
     this._relay = new HttpRelay(config.relay, {

--- a/packages/provider-core/src/config-utils.test.ts
+++ b/packages/provider-core/src/config-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseServiceUnitBillingModelsJson } from './config-utils.js';
+import { parseServiceCapabilitiesJson, parseServiceUnitBillingModelsJson } from './config-utils.js';
 
 describe('parseServiceUnitBillingModelsJson', () => {
   it('rejects unknown service API protocol keys', () => {
@@ -29,5 +29,53 @@ describe('parseServiceUnitBillingModelsJson', () => {
         },
       },
     });
+  });
+});
+
+describe('parseServiceCapabilitiesJson', () => {
+  it('returns undefined for empty input', () => {
+    expect(parseServiceCapabilitiesJson(undefined)).toBeUndefined();
+    expect(parseServiceCapabilitiesJson('{}')).toBeUndefined();
+  });
+
+  it('parses and normalizes a full capabilities map', () => {
+    expect(parseServiceCapabilitiesJson(JSON.stringify({
+      'gpt-5.5': {
+        contextWindow: 200000,
+        maxOutputTokens: 16384,
+        inputs: ['text', 'image', 'text'],
+        reasoning: true,
+        toolUse: false,
+      },
+    }))).toEqual({
+      'gpt-5.5': {
+        contextWindow: 200000,
+        maxOutputTokens: 16384,
+        inputs: ['text', 'image'],
+        reasoning: true,
+        toolUse: false,
+      },
+    });
+  });
+
+  it('rejects unknown input modalities', () => {
+    expect(() => parseServiceCapabilitiesJson(JSON.stringify({
+      'gpt-5.5': { inputs: ['text', 'hologram'] },
+    }))).toThrow(/inputs must be an array of/);
+  });
+
+  it('rejects non-integer token counts', () => {
+    expect(() => parseServiceCapabilitiesJson(JSON.stringify({
+      'gpt-5.5': { contextWindow: -1 },
+    }))).toThrow(/positive integer/);
+    expect(() => parseServiceCapabilitiesJson(JSON.stringify({
+      'gpt-5.5': { maxOutputTokens: 1.5 },
+    }))).toThrow(/positive integer/);
+  });
+
+  it('rejects non-boolean flags', () => {
+    expect(() => parseServiceCapabilitiesJson(JSON.stringify({
+      'gpt-5.5': { reasoning: 'yes' },
+    }))).toThrow(/must be a boolean/);
   });
 });

--- a/packages/provider-core/src/config-utils.ts
+++ b/packages/provider-core/src/config-utils.ts
@@ -1,5 +1,5 @@
-import type { Provider, ServiceApiProtocol, ServiceUnitBillingModelsV1, UnitBillingComponentV1, UnitBillingModelV1 } from '@antseed/node';
-import { isKnownServiceApiProtocol, validateUnitBillingModelV1 } from '@antseed/node';
+import type { Provider, ServiceApiProtocol, ServiceCapabilities, ServiceUnitBillingModelsV1, UnitBillingComponentV1, UnitBillingModelV1 } from '@antseed/node';
+import { SERVICE_CAPABILITY_INPUTS, isKnownServiceApiProtocol, validateUnitBillingModelV1 } from '@antseed/node';
 
 export function parseNonNegativeNumber(raw: string | undefined, key: string, fallback: number): number {
   const parsed = raw === undefined ? fallback : Number.parseFloat(raw);
@@ -123,6 +123,58 @@ export function parseCsv(raw: string | undefined): string[] {
         .filter((entry) => entry.length > 0),
     ),
   );
+}
+
+export function parseServiceCapabilitiesJson(raw: string | undefined, key = 'ANTSEED_SERVICE_CAPABILITIES_JSON'): Record<string, ServiceCapabilities> | undefined {
+  if (!raw) return undefined;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    throw new Error(`${key} must be valid JSON`);
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${key} must be an object map of service -> capabilities`);
+  }
+
+  const knownInputs = new Set<string>(SERVICE_CAPABILITY_INPUTS);
+  const out: Record<string, ServiceCapabilities> = {};
+  for (const [service, rawCaps] of Object.entries(parsed as Record<string, unknown>)) {
+    if (!rawCaps || typeof rawCaps !== 'object' || Array.isArray(rawCaps)) {
+      throw new Error(`${key}.${service} must be a capabilities object`);
+    }
+    const caps = rawCaps as Record<string, unknown>;
+    const normalized: ServiceCapabilities = {};
+    for (const field of ['contextWindow', 'maxOutputTokens'] as const) {
+      const value = caps[field];
+      if (value === undefined) continue;
+      if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+        throw new Error(`${key}.${service}.${field} must be a positive integer`);
+      }
+      normalized[field] = value;
+    }
+    if (caps.inputs !== undefined) {
+      if (!Array.isArray(caps.inputs) || caps.inputs.some((input) => typeof input !== 'string' || !knownInputs.has(input))) {
+        throw new Error(`${key}.${service}.inputs must be an array of: ${SERVICE_CAPABILITY_INPUTS.join(', ')}`);
+      }
+      normalized.inputs = [...new Set(caps.inputs)] as ServiceCapabilities['inputs'];
+    }
+    for (const field of ['reasoning', 'toolUse', 'structuredOutput'] as const) {
+      const value = caps[field];
+      if (value === undefined) continue;
+      if (typeof value !== 'boolean') {
+        throw new Error(`${key}.${service}.${field} must be a boolean`);
+      }
+      normalized[field] = value;
+    }
+    if (Object.keys(normalized).length > 0) {
+      out[service] = normalized;
+    }
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
 }
 
 export function parseJsonObject(raw: string | undefined, key: string): Record<string, unknown> | undefined {

--- a/packages/provider-core/src/index.ts
+++ b/packages/provider-core/src/index.ts
@@ -7,6 +7,7 @@ export { BaseProvider, type BaseProviderConfig } from './base-provider.js';
 export { parseServiceAliasMap } from './service-alias.js';
 export {
   parseNonNegativeNumber,
+  parseServiceCapabilitiesJson,
   parseServiceUnitBillingModelsJson,
   parseServicePricingJson,
   parseCsv,

--- a/plugins/provider-openai/src/index.ts
+++ b/plugins/provider-openai/src/index.ts
@@ -5,6 +5,7 @@ import {
   parseCsv,
   parseJsonObject,
   parseNonNegativeNumber,
+  parseServiceCapabilitiesJson,
   parseServiceUnitBillingModelsJson,
   parseServiceAliasMap,
   parseServicePricingJson,
@@ -111,6 +112,7 @@ const plugin: AntseedProviderPlugin = {
     { key: 'ANTSEED_CACHED_INPUT_USD_PER_MILLION', label: 'Cached Input Price', type: 'number', required: false, description: 'Cached input price in USD per 1M tokens (defaults to input price)' },
     { key: 'ANTSEED_SERVICE_PRICING_JSON', label: 'Service Pricing JSON', type: 'string', required: false, description: 'Per-service pricing JSON' },
     { key: 'ANTSEED_SERVICE_UNIT_BILLING_MODELS_JSON', label: 'Service Unit Billing Models JSON', type: 'string', required: false, description: 'Per-service/protocol unit billing model JSON' },
+    { key: 'ANTSEED_SERVICE_CAPABILITIES_JSON', label: 'Service Capabilities JSON', type: 'string', required: false, description: 'Per-service model capability JSON (contextWindow, maxOutputTokens, inputs, reasoning, toolUse, structuredOutput)' },
     { key: 'ANTSEED_MAX_CONCURRENCY', label: 'Max Concurrency', type: 'number', required: false, default: 10, description: 'Max concurrent requests' },
     { key: 'ANTSEED_ALLOWED_SERVICES', label: 'Allowed Services', type: 'string[]', required: false, description: 'Service allow-list' },
     { key: 'ANTSEED_SERVICE_ALIAS_MAP_JSON', label: 'Service Alias Map', type: 'string', required: false, description: 'JSON map of announced service → upstream model name (generic, works across all providers)' },
@@ -159,6 +161,7 @@ const plugin: AntseedProviderPlugin = {
     const serviceRewriteMap = parseServiceAliasMap(config['ANTSEED_SERVICE_ALIAS_MAP_JSON']);
     const serviceApiProtocols = buildOpenAiServiceApiProtocols(allowedServices, flavor, serviceRewriteMap);
     const serviceUnitBillingModels = parseServiceUnitBillingModelsJson(config['ANTSEED_SERVICE_UNIT_BILLING_MODELS_JSON']);
+    const serviceCapabilities = parseServiceCapabilitiesJson(config['ANTSEED_SERVICE_CAPABILITIES_JSON']);
     const pathRewrite = parseJsonObject(config['OPENAI_PATH_REWRITE_JSON'], 'OPENAI_PATH_REWRITE_JSON') as Record<string, string> | undefined;
 
     return new BaseProvider({
@@ -167,6 +170,7 @@ const plugin: AntseedProviderPlugin = {
       pricing,
       ...(serviceApiProtocols ? { serviceApiProtocols } : {}),
       ...(serviceUnitBillingModels ? { serviceUnitBillingModels } : {}),
+      ...(serviceCapabilities ? { serviceCapabilities } : {}),
       relay: {
         baseUrl,
         authHeaderName: 'authorization',


### PR DESCRIPTION
## Summary

Adds per-service model capability announcements — `contextWindow`, `maxOutputTokens`, `inputs`, `reasoning`, `toolUse`, `structuredOutput` — riding the v11 metadata version introduced by #687, so both fields ship in a single version bump.

- Wire format: presence-bit binary encoding in the metadata codec, v11-gated; absent fields mean unknown, so announced booleans distinguish "known false" from "not announced"
- Validation: capabilities must reference announced services; token counts bounded; input modalities restricted to `text|image|audio|video|pdf`
- Plumbing: announcer normalization, `PeerInfo.providerServiceCapabilities` matrix for capability-aware routing, `BaseProvider` passthrough, and `ANTSEED_SERVICE_CAPABILITIES_JSON` provider config

Stacked on #687 (`add-image-gen-support`); retarget to `main` once it merges.

Closes #393

## Validation

- `pnpm --filter @antseed/node test` (878 tests)
- `pnpm --filter @antseed/provider-core test` (45 tests)
- `pnpm --filter @antseed/provider-openai test`, cli suite