### PR TITLE
fix(desktop): polish VPR balance and navigation UX

### DIFF
--- a/apps/desktop/src/main/payments/buyer-channel-control.ts
+++ b/apps/desktop/src/main/payments/buyer-channel-control.ts
@@ -1,3 +1,4 @@
+/** Buyer-daemon client and response normalization for payment channels. */
 import type { CloseChannelResultPayload } from '@antseed/node';
 import { LOCALHOST_URL } from '../constants.js';
 import type { DesktopPaymentChannelSummary } from './buyer-channels.js';
@@ -40,6 +41,17 @@ export type CooperativeCloseRequestOptions = {
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
 };
+
+export async function runInBatches<T>(
+  items: readonly T[],
+  batchSize: number,
+  task: (item: T) => Promise<void>,
+): Promise<void> {
+  for (let offset = 0; offset < items.length; offset += batchSize) {
+    const batch = items.slice(offset, offset + batchSize);
+    await Promise.allSettled(batch.map(task));
+  }
+}
 
 function isCloseChannelResult(value: unknown): value is CloseChannelResultPayload {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;

--- a/apps/desktop/src/main/payments/buyer-channels.test.ts
+++ b/apps/desktop/src/main/payments/buyer-channels.test.ts
@@ -3,7 +3,8 @@ import test from 'node:test';
 import {
   normalizePaymentChannelSummary,
   requestCooperativeChannelCloseAtPort,
-} from './channel-control.js';
+  runInBatches,
+} from './buyer-channel-control.js';
 
 function closeResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -22,6 +23,15 @@ test('normalizePaymentChannelSummary defaults missing cooperative-close support 
 
   assert.equal(unsupported?.cooperativeCloseSupported, false);
   assert.equal(supported?.cooperativeCloseSupported, true);
+});
+
+test('runInBatches processes active-looking channels beyond the first batch', async () => {
+  const processed: number[] = [];
+  await runInBatches(Array.from({ length: 14 }, (_, index) => index), 12, async (index) => {
+    processed.push(index);
+  });
+
+  assert.deepEqual(processed.sort((left, right) => left - right), Array.from({ length: 14 }, (_, index) => index));
 });
 
 test('requestCooperativeChannelCloseAtPort returns a closed result', async () => {

--- a/apps/desktop/src/main/payments/buyer-channels.ts
+++ b/apps/desktop/src/main/payments/buyer-channels.ts
@@ -11,12 +11,13 @@ import { getCachedChannelsClient, loadCachedCryptoConfig, setCachedChannelsClien
 import {
   normalizePaymentChannelSummary,
   requestCooperativeChannelCloseAtPort,
-} from './channel-control.js';
+  runInBatches,
+} from './buyer-channel-control.js';
 
 export {
   normalizePaymentChannelSummary,
   requestCooperativeChannelCloseAtPort,
-} from './channel-control.js';
+} from './buyer-channel-control.js';
 
 /** Per-service usage from the buyer daemon. `serviceIdHash` is
     keccak256(serviceName); `serviceName` is resolved by the main process from
@@ -164,8 +165,8 @@ export function formatAnts(value: bigint): string {
 
 // AntseedChannels grace period between requestClose() and withdraw().
 const CHANNEL_CLOSE_GRACE_SECS = 900;
-// Bound the on-chain enrichment fan-out per refresh.
-const CHANNEL_ENRICH_MAX = 12;
+// Bound concurrent on-chain reads without skipping older active-looking rows.
+const CHANNEL_ENRICH_CONCURRENCY = 12;
 
 // The local ChannelStore can lag the chain (a seller-side settle/close is not
 // always observed), so rows that look active are re-checked on-chain before
@@ -184,9 +185,8 @@ async function enrichChannelStatuses(channels: DesktopPaymentChannelSummary[]): 
     setCachedChannelsClient(client);
   }
   const candidates = channels
-    .filter((row) => row.status === 'active' || row.status === 'open')
-    .slice(0, CHANNEL_ENRICH_MAX);
-  await Promise.allSettled(candidates.map(async (row) => {
+    .filter((row) => row.status === 'active' || row.status === 'open');
+  await runInBatches(candidates, CHANNEL_ENRICH_CONCURRENCY, async (row) => {
     const info = await client.getSession(row.channelId);
     const closeRequestedAt = Number(info.closeRequestedAt);
     row.settledUsdc = info.settled.toString();
@@ -198,7 +198,7 @@ async function enrichChannelStatuses(channels: DesktopPaymentChannelSummary[]): 
     }
     // status 0 (no on-chain record) is ambiguous — a channel may exist
     // locally before its on-chain reserve lands. Keep the local status.
-  }));
+  });
 }
 
 /** Fetch buyer channels from the local proxy and re-check them on-chain. */

--- a/apps/desktop/src/renderer/core/balance.test.ts
+++ b/apps/desktop/src/renderer/core/balance.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { selectHeadlineBalanceUsdc } from './balance';
+
+test('headline balance includes USDC awaiting deposit sweep', () => {
+  const state = {
+    creditsSpendableUsdc: '49.91',
+    creditsTotalOwnedUsdc: '153.78',
+  };
+
+  assert.equal(selectHeadlineBalanceUsdc(state), '153.78');
+});

--- a/apps/desktop/src/renderer/core/balance.ts
+++ b/apps/desktop/src/renderer/core/balance.ts
@@ -1,0 +1,8 @@
+export type HeadlineBalanceState = {
+  creditsTotalOwnedUsdc: string;
+};
+
+/** The buyer's complete owned balance, including USDC awaiting deposit sweep. */
+export function selectHeadlineBalanceUsdc(state: HeadlineBalanceState): string {
+  return state.creditsTotalOwnedUsdc;
+}

--- a/apps/desktop/src/renderer/core/state.ts
+++ b/apps/desktop/src/renderer/core/state.ts
@@ -276,7 +276,7 @@ export type RendererUiState = {
   creditsTotalUsdc: string;
   /** Signed but not yet settled on-chain — spent in every sense but the ledger's. */
   creditsPendingUsdc: string;
-  /** Total minus pending: the balance the user actually still owns. Headline. */
+  /** Deposits minus pending spend; used for spending and low-funds decisions. */
   creditsSpendableUsdc: string;
   /** USDC waiting in the buyer wallet before it can be swept into deposits. */
   creditsWalletUsdc: string;

--- a/apps/desktop/src/renderer/modules/app/float.ts
+++ b/apps/desktop/src/renderer/modules/app/float.ts
@@ -1,4 +1,5 @@
 import type { RendererUiState } from '../../core/state';
+import { selectHeadlineBalanceUsdc } from '../../core/balance';
 import { formatCompactTokens, formatCredits, shortAddress } from '../../core/format';
 import { notifyUiStateChanged } from '../../core/store';
 import type {
@@ -123,9 +124,9 @@ export function initVprFloatModule({ bridge, uiState, onSelectModel, refreshUsag
     return `${formatCompactTokens(usage?.totalInputTokens, usage?.totalOutputTokens)} tok`;
   }
 
-  /** What the user still owns: deposits minus spend already authorized. */
+  /** Complete owned balance, including USDC awaiting deposit sweep. */
   function balanceLabel(): string {
-    return `$${formatCredits(uiState.creditsSpendableUsdc)}`;
+    return `$${formatCredits(selectHeadlineBalanceUsdc(uiState))}`;
   }
 
   /** The buyer identity (signer address), shortened. */

--- a/apps/desktop/src/renderer/ui/AppShell.tsx
+++ b/apps/desktop/src/renderer/ui/AppShell.tsx
@@ -34,21 +34,32 @@ export function AppShell() {
   const [activeView, setActiveView] = useState<ViewName>('home');
   const [setupVisible, setSetupVisible] = useState(false);
   const [setupDismissed, setSetupDismissed] = useState(false);
-  const activeViewRef = useRef<ViewName>('home');
-  const depositReturnViewRef = useRef<ViewName>('credits');
+
+  // Screens visited before the current one, most recent last. Header back
+  // buttons pop this so "back" returns to where the user actually came from;
+  // the per-view fallback target only applies when the stack is empty.
+  const viewHistoryRef = useRef<ViewName[]>([]);
+  const activeViewRef = useRef<ViewName>(activeView);
 
   const handleSelectView = useCallback((view: ViewName) => {
     const current = activeViewRef.current;
     if (view === current) return;
-    if (view === 'deposit') depositReturnViewRef.current = current;
+    const stack = viewHistoryRef.current;
+    stack.push(current);
+    if (stack.length > 32) stack.shift();
     activeViewRef.current = view;
     setActiveView(view);
   }, []);
 
-  const handleLeaveDeposit = useCallback(() => {
-    const target = depositReturnViewRef.current;
-    activeViewRef.current = target;
-    setActiveView(target);
+  const handleNavigateBack = useCallback((fallback: ViewName) => {
+    const current = activeViewRef.current;
+    const stack = viewHistoryRef.current;
+    let target = stack.pop();
+    while (target === current) target = stack.pop();
+    const next = target ?? fallback;
+    if (next === current) return;
+    activeViewRef.current = next;
+    setActiveView(next);
   }, []);
 
   const hasServices = snap.chatServiceCount > 0;
@@ -129,11 +140,7 @@ export function AppShell() {
   }
 
   return (
-    <VprShell
-      activeView={activeView}
-      onSelectView={handleSelectView}
-      onLeaveDeposit={handleLeaveDeposit}
-    >
+    <VprShell activeView={activeView} onSelectView={handleSelectView} onNavigateBack={handleNavigateBack}>
       <ViewHost activeView={activeView} onSelectView={handleSelectView} />
     </VprShell>
   );

--- a/apps/desktop/src/renderer/ui/components/VprShell.tsx
+++ b/apps/desktop/src/renderer/ui/components/VprShell.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import type { ViewName } from '../types';
 import { shallowEqual, useUiSelector } from '../hooks/useUiSelector';
+import { selectHeadlineBalanceUsdc } from '../../core/balance';
 import { formatCredits } from '../../core/format';
 import { navViews } from './viewRegistry';
 import { ChatListPanel } from './ChatListPanel';
@@ -32,16 +33,16 @@ declare const __APP_VERSION__: string;
 type VprShellProps = {
   activeView: ViewName;
   onSelectView: (view: ViewName) => void;
-  onLeaveDeposit: () => void;
+  onNavigateBack: (fallback: ViewName) => void;
   children: React.ReactNode;
 };
 
 const mainNavEntries = navViews('main');
 const bottomNavEntries = navViews('bottom');
 
-export function VprShell({ activeView, onSelectView, onLeaveDeposit, children }: VprShellProps) {
+export function VprShell({ activeView, onSelectView, onNavigateBack, children }: VprShellProps) {
   const snap = useUiSelector((state) => ({
-    creditsTotalOwnedUsdc: state.creditsTotalOwnedUsdc,
+    headlineBalanceUsdc: selectHeadlineBalanceUsdc(state),
     connectBadgeLabel: state.connectBadge.label,
     networkHealth: state.ovDhtHealth,
     proxyPort: state.ovProxyPort,
@@ -63,8 +64,8 @@ export function VprShell({ activeView, onSelectView, onLeaveDeposit, children }:
   const chatPanelVisible = activeView === 'chat' && snap.chatPanelExpanded;
 
   const navValue = useMemo(
-    () => ({ navigate: onSelectView, leaveDeposit: onLeaveDeposit }),
-    [onLeaveDeposit, onSelectView],
+    () => ({ navigate: onSelectView, back: onNavigateBack }),
+    [onSelectView, onNavigateBack],
   );
 
   return (
@@ -130,7 +131,7 @@ export function VprShell({ activeView, onSelectView, onLeaveDeposit, children }:
               title="Add credits"
               onClick={() => onSelectView('deposit')}
             >
-              ${formatCredits(snap.creditsTotalOwnedUsdc)}
+              ${formatCredits(snap.headlineBalanceUsdc)}
             </button>
           </div>
         )}

--- a/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ConfigView.tsx
@@ -127,7 +127,7 @@ export function ConfigView({ onSelectView }: ConfigViewProps) {
   return (
     <section className={`view view-config ${styles.view}`} role="tabpanel">
       <div className={styles.stack}>
-        <VprBackTitle title="Configuration" onBack={() => onSelectView?.('help')} />
+        <VprBackTitle title="Configuration" fallback="help" />
 
         <VprCard className={styles.card}>
           <span className={styles.cardTitle}>Buyer</span>

--- a/apps/desktop/src/renderer/ui/components/views/ConnectionView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ConnectionView.tsx
@@ -29,7 +29,7 @@ export function ConnectionView({ onSelectView }: ConnectionViewProps) {
     <section className={`view view-connection ${styles.view}`} role="tabpanel">
       <div className={styles.stack}>
         <div className={styles.headRow}>
-          <VprBackTitle title="Connection" onBack={() => onSelectView?.('help')} />
+          <VprBackTitle title="Connection" fallback="help" />
           <span className={`${styles.badge} ${badgeTone}`}>{connectionMeta.label}</span>
         </div>
 

--- a/apps/desktop/src/renderer/ui/components/views/DesktopView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/DesktopView.tsx
@@ -149,7 +149,7 @@ export function DesktopView({ onSelectView }: DesktopViewProps) {
     <section className={`view view-desktop ${styles.view}`} role="tabpanel">
       <div className={styles.stack}>
         <div className={styles.headRow}>
-          <VprBackTitle title="Logs" onBack={() => onSelectView?.('help')} />
+          <VprBackTitle title="Logs" fallback="help" />
           <div className={`${styles.headActions} ${styles.headActionsLeft}`}>
             <button
               type="button"

--- a/apps/desktop/src/renderer/ui/components/views/PeersView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/PeersView.tsx
@@ -126,7 +126,7 @@ export function PeersView({ onSelectView }: PeersViewProps) {
   return (
     <section className={`view view-peers ${styles.view} ${styles.viewFill}`} role="tabpanel">
       <div className={`${styles.stack} ${styles.stackFill}`}>
-        <VprBackTitle title="Available peers" onBack={() => onSelectView?.('help')} />
+        <VprBackTitle title="Available peers" fallback="help" />
 
         <VprSearch
           value={filter}

--- a/apps/desktop/src/renderer/ui/components/views/VprActivityView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprActivityView.tsx
@@ -125,7 +125,7 @@ export function VprActivityView({ onSelectView }: Props) {
 
   return (
     <section className={`view view-vpr-activity view-pinned-header ${styles.view}`} role="tabpanel">
-      <VprPage title="Activity" backTo="credits">
+      <VprPage title="Activity" backFallback="credits">
       <div className={styles.stack}>
 
         <VprStatRow>

--- a/apps/desktop/src/renderer/ui/components/views/VprChatsView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprChatsView.tsx
@@ -215,6 +215,7 @@ export function VprChatsView({ onSelectView: _onSelectView }: Props) {
           ? (configEntry?.label ?? displayModelLabel(configModel.serviceId))
           : selected ? conversationTitle(selected) : 'Chats'}
         onBack={selected ? (configModel ? configBack : drillBack) : undefined}
+        backFallback="home"
       >
         <div className={styles.stack}>
           {message ? <p className={styles.note} role="status">{message}</p> : null}

--- a/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx
@@ -655,7 +655,7 @@ export function VprDepositView({ onSelectView }: Props) {
   function renderStage(current: Stage): JSX.Element {
     if (current === 'choose') {
       return (
-        <VprPage title="Add credits" backToDepositSource>
+        <VprPage title="Add credits" backFallback="credits">
         <div className={styles.stack}>
 
           <BalanceSummaryCard values={balanceValues} />

--- a/apps/desktop/src/renderer/ui/components/views/VprExploreView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprExploreView.tsx
@@ -102,6 +102,7 @@ export function VprExploreView({ onSelectView }: Props) {
     <section className={`view view-vpr-explore view-pinned-header ${styles.view}`} role="tabpanel">
       <VprPage
         title="Models"
+        backFallback="home"
         header={(
           <>
             <VprSearch

--- a/apps/desktop/src/renderer/ui/components/views/VprHelpView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprHelpView.tsx
@@ -464,7 +464,7 @@ export function VprHelpView({ onSelectView }: Props) {
 
   function renderRootPage() {
     return (
-      <VprPage title="Help & Support">
+      <VprPage title="Help & Support" backFallback="home">
       <div className={styles.stack}>
 
         <div className={styles.section}>

--- a/apps/desktop/src/renderer/ui/components/views/VprModelView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprModelView.tsx
@@ -95,7 +95,7 @@ export function VprModelView({ onSelectView }: Props) {
 
   return (
     <section className={`view view-vpr-model view-pinned-header ${styles.view}`} role="tabpanel">
-      <VprPage title="Models" backTo="explore">
+      <VprPage title="Models" backFallback="explore">
       <div className={styles.stack}>
 
         <div className={styles.headRow}>

--- a/apps/desktop/src/renderer/ui/components/views/VprPreferencesView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprPreferencesView.tsx
@@ -47,7 +47,7 @@ export function VprPreferencesView({ onSelectView }: Props) {
 
   return (
     <section className={`view view-vpr-preferences view-pinned-header ${styles.view}`} role="tabpanel">
-      <VprPage title="Preferences">
+      <VprPage title="Preferences" backFallback="home">
       <div className={styles.stack}>
         <p className={styles.lede}>These preferences apply to every model with Auto select turned on</p>
 

--- a/apps/desktop/src/renderer/ui/components/views/VprRewardsView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprRewardsView.tsx
@@ -47,7 +47,7 @@ export function VprRewardsView({ onSelectView }: Props) {
 
   return (
     <section className={`view view-vpr-rewards view-pinned-header ${styles.view}`} role="tabpanel">
-      <VprPage title="Rewards" backTo="credits">
+      <VprPage title="Rewards" backFallback="credits">
       <div className={styles.stack}>
 
         <VprCard className={styles.heroCard}>

--- a/apps/desktop/src/renderer/ui/components/views/VprToolsView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprToolsView.tsx
@@ -496,7 +496,7 @@ export function VprToolsView() {
 
   return (
     <section className={`view view-vpr-tools view-pinned-header ${styles.view}`} role="tabpanel">
-      <VprPage title="Connected apps">
+      <VprPage title="Connected apps" backFallback="home">
       <div className={styles.stack}>
 
         <VprSearch value={search} onChange={setSearch} placeholder="Search app" />

--- a/apps/desktop/src/renderer/ui/components/vpr/VprKit.module.scss
+++ b/apps/desktop/src/renderer/ui/components/vpr/VprKit.module.scss
@@ -83,16 +83,6 @@
   box-shadow: 0 0 0 2px rgba(var(--brand-rgb), 0.4);
 }
 
-.pageTitle {
-  min-height: 24px;
-  display: inline-flex;
-  align-items: center;
-  color: var(--text-secondary);
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 16px;
-}
-
 /* ---------- Toggle - Switch (48x24) ---------- */
 
 .toggle {

--- a/apps/desktop/src/renderer/ui/components/vpr/VprKit.tsx
+++ b/apps/desktop/src/renderer/ui/components/vpr/VprKit.tsx
@@ -4,7 +4,7 @@ import { HugeiconsIcon } from '@hugeicons/react';
 import { ArrowLeft01Icon, Search01Icon } from '@hugeicons/core-free-icons';
 import { formatCredits } from '../../../core/format';
 import { useUiSelector } from '../../hooks/useUiSelector';
-import { VprNavContext } from './VprNavContext';
+import { VprNavContext, useVprNavBack } from './VprNavContext';
 import type { ViewName } from '../../types';
 import styles from './VprKit.module.scss';
 
@@ -15,13 +15,18 @@ import styles from './VprKit.module.scss';
 
 export { formatCompactTokens, formatUsdShort } from '../../../core/format';
 
-/** Drill-down page header: back chevron + screen title. */
-export function VprBackTitle({ title, onBack }: {
+/** Inner-screen page header: back chevron + screen title. Without an explicit
+ * onBack it pops the shell's nav history — returning to whichever screen the
+ * user actually came from — and lands on `fallback` when there is none.
+ * Passing onBack keeps full control (in-view stages, wizards). */
+export function VprBackTitle({ title, onBack, fallback = 'home' }: {
   title: string;
-  onBack: () => void;
+  onBack?: () => void;
+  fallback?: ViewName;
 }): JSX.Element {
+  const historyBack = useVprNavBack(fallback);
   return (
-    <button type="button" className={styles.backTitle} onClick={onBack} title="Back">
+    <button type="button" className={styles.backTitle} onClick={onBack ?? historyBack} title="Back">
       <HugeiconsIcon icon={ArrowLeft01Icon} size={16} strokeWidth={2} />
       <span>{title}</span>
     </button>
@@ -36,33 +41,24 @@ export function VprBackTitle({ title, onBack }: {
  * section must add the global `view-pinned-header` class, which turns it
  * into a non-scrolling flex column.
  */
-export function VprPage({ title, onBack, backTo, backToDepositSource = false, header, children }: {
+export function VprPage({ title, onBack, backFallback, header, children }: {
   title: string;
-  /** Explicit back handler for in-view stages and wizards. */
+  /** Explicit back handler (in-view stages); omit to pop the nav history. */
   onBack?: () => void;
-  /** Fixed parent view for cross-view drill-downs. Omit on top-level pages. */
-  backTo?: ViewName;
-  /** Return Add Credits to the page that opened it. */
-  backToDepositSource?: boolean;
+  /** History-empty fallback when onBack is omitted; defaults to 'home'. */
+  backFallback?: ViewName;
   /** Extra rows pinned with the header (e.g. search, tabs). */
   header?: ReactNode;
   children: ReactNode;
 }): JSX.Element {
   const nav = useContext(VprNavContext);
   const credits = useUiSelector((state) => state.creditsTotalOwnedUsdc);
-  const backHandler = onBack
-    ?? (backToDepositSource ? () => nav?.leaveDeposit() : undefined)
-    ?? (backTo ? () => nav?.navigate(backTo) : undefined);
   return (
     <>
       <div className={styles.pageTop}>
         <div className={styles.pageTopInner}>
           <div className={styles.pageHeaderRow}>
-            {backHandler ? (
-              <VprBackTitle title={title} onBack={backHandler} />
-            ) : (
-              <span className={styles.pageTitle}>{title}</span>
-            )}
+            <VprBackTitle title={title} onBack={onBack} fallback={backFallback} />
             <button
               type="button"
               className={styles.headerCredits}

--- a/apps/desktop/src/renderer/ui/components/vpr/VprNavContext.ts
+++ b/apps/desktop/src/renderer/ui/components/vpr/VprNavContext.ts
@@ -1,4 +1,4 @@
-import { createContext } from 'react';
+import { createContext, useCallback, useContext } from 'react';
 import type { ViewName } from '../../types';
 
 /**
@@ -9,7 +9,17 @@ import type { ViewName } from '../../types';
  */
 export type VprNav = {
   navigate: (view: ViewName) => void;
-  leaveDeposit: () => void;
+  /** Return to the previously active screen; `fallback` when there is no
+      history left (fresh launch, history exhausted). */
+  back: (fallback: ViewName) => void;
 };
 
 export const VprNavContext = createContext<VprNav | null>(null);
+
+/** Back handler for a view's header: pops the nav history so the back button
+    returns to wherever the user actually came from, with the view's natural
+    parent screen as the empty-history fallback. */
+export function useVprNavBack(fallback: ViewName): () => void {
+  const nav = useContext(VprNavContext);
+  return useCallback(() => nav?.back(fallback), [nav, fallback]);
+}


### PR DESCRIPTION
Unify headline balance semantics across the VPR and extended sidebar, restore explicit back-navigation behavior, and harden buyer-channel status and close handling.

## What

- Use a shared headline-balance selector across the VPR and extended sidebar so both surfaces display total owned USDC, including funds awaiting deposit sweep.
- Keep spendable balance semantics separate for spending and low-funds decisions.
- Restore history-based VPR Back behavior so users return to the screen they actually navigated from.
- Restore explicit per-view fallback destinations when navigation history is empty.
- Normalize buyer-channel daemon responses defensively and validate cooperative-close results before using them.
- Enrich the status of every active-looking channel in bounded concurrent batches instead of checking only the first 12.
- Rename the generic channel-control helper to the buyer-specific `buyer-channel-control`.

## Why

The VPR and extended sidebar could display different headline balances because they used different balance definitions. Navigation changes also replaced history-based Back behavior with fixed parent routes, which could return users to the wrong screen.

Buyer-channel refresh only enriched the first 12 active-looking channels, leaving older channels with potentially stale statuses. Cooperative-close handling also trusted daemon responses without fully validating their structure.

These changes make the displayed balance consistent, restore predictable navigation, and make channel status and close handling more complete and defensive.

## Testing

- Added tests for headline balance selection.
- Updated buyer-channel tests to cover response normalization and batched status enrichment.
- Ran `pnpm -C apps/desktop run typecheck:renderer`.
- Ran the complete desktop test suite; all renderer tests passed.
- Ran the full repository build and test suites.

## Checklist

- [x] `pnpm run build` passes
- [x] `pnpm run test` passes
- [x] Breaking changes documented — not applicable; no breaking changes