### PR TITLE
fix(payments): Attribute image spending metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed image SpendingAuth service attribution when a budget/headroom authorization races ahead of the delivered response. Headroom-only messages no longer consume the request accounting slot, and the eventual image charge is attributed exactly once to the requested service with one request and zero synthetic text tokens.
 - OpenAI-compatible sellers now recognize Venice image-generation model families such as Flux, Qwen Image, Nano Banana, Recraft, Seedream, and Krea as `openai-images` services, so they advertise image output capabilities and route through image endpoints instead of Chat Completions.
 - Fixed three "Read more in the docs" links in the desktop VPR Help view opening 404 pages (`/docs/getting-started/intro`, `/docs/getting-started/configuration`, `/docs/guides/pricing`). They now point at the docs' published slugs (`/docs/`, `/docs/config`, `/docs/pricing`).
 - Fixed Codex auto-compaction failing on Anthropic-backed routes when the compaction request contained `tool_choice: "auto"` but no tools. Cross-protocol request rendering now omits `tool_choice` whenever no compatible tools remain, preventing LiteLLM and Anthropic from rejecting long-running tasks at the context limit.

--- a/packages/buyer-core/src/buyer-payment-manager.ts
+++ b/packages/buyer-core/src/buyer-payment-manager.ts
@@ -25,7 +25,12 @@ import { peerIdToAddress, type PeerId } from '@antseed/protocol/peer-id';
 import type { SellerAddressResolver } from './seller-address-resolver.js';
 import type { PeerMetadata } from '@antseed/protocol/peer-metadata';
 import { BuyerChannelStore, CHANNEL_ROLE, CHANNEL_STATUS, type StoredChannel } from './channel-store-types.js';
-import { advanceUsageMetadata, CountedRequestTracker, RequestServiceTracker } from './channel-usage-accounting.js';
+import {
+  advanceUsageMetadata,
+  CountedRequestTracker,
+  normalizeRequestUsageDelta,
+  RequestServiceTracker,
+} from './channel-usage-accounting.js';
 import {
   estimateCostFromBytes,
   computeCostUsdc,
@@ -103,11 +108,11 @@ interface StoredBuyerRequestBillingEntry extends BuyerRequestBillingEntry {
  * One request's newly authorized spend, reported as it is signed.
  *
  * Both the buyer-initiated (signPerRequestAuth) and seller-initiated
- * (handleNeedAuth) paths can advance the cumulative for the same request, so
- * a single request may produce more than one event; the amounts are disjoint
- * deltas and sum to the request's total. Token counts follow the same
- * lower-bound rule as metadata attribution — whichever path counts the request
- * first reports the tokens, the other reports zero.
+ * (handleNeedAuth) paths can observe the same request. Only the first path to
+ * account for a delivered response reports its service amount and tokens; a
+ * racing duplicate reports zero usage. Headroom-only authorizations may still
+ * produce an event for the newly signed channel delta without claiming that a
+ * response was delivered.
  */
 export interface BuyerSpendEvent {
   sellerPeerId: string;
@@ -520,9 +525,9 @@ export class BuyerPaymentManager {
 
   /**
    * Both signPerRequestAuth (buyer-initiated) and handleNeedAuth (seller-initiated)
-   * can fire for the same request when the proactive auth doesn't fully cover the
-   * seller's required cumulative. Whichever path counts a request's tokens first
-   * records its requestId here so the other path attributes only the amount delta.
+   * can fire for the same delivered response. Whichever path accounts for the
+   * response first records its requestId here so the other path does not
+   * duplicate its service amount, token totals, or request count.
    */
   private readonly _serviceTokensCounted = new CountedRequestTracker();
 
@@ -1004,21 +1009,19 @@ export class BuyerPaymentManager {
     this._cumulativeAmount.set(sellerPeerId, newAmount);
     const signedDelta = newAmount - prevAmount;
 
-    // Update cumulative metadata
-    // If handleNeedAuth already counted this request (seller-initiated NeedAuth
-    // raced ahead), skip service attribution entirely: service totals are
-    // documented as lower bounds, so undercounting beats double-counting.
+    // Update cumulative metadata. NeedAuth may have counted this response
+    // first, so deduplicate the response's service amount and usage together.
     const alreadyCounted = this._serviceTokensCounted.has(responseStats.requestId);
     const newMeta = this._advanceUsageMetadata(
       this._metadata.get(sellerPeerId),
-      alreadyCounted ? undefined : responseStats.service,
-      {
+      responseStats.service,
+      normalizeRequestUsageDelta({
         amount: signedDelta,
         inputTokens: estimatedInputTokens,
         cachedInputTokens: estimatedCachedInputTokens,
         outputTokens: estimatedOutputTokens,
         requests: 1n,
-      },
+      }, { deliveredResponse: true, alreadyCounted }),
     );
     if (!alreadyCounted) this._serviceTokensCounted.mark(responseStats.requestId);
     this._metadata.set(sellerPeerId, newMeta);
@@ -1278,30 +1281,29 @@ export class BuyerPaymentManager {
 
     debugLog(`[BuyerPayment] NeedAuth: channel=${session.sessionId.slice(0, 18)}... required=${requiredCumulativeAmount} effective=${effectiveAmount}`);
 
-    // Advance cumulative metadata. requestCount always increments so the
-    // on-chain metadata stays consistent even when older sellers omit token
-    // fields; absent token fields contribute 0 to the running totals.
+    // Only NeedAuth frames with response cost/usage evidence represent a
+    // completed request. Budget-exhausted/headroom frames can advance the
+    // channel authorization, but must not increment request or token usage.
+    const deliveredResponse = payload.lastRequestCost != null || payload.billingUsage != null;
     const signedDelta = effectiveAmount - currentCumulative;
     const serviceAmountDelta = acceptedServiceCost > 0n
       ? (acceptedServiceCost < signedDelta ? acceptedServiceCost : signedDelta)
       : 0n;
-    // If signPerRequestAuth already counted this request (buyer-initiated auth
-    // raced ahead but didn't fully cover the seller's required cumulative), skip
-    // service attribution entirely: service totals are documented as lower
-    // bounds, so undercounting beats double-counting.
+    // If post-response signing counted this response first, deduplicate the
+    // response's service amount and usage together.
     const alreadyCounted = this._serviceTokensCounted.has(payload.requestId);
     const newMeta = this._advanceUsageMetadata(
       this._metadata.get(sellerPeerId),
-      alreadyCounted ? undefined : buyerService,
-      {
+      buyerService,
+      normalizeRequestUsageDelta({
         amount: serviceAmountDelta,
         inputTokens: reportedInputTokens,
         cachedInputTokens: reportedCachedInputTokens,
         outputTokens: reportedOutputTokens,
         requests: 1n,
-      },
+      }, { deliveredResponse, alreadyCounted }),
     );
-    if (!alreadyCounted) this._serviceTokensCounted.mark(payload.requestId);
+    if (deliveredResponse && !alreadyCounted) this._serviceTokensCounted.mark(payload.requestId);
     this._metadata.set(sellerPeerId, newMeta);
 
     // Send via PaymentMux
@@ -1311,9 +1313,9 @@ export class BuyerPaymentManager {
         sellerPeerId,
         requestId: payload.requestId ?? null,
         amountUsdc: signedDelta.toString(),
-        inputTokens: (alreadyCounted ? 0n : reportedInputTokens).toString(),
-        cachedInputTokens: (alreadyCounted ? 0n : reportedCachedInputTokens).toString(),
-        outputTokens: (alreadyCounted ? 0n : reportedOutputTokens).toString(),
+        inputTokens: (deliveredResponse && !alreadyCounted ? reportedInputTokens : 0n).toString(),
+        cachedInputTokens: (deliveredResponse && !alreadyCounted ? reportedCachedInputTokens : 0n).toString(),
+        outputTokens: (deliveredResponse && !alreadyCounted ? reportedOutputTokens : 0n).toString(),
       });
       debugLog(`[BuyerPayment] NeedAuth responded: new cumulativeAmount=${effectiveAmount}`);
     } catch {

--- a/packages/buyer-core/src/channel-usage-accounting.test.ts
+++ b/packages/buyer-core/src/channel-usage-accounting.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { getServiceMetadataId, ZERO_METADATA } from '@antseed/protocol/signatures';
+import { advanceUsageMetadata, normalizeRequestUsageDelta } from './channel-usage-accounting.js';
+
+describe('normalizeRequestUsageDelta', () => {
+  const delta = {
+    amount: 25_000n,
+    inputTokens: 11n,
+    cachedInputTokens: 3n,
+    outputTokens: 7n,
+    requests: 1n,
+  };
+
+  it('removes duplicate amount and usage for an already-counted response', () => {
+    expect(normalizeRequestUsageDelta(delta, {
+      deliveredResponse: true,
+      alreadyCounted: true,
+    })).toEqual({
+      amount: 0n,
+      inputTokens: 0n,
+      cachedInputTokens: 0n,
+      outputTokens: 0n,
+      requests: 0n,
+    });
+  });
+
+  it('preserves the first delivered response accounting delta unchanged', () => {
+    expect(normalizeRequestUsageDelta(delta, {
+      deliveredResponse: true,
+      alreadyCounted: false,
+    })).toBe(delta);
+  });
+
+  it('does not count a budget/headroom authorization as a response', () => {
+    expect(normalizeRequestUsageDelta(delta, {
+      deliveredResponse: false,
+      alreadyCounted: false,
+    })).toEqual({
+      amount: 0n,
+      inputTokens: 0n,
+      cachedInputTokens: 0n,
+      outputTokens: 0n,
+      requests: 0n,
+    });
+  });
+});
+
+describe('NeedAuth and post-response metadata accounting', () => {
+  it('attributes an image charge exactly once when both paths report it', () => {
+    const service = 'qwen-image-3-pro';
+    const afterNeedAuth = advanceUsageMetadata(ZERO_METADATA, service, {
+      amount: 25_000n,
+      inputTokens: 0n,
+      cachedInputTokens: 0n,
+      outputTokens: 0n,
+      requests: 1n,
+    });
+    const afterPostResponse = advanceUsageMetadata(
+      afterNeedAuth,
+      service,
+      normalizeRequestUsageDelta({
+        amount: 25_000n,
+        inputTokens: 0n,
+        cachedInputTokens: 0n,
+        outputTokens: 0n,
+        requests: 1n,
+      }, { deliveredResponse: true, alreadyCounted: true }),
+    );
+
+    expect(afterPostResponse).toEqual({
+      cumulativeInputTokens: 0n,
+      cumulativeOutputTokens: 0n,
+      cumulativeRequestCount: 1n,
+      services: [{
+        serviceId: getServiceMetadataId(service),
+        cumulativeAmount: 25_000n,
+        cumulativeInputTokens: 0n,
+        cumulativeCachedInputTokens: 0n,
+        cumulativeOutputTokens: 0n,
+        cumulativeRequestCount: 1n,
+      }],
+    });
+  });
+});

--- a/packages/buyer-core/src/channel-usage-accounting.ts
+++ b/packages/buyer-core/src/channel-usage-accounting.ts
@@ -58,6 +58,25 @@ export class CountedRequestTracker {
   }
 }
 
+export function normalizeRequestUsageDelta(
+  delta: ServiceMetadataDelta,
+  options: { deliveredResponse: boolean; alreadyCounted: boolean },
+): ServiceMetadataDelta {
+  if (options.deliveredResponse && !options.alreadyCounted) return delta;
+
+  // NeedAuth and post-response signing can both report the same request cost.
+  // Once a delivered response has been attributed, the racing path must not
+  // count its amount or usage again. A budget/headroom NeedAuth does not
+  // describe a delivered response at all, so it contributes nothing.
+  return {
+    amount: 0n,
+    inputTokens: 0n,
+    cachedInputTokens: 0n,
+    outputTokens: 0n,
+    requests: 0n,
+  };
+}
+
 export function advanceUsageMetadata(
   previous: SpendingAuthMetadata | undefined,
   service: string | undefined,

--- a/packages/node/tests/buyer-payment-manager.test.ts
+++ b/packages/node/tests/buyer-payment-manager.test.ts
@@ -704,9 +704,65 @@ describe('BuyerPaymentManager', () => {
     expect(services).toEqual([{
       serviceId: id('gpt-5'),
       cumulativeAmount: 0n,
-      cumulativeInputTokens: 1000n,
-      cumulativeCachedInputTokens: 200n,
-      cumulativeOutputTokens: 100n,
+      cumulativeInputTokens: 0n,
+      cumulativeCachedInputTokens: 0n,
+      cumulativeOutputTokens: 0n,
+      cumulativeRequestCount: 0n,
+    }]);
+  });
+
+  it('attributes an image charge after a headroom NeedAuth races ahead of the response', async () => {
+    const sellerPeerId = fakePeerId('seller-image-headroom-race');
+    const service = 'qwen-image-3-pro';
+    const requestId = 'req-image-headroom-race';
+    const unitModel = {
+      version: 1 as const,
+      components: [{ unit: 'output_images' as const, priceUsd: 0.025 }],
+    };
+    const channelId = await manager.authorizeSpending(sellerPeerId, mux, 10_000n);
+    manager.trackRequestBilling(requestId, {
+      context: {
+        sellerPeerId,
+        provider: 'openai',
+        service,
+        serviceApiProtocol: 'openai-images',
+        attributes: { model: service },
+        unitLimits: { output_images: 1 },
+      },
+      requestFacts: { model: service, requestedImages: 1 },
+      unitModel,
+    });
+    mux.sentSpendingAuths.length = 0;
+
+    // This only opens payment headroom. It does not report a delivered image
+    // and therefore must not consume the request's service attribution.
+    await manager.handleNeedAuth(sellerPeerId, {
+      channelId,
+      requestId,
+      requiredCumulativeAmount: '10000',
+      currentAcceptedCumulative: '0',
+      deposit: '1000000',
+    }, mux);
+
+    const { payload } = await manager.signPerRequestAuth(sellerPeerId, {
+      inputBytes: new Uint8Array(0),
+      outputBytes: enc.encode(JSON.stringify({ data: [{ url: 'https://example.test/image.png' }] })),
+      sellerClaimedCost: 25_000n,
+      reportedInputTokens: 0n,
+      reportedCachedInputTokens: 0n,
+      reportedOutputTokens: 0n,
+      unitUsage: { units: { output_images: 1 } },
+      service,
+      requestId,
+    });
+
+    const services = decodeMetadataServices(payload.metadata);
+    expect(services).toEqual([{
+      serviceId: id(service),
+      cumulativeAmount: 25_000n,
+      cumulativeInputTokens: 0n,
+      cumulativeCachedInputTokens: 0n,
+      cumulativeOutputTokens: 0n,
       cumulativeRequestCount: 1n,
     }]);
   });


### PR DESCRIPTION
## Description

Fixes buyer SpendingAuth metadata when a payment-headroom request races ahead of an image response. Headroom-only NeedAuth messages no longer consume the request accounting slot, allowing the delivered image charge to be attributed exactly once to the requested service.

## Release Notes

- Fixed image-generation charges sometimes missing their service amount in signed SpendingAuth metadata when payment headroom was authorized before the response arrived
- Image requests remain recorded using native unit billing with zero synthetic text tokens

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
