### PR TITLE
fix(api-adapter): keep compaction requests valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed Codex auto-compaction failing on Anthropic-backed routes when the compaction request contained `tool_choice: "auto"` but no tools. Cross-protocol request rendering now omits `tool_choice` whenever no compatible tools remain, preventing LiteLLM and Anthropic from rejecting long-running tasks at the context limit.
 - Fixed the desktop VPR floating pill moving away from the pointer and becoming difficult to click. The pill now uses Electron's native window dragging across its passive surface, with dedicated controls for conversations, shrinking, closing, deposits, and compact expansion.
 - Fixed the desktop app crashing on launch with `ERR_MODULE_NOT_FOUND: Cannot find package '@antseed/protocol'`: the packaged app was missing the `@antseed/protocol` and `@antseed/buyer-core` workspace packages (split out of `@antseed/node` by the protocol extraction), so the main process could not resolve them from the app bundle. Desktop packaging now bundles both packages and builds them as part of the pre-dist pipeline.
 - Fixed buyers classifying unit-billed services (e.g. image generation) as free because their token pricing is zero: the free-usage gate now resolves the same provider + protocol billing route the seller uses, so paid image requests negotiate payment and record verified cost instead of rejecting the seller's usage claims.

--- a/packages/api-adapter/src/canonical.ts
+++ b/packages/api-adapter/src/canonical.ts
@@ -65,6 +65,16 @@ export interface CanonicalLlmRequest {
   cacheBreakpoints?: CanonicalCacheBreakpoints;
 }
 
+function assignToolsAndToolChoice(
+  body: Record<string, unknown>,
+  tools: unknown[] | undefined,
+  toolChoice: unknown,
+): void {
+  if (!tools || tools.length === 0) return;
+  body.tools = tools;
+  if (toolChoice !== undefined) body.tool_choice = toolChoice;
+}
+
 export type CanonicalOutputItem =
   | { type: 'text'; text: string }
   | { type: 'function_call'; id: string; name: string; arguments: Record<string, unknown> | string };
@@ -150,9 +160,8 @@ export function renderCanonicalRequestToOpenAIChatBody(
   if (typeof request.topP === 'number') body.top_p = request.topP;
   if (request.stop !== undefined) body.stop = request.stop;
   const tools = renderCanonicalToolsToOpenAIChat(request.tools);
-  if (tools) body.tools = tools;
   const toolChoice = renderCanonicalToolChoiceToOpenAIChat(request.toolChoice);
-  if (toolChoice !== undefined) body.tool_choice = toolChoice;
+  assignToolsAndToolChoice(body, tools, toolChoice);
   if (request.metadata) body.metadata = request.metadata;
   if (request.user) body.user = request.user;
   // Routes the request to the cache that holds this conversation's prefix.
@@ -206,9 +215,8 @@ export function renderCanonicalRequestToOpenAIResponsesBody(
   if (typeof request.topP === 'number') body.top_p = request.topP;
   if (request.stop !== undefined) body.stop = request.stop;
   const tools = renderCanonicalToolsToOpenAIResponses(request.tools);
-  if (tools) body.tools = tools;
   const toolChoice = renderCanonicalToolChoiceToOpenAIResponses(request.toolChoice);
-  if (toolChoice !== undefined) body.tool_choice = toolChoice;
+  assignToolsAndToolChoice(body, tools, toolChoice);
   if (options.includeMetadata !== false && request.metadata) body.metadata = request.metadata;
   if (options.includeUser !== false && request.user) body.user = request.user;
   if (request.promptCacheKey) body.prompt_cache_key = request.promptCacheKey;
@@ -318,10 +326,9 @@ export function renderCanonicalRequestToAnthropicMessagesBody(request: Canonical
       const lastTool = tools[tools.length - 1];
       if (lastTool) lastTool.cache_control = EPHEMERAL_CACHE_CONTROL;
     }
-    body.tools = tools;
   }
   const toolChoice = renderCanonicalToolChoiceToAnthropic(request.toolChoice);
-  if (toolChoice !== undefined) body.tool_choice = toolChoice;
+  assignToolsAndToolChoice(body, tools, toolChoice);
   if (request.metadata || request.user) {
     body.metadata = {
       ...(request.metadata ?? {}),

--- a/packages/api-adapter/tests/adapter.test.ts
+++ b/packages/api-adapter/tests/adapter.test.ts
@@ -1088,6 +1088,26 @@ describe('transformRequest responses to chat', () => {
     expect(body.tool_choice).toBe('auto');
   });
 
+  it('omits tool_choice when a Codex compaction request has no tools', () => {
+    const request = makeResponsesRequest({
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'gpt-4.1',
+        input: [{
+          role: 'user',
+          content: [{ type: 'input_text', text: 'summarize the conversation' }],
+        }],
+        tools: [],
+        tool_choice: 'auto',
+        parallel_tool_calls: false,
+      })),
+    });
+    const result = transformRequest(request, { from: 'openai-responses', to: 'openai-chat-completions' });
+    const body = JSON.parse(new TextDecoder().decode(result!.request.body)) as Record<string, unknown>;
+
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
+  });
+
   it('omits tools when only built-in Responses tools are provided', () => {
     const request = makeResponsesRequest({
       body: new TextEncoder().encode(JSON.stringify({
@@ -1256,6 +1276,21 @@ describe('transformRequest responses to chat', () => {
 });
 
 describe('transformRequest responses to anthropic', () => {
+  it('omits tool_choice when no tools are available', () => {
+    const result = transformRequest(makeResponsesRequest({
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'gpt-4.1',
+        input: 'summarize the conversation',
+        tools: [],
+        tool_choice: 'auto',
+      })),
+    }), { from: 'openai-responses', to: 'anthropic-messages' });
+    const body = JSON.parse(new TextDecoder().decode(result!.request.body)) as Record<string, unknown>;
+
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
+  });
+
   it('converts responses input, tools, and shared fields to anthropic messages', () => {
     const result = transformRequest(makeResponsesRequest({
       body: new TextEncoder().encode(JSON.stringify({
@@ -1628,6 +1663,26 @@ describe('transformResponse chat to responses', () => {
 });
 
 describe('transformRequest chat to responses', () => {
+  it('omits tool_choice when no tools are available', () => {
+    const request: SerializedHttpRequest = {
+      requestId: 'req-chat-to-resp-no-tools',
+      method: 'POST',
+      path: '/v1/chat/completions',
+      headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'gpt-4.1',
+        messages: [{ role: 'user', content: 'summarize the conversation' }],
+        tools: [],
+        tool_choice: 'auto',
+      })),
+    };
+    const result = transformRequest(request, { from: 'openai-chat-completions', to: 'openai-responses' });
+    const body = JSON.parse(new TextDecoder().decode(result!.request.body)) as Record<string, unknown>;
+
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
+  });
+
   it('preserves shared request fields when converting chat to responses', () => {
     const request: SerializedHttpRequest = {
       requestId: 'req-chat-to-resp',


### PR DESCRIPTION
## Summary
- omit `tool_choice` whenever cross-protocol rendering produces no compatible tools
- apply the invariant consistently to OpenAI Chat Completions, OpenAI Responses, and Anthropic Messages
- add regression coverage for Codex auto-compaction and the other no-tools protocol conversions

## Root cause
Codex auto-compaction constructs a prompt with default tool settings, so the prompt has no tools:
- https://github.com/openai/codex/blob/279b93242cfef379e65da97e87e44b83c5934fd7/codex-rs/core/src/compact.rs#L267-L281

Codex's Responses request builder independently emits `tool_choice: "auto"`:
- https://github.com/openai/codex/blob/279b93242cfef379e65da97e87e44b83c5934fd7/codex-rs/core/src/client.rs#L926-L933

Before this fix, AntSeed removed the empty `tools` array during protocol rendering but retained `tool_choice`, producing an invalid downstream combination. Anthropic-backed LiteLLM routes then rejected the request with `UnsupportedParamsError: Anthropic doesn't support tool calling without tools=`.

The adapter is the correct fix boundary: tool compatibility is decided during buyer-side cross-protocol rendering, so the renderer that drops all tools must also drop their dependent selection policy. Adding a dummy tool or enabling LiteLLM `modify_params` would mask the malformed payload downstream and would require every seller to compensate.

## Verification
- `pnpm run build`
- `pnpm run typecheck`
- `pnpm run test` — all workspace suites passed, including 68 e2e tests
- `pnpm --filter @antseed/api-adapter test` — 113 tests passed
- `pnpm --filter @antseed/api-adapter typecheck`
- `pnpm --filter @antseed/api-adapter build`
- `git diff --check origin/main --`

## Live reproduction
Started the CLI built from this branch as the local buyer on `127.0.0.1:8377` and sent a Codex compaction-shaped `/v1/responses` request to an Anthropic-backed `claude-opus-5` route:

```json
{
  "input": [{"role":"user","content":[{"type":"input_text","text":"Reply with exactly: compaction-ok"}]}],
  "tools": [],
  "tool_choice": "auto",
  "stream": false,
  "store": false
}
```

Result: HTTP 200, `status: "completed"`, `model: "claude-opus-5"`, `output_text: "compaction-ok"`, and no `UnsupportedParamsError` signature.

## Change type
Buyer-side protocol adapter fix. Seller/LiteLLM behavior is unchanged.
