### PR TITLE
fix(node): Count 429 health probe failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed seller health checks leaving rate-limited services advertised indefinitely. HTTP 429 responses now count toward the failure threshold, and a successful probe automatically restores the service.
 - Fixed the buyer proxy leaking `.buyer.state.*.json.tmp` files (each a full discovered-peers snapshot, ~1 MB) when the atomic state-file rename failed — common on Windows while a reader briefly holds `buyer.state.json` open. The rename is now retried, a failed write cleans up its temp file and logs the error instead of dropping the state update silently, and leftover temp files from earlier runs are swept at startup.
 - Fixed bursty buyer startups causing initial payment-channel reserves to fail when delegated seller accounts reject excess in-flight transactions. Sellers now retry transient transaction backpressure before acknowledging the channel.
 - Fixed seller health checks leaving unavailable upstreams advertised: HTTP 402 responses now count as failures, every failing service can be removed, and a provider with no healthy services is omitted from signed discovery metadata until a probe succeeds.

--- a/packages/node/src/health/model-health-checker.ts
+++ b/packages/node/src/health/model-health-checker.ts
@@ -221,8 +221,8 @@ export class ModelHealthChecker {
 
     if (outcome === 'inconclusive') {
       // The endpoint answered but the probe result proves nothing either way
-      // (e.g. 429 while busy, 400 for an unsupported probe parameter). Leave
-      // failure counters and advertisement untouched.
+      // (for example, 400 for an unsupported probe parameter). Leave failure
+      // counters and advertisement untouched.
       debugLog(`[ModelHealth] ${provider.name}/${service}: inconclusive (${state.lastDetail})`);
       return;
     }
@@ -360,16 +360,18 @@ export function buildHealthProbeRequest(service: string, protocol: ServiceApiPro
  * Classify a probe response status.
  *
  * - 2xx/3xx — the model answered: healthy.
- * - 401/402/403/404 and 5xx — credentials broken, billing unavailable, model
- *   gone, or upstream down: unhealthy. (The relay collapses upstream network
- *   errors/timeouts to 502.)
- * - Everything else (400, 422, 429, ...) — the endpoint is alive but the probe
- *   itself was rejected (unsupported parameter, rate limit, busy): inconclusive,
+ * - 401/402/403/404, 429, and 5xx — credentials broken, billing unavailable,
+ *   rate or usage limited, model gone, or upstream down: unhealthy. (The relay
+ *   collapses upstream network errors/timeouts to 502.)
+ * - Everything else (400, 422, ...) — the endpoint is alive but the probe
+ *   itself was rejected (for example, an unsupported parameter): inconclusive,
  *   so a working model is never unadvertised over a probe quirk.
  */
 export function classifyProbeStatus(statusCode: number): ProbeOutcome {
   if (statusCode >= 200 && statusCode < 400) return 'healthy';
-  if (statusCode === 401 || statusCode === 402 || statusCode === 403 || statusCode === 404) return 'unhealthy';
+  if (statusCode === 401 || statusCode === 402 || statusCode === 403 || statusCode === 404 || statusCode === 429) {
+    return 'unhealthy';
+  }
   if (statusCode >= 500) return 'unhealthy';
   return 'inconclusive';
 }

--- a/packages/node/tests/model-health-checker.test.ts
+++ b/packages/node/tests/model-health-checker.test.ts
@@ -51,10 +51,10 @@ describe('classifyProbeStatus', () => {
     expect(classifyProbeStatus(404)).toBe('unhealthy');
     expect(classifyProbeStatus(500)).toBe('unhealthy');
     expect(classifyProbeStatus(502)).toBe('unhealthy');
+    expect(classifyProbeStatus(429)).toBe('unhealthy');
     // Endpoint alive but probe rejected — must never unadvertise over these.
     expect(classifyProbeStatus(400)).toBe('inconclusive');
     expect(classifyProbeStatus(422)).toBe('inconclusive');
-    expect(classifyProbeStatus(429)).toBe('inconclusive');
   });
 });
 
@@ -145,15 +145,35 @@ describe('ModelHealthChecker', () => {
     expect(provider.services).toContain('model-a');
   });
 
-  it('does not count inconclusive probes (429, 400) as failures', async () => {
+  it('does not count inconclusive probes (400, 422) as failures', async () => {
     const provider = makeProvider({
-      onRequest: statusSequence({ 'model-a': [429, 400, 429, 400, 429] }),
+      onRequest: statusSequence({ 'model-a': [400, 422, 400, 422, 400] }),
     });
     const checker = new ModelHealthChecker({ targets: [{ provider }], failureThreshold: 2 });
 
     for (let i = 0; i < 5; i += 1) {
       await checker.runSweep();
     }
+    expect(provider.services).toEqual(['model-a', 'model-b']);
+  });
+
+  it('unadvertises after three 429 responses and restores after a 200', async () => {
+    const provider = makeProvider({
+      onRequest: statusSequence({
+        'model-a': [429, 429, 429, 200],
+        'model-b': [200, 200, 200, 200],
+      }),
+    });
+    const checker = new ModelHealthChecker({ targets: [{ provider }], failureThreshold: 3 });
+
+    await checker.runSweep();
+    await checker.runSweep();
+    expect(provider.services).toEqual(['model-a', 'model-b']);
+
+    await checker.runSweep();
+    expect(provider.services).toEqual(['model-b']);
+
+    await checker.runSweep();
     expect(provider.services).toEqual(['model-a', 'model-b']);
   });
 


### PR DESCRIPTION
## Description

Treats HTTP 429 health-probe responses as failures for every provider. Services are unadvertised after the configured consecutive-failure threshold and automatically restored after a successful probe.

## Release Notes

- Fixed rate-limited services remaining advertised indefinitely after repeated HTTP 429 health checks.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
