### PR TITLE
fix(desktop): Stabilize floating pill drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed the desktop VPR floating pill moving away from the pointer and becoming difficult to click. The pill now uses Electron's native window dragging across its passive surface, with dedicated controls for conversations, shrinking, closing, deposits, and compact expansion.
 - Fixed the desktop app crashing on launch with `ERR_MODULE_NOT_FOUND: Cannot find package '@antseed/protocol'`: the packaged app was missing the `@antseed/protocol` and `@antseed/buyer-core` workspace packages (split out of `@antseed/node` by the protocol extraction), so the main process could not resolve them from the app bundle. Desktop packaging now bundles both packages and builds them as part of the pre-dist pipeline.
 - Fixed buyers classifying unit-billed services (e.g. image generation) as free because their token pricing is zero: the free-usage gate now resolves the same provider + protocol billing route the seller uses, so paid image requests negotiate payment and record verified cost instead of rejecting the seller's usage claims.
 - Fixed a payment-integrity hole where a seller could claim image delivery (`NeedAuth` with positive unit billing cost) before the buyer received any response and get paid for undelivered images. Positive unit-billing claims are now rejected until the buyer has observed the delivered response; the buyer's own post-response authorization covers honest sellers.

--- a/apps/desktop/src/main/ipc/float.ts
+++ b/apps/desktop/src/main/ipc/float.ts
@@ -16,7 +16,6 @@ import {
   getFloatWindow,
   getFloatWindowCompact,
   getMainWindow,
-  moveFloatWindowBy,
   openFloatWindow,
   setFloatWindowCompact,
   setFloatWindowExpanded,
@@ -43,15 +42,6 @@ export function registerFloatIpc(): void {
   ipcMain.handle('vpr-float:is-open', () => Boolean(getFloatWindow()));
 
   ipcMain.handle('vpr-float:get-compact', () => getFloatWindowCompact());
-
-  // Manual window drag for the compact chip's center button: it must stay a
-  // click target (flip/expand), so it can't be a -webkit-app-region drag
-  // handle — the renderer streams pointer deltas instead.
-  ipcMain.on('vpr-float:move-by', (_event, dx: unknown, dy: unknown) => {
-    if (typeof dx !== 'number' || typeof dy !== 'number') return;
-    if (!Number.isFinite(dx) || !Number.isFinite(dy)) return;
-    moveFloatWindowBy(dx, dy);
-  });
 
   ipcMain.on('vpr-float:update', (_event, data: unknown) => {
     lastVprFloatData = data;

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -614,9 +614,6 @@ const api = {
   vprFloatGetCompact(): Promise<boolean> {
     return ipcRenderer.invoke('vpr-float:get-compact') as Promise<boolean>;
   },
-  vprFloatMoveBy(dx: number, dy: number): void {
-    ipcRenderer.send('vpr-float:move-by', dx, dy);
-  },
   vprFloatUpdate(data: unknown): void {
     ipcRenderer.send('vpr-float:update', data);
   },

--- a/apps/desktop/src/main/ui/window.ts
+++ b/apps/desktop/src/main/ui/window.ts
@@ -141,38 +141,6 @@ export function setFloatWindowCompact(compact: boolean): void {
 }
 
 /**
- * Move the pill by a pointer delta. The chip's centre button and the pill face
- * are click targets, so they can't be `-webkit-app-region` drag handles — the
- * renderer streams pointer deltas here instead.
- *
- * Deliberately `setBounds` with the intended size, never `setPosition`:
- * `setPosition` re-submits the size it reads back off the window, and Windows
- * converts window rects DIP↔pixel with an *enclosing* rounding, so on a
- * display with fractional scaling (125%, 150%) a rect whose origin isn't on a
- * pixel boundary comes back a pixel or two wider than it went in. Feeding that
- * back in on the next pointer tick compounds it — the pill visibly grows as
- * it's dragged. Passing the target size every time makes each move idempotent.
- */
-export function moveFloatWindowBy(dx: number, dy: number): void {
-  const win = getFloatWindow();
-  if (!win) return;
-  const bounds = win.getBounds();
-  const { width, height } = floatTargetSize();
-  const x = Math.round(bounds.x + dx);
-  const y = Math.round(bounds.y + dy);
-  // Recovering a size that already drifted needs the constraints lifted:
-  // a non-resizable window's min/max are pinned to whatever size it had when
-  // the flag went off, so an inflated size otherwise clamps itself in place.
-  const drifted = bounds.width !== width || bounds.height !== height;
-  if (drifted) {
-    win.setResizable(true);
-    win.setMinimumSize(FLOAT_WINDOW_COMPACT_SIZE, FLOAT_WINDOW_MIN_HEIGHT);
-  }
-  win.setBounds({ x, y, width, height });
-  if (drifted) win.setResizable(false);
-}
-
-/**
  * Grow the pill window downward while one of its custom dropdowns is open
  * (DOM popovers can't escape the window bounds the way native selects can),
  * and shrink back when it closes. No-op in compact mode.

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -475,7 +475,6 @@ export type DesktopBridge = {
   vprFloatClose?: () => Promise<{ ok: boolean }>;
   vprFloatIsOpen?: () => Promise<boolean>;
   vprFloatGetCompact?: () => Promise<boolean>;
-  vprFloatMoveBy?: (dx: number, dy: number) => void;
   vprFloatUpdate?: (data: VprFloatData) => void;
   vprFloatAction?: (action: VprFloatAction) => void;
   onVprFloatData?: (handler: (data: VprFloatData) => void) => () => void;

--- a/apps/desktop/src/renderer/ui/float/FloatApp.module.scss
+++ b/apps/desktop/src/renderer/ui/float/FloatApp.module.scss
@@ -1,7 +1,7 @@
 /* Floating pill (Figma "flowing window"): 256x64 content (model + usage
    lines), radius 16. The window adds an 8px transparent margin so the drop
-   shadow isn't clipped. The whole pill is a drag region; interactive
-   children opt out. */
+   shadow isn't clipped. The full pill is a native Electron drag region;
+   explicit controls opt out. */
 
 .pill {
   position: fixed;
@@ -32,11 +32,10 @@
    transparency). Fixed size so it stays a circle even mid-resize; centered
    with a 16px margin for the drop shadow.
 
-   The whole window — chip AND the transparent margin around it — is one big
-   drag handle; only the small icon button in the middle opts out. Clicking
-   the icon flips the chip over to reveal the expand button (the flip makes
-   the intent explicit — no accidental expands while grabbing the chip to
-   move it). */
+   The whole window — chip AND the transparent margin around it — is a native
+   drag handle; only the small icon button in the middle opts out. Keeping the
+   button click-only avoids feeding renderer pointer movement back into a
+   window that is moving underneath the pointer. */
 .compactRoot {
   position: fixed;
   inset: 0;
@@ -138,7 +137,7 @@
   border: none;
   border-radius: 50%;
   background: var(--bg-surface);
-  cursor: pointer;
+  cursor: grab;
 }
 
 .appBadge:focus-visible {
@@ -146,7 +145,7 @@
   box-shadow: 0 0 0 2px rgba(var(--brand-rgb), 0.4);
 }
 
-/* Flex column (not grid): percentage max-widths on the trigger buttons
+/* Flex column (not grid): percentage max-widths on the pill content
    resolve against the container, so long labels reliably ellipsize instead
    of pushing past the pill edge. */
 .body {
@@ -158,33 +157,21 @@
   gap: 2px;
 }
 
-/* The whole pill face is the dropdown trigger: badge + model label + usage
-   in one button. It opens a custom DOM panel (not a native select) so the
-   rows can carry icons, pins and timestamps; the window grows while the
-   panel is open since DOM content can't escape the window bounds. Dragging
-   is manual (pointer deltas), so the button surface stays grabbable. */
-.pillTrigger {
+/* Passive pill content stays inside the native drag region. The dedicated
+   menu button below is the only control that opens the conversations panel. */
+.pillContent {
   flex: 1 1 auto;
   min-width: 0;
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 0;
-  border: none;
-  background: transparent;
   text-align: left;
-  cursor: pointer;
-  outline: none;
+  cursor: grab;
 }
 
-/* The trigger covers the whole pill face, so any focus decoration reads as
-   the pill itself changing — including the global button focus tint
-   (`button:focus-visible` in global.scss, which outranks the transparent
-   background above). Keep the face completely unstyled on focus; the panel
-   opening is the affordance. */
-.pillTrigger:focus-visible {
-  background: transparent;
-  box-shadow: none;
+.menuToggle {
+  right: 52px;
 }
 
 .triggerLabel {
@@ -645,6 +632,7 @@
 /* Empty balance + paid model: warning-toned label jumping to the deposit
    screen. */
 .addBalance {
+  -webkit-app-region: no-drag;
   margin-left: 8px;
   padding: 1px 8px;
   border: 1px solid #edd191;
@@ -675,7 +663,8 @@
 }
 
 .close,
-.shrink {
+.shrink,
+.menuToggle {
   position: absolute;
   top: 10px;
   width: 20px;
@@ -699,7 +688,10 @@
 }
 
 .close:hover,
-.shrink:hover {
+.shrink:hover,
+.menuToggle:hover,
+.menuToggle:focus-visible,
+.menuToggleOpen {
   color: var(--text-primary);
 }
 

--- a/apps/desktop/src/renderer/ui/float/FloatApp.tsx
+++ b/apps/desktop/src/renderer/ui/float/FloatApp.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
-import { ArrowExpand02Icon, ArrowRight01Icon, ArrowShrink02Icon, ArrowUpRight01Icon, Cancel01Icon } from '@hugeicons/core-free-icons';
+import { ArrowExpand02Icon, ArrowRight01Icon, ArrowShrink02Icon, ArrowUpRight01Icon, Cancel01Icon, LeftToRightListBulletIcon } from '@hugeicons/core-free-icons';
 import type { VprFloatApp, VprFloatData } from '../../types/bridge';
 import { conversationAge, conversationMatchesApp } from '../../modules/routing/conversations';
 import { displayToolName } from '../../modules/routing/tool-names';
@@ -55,88 +55,6 @@ export function FloatApp() {
   const [compact, setCompact] = useState(() => window.innerWidth <= COMPACT_MAX_WIDTH);
   // Compact chip flipped over, showing the expand button on its back face.
   const [flipped, setFlipped] = useState(false);
-
-  // The chip's center buttons must be clickable AND draggable, which
-  // -webkit-app-region can't express (drag regions swallow clicks). So the
-  // buttons are no-drag and dragging is done by hand: pointer deltas stream
-  // to the main process, and a press that never moved past the threshold
-  // counts as the click.
-  const chipDrag = useRef<{ x: number; y: number; moved: boolean } | null>(null);
-  const chipDragHandlers = {
-    onPointerDown: (event: React.PointerEvent<HTMLButtonElement>) => {
-      if (event.button !== 0) return;
-      event.currentTarget.setPointerCapture(event.pointerId);
-      chipDrag.current = { x: event.screenX, y: event.screenY, moved: false };
-    },
-    onPointerMove: (event: React.PointerEvent<HTMLButtonElement>) => {
-      const state = chipDrag.current;
-      if (!state) return;
-      const dx = event.screenX - state.x;
-      const dy = event.screenY - state.y;
-      if (!state.moved && Math.hypot(dx, dy) < 3) return;
-      state.moved = true;
-      state.x = event.screenX;
-      state.y = event.screenY;
-      bridge?.vprFloatMoveBy?.(dx, dy);
-    },
-    onPointerUp: () => {
-      // Leave `moved` for onClick (fires right after) to consume.
-      if (chipDrag.current && !chipDrag.current.moved) chipDrag.current = null;
-    },
-    onPointerCancel: () => {
-      chipDrag.current = null;
-    },
-  };
-  /** True when the press that triggered this click was actually a drag. */
-  const chipClickWasDrag = () => {
-    const dragged = chipDrag.current?.moved ?? false;
-    chipDrag.current = null;
-    return dragged;
-  };
-
-  // The expanded pill and the open dropdown drag the same way as the chip:
-  // manual pointer deltas, with a press that never crossed the threshold
-  // counting as the click. Capture starts only once movement crosses the
-  // threshold — capturing on pointerdown would retarget the eventual click
-  // away from dropdown rows and make them unclickable.
-  const pillDrag = useRef<{ x: number; y: number; moved: boolean } | null>(null);
-  const pillDragHandlers = {
-    onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
-      if (event.button !== 0) return;
-      pillDrag.current = { x: event.screenX, y: event.screenY, moved: false };
-    },
-    onPointerMove: (event: React.PointerEvent<HTMLElement>) => {
-      const state = pillDrag.current;
-      if (!state) return;
-      const dx = event.screenX - state.x;
-      const dy = event.screenY - state.y;
-      if (!state.moved && Math.hypot(dx, dy) < 3) return;
-      if (!state.moved) {
-        state.moved = true;
-        event.currentTarget.setPointerCapture(event.pointerId);
-      }
-      state.x = event.screenX;
-      state.y = event.screenY;
-      bridge?.vprFloatMoveBy?.(dx, dy);
-    },
-    onPointerUp: () => {
-      // Leave `moved` for the click (fires right after) to consume.
-      if (pillDrag.current && !pillDrag.current.moved) pillDrag.current = null;
-    },
-    onPointerCancel: () => {
-      pillDrag.current = null;
-    },
-    // Swallow the click a drag would otherwise end with — runs in the
-    // capture phase so dropdown rows never see it.
-    onClickCapture: (event: React.MouseEvent<HTMLElement>) => {
-      const dragged = pillDrag.current?.moved ?? false;
-      pillDrag.current = null;
-      if (dragged) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-    },
-  };
 
   // Reset the flip whenever the chip leaves/enters compact mode, and flip
   // back on its own if the user doesn't take the expand action.
@@ -297,8 +215,7 @@ export function FloatApp() {
               <button
                 type="button"
                 className={styles.chipIconButton}
-                {...chipDragHandlers}
-                onClick={() => { if (!chipClickWasDrag()) setFlipped(true); }}
+                onClick={() => setFlipped(true)}
                 title="Options"
                 aria-label="Show expand button"
               >
@@ -311,8 +228,7 @@ export function FloatApp() {
             <button
               type="button"
               className={styles.chipExpandButton}
-              {...chipDragHandlers}
-              onClick={() => { if (!chipClickWasDrag()) setCompactMode(false); }}
+              onClick={() => setCompactMode(false)}
               title="Expand"
               aria-label="Expand floating window"
             >
@@ -327,17 +243,11 @@ export function FloatApp() {
 
   return (
     <div className={styles.pill}>
-      {/* The whole pill face is the dropdown trigger — badge, label and
-          usage line together — and doubles as a drag handle: pointer deltas
-          move the window, and only a press that never moved counts as the
-          click that toggles the panel. */}
-      <button
-        type="button"
-        className={styles.pillTrigger}
-        {...pillDragHandlers}
-        onClick={() => setMenuOpen(!menuOpen)}
-        aria-expanded={menuOpen}
-        aria-label="Usage and conversations"
+      {/* The full pill face is a native Electron drag region. Interactive
+          actions opt out individually, so dragging never competes with a
+          click on the same pixels. */}
+      <div
+        className={styles.pillContent}
         title="AntSeed"
       >
         <span className={styles.appBadge}>{badgeIcon}</span>
@@ -345,26 +255,16 @@ export function FloatApp() {
           <span className={styles.triggerLabel}>
             {data?.balanceLabel ?? '$0.00'}
             {/* Empty balance + paid default model: jump straight to Add
-                balance. A span (not a button) — it lives inside the trigger
-                button, so a real nested button would be invalid markup. */}
+                balance. This button carves a no-drag control out of the native
+                pill drag region. */}
             {data?.needsFunds ? (
-              <span
-                role="button"
-                tabIndex={0}
+              <button
+                type="button"
                 className={styles.addBalance}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  bridge?.vprFloatAction?.({ type: 'open-deposit' });
-                }}
-                onKeyDown={(event) => {
-                  if (event.key !== 'Enter' && event.key !== ' ') return;
-                  event.stopPropagation();
-                  event.preventDefault();
-                  bridge?.vprFloatAction?.({ type: 'open-deposit' });
-                }}
+                onClick={() => bridge?.vprFloatAction?.({ type: 'open-deposit' })}
               >
                 Add balance
-              </span>
+              </button>
             ) : null}
           </span>
           <span className={styles.usage} title={statusHint}>
@@ -381,13 +281,24 @@ export function FloatApp() {
             <span className={styles.usageLabel}>{statusLabel}</span>
           </span>
         </span>
+      </div>
+
+      <button
+        type="button"
+        className={`${styles.menuToggle}${menuOpen ? ` ${styles.menuToggleOpen}` : ''}`}
+        onClick={() => setMenuOpen(!menuOpen)}
+        aria-expanded={menuOpen}
+        aria-label={menuOpen ? 'Close conversations menu' : 'Open conversations menu'}
+        title={menuOpen ? 'Close menu' : 'Open menu'}
+      >
+        <HugeiconsIcon icon={LeftToRightListBulletIcon} size={14} strokeWidth={2} />
       </button>
 
       {/* Manage conversations: level 1 lists the default-model row plus one
           row per chat; clicking a row slides to the shared rich model list
           (same rows as the Home dropdown) with a back header. */}
       {menuOpen ? (
-        <div className={styles.menuPanel} aria-label="Manage conversations" {...pillDragHandlers}>
+        <div className={styles.menuPanel} aria-label="Manage conversations">
           <OverlayScrollArea className={styles.menuScroll} contentClassName={styles.menuScrollContent}>
           {chatTarget === null ? (
             <div key="list" className={slideClass}>


### PR DESCRIPTION
## Description

Replaces the VPR floating pill's renderer-driven pointer-delta movement with Electron native drag regions. The passive pill surface is draggable while dedicated controls handle the conversations list, balance deposit, compact expansion, shrinking, and closing without competing with window movement.

The obsolete movement IPC, preload bridge, and main-process window positioning path are removed.

## Release Notes

- Fixed the VPR floating pill moving away from the pointer and becoming difficult to click.
- Added a dedicated conversations-list control while keeping the passive pill surface natively draggable.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes

## Validation

- `pnpm -C apps/desktop run typecheck:renderer`
- `pnpm -C apps/desktop run build:main`
- `pnpm -C apps/desktop run test:renderer` (181 tests passed)
