### PR TITLE
fix(provider): Skip image body injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Provider body injection configured for OpenAI-compatible chat requests no longer leaks into `/v1/images/*` requests, preventing strict image-generation upstreams from rejecting otherwise valid payloads.
 - Conversations can now switch from a Chat Completions-backed model to a native OpenAI Responses model without failing on incompatible synthetic message IDs. Existing affected histories are repaired narrowly on continuation, while native Responses conversations remain byte-for-byte passthrough so cache keys, response chaining, encrypted reasoning, and prompt history are preserved.
 - Documentation, integration guides, buyer skills, and CLI/Desktop help now consistently describe model-only routing through the network-wide `/v1/models` catalog, shared Price + Trust preferences, soft conversation affinity, retry fallback, and persistent explicit peer pins. Automatic routes use catalog model IDs, while `<peerId>@<serviceId>` is reserved for explicitly selecting a seller offer.
 - Buyer conversations now retain the actual seller selected for each request, softly prefer that seller on later turns with automatic failover, and expose routed seller names in Desktop only when the existing Show routed peer preference is enabled.

--- a/packages/provider-core/src/http-relay.test.ts
+++ b/packages/provider-core/src/http-relay.test.ts
@@ -101,6 +101,34 @@ describe('HttpRelay', () => {
     expect(responses[0]!.statusCode).toBe(200);
   });
 
+  it('does not inject chat-only fields into image requests', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+    const relay = new HttpRelay(
+      makeConfig({
+        allowedServices: ['venice-sd35'],
+        injectJsonFields: {
+          venice_parameters: { include_venice_system_prompt: false },
+        },
+      }),
+      { onResponse: () => undefined },
+    );
+
+    await relay.handleRequest(makeRequest({
+      path: '/v1/images/generations',
+      body: new TextEncoder().encode(JSON.stringify({
+        model: 'venice-sd35',
+        prompt: 'A seedling',
+      })),
+    }));
+
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const upstreamBody = JSON.parse(
+      new TextDecoder().decode(options.body as Uint8Array),
+    ) as Record<string, unknown>;
+    expect(upstreamBody).toEqual({ model: 'venice-sd35', prompt: 'A seedling' });
+  });
+
   it('rewrites announced service names to upstream service IDs before relay', async () => {
     fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
 

--- a/packages/provider-core/src/http-relay.ts
+++ b/packages/provider-core/src/http-relay.ts
@@ -203,7 +203,8 @@ export class HttpRelay {
             }
           }
 
-          const merged = this._config.injectJsonFields
+          const isImageRequest = request.path.toLowerCase().startsWith('/v1/images/');
+          const merged = this._config.injectJsonFields && !isImageRequest
             ? deepMerge(transformed, this._config.injectJsonFields)
             : transformed;
 


### PR DESCRIPTION
## Description

Prevents `OPENAI_BODY_INJECT_JSON` fields intended for chat-compatible upstreams from being merged into `/v1/images/*` request bodies. Image payload normalization and service rewriting continue unchanged.

Fixes #835

## Release Notes

- Image-generation requests are no longer rejected by strict upstreams because of chat-only injected fields.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
- [x] I have updated the changelog for user-facing changes
