### PR TITLE
feat(desktop): label card deposit CTA 'Deposit with Stripe'

### DIFF
--- a/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
@@ -641,7 +641,7 @@ export function VprDepositView({ onSelectView }: Props) {
                 <StripeMark size={18} />
               </span>
               <span className={styles.funCtaText}>
-                <span className={styles.funCtaTitle}>Deposit</span>
+                <span className={styles.funCtaTitle}>Deposit with Stripe</span>
                 <span className={styles.funCtaCaption}>Powered by Outerfound</span>
               </span>
               {/* Stripe's onramp takes cards + US bank (Link) — no


### PR DESCRIPTION
Renames the primary card-deposit button (US users) from "Deposit" to "Deposit with Stripe" — the caption stays "Powered by Outerfound".

One-line label change; covered by the existing Unreleased changelog entry for the Outerfound deposit path (#793).