### PR TITLE
docs: correct channel timeout close API

### DIFF
--- a/apps/website/docs/faq.mdx
+++ b/apps/website/docs/faq.mdx
@@ -266,7 +266,7 @@ Providers set their own prices. The routing layer scores all available providers
 
 ### How do providers get paid?
 
-Buyers pre-deposit USDC into the on-chain AntseedDeposits contract. Each session is authorized by an EIP-712 ReserveAuth that caps the seller's charge. The seller calls `reserve()` on AntseedChannels to lock funds. During the session, the buyer signs cumulative SpendingAuth messages that authorize spending. The seller calls `close()` with the buyer's latest SpendingAuth to settle and release remaining funds. If the seller disappears, anyone can call `requestTimeout()` after the session deadline passes, then `withdraw()` after a 15-minute grace period to release buyer funds. No invoicing, no monthly billing — automatic settlement per session.
+Buyers pre-deposit USDC into the on-chain AntseedDeposits contract. Each session is authorized by an EIP-712 ReserveAuth that caps the seller's charge. The seller calls `reserve()` on AntseedChannels to lock funds. During the session, the buyer signs cumulative SpendingAuth messages that authorize spending. The seller calls `close()` with the buyer's latest SpendingAuth to settle and release remaining funds. If the seller disappears, the buyer (or their deposits operator) calls `requestClose()`, then `withdraw()` after a 15-minute grace period to release remaining funds. No invoicing, no monthly billing — automatic settlement per session.
 
 ### Are seller ANTS incentives claimable now?
 

--- a/apps/website/docs/guides/payments.md
+++ b/apps/website/docs/guides/payments.md
@@ -154,7 +154,7 @@ All contracts verified on [BaseScan](https://basescan.org). For testnet (Base Se
 
 If a provider disappears mid-session, the buyer's funds are not lost:
 
-1. After the session deadline passes, anyone can call `requestTimeout()`
-2. After a 15-minute grace period, the buyer calls `withdraw()` to release locked funds
+1. The buyer (or their deposits operator) calls `requestClose()` on AntseedChannels — callable anytime while the channel is active
+2. After a 15-minute grace period (so the seller can still submit a final SpendingAuth), the buyer calls `withdraw()` to release remaining locked funds back to their deposit
 
-This is handled automatically by the protocol.
+If the seller is still online, the buyer can instead request a cooperative close and skip the grace period. Desktop and CLI expose both paths.

--- a/docs/protocol/spec/04-payments.md
+++ b/docs/protocol/spec/04-payments.md
@@ -30,10 +30,9 @@ BUYER                              SELLER                           ON-CHAIN
   │                                  │    releases remaining lock     │   session finalized
   │                                  │                                │
   │  === TIMEOUT (seller gone) ====  │                                │
-  │                                  │   (deadline passes)            │
-  │   anyone ── requestTimeout() ──────────────────────────────────── ►│ ← marks timed out
+  │   buyer ── requestClose() ─────────────────────────────────────── ►│ ← starts grace period
   │   (15min grace)                  │                                │
-  │   anyone ── withdraw() ────────────────────────────────────────── ►│ ← funds returned
+  │   buyer ── withdraw() ─────────────────────────────────────────── ►│ ← funds returned
 ```
 
 ### Reserve
@@ -52,7 +51,7 @@ The seller calls `settle()` with the latest SpendingAuth to charge the cumulativ
 
 ### Timeout
 
-If the seller disappears after the deadline, anyone can call `requestTimeout()`. After a 15-minute grace period, `withdraw()` releases the locked funds back to the buyer's deposit.
+If the seller disappears, the buyer (or their deposits operator) calls `requestClose()` anytime while the channel is active. After a 15-minute grace period, the buyer calls `withdraw()` to release remaining locked funds back to their deposit.
 
 ### Cooperative close (buyer-requested)
 
@@ -92,7 +91,7 @@ The seller agrees only when it is **not mid-accumulation** with that buyer:
   `pending_auth` plus `requiredCumulativeAmount`. The buyer signs and retries.
 
 Rejections are normal outcomes, not errors — the channel is left untouched and
-the buyer can retry or fall back to `requestTimeout()`. When neither side holds
+the buyer can retry or fall back to `requestClose()`. When neither side holds
 a usable auth the seller closes at the current on-chain `settled` amount with an
 empty signature, which the contract accepts without signature verification
 (`finalAmount == settled`) and which claims no unproven spend.

--- a/docs/protocol/spec/06-security-overview.md
+++ b/docs/protocol/spec/06-security-overview.md
@@ -65,7 +65,7 @@ The buyer-seller flow enforces:
 - Per request: buyer signs EIP-712 SpendingAuth (channelId, cumulativeAmount, metadataHash).
 - Seller submits latest SpendingAuth to settle() or close() on-chain.
 - On buyer disconnect: seller calls close() with last SpendingAuth to finalize.
-- On seller disappearance: requestTimeout() (permissionless after deadline) + withdraw() after 15min grace.
+- On seller disappearance: buyer/operator requestClose() + withdraw() after 15min grace.
 - Channels contract holds no USDC — all funds managed by AntseedDeposits.
 
 ## 4. Cryptographic Control Plane

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -77,9 +77,9 @@ Session lifecycle with EIP-712 ReserveAuth + SpendingAuth. Holds NO USDC — all
 - `settle(bytes32 channelId, uint128 amount, bytes calldata metadata, bytes calldata buyerSig)` — validates SpendingAuth, calls Deposits.chargeAndCreditPayouts(), session stays open
 - `close(bytes32 channelId, uint128 amount, bytes calldata metadata, bytes calldata buyerSig)` — like settle but finalizes session, releases remaining lock
 
-**Timeout (permissionless):**
-- `requestTimeout(bytes32 channelId)` — after deadline, marks session timed out
-- `withdraw(bytes32 channelId)` — after 15min grace, releases locked funds to buyer
+**Timeout (buyer/operator):**
+- `requestClose(bytes32 channelId)` — buyer/operator, anytime while active; starts grace period
+- `withdraw(bytes32 channelId)` — after 15min grace, releases remaining locked funds to buyer deposit
 
 **EIP-712 types (domain: name="AntseedChannels", version="7"):**
 ```
@@ -176,7 +176,7 @@ All constants are configurable by the contract owner via dedicated setter functi
 |---|---|---|
 | `MIN_BUYER_DEPOSIT` | 10 USDC | Minimum deposit to participate |
 | `MIN_SELLER_STAKE` | 10 USDC | Minimum stake to accept sessions |
-| `TIMEOUT_GRACE_PERIOD` | 15 min | Grace period after requestTimeout before withdraw |
+| `TIMEOUT_GRACE_PERIOD` | 15 min | Grace period after requestClose before withdraw |
 | `PLATFORM_FEE_BPS` | 500 (5%) | Platform fee in basis points |
 | `MAX_PLATFORM_FEE_BPS` | 1000 (10%) | Maximum platform fee |
 


### PR DESCRIPTION
## Summary

- Fix outdated timeout protection docs that still referenced `requestTimeout()` and permissionless post-deadline close
- Document the real flow: buyer/operator `requestClose()` anytime → 15-minute grace → `withdraw()`
- Note cooperative close as the faster path when the seller is online

## Test plan

- [ ] Spot-check website payments guide Timeout Protection section
- [ ] Spot-check FAQ payment settlement answer
- [ ] Confirm protocol payment/security specs and contracts README match `AntseedChannels.requestClose` / `withdraw`