### PR TITLE
website: fix canonical/sitemap URL form, integration titles, sitemap lastmod

### DIFF
--- a/apps/website/docusaurus.config.ts
+++ b/apps/website/docusaurus.config.ts
@@ -42,6 +42,11 @@ const config: Config = {
   favicon: 'logo.svg',
   url: 'https://antseed.com',
   baseUrl: '/',
+  // The host 308-redirects /path to /path/, so without this Docusaurus emitted
+  // canonical tags and sitemap entries pointing at the pre-redirect form: every
+  // URL was a redirect source and no page's canonical actually resolved to
+  // itself. `true` makes the emitted URLs match what the host already serves.
+  trailingSlash: true,
   onBrokenLinks: 'throw',
 
   markdown: {
@@ -62,8 +67,16 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           routeBasePath: 'docs',
+          // Feeds the sitemap's `lastmod` from the file's git commit date.
+          // Without it every URL carried the build date, so each deploy told
+          // crawlers all 59 pages had changed.
+          showLastUpdateTime: true,
+        },
+        pages: {
+          showLastUpdateTime: true,
         },
         blog: {
+          showLastUpdateTime: true,
           showReadingTime: true,
           blogTitle: 'AntSeed Blog',
           blogDescription: 'Insights on OpenRouter alternatives, P2P AI networks, and the future of AI inference.',

--- a/apps/website/src/integrations/IntegrationPage.tsx
+++ b/apps/website/src/integrations/IntegrationPage.tsx
@@ -602,7 +602,9 @@ export default function IntegrationPage({integration}: {integration: Integration
     .filter((x) => x.category === i.category && x.slug !== i.slug)
     .slice(0, 4);
 
-  const pageUrl = `https://antseed.com/integrations/${i.slug}`;
+  // Trailing slash matches `trailingSlash: true` in docusaurus.config.ts, so the
+  // URLs in JSON-LD are the same ones the canonical tag and sitemap point at.
+  const pageUrl = `https://antseed.com/integrations/${i.slug}/`;
 
   // `oneLiner` is authored with markdown backticks for on-page code styling.
   // Meta descriptions are plain text, so Google and social cards would print the
@@ -611,7 +613,8 @@ export default function IntegrationPage({integration}: {integration: Integration
 
   // Mirrors what Docusaurus renders into <title> (Layout title + site title), so
   // og:title can't drift from the page title (X falls back to og:title).
-  const pageTitle = `${i.name} | AntSeed`;
+  const titleText = i.seoTitle ?? i.name;
+  const pageTitle = `${titleText} | AntSeed`;
 
   // Marks up the breadcrumb rendered below so search engines read the hierarchy.
   const breadcrumbLd = {
@@ -619,7 +622,7 @@ export default function IntegrationPage({integration}: {integration: Integration
     '@type': 'BreadcrumbList',
     itemListElement: [
       {'@type': 'ListItem', position: 1, name: 'Home', item: 'https://antseed.com/'},
-      {'@type': 'ListItem', position: 2, name: 'Integrations', item: 'https://antseed.com/integrations'},
+      {'@type': 'ListItem', position: 2, name: 'Integrations', item: 'https://antseed.com/integrations/'},
       {'@type': 'ListItem', position: 3, name: i.name, item: pageUrl},
     ],
   };
@@ -667,7 +670,7 @@ export default function IntegrationPage({integration}: {integration: Integration
 
   return (
     <Layout
-      title={i.name}
+      title={titleText}
       description={`Connect ${i.name} to the AntSeed peer-to-peer inference network. ${metaOneLiner}`}>
       <Head>
         <link rel="alternate" type="text/markdown" href="/skill.md" title="Agent-readable integration guide" />
@@ -696,7 +699,7 @@ export default function IntegrationPage({integration}: {integration: Integration
             )}
           </div>
           <div className={styles.detailHeaderText}>
-            <h1>{i.name}</h1>
+            <h1>{i.headline ?? i.name}</h1>
             <p className={styles.detailOneLiner}><Ticks>{i.oneLiner}</Ticks></p>
             <div className={styles.detailBadgeRow}>
               <span className={`${styles.detailBadge} ${styles.detailBadgeGreen}`}>{CATEGORY_LABELS[i.category]}</span>

--- a/apps/website/src/integrations/integrations.ts
+++ b/apps/website/src/integrations/integrations.ts
@@ -101,6 +101,14 @@ export type Integration = {
   format: IntegrationFormat;
   setupMinutes: number;
   status: IntegrationStatus;
+  /**
+   * `<title>` text, rendered as `<seoTitle> | AntSeed`. Keep it 40–50 chars so
+   * the full tag lands in the 50–60 Google renders without truncating.
+   * Falls back to `name`, which on its own carries no query intent.
+   */
+  seoTitle?: string;
+  /** Page `<h1>`. Falls back to `name`. */
+  headline?: string;
   /** ≤ 90 chars. Shown on the hub card. */
   oneLiner: string;
   /** 1–3 short paragraphs. Shown at top of the integration page. */
@@ -146,6 +154,8 @@ export const integrations: Integration[] = [
     format: 'anthropic-messages',
     setupMinutes: 2,
     status: 'verified',
+    seoTitle: 'Run Claude Code on any model, no subscription',
+    headline: 'Run Claude Code on any model',
     oneLiner: "Anthropic's official CLI agent - launch through AntSeed with `antseed claude`.",
     description: [
       'Claude Code is the official CLI coding agent from Anthropic. It speaks the Anthropic Messages API natively, so it slots into AntSeed through the `antseed claude` wrapper or by pointing `ANTHROPIC_BASE_URL` at your local proxy.',
@@ -233,6 +243,8 @@ export const integrations: Integration[] = [
     format: 'openai-chat',
     setupMinutes: 2,
     status: 'verified',
+    seoTitle: 'Run OpenAI Codex CLI on any model, pay per use',
+    headline: 'Run OpenAI Codex CLI on any model',
     oneLiner: "OpenAI's official CLI coding agent - use `antseed codex` for per-run proxy config.",
     description: [
       "Codex is OpenAI's terminal coding agent. Recent versions ignore `OPENAI_BASE_URL` and instead read provider config from Codex settings.",
@@ -350,6 +362,8 @@ Deposits reserved:           0 USDC → 1 USDC`,
     format: 'openai-chat',
     setupMinutes: 2,
     status: 'verified',
+    seoTitle: 'Run OpenCode on any model, pay per request',
+    headline: 'Run OpenCode on any model',
     oneLiner: 'Open-source AI coding agent - launch through AntSeed with `antseed opencode`.',
     description: [
       'OpenCode is an MIT-licensed terminal coding agent built on the Vercel AI SDK. It supports 75+ providers out of the box and lets you register custom ones via <code>opencode.json</code>.',
@@ -449,6 +463,8 @@ Deposits reserved:           0 USDC → 1 USDC`,
     format: 'openai-responses',
     setupMinutes: 3,
     status: 'verified',
+    seoTitle: 'Run the Pi coding agent on any model, pay per use',
+    headline: 'Run Pi on any model',
     oneLiner: 'Open-source terminal coding agent with a first-class AntSeed extension.',
     description: [
       '<strong>What Pi is.</strong> Pi (<code>@mariozechner/pi-coding-agent</code>) is a minimal, hackable terminal coding agent by Mario Zechner - the same lineage as <a href="https://github.com/badlogic/pi-mono">pi-mono</a>. It ships with four default tools (<code>read</code>, <code>write</code>, <code>edit</code>, <code>bash</code>) and lets you extend everything else - commands, providers, themes, even the editor UI - through TypeScript <em>extensions</em>, <em>skills</em>, and <em>prompt templates</em>. No fork required.',
@@ -563,6 +579,8 @@ Deposits reserved:           0 USDC → 1 USDC`,
     format: 'anthropic-messages',
     setupMinutes: 3,
     status: 'verified',
+    seoTitle: 'Run OpenClaw agents on any model, pay per use',
+    headline: 'Run OpenClaw on any model',
     oneLiner: 'Open-source autonomous agent runtime - register AntSeed as a custom provider in `openclaw.json`.',
     description: [
       '<strong>What OpenClaw is.</strong> OpenClaw is an open-source agent runtime for autonomous, long-running tasks (research, coding, web automation). It loads its provider catalog from <code>~/.openclaw/openclaw.json</code> - each entry is an HTTP endpoint plus a wire protocol (<code>anthropic-messages</code>, <code>openai-chat</code>, etc.) and a list of models.',
@@ -686,6 +704,8 @@ openclaw config set agents.defaults.model.primary "antseed/claude-sonnet-4-6"`,
     format: 'openai-chat',
     setupMinutes: 3,
     status: 'verified',
+    seoTitle: 'Run Hermes agents on any model, pay per use',
+    headline: 'Run Hermes on any model',
     oneLiner: "Nous Research's agent framework - register AntSeed as a custom provider in `config.yaml`.",
     description: [
       '<strong>What Hermes is.</strong> Hermes is the agent framework from <a href="https://nousresearch.com/">Nous Research</a> (successor to OpenClaw\'s lineage). It\'s designed for autonomous, multi-step workflows - research agents, coding agents, swarms - and reads its model catalog from <code>~/.hermes/config.yaml</code>.',
@@ -804,6 +824,8 @@ auxiliary:
     format: 'openai-chat',
     setupMinutes: 5,
     status: 'verified',
+    seoTitle: 'Add AntSeed inference to GenLayer Studio',
+    headline: 'AntSeed inference in GenLayer Studio',
     oneLiner: 'Use AntSeed as an inference provider inside GenLayer Studio validators.',
     description: [
       '<strong>What GenLayer Studio is.</strong> Studio runs <em>Intelligent Contract</em> validators that consult LLMs to reach consensus. Each validator is configured with a provider entry that has a <code>provider</code> name, a <code>plugin</code> (one of <code>openai-compatible</code> / <code>anthropic</code> / <code>google</code> / <code>ollama</code> / <code>custom</code>), a <code>model</code> id, and a <code>plugin_config</code> with <code>api_url</code> and <code>api_key_env_var</code>.',
@@ -952,6 +974,8 @@ ANTSEED_API_KEY=antseed`,
     format: 'openai-chat',
     setupMinutes: 5,
     status: 'verified',
+    seoTitle: 'Vercel AI SDK on any model, OpenAI-compatible',
+    headline: 'Use AntSeed with the Vercel AI SDK',
     oneLiner: "Use `@ai-sdk/openai-compatible` to call AntSeed from `generateText` / `streamText` / `generateObject`.",
     description: [
       '<strong>What the AI SDK is.</strong> Vercel\'s <code>ai</code> package is a provider-agnostic TypeScript toolkit for building LLM apps and agents. You pick a <em>provider</em> (a small adapter package), instantiate a model from it, and pass that model into one of the framework\'s primitives: <code>generateText</code>, <code>streamText</code>, <code>generateObject</code>, or <code>streamObject</code>. The AI SDK handles tool-calling, structured output, message history, and streaming for you.',
@@ -1091,6 +1115,8 @@ const result = streamText({
     format: 'openai-chat',
     setupMinutes: 5,
     status: 'verified',
+    seoTitle: 'LangChain Python on any model, no OpenAI key',
+    headline: 'Use AntSeed with LangChain in Python',
     oneLiner: 'Drop-in `ChatOpenAI(base_url=…)` - works in chains, LCEL, and LangGraph agents.',
     description: [
       '<strong>What LangChain is.</strong> LangChain is the Python framework for composing LLMs with tools, retrievers, memory, and agents. The chat-model interface is <code>BaseChatModel</code>; <code>ChatOpenAI</code> from <code>langchain-openai</code> is a concrete subclass that talks the OpenAI Chat Completions wire format.',
@@ -1240,6 +1266,8 @@ print(llm.invoke("hi").content)`,
     format: 'multi',
     setupMinutes: 1,
     status: 'verified',
+    seoTitle: 'Call any LLM over plain HTTP with curl, no SDK',
+    headline: 'Call AntSeed with curl or raw HTTP',
     oneLiner: 'Hit the proxy with plain HTTP - useful for scripts and debugging.',
     description: [
       'The buyer proxy is a vanilla HTTP server. Anything that can issue an HTTP POST works. Three endpoints are exposed:',

--- a/apps/website/src/pages/integrations.tsx
+++ b/apps/website/src/pages/integrations.tsx
@@ -169,7 +169,7 @@ export default function ConnectHub(): JSX.Element {
             '@type': 'BreadcrumbList',
             itemListElement: [
               {'@type': 'ListItem', position: 1, name: 'Home', item: 'https://antseed.com/'},
-              {'@type': 'ListItem', position: 2, name: 'Integrations', item: 'https://antseed.com/integrations'},
+              {'@type': 'ListItem', position: 2, name: 'Integrations', item: 'https://antseed.com/integrations/'},
             ],
           })}
         </script>

--- a/apps/website/src/pages/vs/openrouter.tsx
+++ b/apps/website/src/pages/vs/openrouter.tsx
@@ -52,7 +52,9 @@ const ROWS: Array<{dim: string; antseed: string; openrouter: string}> = [
   },
 ];
 
-const TITLE = 'OpenRouter Alternative: Permissionless P2P AI Inference | AntSeed';
+// 49 chars. The previous title ran to 65 and truncated in the SERP, losing the
+// end of the phrase Google had to work with.
+const TITLE = 'OpenRouter Alternative: P2P, No Account | AntSeed';
 const DESCRIPTION =
   'AntSeed is a permissionless, peer-to-peer alternative to OpenRouter. Any provider can join. Requests go direct. Pay per request in USDC - no central account.';
 
@@ -64,7 +66,7 @@ export default function VsOpenRouter(): JSX.Element {
         <meta name="description" content={DESCRIPTION} />
         <meta property="og:title" content={TITLE} />
         <meta property="og:description" content={DESCRIPTION} />
-        <link rel="canonical" href="https://antseed.com/vs/openrouter" />
+        <link rel="canonical" href="https://antseed.com/vs/openrouter/" />
         <script type="application/ld+json">
           {JSON.stringify({
             '@context': 'https://schema.org',


### PR DESCRIPTION
Four defects found auditing the live site after the antseed.com cutover. All four are config or copy; no behaviour changes for users.

## 1. Canonical tags and sitemap point at redirects

The host 308-redirects `/path` to `/path/`, but Docusaurus was emitting the pre-redirect form. Net effect: every one of the 59 sitemap URLs was a redirect source, and no page's canonical tag actually resolved to itself.

```
canonical says  https://antseed.com/integrations/claude-code
that URL         308 -> /integrations/claude-code/
sitemap lists    https://antseed.com/integrations/claude-code
```

Fix is `trailingSlash: true`, which makes the emitted URLs match what the host already serves. No URL actually changes. The hardcoded absolute URLs in the JSON-LD blocks and the `/vs/openrouter` canonical are updated to the same form so all three agree.

## 2. Integration pages shipped default titles

Every integration page was using the Docusaurus fallback: `Claude Code | AntSeed`, 21 characters, and an `<h1>` of just the tool name. Adds optional `seoTitle` and `headline` to the `Integration` type, both falling back to `name` so nothing breaks if an entry omits them, and fills both for all ten integrations. Every rendered title now lands in the 50 to 60 character range that displays without truncating.

Meta descriptions were already unique and well written. Untouched.

## 3. /vs/openrouter title was 65 chars

Truncated in results. Now 49.

## 4. Sitemap lastmod was the build date

All 59 URLs carried the same date, so every deploy announced that the entire site had changed. `showLastUpdateTime` on docs, pages and blog sources it from each file's git commit instead.

Caveat worth knowing: this only helps if CI clones with full git history. A shallow clone falls back to build time and nothing improves.

## Verification

- `showLastUpdateTime` confirmed valid on all three plugins by reading the installed option schemas
- `tsc --noEmit` produces no new errors. The 10 that appear are all the pre-existing `Cannot find namespace 'JSX'`, 7 of them in files this branch does not touch
- Title lengths checked programmatically, all 11 in range
- `origin/main` has not touched any of these files since branching, so no conflicts

## Please check before merging

**I could not run a full build.** `apps/website/package-lock.json` is out of sync with `package.json` on `main`: `npm ci` refuses to run (missing `@lobehub/*`, `antd`, `@fontsource-variable/*`, `@hugeicons/*` from the lock, and it pins react 18 against a package.json wanting react 19). Falling back to `npm install` resolves `@docusaurus/core` to 3.10.2 while the plugins stay at 3.9.2, and that skew crashes plugin init with `Cannot read properties of undefined (reading 'mdxCrossCompilerCache')`.

That failure reproduces on unmodified `main` with this branch's config reverted, so it is not caused by these changes. But it does mean a clean-checkout build does not currently work, which is worth a separate look.

So: please confirm CI builds this before merging, and eyeball one integration page and `/vs/openrouter` in the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
