### PR TITLE
fix(desktop): include @antseed/protocol and buyer-core in asar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed the desktop app crashing on launch with `ERR_MODULE_NOT_FOUND: Cannot find package '@antseed/protocol'`: the packaged app was missing the `@antseed/protocol` and `@antseed/buyer-core` workspace packages (split out of `@antseed/node` by the protocol extraction), so the main process could not resolve them from the app bundle. Desktop packaging now bundles both packages and builds them as part of the pre-dist pipeline.
 - Fixed buyers classifying unit-billed services (e.g. image generation) as free because their token pricing is zero: the free-usage gate now resolves the same provider + protocol billing route the seller uses, so paid image requests negotiate payment and record verified cost instead of rejecting the seller's usage claims.
 - Fixed a payment-integrity hole where a seller could claim image delivery (`NeedAuth` with positive unit billing cost) before the buyer received any response and get paid for undelivered images. Positive unit-billing claims are now rejected until the buyer has observed the delivered response; the buyer's own post-response authorization covers honest sellers.
 - Fixed image billing counting placeholder `data` entries as delivered images. Only response items containing a non-empty image URL or base64 payload are billable now.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "main": "dist/main/main.js",
   "scripts": {
-    "ensure:cli-dist": "pnpm -C ../../packages/api-adapter build && pnpm -C ../../packages/router-core build && pnpm -C ../../plugins/router-local build && pnpm -C ../../packages/node build && pnpm -C ../payments build:server && pnpm -C ../cli build",
+    "ensure:cli-dist": "pnpm -C ../../packages/api-adapter build && pnpm -C ../../packages/protocol build && pnpm -C ../../packages/buyer-core build && pnpm -C ../../packages/router-core build && pnpm -C ../../plugins/router-local build && pnpm -C ../../packages/node build && pnpm -C ../payments build:server && pnpm -C ../cli build",
     "brand:electron-dev": "node ./scripts/brand-electron-dev.mjs",
     "ensure:native": "npm run ensure:runtime-native",
     "ensure:runtime-native": "node ./scripts/ensure-runtime-native-modules.mjs",

--- a/apps/desktop/scripts/prepare-dist.mjs
+++ b/apps/desktop/scripts/prepare-dist.mjs
@@ -30,8 +30,10 @@ const nmDir = path.join(appDir, 'node_modules');
 /** Map of workspace package names to their real source directories. */
 const WORKSPACE_PACKAGES = {
   '@antseed/api-adapter': path.resolve(appDir, '..', '..', 'packages', 'api-adapter'),
+  '@antseed/buyer-core': path.resolve(appDir, '..', '..', 'packages', 'buyer-core'),
   '@antseed/node': path.resolve(appDir, '..', '..', 'packages', 'node'),
   '@antseed/payments': path.resolve(appDir, '..', 'payments'),
+  '@antseed/protocol': path.resolve(appDir, '..', '..', 'packages', 'protocol'),
   '@antseed/ui': path.resolve(appDir, '..', '..', 'packages', 'ui'),
 };
 


### PR DESCRIPTION
## Description

The released desktop app crashes on launch with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@antseed/protocol'
imported from .../app.asar/node_modules/@antseed/node/dist/p2p/identity.js
```

#796 split `@antseed/protocol` and `@antseed/buyer-core` out of `@antseed/node`, making them new workspace dependencies of it. `prepare-dist.mjs` materializes workspace symlinks into `apps/desktop/node_modules` so electron-builder can pack them into the asar, but its `WORKSPACE_PACKAGES` list was never updated — so the packaged app shipped without the two new packages and the main process failed to resolve them at startup. All platforms are affected.

## Changes

- Add `@antseed/protocol` and `@antseed/buyer-core` to `WORKSPACE_PACKAGES` in `apps/desktop/scripts/prepare-dist.mjs`
- Build both packages in `ensure:cli-dist` so their `dist/` is fresh before `@antseed/node` builds and packing
- CHANGELOG entry under Unreleased → Fixed

## Verification

Ran `ensure:cli-dist` → `prepare-dist` → unsigned `electron-builder --dir` pack, extracted the produced `app.asar`, and confirmed both packages are present with their `dist/` files. An ESM import of `@antseed/protocol` and `@antseed/buyer-core` from the exact crashing location (`node_modules/@antseed/node/dist/p2p/`) resolves and loads, transitive deps included.