### PR TITLE
docs(website): document gasless buyer sweep command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- Website docs now cover the gasless `antseed buyer sweep` command: a CLI-reference entry plus a payments-guide section explaining the offline EIP-3009 authorization, the fixed USDC relay fee, broadcast via a running buyer daemon or an ephemeral node, amount clamping to credit-limit headroom, and the first-deposit minimum. The guide also gained a provider note on relaying sweeps for the fee (`relayer.enabled`, `relayer.minProfitBaseUnits`) and the `AntseedDepositRelay` address in the Base Mainnet contract table.
+
 - Desktop: added seller-assisted channel closing to Activity for sellers advertising `payments.cooperative-close.v1`, with clear rejection feedback and the existing wallet-based on-chain close retained as a permanent fallback.
 
 - Discovery metadata v12 widens service catalog and per-service map counts to support up to 512 services per provider. Metadata now allows 64 categories and 4 API protocols per service, a 128 KiB signed binary snapshot, and a bounded 256 KiB HTTP metadata response. Buyers remain compatible with v10/v11 sellers, while sellers validate the same limits before announcing.

--- a/apps/website/docs/cli/commands.md
+++ b/apps/website/docs/cli/commands.md
@@ -35,6 +35,7 @@ antseed seller emissions claim        Claim accumulated seller payouts
 antseed buyer start                   Start the buyer proxy
 antseed buyer start --router <name>   Start the buyer proxy with a non-default router
 antseed buyer deposit <amount>        Deposit USDC for payments
+antseed buyer sweep                   Gaslessly sweep hot-wallet USDC into deposits (fixed relay fee)
 antseed buyer withdraw <amount>       Withdraw USDC from deposits
 antseed buyer balance                 Check wallet and deposit balance
 antseed network browse                Browse available services and pricing

--- a/apps/website/docs/guides/payments.md
+++ b/apps/website/docs/guides/payments.md
@@ -31,6 +31,23 @@ The contract's `deposit(buyer, amount)` pulls USDC from your connected wallet an
 Anyone can deposit on behalf of a buyer — a team treasury, a hardware wallet, or another contract. The funding source is decoupled from the node identity.
 :::
 
+### Sweeping Hot-Wallet USDC
+
+If USDC lands in your node's hot wallet (for example after a QR-code transfer), you can move it into your deposits balance without the wallet ever holding ETH:
+
+```bash
+antseed buyer sweep
+```
+
+The CLI signs an EIP-3009 authorization offline and broadcasts it over the P2P network. A permissionless relayer submits the transaction, pays the gas, and keeps a fixed USDC fee ($0.05 on Base Mainnet); the rest is credited to your deposits balance. If a buyer daemon (`antseed buyer start`) is running, the request goes out over its existing seller connections — otherwise the CLI joins the network with a temporary node.
+
+| Option | Purpose |
+|---|---|
+| `--amount <usdc>` | Amount to sweep (default: full hot-wallet balance, clamped to your credit-limit headroom) |
+| `--timeout <secs>` | How long to wait for on-chain confirmation (default: 120) |
+
+The swept amount must exceed the fixed relay fee, and a first-ever deposit must net at least 1 USDC after the fee. Your funds never move unless a relayer lands the transaction — the authorization simply expires after an hour.
+
 ### Checking Balance
 
 ```bash
@@ -87,6 +104,10 @@ antseed seller start
 
 For a one-off run, use `antseed seller start --base-rpc-url <url>`. For durable config, set `payments.crypto.rpcUrl` in `~/.antseed/config.json`.
 
+### Relaying Deposit Sweeps
+
+Sellers relay buyer deposit sweeps by default: the node verifies and simulates each incoming sweep request, submits it on-chain, and earns the fixed relay fee (minus gas). Opt out with `relayer.enabled: false` in your config, or tune the profitability floor with `relayer.minProfitBaseUnits`.
+
 ### Staking
 
 Providers must stake a minimum of $10 USDC to participate:
@@ -123,6 +144,7 @@ antseed seller emissions info
 | AntseedDeposits | `0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2` |
 | AntseedChannels | `0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d` |
 | AntseedStaking | `0x3652E6B22919bd322A25723B94BB207602E5c8e6` |
+| AntseedDepositRelay | `0x34a44542e76f9b4cff3a31902eDF14AbF2C3B3DD` |
 | AntseedEmissionsV2 | `0xF13bE52c4A3afC6AE29536f073588d01A0564088` |
 | ANTSToken | `0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263` |
 


### PR DESCRIPTION
## Description

Documents the `antseed buyer sweep` command (shipped in the 2026-07-16 gasless deposit sweep release), which was previously absent from the website docs: buyers can gaslessly move hot-wallet USDC into their deposits balance via permissionless relayers, without the wallet ever holding ETH.

## Changes

- **CLI reference** (`docs/cli/commands.md`): `antseed buyer sweep` added to the buyer command list between `deposit` and `withdraw`.
- **Payments guide** (`docs/guides/payments.md`):
  - New "Sweeping Hot-Wallet USDC" section under For Buyers: offline EIP-3009 authorization broadcast over P2P, relayer pays gas and keeps the fixed $0.05 fee, routing through a running buyer daemon with an ephemeral-node fallback, `--amount` / `--timeout` options, fee/first-deposit/credit-limit constraints, and the one-hour authorization expiry.
  - New "Relaying Deposit Sweeps" section under For Providers: sellers relay sweeps by default and earn the fee; opt out with `relayer.enabled: false` or tune `relayer.minProfitBaseUnits`.
  - `AntseedDepositRelay` (`0x34a44542e76f9b4cff3a31902eDF14AbF2C3B3DD`) added to the Base Mainnet contract table.
- **CHANGELOG.md**: entry added under Unreleased → Added.

## Verification

- `docusaurus build` passes.
- Command name, options, defaults, and constraints checked against `apps/cli/src/cli/commands/buyer/sweep.ts`; relayer config keys against `apps/cli/src/config/types.ts`; the relay address against the `base-mainnet` preset in `packages/node/src/payments/chain-config.ts`.