### PR TITLE
feat(contracts): add seller position init faucet

### DIFF
--- a/packages/contracts/interfaces/IAntseedSellerPools.sol
+++ b/packages/contracts/interfaces/IAntseedSellerPools.sol
@@ -110,6 +110,7 @@ interface IAntseedSellerPools {
 
     function antsToken() external view returns (IERC20);
     function currentEpoch() external view returns (uint256);
+    function stakeActivationDelay() external view returns (uint256);
     function agentIdForSeller(address seller) external view returns (uint256);
     function positionWithdrawableEpoch(uint256 positionId) external view returns (uint64);
 

--- a/packages/contracts/script/DeployRecognizedUsage.s.sol
+++ b/packages/contracts/script/DeployRecognizedUsage.s.sol
@@ -9,6 +9,7 @@ import { AntseedLegacyEmissionsEscrow } from "../emissions/AntseedLegacyEmission
 import { AntseedSellerPoolsRewards } from "../emissions/AntseedSellerPoolsRewards.sol";
 import { AntseedUsageAccounting } from "../emissions/AntseedUsageAccounting.sol";
 import { IAntseedRegistry } from "../interfaces/IAntseedRegistry.sol";
+import { AntseedPositionInit } from "../sellers/AntseedPositionInit.sol";
 import { AntseedSellerPools } from "../sellers/AntseedSellerPools.sol";
 import { AntseedSellerRegistry } from "../sellers/AntseedSellerRegistry.sol";
 
@@ -52,6 +53,10 @@ interface IAntseedLegacyEmissionsAdmin {
  *   EMISSIONS_RESERVE_WALLET          Destination for ANTS emission reserve flows
  *                                     via the reserve minter controller. Unset =
  *                                     ANTS reserve flows use protocolReserve.
+ *   POSITION_INIT_AMOUNT              ANTS per starter position (default 1e18).
+ *   POSITION_INIT_END_EPOCH           Shared end epoch of all starter
+ *                                     positions; claims stop once reached
+ *                                     (default effectiveEpoch + 104).
  *
  * Usage:
  *   cd packages/contracts
@@ -85,6 +90,7 @@ contract DeployRecognizedUsage is Script {
         require(existingEmissions != address(0), "existing emissions not set");
         require(existingChannels != address(0), "channels not set");
         require(existingDeposits != address(0), "deposits not set");
+        require(existingStaking != address(0), "staking not set");
 
         address verificationWallet = vm.envAddress("VERIFICATION_WALLET");
         require(verificationWallet != address(0), "verification wallet not set");
@@ -171,6 +177,23 @@ contract DeployRecognizedUsage is Script {
         console.log("EmissionsGate:          ", address(gate));
         gate.setMinter(VERIFICATION_MINTER_ID, verificationWallet, 10_000, true);
 
+        // Starter-position faucet: every existing legacy seller can create one
+        // small ANTS position in their own pool, so pools have nonzero power
+        // (and usage accounting turns on) from the first rewarded epoch even
+        // though nobody holds transferable ANTS yet. All starter positions
+        // share one end epoch (default: max lock measured from the first
+        // rewarded epoch), so a late claim never outweighs an early one and
+        // the faucet expires by itself. Unowned and immutable — it also
+        // switches off when its funded pot runs out.
+        AntseedPositionInit positionInit = new AntseedPositionInit(
+            address(sellerPools),
+            existingStaking,
+            vm.envOr("POSITION_INIT_AMOUNT", uint256(1 ether)),
+            vm.envOr("POSITION_INIT_END_EPOCH", effectiveEpoch + 104)
+        );
+        console.log("PositionInit:         ", address(positionInit));
+        console.log("PositionInit end epoch:", positionInit.initEndEpoch());
+
         AntseedUsageAccounting usageAccounting =
             new AntseedUsageAccounting(address(sellerPools), existingChannels, address(gate));
         console.log("UsageAccounting:        ", address(usageAccounting));
@@ -210,6 +233,9 @@ contract DeployRecognizedUsage is Script {
         IANTSTokenAdmin(antsToken).setTransferWhitelist(address(usageRewards), true);
         IANTSTokenAdmin(antsToken).setTransferWhitelist(address(sellerPoolsRewards), true);
         IANTSTokenAdmin(antsToken).setTransferWhitelist(address(legacyEscrow), true);
+        // The starter-position faucet is the transfer sender when it stakes
+        // into SellerPools on sellers' behalf.
+        IANTSTokenAdmin(antsToken).setTransferWhitelist(address(positionInit), true);
         sellerPools.setRewardStaker(address(sellerPoolsRewards), true);
         gate.setMinter(SELLER_POOLS_MINTER_ID, address(sellerPoolsRewards), 40_000, true);
         gate.setMinter(USAGE_MINTER_ID, address(usageRewards), 20_000, true);
@@ -297,6 +323,13 @@ contract DeployRecognizedUsage is Script {
         console.log("  only after seller pools are seeded with ANTS stake.");
         console.log("- Sellers cannot stake ANTS into pools until they are transfer-");
         console.log("  whitelisted or transfers are enabled.");
+        console.log("- Fund the PositionInit faucet with ANTS from a wallet that already");
+        console.log("  holds them (temporarily whitelist that wallet as a SENDER via");
+        console.log("  ANTSToken.setTransferWhitelist, transfer, then de-whitelist).");
+        console.log("  Fund in small increments: the faucet has no owner and no sweep,");
+        console.log("  leftovers strand forever. Announce the claim window: grants");
+        console.log("  staked before the flip epoch's boundary have power at the first");
+        console.log("  rewarded epoch; later claims activate one epoch after staking.");
         console.log("- Legacy EmissionsV2 is registered against the escrow: all its");
         console.log("  claims and team/reserve flushes (any epoch, any time) pay from");
         console.log("  the pre-minted pot. Sweep the escrow leftovers only after legacy");

--- a/packages/contracts/sellers/AntseedPositionInit.sol
+++ b/packages/contracts/sellers/AntseedPositionInit.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import { IAntseedSellerPools } from "../interfaces/IAntseedSellerPools.sol";
+import { IAntseedStaking } from "../interfaces/IAntseedStaking.sol";
+
+/**
+ * @title AntseedPositionInit
+ * @notice One-shot ANTS starter positions that bootstrap seller-pool
+ *         accounting.
+ *
+ *         Usage accounting ignores pools with zero power, so at cutover no
+ *         recognized-usage reward can accrue until someone stakes ANTS — which
+ *         nobody holds while transfers are disabled. This contract lets each
+ *         existing legacy seller create one small pre-funded position in their
+ *         own agent pool, turning their accounting on.
+ *
+ *         Eligibility is anchored to the legacy USDC staking contract: the
+ *         caller must have an agent binding there and stake above the legacy
+ *         minimum, so only sellers who put up real USDC stake can claim.
+ *
+ *         All starter positions share one fixed `initEndEpoch` instead of a
+ *         fixed lock duration: a claim locks from its activation epoch until
+ *         that end. Position power at epoch e is amount * (endEpoch - e), so
+ *         every starter position has identical power at every epoch no matter
+ *         when it was claimed — a late claim never outweighs an early one.
+ *
+ *         Deliberately unowned: no admin, no sweep, no pause, no setters. The
+ *         faucet switches itself off two ways: when the funded pot runs out,
+ *         and permanently once `initEndEpoch` is no longer a full epoch past
+ *         the activation epoch. Leftover balance strands here forever, so
+ *         fund it in small increments.
+ */
+contract AntseedPositionInit is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    // ─── External Contracts ──────────────────────────────────────────
+    IAntseedSellerPools public immutable sellerPools;
+    IAntseedStaking public immutable legacyStaking;
+    IERC20 public immutable antsToken;
+
+    // ─── Position Terms ──────────────────────────────────────────────
+    uint256 public immutable initAmount;
+    uint256 public immutable initEndEpoch;
+
+    // ─── Claim Tracking ──────────────────────────────────────────────
+    mapping(uint256 => bool) public agentInitialized;
+
+    // ─── Events ──────────────────────────────────────────────────────
+    event PositionInitialized(
+        address indexed seller, uint256 indexed agentId, uint256 positionId, uint256 amount, uint256 stakeEpochs
+    );
+
+    // ─── Errors ──────────────────────────────────────────────────────
+    error InvalidAddress();
+    error InvalidValue();
+    error NotLegacySeller();
+    error AlreadyInitialized();
+    error InitDepleted();
+    error InitExpired();
+
+    // ─── Constructor ─────────────────────────────────────────────────
+    constructor(address _sellerPools, address _legacyStaking, uint256 _initAmount, uint256 _initEndEpoch) {
+        if (_sellerPools == address(0) || _legacyStaking == address(0)) revert InvalidAddress();
+        if (_initAmount == 0) revert InvalidValue();
+        if (_initEndEpoch <= IAntseedSellerPools(_sellerPools).currentEpoch()) revert InvalidValue();
+
+        sellerPools = IAntseedSellerPools(_sellerPools);
+        legacyStaking = IAntseedStaking(_legacyStaking);
+        initAmount = _initAmount;
+        initEndEpoch = _initEndEpoch;
+
+        // Approve the token pools actually pulls — its pinned immutable.
+        IERC20 token = IAntseedSellerPools(_sellerPools).antsToken();
+        if (address(token) == address(0)) revert InvalidAddress();
+        antsToken = token;
+        token.forceApprove(_sellerPools, type(uint256).max);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        CORE — INIT
+    // ═══════════════════════════════════════════════════════════════════
+
+    /**
+     * @notice Create one position of `initAmount` ANTS in the caller's own
+     *         agent pool, locked from the next activation epoch until
+     *         `initEndEpoch`. The lANTS position belongs to the caller.
+     *         One starter position per agent id, forever.
+     */
+    function initPosition() external nonReentrant returns (uint256 positionId) {
+        uint256 agentId = legacyStaking.getAgentId(msg.sender);
+        if (agentId == 0 || !legacyStaking.isStakedAboveMin(msg.sender)) revert NotLegacySeller();
+        if (agentInitialized[agentId]) revert AlreadyInitialized();
+        if (antsToken.balanceOf(address(this)) < initAmount) revert InitDepleted();
+
+        // stakeFor recomputes the same activation epoch in this transaction,
+        // so the created position ends exactly at initEndEpoch.
+        uint256 startEpoch = sellerPools.currentEpoch() + sellerPools.stakeActivationDelay();
+        if (startEpoch >= initEndEpoch) revert InitExpired();
+        uint256 stakeEpochs = initEndEpoch - startEpoch;
+
+        agentInitialized[agentId] = true;
+        positionId = sellerPools.stakeFor(msg.sender, agentId, initAmount, stakeEpochs);
+        emit PositionInitialized(msg.sender, agentId, positionId, initAmount, stakeEpochs);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    //                        VIEWS
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// @notice Number of starter positions the current pot can still pay.
+    function remainingInits() external view returns (uint256) {
+        return antsToken.balanceOf(address(this)) / initAmount;
+    }
+}

--- a/packages/contracts/test/AntseedPositionInit.t.sol
+++ b/packages/contracts/test/AntseedPositionInit.t.sol
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+
+import { ANTSToken } from "../core/ANTSToken.sol";
+import { AntseedRegistry } from "../core/AntseedRegistry.sol";
+import { AntseedPositionInit } from "../sellers/AntseedPositionInit.sol";
+import { AntseedSellerPools } from "../sellers/AntseedSellerPools.sol";
+import { AntseedSellerRegistry } from "../sellers/AntseedSellerRegistry.sol";
+import { MockERC8004Registry } from "./mocks/MockERC8004Registry.sol";
+
+contract MockLegacySellerStaking {
+    mapping(address => uint256) public sellerAgentId;
+    mapping(address => bool) public stakedAboveMin;
+
+    function setAgent(address seller, uint256 agentId) external {
+        sellerAgentId[seller] = agentId;
+    }
+
+    function setStakedAboveMin(address seller, bool value) external {
+        stakedAboveMin[seller] = value;
+    }
+
+    function getAgentId(address seller) external view returns (uint256) {
+        return sellerAgentId[seller];
+    }
+
+    function isStakedAboveMin(address seller) external view returns (bool) {
+        return stakedAboveMin[seller];
+    }
+}
+
+contract AntseedPositionInitTest is Test {
+    uint256 constant EPOCH_DURATION = 1 weeks;
+    uint256 constant INIT_AMOUNT = 1 ether;
+    uint256 constant INIT_END_EPOCH = 105;
+
+    ANTSToken token;
+    AntseedRegistry registry;
+    MockERC8004Registry identityRegistry;
+    MockLegacySellerStaking legacyStaking;
+    AntseedSellerPools pools;
+    AntseedSellerRegistry sellerRegistry;
+    AntseedPositionInit positionInit;
+
+    address seller = address(0x100);
+    address otherSeller = address(0x200);
+    address outsider = address(0x300);
+
+    uint256 agentId;
+    uint256 otherAgentId;
+    uint256 genesis;
+
+    function setUp() public {
+        vm.warp(1_700_000_000);
+        genesis = block.timestamp;
+        registry = new AntseedRegistry();
+        identityRegistry = new MockERC8004Registry();
+        legacyStaking = new MockLegacySellerStaking();
+        token = new ANTSToken();
+        token.setRegistry(address(registry));
+        registry.setAntsToken(address(token));
+        registry.setEmissions(address(this));
+        registry.setIdentityRegistry(address(identityRegistry));
+
+        pools = new AntseedSellerPools(address(token), address(this), address(identityRegistry), address(0));
+        sellerRegistry =
+            new AntseedSellerRegistry(address(identityRegistry), address(pools), address(legacyStaking));
+        pools.setStakingSource(address(sellerRegistry));
+
+        positionInit =
+            new AntseedPositionInit(address(pools), address(legacyStaking), INIT_AMOUNT, INIT_END_EPOCH);
+
+        token.setTransferWhitelist(address(pools), true);
+        token.setTransferWhitelist(address(positionInit), true);
+        token.mint(address(positionInit), 10 * INIT_AMOUNT);
+
+        // Legacy sellers: agent registered in the identity registry and bound
+        // with USDC stake in the legacy staking contract.
+        agentId = _registerLegacySeller(seller);
+        otherAgentId = _registerLegacySeller(otherSeller);
+    }
+
+    function currentEpoch() external view returns (uint256) {
+        if (block.timestamp <= genesis) return 0;
+        return (block.timestamp - genesis) / EPOCH_DURATION;
+    }
+
+    function _registerLegacySeller(address account) internal returns (uint256 id) {
+        vm.prank(account);
+        id = identityRegistry.register();
+        legacyStaking.setAgent(account, id);
+        legacyStaking.setStakedAboveMin(account, true);
+    }
+
+    function test_initCreatesPositionOwnedBySeller() public {
+        assertFalse(token.transfersEnabled());
+
+        vm.prank(seller);
+        uint256 positionId = positionInit.initPosition();
+
+        assertEq(pools.ownerOf(positionId), seller);
+        (, uint256 positionAgentId, uint256 amount,,, uint64 stakeEndEpoch,,) = pools.positions(positionId);
+        assertEq(positionAgentId, agentId);
+        assertEq(amount, INIT_AMOUNT);
+        assertEq(stakeEndEpoch, INIT_END_EPOCH);
+        assertTrue(positionInit.agentInitialized(agentId));
+        assertEq(token.balanceOf(address(positionInit)), 9 * INIT_AMOUNT);
+        assertEq(positionInit.remainingInits(), 9);
+    }
+
+    function test_positionPowerActivatesAtNextEpoch() public {
+        vm.prank(seller);
+        uint256 positionId = positionInit.initPosition();
+
+        assertEq(pools.poolWeightAtEpoch(agentId, 0), 0);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+        assertEq(pools.positionWeightAtEpoch(positionId, 1), INIT_AMOUNT * (INIT_END_EPOCH - 1));
+        assertEq(pools.poolWeightAtEpoch(agentId, 1), INIT_AMOUNT * (INIT_END_EPOCH - 1));
+        assertEq(pools.poolActiveStakeAtEpoch(agentId, 1), INIT_AMOUNT);
+    }
+
+    function test_latePositionNeverOutweighsEarlyPosition() public {
+        vm.prank(seller);
+        uint256 earlyPositionId = positionInit.initPosition();
+
+        // Ten epochs later another seller claims; both positions share the
+        // same end epoch, so from the late position's activation onward their
+        // power is identical at every epoch.
+        vm.warp(block.timestamp + 10 * EPOCH_DURATION);
+        vm.prank(otherSeller);
+        uint256 latePositionId = positionInit.initPosition();
+
+        (,,,,, uint64 lateEndEpoch,,) = pools.positions(latePositionId);
+        assertEq(lateEndEpoch, INIT_END_EPOCH);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+        uint256 epoch = 11;
+        uint256 expectedWeight = INIT_AMOUNT * (INIT_END_EPOCH - epoch);
+        assertEq(pools.positionWeightAtEpoch(earlyPositionId, epoch), expectedWeight);
+        assertEq(pools.positionWeightAtEpoch(latePositionId, epoch), expectedWeight);
+    }
+
+    function test_initsExpireAtEndEpoch() public {
+        // Last claimable epoch: activation (currentEpoch + 1) must stay
+        // below the shared end epoch.
+        vm.warp(genesis + (INIT_END_EPOCH - 2) * EPOCH_DURATION);
+        vm.prank(seller);
+        uint256 positionId = positionInit.initPosition();
+        (,,,, uint64 startEpoch, uint64 stakeEndEpoch,,) = pools.positions(positionId);
+        assertEq(startEpoch, INIT_END_EPOCH - 1);
+        assertEq(stakeEndEpoch, INIT_END_EPOCH);
+
+        vm.warp(genesis + (INIT_END_EPOCH - 1) * EPOCH_DURATION);
+        vm.prank(otherSeller);
+        vm.expectRevert(AntseedPositionInit.InitExpired.selector);
+        positionInit.initPosition();
+    }
+
+    function test_oneInitPerAgent() public {
+        vm.prank(seller);
+        positionInit.initPosition();
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedPositionInit.AlreadyInitialized.selector);
+        positionInit.initPosition();
+    }
+
+    function test_unknownSellerReverts() public {
+        vm.prank(outsider);
+        vm.expectRevert(AntseedPositionInit.NotLegacySeller.selector);
+        positionInit.initPosition();
+    }
+
+    function test_sellerBelowLegacyMinStakeReverts() public {
+        legacyStaking.setStakedAboveMin(seller, false);
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedPositionInit.NotLegacySeller.selector);
+        positionInit.initPosition();
+    }
+
+    function test_depletedPotBlocksInitsUntilRefunded() public {
+        AntseedPositionInit smallInit =
+            new AntseedPositionInit(address(pools), address(legacyStaking), INIT_AMOUNT, INIT_END_EPOCH);
+        token.setTransferWhitelist(address(smallInit), true);
+        token.mint(address(smallInit), INIT_AMOUNT);
+
+        vm.prank(seller);
+        smallInit.initPosition();
+        assertEq(smallInit.remainingInits(), 0);
+
+        vm.prank(otherSeller);
+        vm.expectRevert(AntseedPositionInit.InitDepleted.selector);
+        smallInit.initPosition();
+
+        token.mint(address(smallInit), INIT_AMOUNT);
+        vm.prank(otherSeller);
+        smallInit.initPosition();
+        assertTrue(smallInit.agentInitialized(otherAgentId));
+    }
+
+    function test_initRevertsWithoutTransferWhitelist() public {
+        AntseedPositionInit unlisted =
+            new AntseedPositionInit(address(pools), address(legacyStaking), INIT_AMOUNT, INIT_END_EPOCH);
+        token.mint(address(unlisted), INIT_AMOUNT);
+
+        vm.prank(seller);
+        vm.expectRevert(ANTSToken.TransfersNotEnabled.selector);
+        unlisted.initPosition();
+    }
+
+    function test_constructorValidation() public {
+        vm.expectRevert(AntseedPositionInit.InvalidAddress.selector);
+        new AntseedPositionInit(address(0), address(legacyStaking), INIT_AMOUNT, INIT_END_EPOCH);
+
+        vm.expectRevert(AntseedPositionInit.InvalidAddress.selector);
+        new AntseedPositionInit(address(pools), address(0), INIT_AMOUNT, INIT_END_EPOCH);
+
+        vm.expectRevert(AntseedPositionInit.InvalidValue.selector);
+        new AntseedPositionInit(address(pools), address(legacyStaking), 0, INIT_END_EPOCH);
+
+        // End epoch must be in the future relative to the pools' clock.
+        vm.warp(genesis + 5 * EPOCH_DURATION);
+        vm.expectRevert(AntseedPositionInit.InvalidValue.selector);
+        new AntseedPositionInit(address(pools), address(legacyStaking), INIT_AMOUNT, 5);
+    }
+}


### PR DESCRIPTION
## Description

At cutover nobody holds transferable ANTS, so no pool has power and usage accounting ignores every settlement — no recognized-usage rewards can accrue for anyone. `AntseedPositionInit` is an unowned, immutable faucet that lets each existing legacy seller (agent binding + stake above the legacy minimum in the legacy USDC staking contract) create one small pre-funded ANTS position in their own agent pool via `stakeFor`, turning their accounting on from the first rewarded epoch.

Design points:
- All starter positions share one immutable `initEndEpoch` rather than a fixed lock duration. Position power is `amount * (endEpoch - e)`, so every starter position has identical power at every epoch regardless of claim time — a late claim never outweighs an early one.
- No admin, no sweep, no pause, no setters. Two natural off-switches: the funded pot running out (`InitDepleted`, refundable by topping up) and the end epoch being reached (`InitExpired`, permanent).
- One position per agent id, forever.

Also:
- `IAntseedSellerPools`: expose the existing `stakeActivationDelay` public getter so the faucet computes the same activation epoch as `stakeFor`.
- `DeployRecognizedUsage`: deploys the faucet (envs `POSITION_INIT_AMOUNT`, default 1 ANTS; `POSITION_INIT_END_EPOCH`, default effectiveEpoch + 104), whitelists it as an ANTS transfer sender, and extends the post-deploy checklist with funding and claim-window steps.

## Testing

- `test/AntseedPositionInit.t.sol`: 10 tests — position ownership/terms, power activation at the next epoch, late-vs-early equal power, expiry at the end epoch, one-init-per-agent, non-seller and below-min-stake rejection, depleted-pot top-up cycle, transfer-whitelist requirement, constructor validation.
- Full forge suite green.

Changelog deliberately not updated on this branch (entries added once before merge, per branch policy).