### PR TITLE
fix(openai): Classify Venice image models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- OpenAI-compatible sellers now recognize Venice image-generation model families such as Flux, Qwen Image, Nano Banana, Recraft, Seedream, and Krea as `openai-images` services, so they advertise image output capabilities and route through image endpoints instead of Chat Completions.
 - Fixed three "Read more in the docs" links in the desktop VPR Help view opening 404 pages (`/docs/getting-started/intro`, `/docs/getting-started/configuration`, `/docs/guides/pricing`). They now point at the docs' published slugs (`/docs/`, `/docs/config`, `/docs/pricing`).
 - Fixed Codex auto-compaction failing on Anthropic-backed routes when the compaction request contained `tool_choice: "auto"` but no tools. Cross-protocol request rendering now omits `tool_choice` whenever no compatible tools remain, preventing LiteLLM and Anthropic from rejecting long-running tasks at the context limit.
 - Fixed the desktop VPR floating pill moving away from the pointer and becoming difficult to click. The pill now uses Electron's native window dragging across its passive surface, with dedicated controls for conversations, shrinking, closing, deposits, and compact expansion.

--- a/packages/provider-core/src/config-utils.test.ts
+++ b/packages/provider-core/src/config-utils.test.ts
@@ -1,6 +1,46 @@
 import { describe, expect, it } from 'vitest';
 import { MAX_SERVICES_PER_PROVIDER } from '@antseed/node';
-import { parseServiceCapabilitiesJson, parseServiceUnitBillingModelsJson } from './config-utils.js';
+import { isImageModelId, parseServiceCapabilitiesJson, parseServiceUnitBillingModelsJson } from './config-utils.js';
+
+describe('isImageModelId', () => {
+  it.each([
+    'gpt-image-2',
+    'openai/gpt-image-1-5',
+    'dall-e-3',
+    'grok-imagine-image-2-0',
+    'venice-sd35',
+    'krea-2-turbo',
+    'krea-v2-large',
+    'flux-2-pro',
+    'hunyuan-image-v3',
+    'ideogram-v4',
+    'imagineart-1.5-pro',
+    'luma-uni-1-max',
+    'nano-banana-pro',
+    'recraft-v4-pro',
+    'seedream-v5-lite',
+    'qwen-image-3-pro',
+    'wan-2-7-pro-text-to-image',
+    'lustify-v8',
+    'wai-Illustrious',
+    'z-image-turbo',
+    'chroma',
+  ])('recognizes image model %s', (model) => {
+    expect(isImageModelId(model)).toBe(true);
+  });
+
+  it.each([
+    'gpt-5.5',
+    'flux-capacitor-chat',
+    'qwen3-vl-235b',
+    'recraft-v3-text',
+    'seedream-chat',
+    'acme/chroma-chat',
+    'my-flux-2-pro-wrapper',
+  ])('does not classify text model %s as an image model', (model) => {
+    expect(isImageModelId(model)).toBe(false);
+  });
+});
 
 describe('parseServiceUnitBillingModelsJson', () => {
   it('rejects unknown service API protocol keys', () => {

--- a/packages/provider-core/src/config-utils.ts
+++ b/packages/provider-core/src/config-utils.ts
@@ -207,7 +207,14 @@ export function buildServiceApiProtocols(
  * Well-known image-generation model families. Shared by the openai plugin's
  * protocol classification and the seller setup wizard's capability prompts so
  * "what counts as an image model" cannot drift between the two.
+ *
+ * Match the final path segment so namespaced model IDs such as
+ * `venice/flux-2-pro` work without treating an unrelated namespace as a model
+ * family. Keep generic one-word IDs exact to avoid false positives.
  */
+const IMAGE_MODEL_ID_PATTERN = /^(?:gpt-image-|dall-e(?:-|$)|grok-imagine-image(?:-|$)|venice-sd35$|krea-(?:2-|v2-)|flux-2-|hunyuan-image-|ideogram-v4(?:-|$)|imagineart-|luma-uni-|nano-banana-|recraft-v4(?:-|$)|seedream-v[45](?:-|$)|qwen-image(?:-|$)|wan-2-7(?:-pro)?-text-to-image$|lustify-|wai-illustrious$|z-image-|chroma$)/;
+
 export function isImageModelId(model: string): boolean {
-  return /(^|\/)(gpt-image-|dall-e|grok-imagine-image)/.test(model.trim().toLowerCase());
+  const modelId = model.trim().toLowerCase().split('/').pop() ?? '';
+  return IMAGE_MODEL_ID_PATTERN.test(modelId);
 }

--- a/plugins/provider-openai/src/index.test.ts
+++ b/plugins/provider-openai/src/index.test.ts
@@ -184,15 +184,27 @@ describe('provider-openai plugin', () => {
     });
   });
 
-  it('advertises grok imagine services as openai-images', async () => {
+  it('advertises supported image model families as openai-images', async () => {
+    const imageServices = [
+      'grok-imagine-image',
+      'grok-imagine-image-quality',
+      'venice-sd35',
+      'flux-2-pro',
+      'krea-v2-large',
+      'nano-banana-pro',
+      'qwen-image-3-pro',
+      'wan-2-7-pro-text-to-image',
+    ];
     const provider = await plugin.createProvider({
       OPENAI_API_KEY: 'sk-test-key',
-      OPENAI_BASE_URL: 'https://api.x.ai',
-      ANTSEED_ALLOWED_SERVICES: 'grok-imagine-image,grok-imagine-image-quality',
+      OPENAI_BASE_URL: 'https://api.venice.ai/api',
+      ANTSEED_ALLOWED_SERVICES: imageServices.join(','),
     });
 
-    expect(provider.serviceApiProtocols?.['grok-imagine-image']).toEqual(['openai-images']);
-    expect(provider.serviceApiProtocols?.['grok-imagine-image-quality']).toEqual(['openai-images']);
+    for (const service of imageServices) {
+      expect(provider.serviceApiProtocols?.[service]).toEqual(['openai-images']);
+      expect(provider.serviceCapabilities?.[service]).toEqual({ outputs: ['image'] });
+    }
   });
 
   it('does not advertise image services for openrouter flavor yet', async () => {


### PR DESCRIPTION
## Description

Expands the shared image-model classifier to recognize Venice image-generation families such as Flux, Qwen Image, Nano Banana, Recraft, Seedream, Krea, and others. OpenAI-compatible sellers now advertise these models with the `openai-images` protocol and image output capabilities instead of treating them as Chat Completions services.

## Release Notes

- Fixed Venice image models being advertised as text chat services instead of image-generation services.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation
- [x] I have added tests
- [x] Lint and unit tests pass locally with my changes

## Validation

- `pnpm --filter @antseed/provider-core test`
- `pnpm --filter @antseed/provider-core typecheck`
- `pnpm --filter @antseed/provider-core build`
- `pnpm --filter @antseed/provider-openai test`
- `pnpm --filter @antseed/provider-openai typecheck`
- `pnpm --filter @antseed/provider-openai build`
