### PR TITLE
fix(node): use aes-256-gcm for transport encryption (boringssl compat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Security
 
-- P2P TCP transport is now encrypted end-to-end (`transport.tcp-enc.v1`): a wallet-signed ephemeral X25519 handshake with forward secrecy and mutual peer authentication, ChaCha20-Poly1305 framing for all payload traffic. Enabled automatically between peers that advertise the capability in discovery metadata; once offered, the handshake fails closed rather than downgrading to plaintext, and the intro signature covers the advertised capabilities and encryption offer so an on-path attacker cannot strip them to force a legacy fallback. Legacy peers still connect over plaintext unless the new `requireSecureTransport` node option is set.
+- P2P TCP transport is now encrypted end-to-end (`transport.tcp-enc.v1`): a wallet-signed ephemeral X25519 handshake with forward secrecy and mutual peer authentication, AES-256-GCM framing for all payload traffic. Enabled automatically between peers that advertise the capability in discovery metadata; once offered, the handshake fails closed rather than downgrading to plaintext, and the intro signature covers the advertised capabilities and encryption offer so an on-path attacker cannot strip them to force a legacy fallback. Legacy peers still connect over plaintext unless the new `requireSecureTransport` node option is set.
 - WebRTC signaling now signs SDP descriptions (`transport.signed-sdp.v1`), binding the DTLS certificate fingerprint to the peer's wallet identity so a man-in-the-middle on the signaling socket can no longer substitute its own SDP.
 
 ### Fixed

--- a/docs/protocol/spec/02-transport.md
+++ b/docs/protocol/spec/02-transport.md
@@ -154,7 +154,7 @@ Note: WebRTC DataChannel messages are capped at 256 KiB, which is why encrypted 
 
 - The initiator's `intro` line carries an `enc` offer: an ephemeral X25519 public key signed by the initiator's wallet, bound to the intro envelope's ts/nonce.
 - The responder answers with a single `enc-ack` line: its own signed ephemeral key, whose signature also covers the initiator's nonce (freshness + mutual authentication — the initiator verifies the ack's peerId against the peer it dialed).
-- Session keys: HKDF-SHA256 over the X25519 shared secret, salted with a transcript hash binding both peer ids, both nonces, and both public keys. One ChaCha20-Poly1305 key per direction.
+- Session keys: HKDF-SHA256 over the X25519 shared secret, salted with a transcript hash binding both peer ids, both nonces, and both public keys. One AES-256-GCM key per direction.
 - All subsequent traffic is length-prefixed AEAD frames (`u32be length | ciphertext+tag`) with implicit per-direction counter nonces. Ephemeral keys give forward secrecy.
 - Once an `enc` offer is sent, the handshake fails closed — there is no downgrade to plaintext.
 

--- a/packages/node/src/p2p/secure-channel.ts
+++ b/packages/node/src/p2p/secure-channel.ts
@@ -1,8 +1,13 @@
 /**
  * Encrypted TCP transport (transport.tcp-enc.v1): wallet-signed ephemeral
- * X25519 handshake, HKDF-SHA256 with transcript-bound salt, one
- * ChaCha20-Poly1305 key per direction, length-prefixed frames with implicit
- * counter nonces (safe: per-direction keys, TCP ordering).
+ * X25519 handshake, HKDF-SHA256 with transcript-bound salt, one AES-256-GCM
+ * key per direction, length-prefixed frames with implicit counter nonces
+ * (safe: per-direction keys, TCP ordering).
+ *
+ * AES-256-GCM (not ChaCha20-Poly1305) because it is registered in both OpenSSL
+ * and BoringSSL; the desktop app runs the node under Electron's BoringSSL,
+ * which does not expose chacha20-poly1305 via createCipheriv ("Unknown
+ * cipher").
  */
 
 import {
@@ -16,7 +21,7 @@ import {
   type KeyObject,
 } from "node:crypto";
 
-const AEAD_ALGORITHM = "chacha20-poly1305";
+const AEAD_ALGORITHM = "aes-256-gcm";
 const AEAD_TAG_BYTES = 16;
 const FRAME_HEADER_BYTES = 4;
 export const MAX_FRAME_PLAINTEXT_BYTES = 16 * 1024 * 1024;

--- a/packages/node/tests/secure-channel.test.ts
+++ b/packages/node/tests/secure-channel.test.ts
@@ -1,3 +1,4 @@
+import { getCiphers } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import {
   FrameDecryptor,
@@ -128,5 +129,12 @@ describe('secure channel', () => {
 
   it('hashes sdp strings deterministically', () => {
     expect(sha256Hex('abc')).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+  });
+
+  it('uses a cipher available in both OpenSSL and BoringSSL', () => {
+    // The desktop app runs the node under Electron's BoringSSL, which does not
+    // register chacha20-poly1305 via createCipheriv ("Unknown cipher").
+    // aes-256-gcm is registered in both; regression guard for that break.
+    expect(getCiphers()).toContain('aes-256-gcm');
   });
 });

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -59,7 +59,7 @@ export const CONNECTION_CAPABILITY_COOPERATIVE_CLOSE_V1 = 'payments.cooperative-
 export const CONNECTION_CAPABILITY_MODEL_HEALTH_V1 = 'seller.model-health.v1' as const;
 /** Peer signs WebRTC SDP over the signaling socket (DTLS fingerprint binding). */
 export const CONNECTION_CAPABILITY_SIGNED_SDP_V1 = 'transport.signed-sdp.v1' as const;
-/** Peer supports the encrypted TCP transport handshake (X25519 + ChaCha20-Poly1305). */
+/** Peer supports the encrypted TCP transport handshake (X25519 + AES-256-GCM). */
 export const CONNECTION_CAPABILITY_TCP_ENC_V1 = 'transport.tcp-enc.v1' as const;
 /** Peer has a working WebRTC stack and accepts `hello` signaling. */
 export const CONNECTION_CAPABILITY_WEBRTC_V1 = 'transport.webrtc.v1' as const;


### PR DESCRIPTION
## Description

The desktop app fails encrypted P2P requests with `502 P2P request failed: Unknown cipher`. The encrypted TCP transport used `chacha20-poly1305`, which Node's `createCipheriv` supports under OpenSSL but not under Electron's BoringSSL — and the packaged desktop runs the buyer node under Electron's runtime. Dev, CI, and e2e all use system Node (OpenSSL), so this only surfaced in packaged builds.

Switches the AEAD cipher to `aes-256-gcm`, which is registered in both OpenSSL and BoringSSL. The frame format is unchanged (32-byte key, 12-byte IV, 16-byte tag), so this is a drop-in swap; AES-256-GCM is equally strong and the TLS 1.3 default. No interop cost — the encrypted transport has not shipped to npm yet, and deployed sellers still run plaintext.

Adds a regression test asserting the chosen cipher is one both SSL backends expose. Docs/changelog updated to name AES-256-GCM.