### PR TITLE
feat(desktop): open Fun checkout popups as app windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Changed
 
-- Desktop: redesigned the Add Credits chooser. The Fun checkout is now a "Deposit with fun.xyz" row showing the accepted card networks (Mastercard, Apple Pay, Google Pay, Visa) and an email-required note, the USDC-on-Base quick deposit is always visible with a note that the AntSeed relayer network credits it, and the Meridian option moved behind "More options" as "Deposit using Meridian". Payment and chain badges now use the official brand logos, and the primary CTA follows the app theme (dark surface in light mode, light surface in dark mode).
+- Desktop: redesigned the Add Credits chooser. The Fun checkout is now a "Deposit" row ("Powered by fun.xyz") showing the accepted card networks (Mastercard, Apple Pay, Google Pay, Visa), the USDC-on-Base quick deposit is always visible with a note that the AntSeed relayer network credits it, and the Meridian option moved behind "More options" as "Deposit using Meridian". Payment and chain badges now use the official brand logos, and the primary CTA follows the app theme (dark surface in light mode, light surface in dark mode).
+- Desktop: the Fun checkout's sign-in and payment popups (Google sign-in, card checkout pages) now open as app-owned windows instead of tabs in the default browser, and close automatically once the sign-in completes or the purchased USDC arrives at the wallet. Popups from those pages carry a standard browser user agent so Google no longer rejects the embedded sign-in, and the desktop IPC bridge is only exposed to the app's own pages, never to third-party checkout content.
 
 ### Fixed
 

--- a/apps/desktop/src/main/ipc/payments.ts
+++ b/apps/desktop/src/main/ipc/payments.ts
@@ -48,6 +48,7 @@ import {
   PAY_PAGE_KINDS,
   type PayPageKind,
   crossmintApiBase,
+  focusMainWindow,
   getPaymentsPortalToken,
   openPaymentsPopup,
   readCardProviders,
@@ -55,6 +56,7 @@ import {
   readFunkitApiKey,
   startPaymentsPortal,
 } from '../payments/portal.js';
+import { closeCheckoutWindows } from '../payments/checkout-window.js';
 import {
   lookupPeer,
   refreshPeerCache,
@@ -213,6 +215,14 @@ export function registerPaymentsIpc(): void {
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }
+  });
+
+  // The renderer closes the Fun checkout/sign-in popup windows on flows that
+  // never produce a deposit — e.g. a Google login, where "success" is the
+  // SDK's connection status flipping to connected, not funds arriving.
+  ipcMain.handle('payments:close-checkout-windows', () => {
+    if (closeCheckoutWindows()) focusMainWindow();
+    return { ok: true };
   });
 
   ipcMain.handle('credits:get-info', async (): Promise<{ ok: boolean; data: CreditsInfo | null; error: string | null }> => {

--- a/apps/desktop/src/main/payments/checkout-window.ts
+++ b/apps/desktop/src/main/payments/checkout-window.ts
@@ -1,0 +1,90 @@
+/**
+ * Fun (fun.xyz) checkout popup windows.
+ *
+ * The Fun SDK opens its external payment flows — Meld/Swapped card pages,
+ * brokerage sign-ins ("continue with Google", Coinbase, …) — via window.open
+ * with explicit popup dimensions, then writes a loading spinner into the
+ * about:blank document before pointing it at the real URL. Punting those to
+ * the system browser (the old blanket deny + shell.openExternal) breaks that
+ * dance and leaves an orphaned browser tab the app can never close.
+ *
+ * Instead, sized popups open as plain Electron child windows: no browser
+ * chrome (the `--app` look), window.opener intact for the OAuth postMessage
+ * flows, and the app owns the handle — the deposit watcher closes every
+ * checkout window the moment the bought USDC lands at the hot wallet.
+ *
+ * Plain `_blank` links (terms, explorers) still go to the system browser.
+ */
+import { app, shell, type BrowserWindow, type BrowserWindowConstructorOptions, type HandlerDetails } from 'electron';
+
+type WindowOpenResponse =
+  | { action: 'deny' }
+  | { action: 'allow'; overrideBrowserWindowOptions?: BrowserWindowConstructorOptions };
+
+const checkoutWindows = new Set<BrowserWindow>();
+
+/** The SDK's checkout/sign-in popups always pass centered dimensions;
+ *  ordinary link-outs pass "noopener" or nothing. */
+function isSizedPopup(features: string): boolean {
+  return /(?:^|,)\s*(?:width|height)\s*=/.test(features);
+}
+
+/** Chrome-equivalent UA. Google sign-in refuses agents that identify as an
+ *  embedded shell (`disallowed_useragent`); dropping the app and Electron
+ *  tokens leaves the stock Chrome UA, which it accepts. */
+function browserUserAgent(): string {
+  return app.userAgentFallback
+    .split(`${app.getName()}/${app.getVersion()}`)
+    .join('')
+    .replace(/\sElectron\/\S+/, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+/**
+ * Window-open handler for any webContents that can host the Fun widget or
+ * its checkout pages: sized popups become child windows, links leave for the
+ * system browser.
+ */
+export function checkoutWindowOpenHandler(details: HandlerDetails): WindowOpenResponse {
+  if (isSizedPopup(details.features)) {
+    return {
+      action: 'allow',
+      overrideBrowserWindowOptions: {
+        title: 'AntSeed — Secure checkout',
+        autoHideMenuBar: true,
+        // webPreferences stay inherited on purpose: the SDK's spinner
+        // injection needs the about:blank child in the opener's renderer
+        // process, and the inherited preload refuses to expose the IPC
+        // bridge to any document that isn't the app's own.
+      },
+    };
+  }
+  void shell.openExternal(details.url);
+  return { action: 'deny' };
+}
+
+/**
+ * Track a child window created by the handler above. Sign-in flows inside a
+ * checkout page open popups of their own (Google OAuth needs window.opener),
+ * so children get the same handler recursively.
+ */
+export function adoptCheckoutWindow(win: BrowserWindow): void {
+  checkoutWindows.add(win);
+  win.webContents.setUserAgent(browserUserAgent());
+  win.webContents.setWindowOpenHandler(checkoutWindowOpenHandler);
+  win.webContents.on('did-create-window', adoptCheckoutWindow);
+  win.on('closed', () => {
+    checkoutWindows.delete(win);
+  });
+}
+
+/** Close every open checkout window. Returns whether any were open. */
+export function closeCheckoutWindows(): boolean {
+  const hadWindows = checkoutWindows.size > 0;
+  for (const win of [...checkoutWindows]) {
+    if (!win.isDestroyed()) win.close();
+  }
+  checkoutWindows.clear();
+  return hadWindows;
+}

--- a/apps/desktop/src/main/payments/deposit-sweep.ts
+++ b/apps/desktop/src/main/payments/deposit-sweep.ts
@@ -19,6 +19,8 @@ import { LOCALHOST_URL } from '../constants.js';
 import { getSecureIdentity } from '../identity.js';
 import { resolveBuyerProxyPort } from '../runtime/active-config.js';
 import { getMainWindow } from '../ui/window.js';
+import { closeCheckoutWindows } from './checkout-window.js';
+import { focusMainWindow } from './portal.js';
 import { invalidateCreditsCache, loadCachedCryptoConfig } from './credits.js';
 
 type DepositWatchStatus = {
@@ -67,6 +69,12 @@ export function makeDepositsClient(cc: NonNullable<Awaited<ReturnType<typeof loa
 }
 
 function sendDepositWatchStatus(status: DepositWatchStatus): void {
+  // Funds arriving at the hot wallet means an in-flight checkout (Fun card /
+  // sign-in popup) succeeded — close its windows and bring the app back up
+  // so the user lands on the deposit progress banner.
+  if (status.phase === 'received' || status.phase === 'credited') {
+    if (closeCheckoutWindows()) focusMainWindow();
+  }
   getMainWindow()?.webContents.send('deposits:watch-status', status);
 }
 

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -540,6 +540,7 @@ const api = {
   paymentsOpenCardProvider: (opts?: { providerId?: string; amountUsdc?: string }) => ipcRenderer.invoke('payments:open-card-provider', opts),
   paymentsCrossmintConfig: () => ipcRenderer.invoke('payments:crossmint-config'),
   paymentsFunkitConfig: () => ipcRenderer.invoke('payments:funkit-config'),
+  paymentsCloseCheckoutWindows: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('payments:close-checkout-windows') as Promise<{ ok: boolean }>,
   paymentsGetBuyerUsage: () => ipcRenderer.invoke('payments:get-buyer-usage'),
   paymentsGetChannels: () => ipcRenderer.invoke('payments:get-channels'),
   paymentsGetRewardsSummary: () => ipcRenderer.invoke('payments:get-rewards-summary'),
@@ -666,6 +667,22 @@ const api = {
   },
 };
 
-contextBridge.exposeInMainWorld('antseedDesktop', api);
+// The preload runs in the renderer, where `location` exists — this file is
+// compiled with the main-process tsconfig (node libs only), which doesn't
+// know the DOM globals.
+declare const location: { protocol: string; hostname: string };
+
+// Child windows opened via window.open (the Fun checkout popups —
+// payments/checkout-window.ts) inherit this preload from the main window but
+// load third-party payment pages. The IPC bridge must never reach those
+// documents: expose it only on the app's own origins (file:// in packaged
+// builds, the localhost dev server / payments portal in dev).
+const isAppDocument =
+  location.protocol === 'file:' ||
+  location.hostname === 'localhost' ||
+  location.hostname === '127.0.0.1';
+if (isAppDocument) {
+  contextBridge.exposeInMainWorld('antseedDesktop', api);
+}
 
 export type DesktopBridge = typeof api;

--- a/apps/desktop/src/main/ui/window.ts
+++ b/apps/desktop/src/main/ui/window.ts
@@ -1,6 +1,5 @@
 import {
   BrowserWindow,
-  shell,
   Menu,
   dialog,
   nativeImage,
@@ -11,6 +10,7 @@ import {
 } from 'electron';
 import { windowPresetForView, type WindowSizePresetName } from '../../shared/view-windows.js';
 import { PRELOAD_PATH } from '../paths.js';
+import { adoptCheckoutWindow, checkoutWindowOpenHandler, closeCheckoutWindows } from '../payments/checkout-window.js';
 
 let mainWindow: BrowserWindow | null = null;
 
@@ -478,10 +478,11 @@ export function createWindow(config: WindowConfig): void {
     ...macosWindowChrome,
   });
 
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    void shell.openExternal(url);
-    return { action: 'deny' };
-  });
+  // Sized popups (the Fun checkout's card/sign-in flows) open as app-owned
+  // child windows so they can be closed when the payment lands; everything
+  // else leaves for the system browser.
+  mainWindow.webContents.setWindowOpenHandler(checkoutWindowOpenHandler);
+  mainWindow.webContents.on('did-create-window', (child) => adoptCheckoutWindow(child));
 
   mainWindow.on('enter-full-screen', () => {
     mainWindow?.webContents.send('fullscreen-change', true);
@@ -543,6 +544,7 @@ export function createWindow(config: WindowConfig): void {
   mainWindow.on('closed', () => {
     mainWindow = null;
     closeFloatWindow();
+    closeCheckoutWindows();
   });
 }
 

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -404,6 +404,8 @@ export type DesktopBridge = {
   paymentsOpenCardProvider?: (opts?: { providerId?: string; amountUsdc?: string }) => Promise<{ ok: boolean; url?: string; error?: string }>;
   paymentsCrossmintConfig?: () => Promise<{ ok: boolean; data?: { clientKey: string; apiBase: string } | null; error?: string }>;
   paymentsFunkitConfig?: () => Promise<{ ok: boolean; data?: { apiKey: string } | null; error?: string }>;
+  /** Closes any app-owned Fun checkout/sign-in popup windows (login-only flows produce no deposit, so the deposit watcher can't close them). */
+  paymentsCloseCheckoutWindows?: () => Promise<{ ok: boolean }>;
   paymentsGetBuyerUsage?: () => Promise<{ ok: boolean; data: DesktopBuyerUsageTotals | null; error: string | null; lastActivityAt?: number | null }>;
   paymentsGetChannels?: () => Promise<{ ok: boolean; data: DesktopPaymentChannelSummary[]; error: string | null }>;
   paymentsGetRewardsSummary?: () => Promise<{ ok: boolean; data: DesktopRewardsSummary | null; error: string | null }>;

--- a/apps/desktop/src/renderer/ui/components/views/FunkitDeposit.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/FunkitDeposit.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import '@funkit/connect/styles.css';
 import './FunkitDeposit.scss';
 import {
   FunkitProvider,
+  useConnectionStatus,
   useFunkitCheckout,
   useActiveTheme,
   darkTheme,
@@ -80,6 +81,24 @@ function ThemeSync({ mode }: { mode: ThemeMode }) {
   return null;
 }
 
+/**
+ * Sign-in popups (main/payments/checkout-window.ts) don't produce a deposit,
+ * so the deposit watcher's close-on-arrival never fires for them — the SDK's
+ * connection status flipping to `connected` is that flow's success signal.
+ * Payment popups are covered by the watcher when the USDC lands.
+ */
+function CloseCheckoutWindowsOnLogin() {
+  const status = useConnectionStatus();
+  const previous = useRef(status);
+  useEffect(() => {
+    if (status === 'connected' && previous.current !== 'connected') {
+      void window.antseedDesktop?.paymentsCloseCheckoutWindows?.();
+    }
+    previous.current = status;
+  }, [status]);
+  return null;
+}
+
 function DepositButton({ recipient, usdcAddress, className, children, onError }: Props) {
   const checkoutConfig = useMemo<FunkitCheckoutConfig>(() => ({
     modalTitle: 'Deposit',
@@ -139,6 +158,7 @@ export default function FunkitDeposit(props: Props) {
           initialChain={8453}
         >
           <ThemeSync mode={mode} />
+          <CloseCheckoutWindowsOnLogin />
           <DepositButton {...props} />
         </FunkitProvider>
       </QueryClientProvider>

--- a/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
@@ -503,8 +503,8 @@ export function VprDepositView({ onSelectView }: Props) {
         <FunMark size={18} />
       </span>
       <span className={styles.funCtaText}>
-        <span className={styles.funCtaTitle}>Deposit with fun.xyz</span>
-        <span className={styles.funCtaCaption}>Email address required</span>
+        <span className={styles.funCtaTitle}>Deposit</span>
+        <span className={styles.funCtaCaption}>Powered by fun.xyz</span>
       </span>
       <span className={styles.methodBadges} aria-hidden="true">
         <MastercardRoundMark />


### PR DESCRIPTION
## Description

The Fun (fun.xyz) SDK opens its external flows — Google sign-in, Meld/Swapped card checkout pages — via `window.open` with popup dimensions, then injects a loading spinner into the `about:blank` document before navigating it. The main window's blanket `deny` + `shell.openExternal` handler broke that mechanism and left orphaned tabs in the default browser that the app could never close.

## Changes

- **New `main/payments/checkout-window.ts`**: sized popups (the SDK's checkout/sign-in flows always pass `width=`/`height=` features) open as plain Electron child windows — no browser chrome, `window.opener` intact for the OAuth postMessage flows, and the app owns the handle. Plain `_blank` links (terms, explorers) still go to the system browser. Popups opened from inside a checkout page (e.g. Google OAuth) get the same treatment recursively.
- **Close on success**, via both signals:
  - Login-only flows: `FunkitDeposit` watches the SDK's `useConnectionStatus()` and closes the popup windows when it flips to `connected` (new `payments:close-checkout-windows` IPC).
  - Payment flows: `deposit-sweep.ts` closes them when the bought USDC arrives at the hot wallet (`received`/`credited` watch status) and refocuses the main window.
  - Both are no-ops when the page already closed itself (Google's OAuth callback does).
- **User agent**: checkout windows carry a Chrome-equivalent UA (Electron/app tokens stripped) so Google sign-in isn't rejected with `disallowed_useragent`.
- **Security**: child windows inherit the main window's preload, so the `antseedDesktop` IPC bridge is now origin-guarded — exposed only on the app's own pages (`file:`/localhost), never to third-party checkout content.
- Deposit CTA copy simplified to "Deposit — Powered by fun.xyz".

## Changelog

Updated `CHANGELOG.md` (Unreleased → Changed): new entry for the checkout windows, and the existing deposit-chooser entry brought in line with the new CTA copy.

## Testing

- `tsc` clean for both the main (`tsconfig.main.json`) and renderer (`tsconfig.renderer.json`) programs.
- Manual flow to verify: restart dev, open the Fun deposit, sign in with Google (popup should be a chromeless app window and close on completion), then a card checkout (window should close when the USDC lands and the app refocuses).