### PR TITLE
chore: bump versions for npm release

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.149",
+  "version": "0.1.150",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [

--- a/apps/payments/package.json
+++ b/apps/payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/payments",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Buyer payments portal for AntSeed",
   "files": [
     "dist"

--- a/packages/api-adapter/package.json
+++ b/packages/api-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/api-adapter",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "HTTP-level format translation between LLM API protocols (Anthropic Messages, OpenAI Chat Completions, OpenAI Responses)",
   "type": "module",
   "files": [

--- a/packages/buyer-core/package.json
+++ b/packages/buyer-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/buyer-core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Transport-agnostic AntSeed buyer machinery: request handling, payment negotiation, channel accounting. Portable — no Node-only dependencies",
   "type": "module",
   "files": [

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/node",
-  "version": "0.2.111",
+  "version": "0.2.112",
   "description": "Antseed Network protocol SDK — P2P inference marketplace",
   "type": "module",
   "files": [

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/protocol",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "AntSeed wire protocol: message types, frame/HTTP/payment codecs, and EIP-712 payment signatures. Portable — no Node-only dependencies",
   "type": "module",
   "files": [

--- a/packages/provider-core/package.json
+++ b/packages/provider-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-core",
-  "version": "0.2.52",
+  "version": "0.2.53",
   "description": "Shared provider infrastructure for Antseed plugins",
   "type": "module",
   "files": [

--- a/plugins/provider-anthropic/package.json
+++ b/plugins/provider-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-anthropic",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "description": "Anthropic API key provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/provider-claude-code/package.json
+++ b/plugins/provider-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-claude-code",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "description": "Claude Code keychain provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/provider-claude-oauth/package.json
+++ b/plugins/provider-claude-oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-claude-oauth",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "description": "Third-party Anthropic Claude provider with OAuth authentication",
   "type": "module",
   "files": [

--- a/plugins/provider-local-llm/package.json
+++ b/plugins/provider-local-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-local-llm",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "description": "Local LLM provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/provider-openai-responses/package.json
+++ b/plugins/provider-openai-responses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-openai-responses",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "OpenAI Responses provider plugin for Antseed via Codex backend auth",
   "type": "module",
   "files": [

--- a/plugins/provider-openai/package.json
+++ b/plugins/provider-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-openai",
-  "version": "0.2.44",
+  "version": "0.2.45",
   "description": "OpenAI-compatible provider plugin for Antseed",
   "type": "module",
   "files": [


### PR DESCRIPTION
Version bumps for the next npm release (13 packages). Derived per package from commits since its last version bump, plus the exact-pin cascade (`workspace:` regular dependencies resolve to exact versions at publish).

**Changed directly:**
- `@antseed/protocol` 0.1.4 — metadata v3 image counting, AES-256-GCM transport fix
- `@antseed/api-adapter` 0.1.44 — Responses message-ID fix, image prompt-token estimation
- `@antseed/buyer-core` 0.1.4 — metadata v3
- `@antseed/provider-core` 0.2.53 — skip body injection for image requests
- `@antseed/provider-local-llm` 0.1.47 — per-service pricing
- `@antseed/cli` 0.1.150 — deposit flow + daemon auto-sweep + `buyer activity` (#862), local-LLM base URL mapping, npm-error message

**Cascade (exact pins):**
- `@antseed/node` 0.2.112 — pins protocol/buyer-core/api-adapter
- `@antseed/payments` 0.1.39 — pins node
- `@antseed/provider-anthropic` 0.1.47, `@antseed/provider-claude-code` 0.1.47, `@antseed/provider-claude-oauth` 0.1.50, `@antseed/provider-openai` 0.2.45, `@antseed/provider-openai-responses` 0.1.37 — pin provider-core

**Skipped (unchanged, nothing they pin is moving):** router-core, router-local, ant-agent.

Validated with `node scripts/npm-publish-plan.mjs`: 13 to publish, no cascade violations.

After merge: trigger the `Publish npm packages` workflow from the Actions tab (optionally with `dry_run` first).

No user-facing behavior change — versions only.
