### PR TITLE
feat(desktop): Outerfound card deposit via antseed-pay Stripe checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- Desktop: added a card deposit path powered by AntSeed Pay (antseed-pay.com) with Stripe checkout for US users. The app asks the hosted pay page which providers serve the user's region (its public `/api/options` endpoint, geo-resolved at Cloudflare's edge) and, when Stripe is available, leads the Add Credits chooser with a "Deposit — Powered by Outerfound" CTA (Visa, Mastercard, Amex); the Fun checkout moves under "More options" as "Deposit using Fun". Selecting it opens a narrow app-owned checkout window (420×700) on the signed funding link pinned to the Stripe integration (`provider=stripe`); the existing deposit watcher sweeps the purchased USDC into credits and closes the window when funds arrive. The region check fails closed — if the pay page is unreachable or the region unsupported, the chooser is unchanged.
+
 - Sellers now run periodic model health self-checks (a 1-token probe per advertised service, every 5 minutes by default) and unadvertise services that keep failing, restoring them automatically when they recover. Configurable via `seller.healthCheck` (`enabled`, `intervalMs`, `failureThreshold`); sellers announcing this behavior advertise the `seller.model-health.v1` capability in discovery metadata. Exposed as `ModelHealthChecker` in `@antseed/node`, alongside `AntseedNode.refreshSellerMetadata()` for runtime service-list changes.
 - The buyer proxy now treats `model_not_found` responses as routing failures (instead of successes) and refreshes peer discovery metadata in the background, so a stale cached model list recovers quickly after a seller unadvertises a model.
 

--- a/apps/desktop/src/main/ipc/payments.ts
+++ b/apps/desktop/src/main/ipc/payments.ts
@@ -194,8 +194,9 @@ export function registerPaymentsIpc(): void {
       if (provider.id === 'antseed-pay') {
         // The full signed funding link — nothing secret in it (the sig is in
         // the URL by design), and having it in the dev log makes testing the
-        // hosted page outside the popup trivial.
-        console.log('[payments] antseed-pay funding link:', url);
+        // hosted page outside the popup trivial. Dev only: production output
+        // shouldn't carry the buyer's address.
+        if (isDev) console.log('[payments] antseed-pay funding link:', url);
         openCheckoutPopup(url, getMainWindow());
         return { ok: true, url };
       }

--- a/apps/desktop/src/main/ipc/payments.ts
+++ b/apps/desktop/src/main/ipc/payments.ts
@@ -48,6 +48,7 @@ import {
   PAY_PAGE_KINDS,
   type PayPageKind,
   crossmintApiBase,
+  fetchOnrampAvailability,
   focusMainWindow,
   getPaymentsPortalToken,
   openPaymentsPopup,
@@ -56,7 +57,8 @@ import {
   readFunkitApiKey,
   startPaymentsPortal,
 } from '../payments/portal.js';
-import { closeCheckoutWindows } from '../payments/checkout-window.js';
+import { closeCheckoutWindows, openCheckoutPopup } from '../payments/checkout-window.js';
+import { getMainWindow } from '../ui/window.js';
 import {
   lookupPeer,
   refreshPeerCache,
@@ -180,8 +182,23 @@ export function registerPaymentsIpc(): void {
         parsed.searchParams.set('cur', cur);
         if (amountStr) parsed.searchParams.set('amount', amountStr);
         parsed.searchParams.set('sig', await identity.wallet.signMessage(message));
+        // The chooser's Stripe row is the only path here — open the page on
+        // exactly that integration (no provider tab strip). Unsigned, UX-only.
+        parsed.searchParams.set('provider', 'stripe');
       }
       const url = parsed.toString();
+
+      // AntSeed Pay needs no wallet extension (the link is pre-signed), so it
+      // opens as an app-owned checkout popup: the deposit watcher closes it
+      // the moment the bought USDC lands, instead of stranding a browser tab.
+      if (provider.id === 'antseed-pay') {
+        // The full signed funding link — nothing secret in it (the sig is in
+        // the URL by design), and having it in the dev log makes testing the
+        // hosted page outside the popup trivial.
+        console.log('[payments] antseed-pay funding link:', url);
+        openCheckoutPopup(url, getMainWindow());
+        return { ok: true, url };
+      }
 
       try {
         await shell.openExternal(url);
@@ -192,6 +209,18 @@ export function registerPaymentsIpc(): void {
       console.log('[payments] no system browser available — using Electron popup');
       openPaymentsPopup(url);
       return { ok: true, url };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
+
+  // Region-gated deposit options: the hosted pay page reports which providers
+  // it would offer this machine's region (Stripe = US only). Fail-closed —
+  // an unreachable page just hides the gated rows.
+  ipcMain.handle('payments:onramp-availability', async () => {
+    try {
+      const availability = await fetchOnrampAvailability();
+      return { ok: true, data: availability };
     } catch (err) {
       return { ok: false, error: err instanceof Error ? err.message : String(err) };
     }

--- a/apps/desktop/src/main/payments/checkout-window.ts
+++ b/apps/desktop/src/main/payments/checkout-window.ts
@@ -15,7 +15,7 @@
  *
  * Plain `_blank` links (terms, explorers) still go to the system browser.
  */
-import { app, shell, type BrowserWindow, type BrowserWindowConstructorOptions, type HandlerDetails } from 'electron';
+import { app, shell, BrowserWindow, type BrowserWindowConstructorOptions, type HandlerDetails } from 'electron';
 
 type WindowOpenResponse =
   | { action: 'deny' }
@@ -77,6 +77,40 @@ export function adoptCheckoutWindow(win: BrowserWindow): void {
   win.on('closed', () => {
     checkoutWindows.delete(win);
   });
+}
+
+/**
+ * Open a hosted checkout page (e.g. the antseed-pay.com Stripe flow) as an
+ * app-owned popup rather than a system-browser tab. These pages carry a
+ * pre-signed funding link, so no wallet extension is needed — and adopting
+ * the window means the deposit watcher closes it the moment the bought USDC
+ * lands at the hot wallet, same as the Fun checkout windows.
+ *
+ * `parent` comes from the caller (ui/window.js imports this module, so
+ * importing getMainWindow here would be a cycle).
+ */
+export function openCheckoutPopup(url: string, parent?: BrowserWindow | null): BrowserWindow {
+  // Narrow, like the Fun SDK's sign-in popups — the page renders its bare
+  // one-column checkout at this width.
+  const win = new BrowserWindow({
+    width: 420,
+    height: 700,
+    minWidth: 360,
+    minHeight: 560,
+    ...(parent && !parent.isDestroyed() ? { parent } : {}),
+    title: 'AntSeed — Secure checkout',
+    autoHideMenuBar: true,
+    backgroundColor: '#ffffff',
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+  win.setMenuBarVisibility(false);
+  adoptCheckoutWindow(win);
+  void win.loadURL(url);
+  return win;
 }
 
 /** Close every open checkout window. Returns whether any were open. */

--- a/apps/desktop/src/main/payments/portal.ts
+++ b/apps/desktop/src/main/payments/portal.ts
@@ -143,6 +143,46 @@ export async function readCardProviders(): Promise<CardProvider[]> {
 
 
 
+// Onramp availability — asks the hosted pay page (antseed-pay.com/api/options)
+// which providers it would offer this machine's region. The page owns the
+// gating rules (Stripe sells USDC-on-Base in the US only) and reads geo from
+// Cloudflare, so the app never guesses from locale. The deposit chooser uses
+// this to decide whether region-gated options (the Stripe row) appear at all.
+// Fail closed: any error, timeout, or unexpected payload hides them — every
+// other deposit path is unaffected.
+export type OnrampAvailability = { country: string | null; stripe: boolean };
+
+const ONRAMP_AVAILABILITY_TIMEOUT_MS = 5000;
+let onrampAvailabilityCache: OnrampAvailability | null = null;
+
+export async function fetchOnrampAvailability(): Promise<OnrampAvailability> {
+  // Geo doesn't change within an app run — one successful probe is enough.
+  // Failures are not cached so a flaky network retries on the next open.
+  if (onrampAvailabilityCache) return onrampAvailabilityCache;
+  const closed: OnrampAvailability = { country: null, stripe: false };
+  try {
+    const providers = await readCardProviders();
+    const entry = providers.find((p) => p.id === 'antseed-pay')
+      ?? DEFAULT_CARD_PROVIDERS.find((p) => p.id === 'antseed-pay');
+    if (!entry) return closed;
+    const res = await fetch(new URL('/api/options', entry.url), {
+      signal: AbortSignal.timeout(ONRAMP_AVAILABILITY_TIMEOUT_MS),
+    });
+    if (!res.ok) return closed;
+    const body = asRecord(await res.json());
+    const list = Array.isArray(body.providers) ? body.providers : [];
+    const stripeEntry = asRecord(list.find((p) => asRecord(p).id === 'stripe'));
+    const country = asString(asRecord(body.geo).country as string, '');
+    onrampAvailabilityCache = {
+      country: country || null,
+      stripe: stripeEntry.available === true,
+    };
+    return onrampAvailabilityCache;
+  } catch {
+    return closed;
+  }
+}
+
 // Crossmint Stablecoin Onramp — in-app embedded checkout for buying USDC on
 // Base with a card, delivered to the buyer hot wallet (then swept into
 // deposits by the same watcher as QR/card transfers). The client-side key is

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -540,6 +540,7 @@ const api = {
   paymentsOpenCardProvider: (opts?: { providerId?: string; amountUsdc?: string }) => ipcRenderer.invoke('payments:open-card-provider', opts),
   paymentsCrossmintConfig: () => ipcRenderer.invoke('payments:crossmint-config'),
   paymentsFunkitConfig: () => ipcRenderer.invoke('payments:funkit-config'),
+  paymentsOnrampAvailability: () => ipcRenderer.invoke('payments:onramp-availability'),
   paymentsCloseCheckoutWindows: (): Promise<{ ok: boolean }> => ipcRenderer.invoke('payments:close-checkout-windows') as Promise<{ ok: boolean }>,
   paymentsGetBuyerUsage: () => ipcRenderer.invoke('payments:get-buyer-usage'),
   paymentsGetChannels: () => ipcRenderer.invoke('payments:get-channels'),

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -404,6 +404,7 @@ export type DesktopBridge = {
   paymentsOpenCardProvider?: (opts?: { providerId?: string; amountUsdc?: string }) => Promise<{ ok: boolean; url?: string; error?: string }>;
   paymentsCrossmintConfig?: () => Promise<{ ok: boolean; data?: { clientKey: string; apiBase: string } | null; error?: string }>;
   paymentsFunkitConfig?: () => Promise<{ ok: boolean; data?: { apiKey: string } | null; error?: string }>;
+  paymentsOnrampAvailability?: () => Promise<{ ok: boolean; data?: { country: string | null; stripe: boolean }; error?: string }>;
   /** Closes any app-owned Fun checkout/sign-in popup windows (login-only flows produce no deposit, so the deposit watcher can't close them). */
   paymentsCloseCheckoutWindows?: () => Promise<{ ok: boolean }>;
   paymentsGetBuyerUsage?: () => Promise<{ ok: boolean; data: DesktopBuyerUsageTotals | null; error: string | null; lastActivityAt?: number | null }>;

--- a/apps/desktop/src/renderer/ui/components/views/VprDepositView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositView.module.scss
@@ -224,6 +224,9 @@
   display: flex;
   align-items: center;
   gap: 12px;
+  /* Explicit: the Fun SDK wraps its button in a provider div, so the row
+     can't rely on grid-item stretch like the plain buttons do. */
+  width: 100%;
   padding: 10px 14px;
   border: 1px solid var(--border);
   border-radius: 14px;

--- a/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
@@ -170,15 +170,6 @@ function BaseMark({ size = 18 }: { size?: number }) {
   );
 }
 
-function MastercardMark({ size = 18 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
-      <circle cx="9" cy="12" r="7.5" fill="#EB001B" />
-      <circle cx="15" cy="12" r="7.5" fill="#F79E1B" fillOpacity="0.9" />
-    </svg>
-  );
-}
-
 /** Apple logo silhouette (the classic bitten-apple path, 814×1000 box). */
 const APPLE_LOGO_PATH =
   'M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 ' +
@@ -236,12 +227,11 @@ function VisaRoundMark({ size = 18 }: { size?: number }) {
   );
 }
 
-function VisaMark({ size = 18 }: { size?: number }) {
-  const width = Math.round(size * (34 / 24));
+function AmexRoundMark({ size = 18 }: { size?: number }) {
   return (
-    <svg width={width} height={size} viewBox="0 0 34 24" aria-hidden="true">
-      <rect width="34" height="24" rx="5" fill="#1434CB" />
-      <text x="17" y="15.8" textAnchor="middle" fontSize="9" fontWeight="800" fontStyle="italic" fill="#fff">VISA</text>
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="12" cy="12" r="12" fill="#016FD0" />
+      <text x="12" y="14.6" textAnchor="middle" fontSize="6" fontWeight="800" fill="#fff">AMEX</text>
     </svg>
   );
 }
@@ -350,15 +340,14 @@ function explorerTxUrl(chainId: number | undefined, txHash: string): string | nu
 }
 
 /**
- * Deposit flow: the chooser leads with the Fun (fun.xyz) checkout (card/cash
- * or crypto transfer, in-app), followed by the quick USDC-on-Base transfer
+ * Deposit flow: for US users (per the pay page's region gating) the chooser
+ * leads with the antseed-pay card checkout (hosted Stripe page in a narrow
+ * app popup) and Fun moves under "More options"; elsewhere the Fun (fun.xyz)
+ * checkout leads as before. Then the quick USDC-on-Base transfer
  * (scan-to-pay QR), with hosted providers (Meridian) behind "More options".
  * Everything lands in the hot wallet the main-process sweeper watches. Only
  * pages that need an external wallet signature leave the app.
  */
-// The Stripe pay page is hidden until it's ready to ship.
-const SHOW_STRIPE_OPTION = false;
-
 export function VprDepositView({ onSelectView }: Props) {
   const actions = useActions();
   const snap = useUiSelector((state) => ({
@@ -484,6 +473,21 @@ export function VprDepositView({ onSelectView }: Props) {
     return () => { cancelled = true; };
   }, []);
 
+  // Region-gated card checkout (Stripe via the hosted antseed-pay page):
+  // the main process asks the pay page which providers serve this machine's
+  // region — Stripe sells USDC-on-Base in the US only. Fail-closed: until a
+  // positive answer arrives, the row simply isn't there.
+  const [stripeAvailable, setStripeAvailable] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    void window.antseedDesktop?.paymentsOnrampAvailability?.().then((result) => {
+      if (!cancelled && result.ok && result.data?.stripe) setStripeAvailable(true);
+    }).catch(() => {
+      // Unreachable pay page — leave the row hidden.
+    });
+    return () => { cancelled = true; };
+  }, []);
+
   // Fun checkout preconditions: an API key, watcher info (it supplies the
   // recipient wallet), and the app on Base mainnet — the only chain Fun
   // delivers to. Otherwise (local/testnet) the option list shows directly.
@@ -505,6 +509,26 @@ export function VprDepositView({ onSelectView }: Props) {
       <span className={styles.funCtaText}>
         <span className={styles.funCtaTitle}>Deposit</span>
         <span className={styles.funCtaCaption}>Powered by fun.xyz</span>
+      </span>
+      <span className={styles.methodBadges} aria-hidden="true">
+        <MastercardRoundMark />
+        <ApplePayRoundMark />
+        <GooglePayRoundMark />
+        <VisaRoundMark />
+      </span>
+    </>
+  );
+
+  // Fun as a "More options" row — used when the antseed-pay checkout takes
+  // the primary slot (US users). Same Fun wiring, method-row anatomy.
+  const funMethodRowContent = (
+    <>
+      <span className={styles.methodCtaIcon}>
+        <FunMark size={20} />
+      </span>
+      <span className={styles.methodCtaText}>
+        <span className={styles.methodCtaTitle}>Deposit using Fun</span>
+        <span className={styles.methodCtaCaption}>Card or crypto · fun.xyz</span>
       </span>
       <span className={styles.methodBadges} aria-hidden="true">
         <MastercardRoundMark />
@@ -604,11 +628,29 @@ export function VprDepositView({ onSelectView }: Props) {
             </span>
           </VprCard>
 
-          {/* Primary path: the in-app Fun (fun.xyz) checkout — card/cash or a
-              crypto transfer, delivered to the hot wallet the deposit watcher
-              sweeps. Fun delivers on Base mainnet only, so the CTA waits for
-              the watcher info and hides on other chains. */}
-          {funAvailable && (funWatchInfo && funkitApiKey ? (
+          {/* Primary path — for US users (the pay page's region gating
+              decides) the antseed-pay card checkout leads and Fun moves under
+              "More options"; elsewhere the Fun (fun.xyz) checkout leads as
+              before. Both deliver to the hot wallet the deposit watcher
+              sweeps. */}
+          {stripeAvailable ? (
+            <button type="button" className={styles.funCta} onClick={() => openCardProvider('antseed-pay')}>
+              <span className={styles.funCtaIcon}>
+                <StripeMark size={18} />
+              </span>
+              <span className={styles.funCtaText}>
+                <span className={styles.funCtaTitle}>Deposit</span>
+                <span className={styles.funCtaCaption}>Powered by Outerfound</span>
+              </span>
+              {/* Stripe's onramp takes cards + US bank (Link) — no
+                  Apple/Google Pay, so no wallet badges here. */}
+              <span className={styles.methodBadges} aria-hidden="true">
+                <VisaRoundMark />
+                <MastercardRoundMark />
+                <AmexRoundMark />
+              </span>
+            </button>
+          ) : funAvailable && (funWatchInfo && funkitApiKey ? (
             <Suspense fallback={<button type="button" className={styles.funCta} disabled>{funCtaContent}</button>}>
               <FunkitDeposit
                 apiKey={funkitApiKey}
@@ -643,6 +685,7 @@ export function VprDepositView({ onSelectView }: Props) {
             </button>
             <span className={styles.methodFootnote}>* Deposited to your credits by the AntSeed relayer network</span>
           </div>
+          {cardNotice && <div className={styles.cardNotice} role="alert">{cardNotice}</div>}
 
           <button
             type="button"
@@ -664,6 +707,21 @@ export function VprDepositView({ onSelectView }: Props) {
               {/* Fixed lineup — deliberately NOT the configurable card
                   provider list, which may carry legacy entries. These ids
                   always resolve in the main process. */}
+              {stripeAvailable && funAvailable && (funWatchInfo && funkitApiKey ? (
+                <Suspense fallback={<button type="button" className={styles.methodCta} disabled>{funMethodRowContent}</button>}>
+                  <FunkitDeposit
+                    apiKey={funkitApiKey}
+                    recipient={funWatchInfo.address}
+                    usdcAddress={funWatchInfo.usdcAddress}
+                    className={styles.methodCta}
+                    onError={(message) => setPayPageNotice(message || null)}
+                  >
+                    {funMethodRowContent}
+                  </FunkitDeposit>
+                </Suspense>
+              ) : (
+                <button type="button" className={styles.methodCta} disabled>{funMethodRowContent}</button>
+              ))}
               <button type="button" className={styles.methodCta} onClick={() => openCardProvider('meridian')}>
                 <span className={styles.methodCtaIcon}>
                   <MeridianMark />
@@ -680,21 +738,6 @@ export function VprDepositView({ onSelectView }: Props) {
                 </span>
               </button>
 
-              {SHOW_STRIPE_OPTION && (
-                <button type="button" className={styles.methodCta} onClick={() => openCardProvider('antseed-pay')}>
-                  <span className={styles.methodCtaIcon}>
-                    <StripeMark />
-                  </span>
-                  <span className={styles.methodCtaText}>
-                    <span className={styles.methodCtaTitle}>Stripe</span>
-                  </span>
-                  <span className={styles.methodBadges} aria-hidden="true">
-                    <VisaMark />
-                    <MastercardMark />
-                  </span>
-                </button>
-              )}
-              {cardNotice && <div className={styles.cardNotice} role="alert">{cardNotice}</div>}
             </div>
           )}
 

--- a/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
@@ -476,7 +476,9 @@ export function VprDepositView({ onSelectView }: Props) {
   // Region-gated card checkout (Stripe via the hosted antseed-pay page):
   // the main process asks the pay page which providers serve this machine's
   // region — Stripe sells USDC-on-Base in the US only. Fail-closed: until a
-  // positive answer arrives, the row simply isn't there.
+  // positive answer arrives, the checkout leads nowhere useful, so the row
+  // demotes to "More options" (the pay page itself explains region
+  // unavailability with a proper dead-end screen).
   const [stripeAvailable, setStripeAvailable] = useState(false);
   useEffect(() => {
     let cancelled = false;
@@ -722,6 +724,25 @@ export function VprDepositView({ onSelectView }: Props) {
               ) : (
                 <button type="button" className={styles.methodCta} disabled>{funMethodRowContent}</button>
               ))}
+              {/* Outerfound demoted here when the region probe said no (or
+                  failed): still reachable, and the pay page itself shows the
+                  "not available in your region" screen. */}
+              {!stripeAvailable && (
+                <button type="button" className={styles.methodCta} onClick={() => openCardProvider('antseed-pay')}>
+                  <span className={styles.methodCtaIcon}>
+                    <StripeMark size={20} />
+                  </span>
+                  <span className={styles.methodCtaText}>
+                    <span className={styles.methodCtaTitle}>Deposit using Outerfound</span>
+                    <span className={styles.methodCtaCaption}>Card · US only</span>
+                  </span>
+                  <span className={styles.methodBadges} aria-hidden="true">
+                    <VisaRoundMark />
+                    <MastercardRoundMark />
+                    <AmexRoundMark />
+                  </span>
+                </button>
+              )}
               <button type="button" className={styles.methodCta} onClick={() => openCardProvider('meridian')}>
                 <span className={styles.methodCtaIcon}>
                   <MeridianMark />


### PR DESCRIPTION
## Summary

Integrates the AntSeed Pay hosted checkout (antseed-pay.com, Stripe-powered — merchant: Outerfound, Inc.) as a first-class desktop deposit path for US users. Pairs with refoundhq/antseed-pay#3 on the pay-page side.

- **Region-gated availability**: the main process asks the pay page's public `GET /api/options` which providers serve this machine's region (geo resolved from the request IP at Cloudflare's edge — no locale guessing). Cached per app run on success; **fails closed** on any error, so an unreachable page or unsupported region leaves the chooser exactly as it is today.
- **Chooser layout**: when Stripe is available, the primary CTA becomes "Deposit — Powered by Outerfound" with Visa/Mastercard/Amex badges (Stripe's onramp takes cards + US bank via Link — no Apple/Google Pay, so no wallet badges), and the Fun checkout moves under "More options" as a fully-functional "Deposit using Fun" row. Non-US users see the existing layout unchanged.
- **Checkout window**: selecting it opens a narrow (420×700) app-owned popup via the shared checkout-window infrastructure — Chrome UA, recursive popup adoption, and auto-close when the deposit watcher sees the purchased USDC land. The funding link is signed as before and now carries `provider=stripe`, which the new pay page renders as a single-provider checkout.
- **IPC surface**: new `payments:onramp-availability` handler + `paymentsOnrampAvailability` bridge; `payments:open-card-provider` routes antseed-pay to the popup (no wallet extension needed — the link is pre-signed) and logs the minted funding link in dev.
- CHANGELOG updated (user-facing desktop change).

## Test plan
- `tsc` clean for both main and renderer configs; all 190 main-process tests and 171 renderer tests pass.
- Manually verified end-to-end against the pay page dev server (test-plane Stripe keys): row gating via `/api/options`, popup opening on the signed `provider=stripe` link, live quote + Stripe embedded form, USDC delivery path unchanged (hot-wallet watcher).
- Fail-closed verified: with the pay page unreachable, the Stripe row is absent and the chooser matches current production behavior.

## Notes
- End-to-end against production activates once refoundhq/antseed-pay#3 is deployed (the live worker predates `/api/options`, so until then the row simply stays hidden).