### PR TITLE
feat(desktop): redesign deposit chooser with fun.xyz-led layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ This project uses selective package publishing. Each release entry lists the pub
 - Added `antseed buyer channels close <channelId>` (with `--no-auth` and `--json`), which runs the request through a running `antseed buyer start` daemon's live seller connection via the new `/_antseed/channels/close` control-plane endpoint.
 - Added `AntseedNode.requestChannelClose(peerId, opts)` to `@antseed/node`, plus the `payments.cooperative-close.v1` capability advertised in discovery metadata and the connection handshake.
 
+### Changed
+
+- Desktop: redesigned the Add Credits chooser. The Fun checkout is now a "Deposit with fun.xyz" row showing the accepted card networks (Mastercard, Apple Pay, Google Pay, Visa) and an email-required note, the USDC-on-Base quick deposit is always visible with a note that the AntSeed relayer network credits it, and the Meridian option moved behind "More options" as "Deposit using Meridian". Payment and chain badges now use the official brand logos, and the primary CTA follows the app theme (dark surface in light mode, light surface in dark mode).
+
 ### Fixed
 
 - Fixed the buyer proxy leaking `.buyer.state.*.json.tmp` files (each a full discovered-peers snapshot, ~1 MB) when the atomic state-file rename failed — common on Windows while a reader briefly holds `buyer.state.json` open. The rename is now retried, a failed write cleans up its temp file and logs the error instead of dropping the state update silently, and leftover temp files from earlier runs are swept at startup.

--- a/apps/desktop/src/renderer/ui/components/views/FunkitDeposit.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/FunkitDeposit.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 import '@funkit/connect/styles.css';
 import './FunkitDeposit.scss';
 import {
@@ -36,6 +36,8 @@ type Props = {
   usdcAddress: string;
   /** Styling for the CTA button (the parent owns the look). */
   className?: string;
+  /** CTA button content (the parent owns the label/logo too). */
+  children?: ReactNode;
   onError?: (message: string) => void;
 };
 
@@ -78,7 +80,7 @@ function ThemeSync({ mode }: { mode: ThemeMode }) {
   return null;
 }
 
-function DepositButton({ recipient, usdcAddress, className, onError }: Props) {
+function DepositButton({ recipient, usdcAddress, className, children, onError }: Props) {
   const checkoutConfig = useMemo<FunkitCheckoutConfig>(() => ({
     modalTitle: 'Deposit',
     targetChain: '8453',
@@ -100,7 +102,7 @@ function DepositButton({ recipient, usdcAddress, className, onError }: Props) {
 
   return (
     <button type="button" className={className} onClick={() => { onError?.(''); void beginCheckout(); }}>
-      Deposit
+      {children ?? 'Deposit'}
     </button>
   );
 }

--- a/apps/desktop/src/renderer/ui/components/views/VprDepositView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositView.module.scss
@@ -46,16 +46,18 @@
 
 /* ---------- Method chooser (CTAs) ---------- */
 
-/* Primary Fun CTA: Fun's near-black brand surface with an inverted wordmark
-   chip. Swap the chip for the official asset once their brand kit lands. */
+/* Primary Fun CTA: same row anatomy as .methodCta (icon chip · title +
+   caption · badge cluster · arrow) but on Fun's near-black brand surface. */
 .funCta {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 8px;
+  gap: 12px;
   width: 100%;
   margin-top: 4px;
-  padding: 14px 16px;
+  /* Same padding + two-line text block as .methodCta, so the primary CTA and
+     the method rows all land on the same height. */
+  padding: 10px 14px;
+  text-align: left;
   border: 1px solid var(--border);
   border-radius: 14px;
   background: #0e0e12;
@@ -73,9 +75,82 @@
   transform: translateY(-1px);
 }
 
+/* Dark mode inverts the CTA: light surface, near-black content — the
+   high-contrast primary in both themes. */
+:global(body.dark-theme) .funCta {
+  background: #f4f4f6;
+  color: #0e0e12;
+}
+
+:global(body.dark-theme) .funCta:hover {
+  filter: brightness(0.96);
+}
+
 .funCta:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px rgba(var(--brand-rgb), 0.4);
+}
+
+.funCta:disabled {
+  cursor: default;
+  opacity: 0.65;
+  transform: none;
+  filter: none;
+  box-shadow: none;
+}
+
+/* One deposit option: its CTA plus the supporting icon row / footnote. */
+.methodGroup {
+  display: grid;
+  justify-items: center;
+  gap: 6px;
+}
+
+.methodGroup > button {
+  justify-self: stretch;
+}
+
+/* Leading Fun-logo chip — .methodCtaIcon's geometry, tinted from the CTA's
+   own text color so it holds up in both themes. */
+.funCtaIcon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  background: color-mix(in srgb, currentColor 14%, transparent);
+}
+
+/* Text block takes the middle so the badge cluster hugs the right edge,
+   matching the method rows below. */
+.funCtaText {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.funCtaTitle {
+  font-size: 15px;
+  font-weight: 650;
+  line-height: 20px;
+}
+
+.funCtaCaption {
+  color: color-mix(in srgb, currentColor 65%, transparent);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+}
+
+/* Small-print qualifier under an option ("* Email required…"). */
+.methodFootnote {
+  color: var(--text-faint, var(--text-secondary));
+  font-size: 11px;
+  line-height: 14px;
+  text-align: center;
 }
 
 /* Expander for the secondary deposit methods. */
@@ -165,11 +240,6 @@
   transform: translateY(-1px);
 }
 
-.methodCta:hover .methodCtaArrow {
-  color: var(--brand);
-  transform: translateX(2px);
-}
-
 .methodCtaIcon {
   flex: 0 0 auto;
   display: inline-flex;
@@ -199,12 +269,6 @@
   color: var(--text-secondary);
   font-size: 12px;
   line-height: 16px;
-}
-
-.methodCtaArrow {
-  flex: 0 0 auto;
-  color: var(--text-secondary);
-  transition: color 0.12s ease, transform 0.12s ease;
 }
 
 /* ---------- Amount card ---------- */
@@ -517,24 +581,13 @@
 
 /* ---------- Trust footer ---------- */
 
-/* Compact trust strip: one row of payment/security/crypto marks with a
-   single reassurance line beneath. */
+/* Compact trust strip: short reassurance lines (the payment marks now sit
+   under the primary CTA). */
 .trustStrip {
   display: grid;
   justify-items: center;
   gap: 6px;
   margin-top: 4px;
-}
-
-.trustIcons {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--text-secondary);
-}
-
-.trustIcons svg {
-  display: block;
 }
 
 .trustLine {

--- a/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
@@ -3,7 +3,6 @@ import QRCode from 'qrcode';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
   ArrowDown01Icon,
-  ArrowRight01Icon,
   ArrowUpRight01Icon,
   Copy01Icon,
   QrCodeIcon,
@@ -180,12 +179,83 @@ function MastercardMark({ size = 18 }: { size?: number }) {
   );
 }
 
+/** Apple logo silhouette (the classic bitten-apple path, 814×1000 box). */
+const APPLE_LOGO_PATH =
+  'M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 ' +
+  '202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5' +
+  '-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57-155.5-127C46.7 ' +
+  '790.7 0 663 0 541.8c0-194.4 126.4-297.5 250.8-297.5 66.1 0 121.2 43.4 ' +
+  '162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-' +
+  '181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-' +
+  '110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 ' +
+  '18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z';
+
+/* Circular payment badges for the Fun CTA — same idiom as the chain marks
+   (filled discs), with a hairline ring on the white ones so they hold up on
+   any surface. */
+
+function ApplePayRoundMark({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="12" cy="12" r="11.5" fill="#fff" stroke="#d5d7db" />
+      <path d={APPLE_LOGO_PATH} fill="#000" transform="translate(7.3 6.4) scale(0.0115)" />
+    </svg>
+  );
+}
+
+function MastercardRoundMark({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="12" cy="12" r="11.5" fill="#fff" stroke="#d5d7db" />
+      <circle cx="9.4" cy="12" r="4.6" fill="#EB001B" />
+      <circle cx="14.6" cy="12" r="4.6" fill="#F79E1B" fillOpacity="0.9" />
+    </svg>
+  );
+}
+
+function GooglePayRoundMark({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="12" cy="12" r="11.5" fill="#fff" stroke="#d5d7db" />
+      <g transform="translate(6 6) scale(0.5)">
+        <path fill="#4285F4" d="M23.49 12.27c0-.79-.07-1.54-.19-2.27H12v4.51h6.47c-.29 1.48-1.14 2.73-2.4 3.58v3h3.86c2.26-2.09 3.56-5.17 3.56-8.82z" />
+        <path fill="#34A853" d="M12 24c3.24 0 5.95-1.08 7.93-2.91l-3.86-3c-1.08.72-2.45 1.16-4.07 1.16-3.13 0-5.78-2.11-6.73-4.96H1.29v3.09C3.26 21.31 7.31 24 12 24z" />
+        <path fill="#FBBC05" d="M5.27 14.29c-.25-.72-.38-1.49-.38-2.29s.14-1.57.38-2.29V6.62H1.29C.47 8.24 0 10.06 0 12s.47 3.76 1.29 5.38l3.98-3.09z" />
+        <path fill="#EA4335" d="M12 4.75c1.77 0 3.35.61 4.6 1.8l3.42-3.42C17.95 1.19 15.24 0 12 0 7.31 0 3.26 2.69 1.29 6.62l3.98 3.09C6.22 6.86 8.87 4.75 12 4.75z" />
+      </g>
+    </svg>
+  );
+}
+
+function VisaRoundMark({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="12" cy="12" r="12" fill="#1434CB" />
+      <text x="12" y="14.6" textAnchor="middle" fontSize="7" fontWeight="800" fontStyle="italic" fill="#fff">VISA</text>
+    </svg>
+  );
+}
+
 function VisaMark({ size = 18 }: { size?: number }) {
   const width = Math.round(size * (34 / 24));
   return (
     <svg width={width} height={size} viewBox="0 0 34 24" aria-hidden="true">
       <rect width="34" height="24" rx="5" fill="#1434CB" />
       <text x="17" y="15.8" textAnchor="middle" fontSize="9" fontWeight="800" fontStyle="italic" fill="#fff">VISA</text>
+    </svg>
+  );
+}
+
+/** Official Fun (fun.xyz) mark — their site's SVG favicon, recolored via
+    currentColor (white on the dark Fun CTA). */
+function FunMark({ size = 20 }: { size?: number }) {
+  const width = Math.round(size * (15 / 20));
+  return (
+    <svg width={width} height={size} viewBox="0 0 15 20" fill="currentColor" aria-hidden="true">
+      <path d="M6.44189 1.38892L14.1668 5.5V14.4999L6.44189 18.611V1.38892Z" />
+      <path d="M7.27555 2.775L13.3339 6V13.9972L7.27555 17.2222V2.775ZM5.60889 0V20L15.0006 15V5L5.60889 0Z" />
+      <path d="M2.80615 0V20L4.20893 19.2528V0.747222L2.80615 0Z" />
+      <path d="M0 0V20L1.40278 19.2528V0.747222L0 0Z" />
     </svg>
   );
 }
@@ -202,50 +272,63 @@ function MeridianMark({ size = 20 }: { size?: number }) {
   );
 }
 
+/** Official Arbitrum mark (arbitrum.foundation brand asset). */
 function ArbitrumMark({ size = 18 }: { size?: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
-      <circle cx="12" cy="12" r="12" fill="#213147" />
-      <path d="M12 4.5l5.5 9.5-2.3 4-5.4-9.4L12 4.5z" fill="#12AAFF" />
-      <path d="M10.4 8.4l4.2 7.3-1.7 3-5.4-9.4 2.9-.9z" fill="#9DCCED" />
-      <path d="M6.5 14l3-8.3 1.6 2.8-2.9 8.2L6.5 14z" fill="#fff" fillOpacity="0.9" />
+    <svg width={size} height={size} viewBox="0 0 2500 2500" aria-hidden="true">
+      <path fill="#213147" d="M226,760v980c0,63,33,120,88,152l849,490c54,31,121,31,175,0l849-490c54-31,88-89,88-152V760c0-63-33-120-88-152l-849-490c-54-31-121-31-175,0L314,608c-54,31-87,89-87,152H226z" />
+      <path fill="#12AAFF" d="M1435,1440l-121,332c-3,9-3,19,0,29l208,571l241-139l-289-793C1467,1422,1442,1422,1435,1440z" />
+      <path fill="#12AAFF" d="M1678,882c-7-18-32-18-39,0l-121,332c-3,9-3,19,0,29l341,935l241-139L1678,883V882z" />
+      <path fill="#9DCCED" d="M1250,155c6,0,12,2,17,5l918,530c11,6,17,18,17,30v1060c0,12-7,24-17,30l-918,530c-5,3-11,5-17,5s-12-2-17-5l-918-530c-11-6-17-18-17-30V719c0-12,7-24,17-30l918-530c5-3,11-5,17-5l0,0V155z M1250,0c-33,0-65,8-95,25L237,555c-59,34-95,96-95,164v1060c0,68,36,130,95,164l918,530c29,17,62,25,95,25s65-8,95-25l918-530c59-34,95-96,95-164V719c0-68-36-130-95-164L1344,25c-29-17-62-25-95-25l0,0H1250z" />
+      <polygon fill="#213147" points="642,2179 727,1947 897,2088 738,2234" />
+      <path fill="#fff" d="M1172,644H939c-17,0-33,11-39,27L401,2039l241,139l550-1507c5-14-5-28-19-28L1172,644z" />
+      <path fill="#fff" d="M1580,644h-233c-17,0-33,11-39,27L738,2233l241,139l620-1701c5-14-5-28-19-28V644z" />
     </svg>
   );
 }
 
+/** Official BNB Chain mark (yellow disc + notched-diamond glyph). */
 function BnbMark({ size = 18 }: { size?: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
-      <circle cx="12" cy="12" r="12" fill="#F3BA2F" />
+    <svg width={size} height={size} viewBox="0 0 2496 2496" aria-hidden="true">
+      <path fill="#F0B90B" fillRule="evenodd" clipRule="evenodd" d="M1248,0c689.3,0,1248,558.7,1248,1248s-558.7,1248-1248,1248S0,1937.3,0,1248S558.7,0,1248,0L1248,0z" />
       <g fill="#fff">
-        <path d="M12 9.6l2.4 2.4-2.4 2.4-2.4-2.4L12 9.6z" />
-        <path d="M12 4.9l2.4 2.4L12 9.7 9.6 7.3 12 4.9z" />
-        <path d="M12 14.3l2.4 2.4L12 19.1l-2.4-2.4 2.4-2.4z" />
-        <path d="M7.3 9.6l2.4 2.4-2.4 2.4L4.9 12l2.4-2.4z" />
-        <path d="M16.7 9.6l2.4 2.4-2.4 2.4-2.4-2.4 2.4-2.4z" />
+        <path d="M685.9,1248l0.9,330l280.4,165v193.2l-444.5-260.7v-524L685.9,1248L685.9,1248z M685.9,918v192.3l-163.3-96.6V821.4l163.3-96.6l164.1,96.6L685.9,918L685.9,918z M1084.3,821.4l163.3-96.6l164.1,96.6L1247.6,918L1084.3,821.4L1084.3,821.4z" />
+        <path d="M803.9,1509.6v-193.2l163.3,96.6v192.3L803.9,1509.6L803.9,1509.6z M1084.3,1812.2l163.3,96.6l164.1-96.6v192.3l-164.1,96.6l-163.3-96.6V1812.2L1084.3,1812.2z M1645.9,821.4l163.3-96.6l164.1,96.6v192.3l-164.1,96.6V918L1645.9,821.4L1645.9,821.4L1645.9,821.4z M1809.2,1578l0.9-330l163.3-96.6v524l-444.5,260.7v-193.2L1809.2,1578L1809.2,1578L1809.2,1578z" />
+        <polygon points="1692.1,1509.6 1528.8,1605.3 1528.8,1413 1692.1,1316.4 1692.1,1509.6" />
+        <path d="M1692.1,986.4l0.9,193.2l-281.2,165v330.8l-163.3,95.7l-163.3-95.7v-330.8l-281.2-165V986.4L968,889.8l279.5,165.8l281.2-165.8l164.1,96.6H1692.1L1692.1,986.4z M803.9,656.5l443.7-261.6l444.5,261.6l-163.3,96.6l-281.2-165.8L967.2,753.1L803.9,656.5L803.9,656.5z" />
       </g>
     </svg>
   );
 }
 
+/** Official Polygon glyph (polygon.technology brand asset) on the brand disc. */
 function PolygonMark({ size = 18 }: { size?: number }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
-      <circle cx="12" cy="12" r="12" fill="#8247E5" />
+      <circle cx="12" cy="12" r="12" fill="#6C00F6" />
       <path
-        d="M15.9 9.8v3l-2.6 1.5v2.9l5.2-3v-5.9l-2.6 1.5zM8.1 8.3l2.6-1.5 2.6 1.5v3L10.7 12 8.1 10.5v-2.2zM5.5 9.8v5.9l5.2 3v-2.9l-2.6-1.5v-3L5.5 9.8z"
         fill="#fff"
+        transform="translate(5.5 6.15) scale(0.0731)"
+        d="M66.8,54.7l-16.7-9.7L0,74.1v58l50.1,29l50.1-29V41.9L128,25.8l27.8,16.1v32.2L128,90.2l-16.7-9.7v25.8l16.7,9.7l50.1-29V29L128,0L77.9,29v90.2l-27.8,16.1l-27.8-16.1V86.9l27.8-16.1l16.7,9.7V54.7z"
       />
     </svg>
   );
 }
 
+/** Official Ethereum mark (ethereum.org diamond on the #627EEA disc). */
 function EthMark({ size = 18 }: { size?: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
-      <circle cx="12" cy="12" r="12" fill="#627EEA" />
-      <path d="M12 4l4.5 8.1L12 14.9 7.5 12.1 12 4z" fill="#fff" fillOpacity="0.9" />
-      <path d="M12 16.1l4.5-2.9L12 20l-4.5-6.8 4.5 2.9z" fill="#fff" fillOpacity="0.75" />
+    <svg width={size} height={size} viewBox="0 0 32 32" aria-hidden="true">
+      <circle cx="16" cy="16" r="16" fill="#627EEA" />
+      <g fill="#fff" fillRule="nonzero">
+        <path fillOpacity="0.602" d="M16.498 4v8.87l7.497 3.35z" />
+        <path d="M16.498 4L9 16.22l7.498-3.35z" />
+        <path fillOpacity="0.602" d="M16.498 21.968v6.027L24 17.616z" />
+        <path d="M16.498 27.995v-6.028L9 17.616z" />
+        <path fillOpacity="0.2" d="M16.498 20.573l7.497-4.353-7.497-3.348z" />
+        <path fillOpacity="0.602" d="M9 16.22l7.498 4.353v-7.701z" />
+      </g>
     </svg>
   );
 }
@@ -268,10 +351,10 @@ function explorerTxUrl(chainId: number | undefined, txHash: string): string | nu
 
 /**
  * Deposit flow: the chooser leads with the Fun (fun.xyz) checkout (card/cash
- * or crypto transfer, in-app), with the scan-to-pay QR and hosted providers
- * behind "More options". Everything lands in the hot wallet the main-process
- * sweeper watches. Only pages that need an external wallet signature leave
- * the app.
+ * or crypto transfer, in-app), followed by the quick USDC-on-Base transfer
+ * (scan-to-pay QR), with hosted providers (Meridian) behind "More options".
+ * Everything lands in the hot wallet the main-process sweeper watches. Only
+ * pages that need an external wallet signature leave the app.
  */
 // The Stripe pay page is hidden until it's ready to ship.
 const SHOW_STRIPE_OPTION = false;
@@ -410,6 +493,28 @@ export function VprDepositView({ onSelectView }: Props) {
   const funPending = funkitApiKey !== '' && (funkitApiKey === null || (!watchInfo && !watchError));
   const funAvailable = funWatchInfo !== null || funPending;
 
+  // Shared between the live Fun CTA, its Suspense fallback, and the disabled
+  // placeholder so the button never changes content while loading. Same row
+  // anatomy as the method rows below (logo · title · badge cluster), but on
+  // the primary dark surface.
+  const funCtaContent = (
+    <>
+      <span className={styles.funCtaIcon}>
+        <FunMark size={18} />
+      </span>
+      <span className={styles.funCtaText}>
+        <span className={styles.funCtaTitle}>Deposit with fun.xyz</span>
+        <span className={styles.funCtaCaption}>Email address required</span>
+      </span>
+      <span className={styles.methodBadges} aria-hidden="true">
+        <MastercardRoundMark />
+        <ApplePayRoundMark />
+        <GooglePayRoundMark />
+        <VisaRoundMark />
+      </span>
+    </>
+  );
+
   const statusLine = (() => {
     if (watchError) return { tone: 'error' as const, text: watchError };
     if (!watchStatus) return { tone: 'idle' as const, text: 'Waiting for USDC on Base…' };
@@ -504,64 +609,68 @@ export function VprDepositView({ onSelectView }: Props) {
               sweeps. Fun delivers on Base mainnet only, so the CTA waits for
               the watcher info and hides on other chains. */}
           {funAvailable && (funWatchInfo && funkitApiKey ? (
-            <Suspense fallback={<button type="button" className={styles.funCta} disabled>Deposit</button>}>
+            <Suspense fallback={<button type="button" className={styles.funCta} disabled>{funCtaContent}</button>}>
               <FunkitDeposit
                 apiKey={funkitApiKey}
                 recipient={funWatchInfo.address}
                 usdcAddress={funWatchInfo.usdcAddress}
                 className={styles.funCta}
                 onError={(message) => setPayPageNotice(message || null)}
-              />
+              >
+                {funCtaContent}
+              </FunkitDeposit>
             </Suspense>
           ) : (
-            <button type="button" className={styles.funCta} disabled>Deposit</button>
+            <button type="button" className={styles.funCta} disabled>{funCtaContent}</button>
           ))}
           {payPageNotice && <div className={styles.cardNotice} role="alert">{payPageNotice}</div>}
 
-          {funAvailable && (
-            <button
-              type="button"
-              className={styles.moreLink}
-              aria-expanded={moreOpen}
-              onClick={() => setMoreOpen((open) => !open)}
-            >
-              <span>More options</span>
-              <HugeiconsIcon
-                icon={ArrowDown01Icon}
-                size={16}
-                strokeWidth={2}
-                className={`${styles.moreLinkChevron}${moreOpen ? ` ${styles.moreLinkChevronOpen}` : ''}`}
-              />
+          <div className={styles.methodGroup}>
+            <button type="button" className={styles.methodCta} onClick={() => goToStage('crypto')}>
+              <span className={styles.methodCtaIcon}>
+                <BaseMark size={22} />
+              </span>
+              <span className={styles.methodCtaText}>
+                <span className={styles.methodCtaTitle}>Quick deposit</span>
+                <span className={styles.methodCtaCaption}>USDC on Base</span>
+              </span>
+              <span className={styles.methodBadges} aria-hidden="true">
+                <UsdcMark />
+                <span className={styles.badgeChip}>
+                  <HugeiconsIcon icon={QrCodeIcon} size={12} strokeWidth={2} />
+                </span>
+              </span>
             </button>
-          )}
+            <span className={styles.methodFootnote}>* Deposited to your credits by the AntSeed relayer network</span>
+          </div>
 
-          {(moreOpen || !funAvailable) && (
+          <button
+            type="button"
+            className={styles.moreLink}
+            aria-expanded={moreOpen}
+            onClick={() => setMoreOpen((open) => !open)}
+          >
+            <span>More options</span>
+            <HugeiconsIcon
+              icon={ArrowDown01Icon}
+              size={16}
+              strokeWidth={2}
+              className={`${styles.moreLinkChevron}${moreOpen ? ` ${styles.moreLinkChevronOpen}` : ''}`}
+            />
+          </button>
+
+          {moreOpen && (
             <div className={styles.optionList}>
-              <button type="button" className={styles.methodCta} onClick={() => goToStage('crypto')}>
-                <span className={styles.methodCtaIcon}>
-                  <UsdcMark size={22} />
-                </span>
-                <span className={styles.methodCtaText}>
-                  <span className={styles.methodCtaTitle}>USDC on Base</span>
-                </span>
-                <span className={styles.methodBadges} aria-hidden="true">
-                  <BaseMark />
-                  <span className={styles.badgeChip}>
-                    <HugeiconsIcon icon={QrCodeIcon} size={12} strokeWidth={2} />
-                  </span>
-                </span>
-                <HugeiconsIcon icon={ArrowRight01Icon} size={18} strokeWidth={2} className={styles.methodCtaArrow} />
-              </button>
-
               {/* Fixed lineup — deliberately NOT the configurable card
-                  provider list, which may carry legacy entries. These two ids
+                  provider list, which may carry legacy entries. These ids
                   always resolve in the main process. */}
               <button type="button" className={styles.methodCta} onClick={() => openCardProvider('meridian')}>
                 <span className={styles.methodCtaIcon}>
                   <MeridianMark />
                 </span>
                 <span className={styles.methodCtaText}>
-                  <span className={styles.methodCtaTitle}>USDC from any chain</span>
+                  <span className={styles.methodCtaTitle}>Deposit using Meridian</span>
+                  <span className={styles.methodCtaCaption}>USDC from any chain</span>
                 </span>
                 <span className={styles.methodBadges} aria-hidden="true">
                   <EthMark />
@@ -569,7 +678,6 @@ export function VprDepositView({ onSelectView }: Props) {
                   <BnbMark />
                   <PolygonMark />
                 </span>
-                <HugeiconsIcon icon={ArrowUpRight01Icon} size={18} strokeWidth={2} className={styles.methodCtaArrow} />
               </button>
 
               {SHOW_STRIPE_OPTION && (
@@ -584,7 +692,6 @@ export function VprDepositView({ onSelectView }: Props) {
                     <VisaMark />
                     <MastercardMark />
                   </span>
-                  <HugeiconsIcon icon={ArrowUpRight01Icon} size={18} strokeWidth={2} className={styles.methodCtaArrow} />
                 </button>
               )}
               {cardNotice && <div className={styles.cardNotice} role="alert">{cardNotice}</div>}
@@ -592,12 +699,6 @@ export function VprDepositView({ onSelectView }: Props) {
           )}
 
           <div className={styles.trustStrip}>
-            <div className={styles.trustIcons} aria-hidden="true">
-              <VisaMark size={16} />
-              <MastercardMark size={16} />
-              <UsdcMark size={16} />
-              <EthMark size={16} />
-            </div>
             <span className={styles.trustLine}>
               <HugeiconsIcon icon={SquareLock01Icon} size={12} strokeWidth={2} />
               <span>Encrypted &amp; secure · Non-custodial escrow on Base</span>


### PR DESCRIPTION
Redesigns the Add Credits chooser in the desktop app:

- The Fun checkout is now a "Deposit with fun.xyz" row with the official fun.xyz logo, circular card-network badges (Mastercard, Apple Pay, Google Pay, Visa), and an "Email address required" caption.
- The USDC-on-Base quick deposit is always visible (no longer behind More options), with a footnote that the AntSeed relayer network credits the deposit.
- Meridian moved behind the More options dropdown as "Deposit using Meridian — USDC from any chain".
- Chain badges on the Meridian row now use the official Ethereum, Arbitrum, BNB Chain, and Polygon logos.
- Arrows removed from all option rows; the primary CTA inverts to a light surface in dark mode.

CHANGELOG updated under Unreleased.