### PR TITLE
fix(desktop): point VPR help docs links at published docs slugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed three "Read more in the docs" links in the desktop VPR Help view opening 404 pages (`/docs/getting-started/intro`, `/docs/getting-started/configuration`, `/docs/guides/pricing`). They now point at the docs' published slugs (`/docs/`, `/docs/config`, `/docs/pricing`).
 - Fixed Codex auto-compaction failing on Anthropic-backed routes when the compaction request contained `tool_choice: "auto"` but no tools. Cross-protocol request rendering now omits `tool_choice` whenever no compatible tools remain, preventing LiteLLM and Anthropic from rejecting long-running tasks at the context limit.
 - Fixed the desktop VPR floating pill moving away from the pointer and becoming difficult to click. The pill now uses Electron's native window dragging across its passive surface, with dedicated controls for conversations, shrinking, closing, deposits, and compact expansion.
 - Fixed the desktop app crashing on launch with `ERR_MODULE_NOT_FOUND: Cannot find package '@antseed/protocol'`: the packaged app was missing the `@antseed/protocol` and `@antseed/buyer-core` workspace packages (split out of `@antseed/node` by the protocol extraction), so the main process could not resolve them from the app bundle. Desktop packaging now bundles both packages and builds them as part of the pre-dist pipeline.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed VPR",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/renderer/ui/components/views/VprHelpView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprHelpView.tsx
@@ -52,7 +52,7 @@ const HELP_TOPICS: HelpTopic[] = [
             body: 'The power button on the main screen starts and stops the router. The status strip at the bottom shows network health, your port, and how many peers and services are currently visible.',
           },
         ],
-        docsPath: '/getting-started/intro',
+        docsPath: '/',
       },
       {
         key: 'models',
@@ -68,7 +68,7 @@ const HELP_TOPICS: HelpTopic[] = [
             body: 'Prefer a specific seller? Tap it in the sellers list to pin it. Pinned sellers stay fixed until you unpin them from the model page or Preferences.',
           },
         ],
-        docsPath: '/guides/pricing',
+        docsPath: '/pricing',
       },
       {
         key: 'apps',
@@ -84,7 +84,7 @@ const HELP_TOPICS: HelpTopic[] = [
             body: 'Each connected app shows a pill on the main screen. The pop-out button detaches a small floating window you can keep above the app you are working in.',
           },
         ],
-        docsPath: '/getting-started/configuration',
+        docsPath: '/config',
       },
       {
         key: 'float',
@@ -132,7 +132,7 @@ const HELP_TOPICS: HelpTopic[] = [
             body: 'Turning Auto select off pauses routing decisions everywhere — connected apps stay on their last picked seller.',
           },
         ],
-        docsPath: '/guides/pricing',
+        docsPath: '/pricing',
       },
     ],
   },
@@ -170,7 +170,7 @@ const HELP_TOPICS: HelpTopic[] = [
             body: 'If the app was already running with its own API settings, check it is not overriding the base URL AntSeed configured.',
           },
         ],
-        docsPath: '/getting-started/configuration',
+        docsPath: '/config',
       },
       {
         key: 'trust-ca',


### PR DESCRIPTION
## Description

Three "Read more in the docs" links in the desktop VPR Help view opened 404 pages because they used the docs' file paths instead of their published Docusaurus slugs:

- `/docs/getting-started/intro` → `/docs/`
- `/docs/getting-started/configuration` → `/docs/config`
- `/docs/guides/pricing` → `/docs/pricing`

All other external links in the desktop app (help view, chat system prompt, payment portal, legal links including the privacy anchor) were audited against the live site and return 200.

Also bumps the desktop app to 0.2.12.

## Changelog

User-facing fix — CHANGELOG.md updated under Unreleased → Fixed.