### PR TITLE
fix(images): Preserve multipart edit models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Fixed Desktop image edits losing their selected model while crossing the multipart buyer/seller relay, which caused compatible upstreams to reject follow-up prompts with `model is required`. The image generation shimmer now also appears reliably for the first prompt, before the conversation has entered persistent image mode.
 - Local-LLM providers now consume per-service pricing from seller configuration, so differently priced local models are advertised with their configured rates instead of inheriting the provider default.
 - CLI plugin installation now reports an actionable Node.js/npm requirement when `npm` is unavailable instead of exposing the raw `spawn npm ENOENT` process error.
 - CLI seller configuration now passes a configured `baseUrl` to the local-LLM plugin using its declared `LOCAL_LLM_BASE_URL` key instead of silently falling back to the default Ollama endpoint.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.150",
+  "version": "0.1.151",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -29,7 +29,7 @@ import {
   substituteRoutedModelAlias,
   sweepStaleStateTmpFiles,
 } from './buyer-proxy.js'
-import { overrideRoutedModelInBody, SYSTEM_ROUTED_MODEL_HEADER } from './request-utils.js'
+import { extractRequestedService, overrideRoutedModelInBody, SYSTEM_ROUTED_MODEL_HEADER } from './request-utils.js'
 
 function makePeer(seed: string, providers: string[]): PeerInfo {
   const repeated = (seed.repeat(40) + 'a'.repeat(40)).slice(0, 40)
@@ -2331,6 +2331,31 @@ function parseJsonBody(body: Uint8Array): Record<string, unknown> {
 }
 
 const jsonHeaders: Record<string, string> = { 'content-type': 'application/json' }
+
+test('extractRequestedService reads the model from multipart image edits', () => {
+  const boundary = 'image-edit-boundary'
+  const body = new TextEncoder().encode([
+    `--${boundary}`,
+    'Content-Disposition: form-data; name="model"',
+    '',
+    'gpt-image-2',
+    `--${boundary}`,
+    'Content-Disposition: form-data; name="image"; filename="source.png"',
+    'Content-Type: image/png',
+    '',
+    'image-bytes',
+    `--${boundary}--`,
+    '',
+  ].join('\r\n'))
+
+  assert.equal(extractRequestedService({
+    requestId: 'request-1',
+    method: 'POST',
+    path: '/v1/images/edits',
+    headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+    body,
+  }), 'gpt-image-2')
+})
 
 test('parsePeerPinnedService parses 40-char hex peer prefixes', () => {
   assert.deepEqual(parsePeerPinnedService(`${validPeerId}@claude-sonnet-4-5`), {

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -2810,6 +2810,7 @@ export class BuyerProxy {
       headers: {
         ...headersForPeer,
         'x-antseed-provider': selectedRoutePlan.provider,
+        ...(requestedService ? { 'x-antseed-service': requestedService } : {}),
       },
     }
     if (selectedRoutePlan.serviceId) {

--- a/apps/cli/src/proxy/request-utils.ts
+++ b/apps/cli/src/proxy/request-utils.ts
@@ -1,5 +1,5 @@
 import { shouldEmitDebugLine, type PeerInfo, type SerializedHttpRequest, type SerializedHttpResponse } from '@antseed/node'
-import { parseJsonObject } from '@antseed/api-adapter'
+import { extractRequestBodyFields, parseJsonObject } from '@antseed/api-adapter'
 
 function isTruthyDebugValue(value: string | undefined): boolean {
   return ['1', 'true', 'yes', 'on'].includes((value ?? '').trim().toLowerCase())
@@ -42,11 +42,11 @@ export function parsePeerPinnedService(value: string): { peerId: string; service
 }
 
 export function extractRequestedService(request: SerializedHttpRequest): string | null {
-  if (!getHeader(request.headers, 'content-type').toLowerCase().includes('application/json')) {
+  const contentType = getHeader(request.headers, 'content-type').toLowerCase()
+  if (!contentType.includes('application/json') && !contentType.startsWith('multipart/form-data')) {
     return null
   }
-
-  const parsed = parseJsonObject(request.body)
+  const parsed = extractRequestBodyFields(request.headers, request.body)
   if (!parsed) return null
 
   const service = parsed.service ?? parsed.model

--- a/apps/desktop/src/renderer/ui/components/chat/ImageGenerationPlaceholder.test.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ImageGenerationPlaceholder.test.tsx
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { ImageGenerationPlaceholder } from './ImageGenerationPlaceholder';
+import { ImageGenerationPlaceholder, isImageGenerationPhase } from './ImageGenerationPlaceholder';
+
+test('image phases include both first generations and follow-up edits', () => {
+  assert.equal(isImageGenerationPhase('Generating image'), true);
+  assert.equal(isImageGenerationPhase('Editing image'), true);
+  assert.equal(isImageGenerationPhase('Calling tool'), false);
+});
 
 test('image generation placeholder announces generation state', () => {
   const markup = renderToStaticMarkup(<ImageGenerationPlaceholder />);

--- a/apps/desktop/src/renderer/ui/components/chat/ImageGenerationPlaceholder.tsx
+++ b/apps/desktop/src/renderer/ui/components/chat/ImageGenerationPlaceholder.tsx
@@ -6,6 +6,10 @@ type ImageGenerationPlaceholderProps = {
   editing?: boolean;
 };
 
+export function isImageGenerationPhase(phase: string | null | undefined): boolean {
+  return phase === 'Generating image' || phase === 'Editing image';
+}
+
 export function ImageGenerationPlaceholder({ editing = false }: ImageGenerationPlaceholderProps) {
   const label = editing ? 'Editing your image' : 'Generating your image';
 

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -24,7 +24,7 @@ import { useRetainedState } from '../../hooks/useRetainedState';
 import { ChatBubble } from '../chat/ChatBubble';
 import { hasSearchPhraseMatch, isToolResultOnlyMessage } from '../chat/chat-utils.js';
 import { WalkingAnt } from '../chat/WalkingAnt';
-import { ImageGenerationPlaceholder } from '../chat/ImageGenerationPlaceholder';
+import { ImageGenerationPlaceholder, isImageGenerationPhase } from '../chat/ImageGenerationPlaceholder';
 import { SessionApprovalCard } from '../chat/SessionApprovalCard';
 import { ToolApprovalCard } from '../chat/ToolApprovalCard';
 import { LowBalanceWarning } from '../chat/LowBalanceWarning';
@@ -1118,9 +1118,8 @@ export function ChatView({ onSelectView }: ChatViewProps) {
     snap.chatSendingConversationId === snap.chatActiveConversation ||
     activeConversationIsSending
   );
-  const showImageGenerationPlaceholder = showThinkingIndicator
-    && imageMode
-    && (snap.chatThinkingPhase === 'Generating image' || snap.chatThinkingPhase === 'Editing image');
+  const imageRequestInProgress = showThinkingIndicator && isImageGenerationPhase(snap.chatThinkingPhase);
+  const imageUiMode = imageMode || imageRequestInProgress;
   const chatComposerDisabled = currentPeerNotFound && !imageMode;
   const chatSendDisabled = chatComposerDisabled
     || (imageMode ? snap.chatSendDisabled || inputValue.trim().length === 0 : snap.chatSendDisabled && attachedFiles.length === 0);
@@ -1164,11 +1163,11 @@ export function ChatView({ onSelectView }: ChatViewProps) {
           <div className={styles.serviceSwitcherAnchor}>
             <VprModelDropdown
               catalog={snap.vprModelCatalog}
-              kind={imageMode ? 'image' : 'text'}
+              kind={imageUiMode ? 'image' : 'text'}
               selectedProvider={selectedModelProvider}
               selectedServiceId={selectedModelServiceId}
               fallbackLabel={currentServiceLabel}
-              disabled={(snap.chatInputDisabled || snap.chatSending) && !(imageMode && snap.chatSending)}
+              disabled={(snap.chatInputDisabled || snap.chatSending) && !imageRequestInProgress}
               onSelect={handleModelSwitch}
               onBrowseAll={() => onSelectView?.('explore')}
             />
@@ -1334,7 +1333,7 @@ export function ChatView({ onSelectView }: ChatViewProps) {
                 conversationId={snap.chatActiveConversation || undefined}
               />
             ) : null}
-            {showImageGenerationPlaceholder ? (
+            {imageRequestInProgress ? (
               <ImageGenerationPlaceholder editing={snap.chatThinkingPhase === 'Editing image'} />
             ) : showThinkingIndicator ? (
               <WalkingAnt

--- a/apps/website/docs/guides/using-the-api.md
+++ b/apps/website/docs/guides/using-the-api.md
@@ -156,7 +156,7 @@ curl http://localhost:8377/v1/images/edits \
 #   -H 'x-antseed-pin-peer: <peerId>'
 ```
 
-Image edits are multipart requests, but their `model` field follows the same routing and seller-side alias rewriting rules as JSON generation requests. Upgrade the buyer and seller together if an upstream rejects an edit with `model is required`: `@antseed/cli@0.1.150`, `@antseed/provider-core@0.2.53`, and `@antseed/provider-openai@0.2.45` predate multipart model preservation, so edits that depend on a seller service rewrite can fail on those versions. The provider plugin pins its provider-core version, so updating only the buyer is not sufficient. Desktop v0.2.16 predates conversational image editing entirely.
+Image edits are multipart requests, but their `model` field follows the same routing and seller-side alias rewriting rules as JSON generation requests. Upgrade the buyer and seller together if an upstream rejects an edit with `model is required`: `@antseed/cli@0.1.150`, `@antseed/provider-core@0.2.53`, and `@antseed/provider-openai@0.2.45` predate multipart model preservation, so edits that depend on a seller service rewrite can fail on those versions. Use `@antseed/cli@0.1.151`, `@antseed/provider-core@0.2.54`, and `@antseed/provider-openai@0.2.46` or newer. The provider plugin pins its provider-core version, so updating only the buyer is not sufficient. Desktop v0.2.16 predates conversational image editing entirely.
 
 ## Claude Code
 

--- a/apps/website/docs/guides/using-the-api.md
+++ b/apps/website/docs/guides/using-the-api.md
@@ -144,11 +144,19 @@ curl http://localhost:8377/v1/images/generations \
     "size": "1024x1024"
   }'
 
+curl http://localhost:8377/v1/images/edits \
+  -F 'model=flux.1-schnell' \
+  -F 'prompt=Now with a blue background' \
+  -F 'image=@source.png' \
+  -F 'n=1'
+
 # Discover image models first: GET /v1/models?type=images
 # A bare model id uses automatic routing and can fail over.
 # To explicitly pin a multipart /v1/images/edits request, use:
 #   -H 'x-antseed-pin-peer: <peerId>'
 ```
+
+Image edits are multipart requests, but their `model` field follows the same routing and seller-side alias rewriting rules as JSON generation requests. Upgrade the buyer and seller together if an upstream rejects an edit with `model is required`: `@antseed/cli@0.1.150`, `@antseed/provider-core@0.2.53`, and `@antseed/provider-openai@0.2.45` predate multipart model preservation, so edits that depend on a seller service rewrite can fail on those versions. The provider plugin pins its provider-core version, so updating only the buyer is not sufficient. Desktop v0.2.16 predates conversational image editing entirely.
 
 ## Claude Code
 

--- a/packages/provider-core/package.json
+++ b/packages/provider-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-core",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "description": "Shared provider infrastructure for Antseed plugins",
   "type": "module",
   "files": [

--- a/packages/provider-core/src/http-headers.ts
+++ b/packages/provider-core/src/http-headers.ts
@@ -5,6 +5,7 @@ const HOP_BY_HOP_HEADERS = new Set([
 
 const INTERNAL_HEADERS = new Set([
   'x-antseed-provider',
+  'x-antseed-service',
 ]);
 
 export interface StripRelayRequestHeadersOptions {

--- a/packages/provider-core/src/http-relay.test.ts
+++ b/packages/provider-core/src/http-relay.test.ts
@@ -162,6 +162,43 @@ describe('HttpRelay', () => {
     expect(parsed.model).toBe('together/kimi2.5');
   });
 
+  it('preserves and rewrites model fields in multipart image edits', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
+
+    const responses: SerializedHttpResponse[] = [];
+    const relay = new HttpRelay(
+      makeConfig({
+        allowedServices: ['gpt-image-2'],
+        serviceRewriteMap: { 'gpt-image-2': 'upstream/gpt-image-2' },
+      }),
+      { onResponse: (response) => responses.push(response) },
+    );
+    const form = new FormData();
+    form.append('prompt', 'Now with a blue background');
+    form.append('image', new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' }), 'source.png');
+    const webRequest = new Request('https://buyer.invalid/v1/images/edits', { method: 'POST', body: form });
+
+    await relay.handleRequest(makeRequest({
+      path: '/v1/images/edits',
+      headers: {
+        'content-type': webRequest.headers.get('content-type') ?? '',
+        'x-antseed-service': 'gpt-image-2',
+      },
+      body: new Uint8Array(await webRequest.arrayBuffer()),
+    }));
+
+    expect(responses[0]?.statusCode).toBe(200);
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const sentHeaders = options.headers as Record<string, string>;
+    expect(sentHeaders['x-antseed-service']).toBeUndefined();
+    const forwarded = await new Response(options.body, {
+      headers: { 'content-type': sentHeaders['content-type'] ?? '' },
+    }).formData();
+    expect(forwarded.get('model')).toBe('upstream/gpt-image-2');
+    expect(forwarded.get('prompt')).toBe('Now with a blue background');
+    expect(forwarded.get('image')).toBeInstanceOf(Blob);
+  });
+
   it('enforces concurrency limit', async () => {
     // Create a fetch that blocks until we resolve it
     let resolveFirst!: (value: Response) => void;
@@ -220,6 +257,7 @@ describe('HttpRelay', () => {
         'content-type': 'application/json',
         'connection': 'keep-alive',
         'x-antseed-provider': 'anthropic',
+        'x-antseed-service': 'claude-sonnet-4-20250514',
         'host': 'localhost:3000',
         'x-custom': 'keep-me',
       },
@@ -229,6 +267,7 @@ describe('HttpRelay', () => {
     const sentHeaders = opts.headers as Record<string, string>;
     expect(sentHeaders['connection']).toBeUndefined();
     expect(sentHeaders['x-antseed-provider']).toBeUndefined();
+    expect(sentHeaders['x-antseed-service']).toBeUndefined();
     expect(sentHeaders['host']).toBeUndefined();
     expect(sentHeaders['x-custom']).toBe('keep-me');
   });

--- a/packages/provider-core/src/http-relay.ts
+++ b/packages/provider-core/src/http-relay.ts
@@ -70,6 +70,86 @@ function deepMerge(target: Record<string, unknown>, source: Record<string, unkno
   return out;
 }
 
+function getHeader(headers: Record<string, string>, name: string): string {
+  const entry = Object.entries(headers).find(([key]) => key.toLowerCase() === name.toLowerCase());
+  return entry?.[1] ?? '';
+}
+
+function multipartBoundary(contentType: string): string {
+  const match = /^multipart\/form-data\s*;.*?boundary=(?:"([^"]+)"|([^;\s]+))/i.exec(contentType.trim());
+  return (match?.[1] ?? match?.[2] ?? '').trim();
+}
+
+function readMultipartTextField(body: Uint8Array, contentType: string, fieldName: string): string | null {
+  const boundary = multipartBoundary(contentType);
+  if (!boundary) return null;
+  const text = new TextDecoder('latin1').decode(body);
+  const delimiter = `--${boundary}`;
+  let index = text.indexOf(delimiter);
+  while (index !== -1) {
+    index += delimiter.length;
+    if (text.startsWith('--', index)) break;
+    const headerEnd = text.indexOf('\r\n\r\n', index);
+    if (headerEnd === -1) break;
+    const next = text.indexOf(`\r\n${delimiter}`, headerEnd + 4);
+    if (next === -1) break;
+    const headers = text.slice(index, headerEnd);
+    const params = /content-disposition:\s*form-data\s*;([^\r\n]*)/i.exec(headers)?.[1] ?? '';
+    const name = /name="([^"]*)"/i.exec(params)?.[1] ?? '';
+    if (name === fieldName && !/filename\s*=/i.test(params)) {
+      const raw = body.subarray(headerEnd + 4, next);
+      return new TextDecoder().decode(raw).trim();
+    }
+    index = next + 2;
+  }
+  return null;
+}
+
+function setMultipartTextField(
+  body: Uint8Array,
+  contentType: string,
+  fieldName: string,
+  value: string,
+): Uint8Array | null {
+  const boundary = multipartBoundary(contentType);
+  if (!boundary || !/^[A-Za-z0-9_.-]+$/.test(fieldName)) return null;
+  const text = new TextDecoder('latin1').decode(body);
+  const delimiter = `--${boundary}`;
+  let index = text.indexOf(delimiter);
+  while (index !== -1) {
+    index += delimiter.length;
+    if (text.startsWith('--', index)) break;
+    const headerEnd = text.indexOf('\r\n\r\n', index);
+    if (headerEnd === -1) break;
+    const next = text.indexOf(`\r\n${delimiter}`, headerEnd + 4);
+    if (next === -1) break;
+    const headers = text.slice(index, headerEnd);
+    const params = /content-disposition:\s*form-data\s*;([^\r\n]*)/i.exec(headers)?.[1] ?? '';
+    const name = /name="([^"]*)"/i.exec(params)?.[1] ?? '';
+    if (name === fieldName && !/filename\s*=/i.test(params)) {
+      const replacement = new TextEncoder().encode(value);
+      const out = new Uint8Array(headerEnd + 4 + replacement.length + body.length - next);
+      out.set(body.subarray(0, headerEnd + 4), 0);
+      out.set(replacement, headerEnd + 4);
+      out.set(body.subarray(next), headerEnd + 4 + replacement.length);
+      return out;
+    }
+    index = next + 2;
+  }
+
+  const finalDelimiter = `${delimiter}--`;
+  const finalIndex = text.lastIndexOf(finalDelimiter);
+  if (finalIndex === -1) return null;
+  const insertion = new TextEncoder().encode(
+    `${delimiter}\r\nContent-Disposition: form-data; name="${fieldName}"\r\n\r\n${value}\r\n`,
+  );
+  const out = new Uint8Array(finalIndex + insertion.length + body.length - finalIndex);
+  out.set(body.subarray(0, finalIndex), 0);
+  out.set(insertion, finalIndex);
+  out.set(body.subarray(finalIndex), finalIndex + insertion.length);
+  return out;
+}
+
 export class HttpRelay {
   private readonly _config: RelayConfig;
   private readonly _callbacks: RelayCallbacks;
@@ -156,61 +236,76 @@ export class HttpRelay {
       // Swap auth headers
       let swappedRequest = swapAuthHeader(request, effectiveConfig);
 
-      // Always process JSON bodies to normalize "service" → "model" for upstream APIs,
-      // apply service rewrites, and inject extra fields.
+      // Normalize the requested service into the upstream model for both JSON
+      // and multipart Images API requests. Multipart edits otherwise bypass
+      // alias rewriting and some upstreams report the model as missing.
       if (swappedRequest.method !== 'GET' && swappedRequest.method !== 'HEAD') {
-        try {
-          const decoded = JSON.parse(new TextDecoder().decode(swappedRequest.body)) as Record<string, unknown>;
-          const transformed: Record<string, unknown> = { ...decoded };
+        const contentType = getHeader(swappedRequest.headers, 'content-type');
+        if (/^multipart\/form-data/i.test(contentType.trim())) {
+          const requestedService = getHeader(swappedRequest.headers, 'x-antseed-service').trim()
+            || readMultipartTextField(swappedRequest.body, contentType, 'service')
+            || readMultipartTextField(swappedRequest.body, contentType, 'model')
+            || '';
+          if (requestedService) {
+            const rewrittenService = this._config.serviceRewriteMap?.[requestedService.toLowerCase()]?.trim();
+            const upstreamModel = rewrittenService || requestedService;
+            const rewrittenBody = setMultipartTextField(swappedRequest.body, contentType, 'model', upstreamModel);
+            if (rewrittenBody) swappedRequest = { ...swappedRequest, body: rewrittenBody };
+          }
+        } else {
+          try {
+            const decoded = JSON.parse(new TextDecoder().decode(swappedRequest.body)) as Record<string, unknown>;
+            const transformed: Record<string, unknown> = { ...decoded };
 
-          // Read from both "model" (upstream API compat) and "service" (native) fields
-          const requestedService = (transformed.service ?? transformed.model) as string | undefined;
+            // Read from both "model" (upstream API compat) and "service" (native) fields
+            const requestedService = (transformed.service ?? transformed.model) as string | undefined;
 
-          if (this._config.serviceRewriteMap && typeof requestedService === 'string' && requestedService.trim().length > 0) {
-            const rewrittenService = this._config.serviceRewriteMap[requestedService.trim().toLowerCase()];
-            if (typeof rewrittenService === 'string' && rewrittenService.trim().length > 0) {
-              transformed.model = rewrittenService.trim();
+            if (this._config.serviceRewriteMap && typeof requestedService === 'string' && requestedService.trim().length > 0) {
+              const rewrittenService = this._config.serviceRewriteMap[requestedService.trim().toLowerCase()];
+              if (typeof rewrittenService === 'string' && rewrittenService.trim().length > 0) {
+                transformed.model = rewrittenService.trim();
+              }
             }
-          }
 
-          // Normalize: if client sent "service" without "model", copy to "model" for upstream API compat.
-          if (transformed.service !== undefined && transformed.model === undefined) {
-            transformed.model = transformed.service;
-          }
-          // Remove the "service" field — upstream APIs don't understand it.
-          delete transformed.service;
-
-          // Force `stream_options.include_usage = true` on streaming OpenAI Chat
-          // Completions requests. Without this, strict OpenAI-spec upstreams
-          // (e.g. api.minimax.io) return SSE streams with no `usage` chunk,
-          // which makes `parseResponseUsage` return zeros and causes the
-          // seller to record `cost=0 (in=0 out=0)` for every request —
-          // effectively giving away inference for free.
-          //
-          // We only touch `/v1/chat/completions` with `stream:true`, and we
-          // preserve any caller-supplied `stream_options` fields. We don't
-          // override an explicit `include_usage:false` (operators can still
-          // disable via `injectJsonFields` below if they really need to).
-          if (
-            request.path.toLowerCase().startsWith('/v1/chat/completions')
-            && transformed.stream === true
-          ) {
-            const existing = transformed.stream_options && typeof transformed.stream_options === 'object' && !Array.isArray(transformed.stream_options)
-              ? transformed.stream_options as Record<string, unknown>
-              : {};
-            if (existing.include_usage === undefined) {
-              transformed.stream_options = { ...existing, include_usage: true };
+            // Normalize: if client sent "service" without "model", copy to "model" for upstream API compat.
+            if (transformed.service !== undefined && transformed.model === undefined) {
+              transformed.model = transformed.service;
             }
+            // Remove the "service" field — upstream APIs don't understand it.
+            delete transformed.service;
+
+            // Force `stream_options.include_usage = true` on streaming OpenAI Chat
+            // Completions requests. Without this, strict OpenAI-spec upstreams
+            // (e.g. api.minimax.io) return SSE streams with no `usage` chunk,
+            // which makes `parseResponseUsage` return zeros and causes the
+            // seller to record `cost=0 (in=0 out=0)` for every request —
+            // effectively giving away inference for free.
+            //
+            // We only touch `/v1/chat/completions` with `stream:true`, and we
+            // preserve any caller-supplied `stream_options` fields. We don't
+            // override an explicit `include_usage:false` (operators can still
+            // disable via `injectJsonFields` below if they really need to).
+            if (
+              request.path.toLowerCase().startsWith('/v1/chat/completions')
+              && transformed.stream === true
+            ) {
+              const existing = transformed.stream_options && typeof transformed.stream_options === 'object' && !Array.isArray(transformed.stream_options)
+                ? transformed.stream_options as Record<string, unknown>
+                : {};
+              if (existing.include_usage === undefined) {
+                transformed.stream_options = { ...existing, include_usage: true };
+              }
+            }
+
+            const isImageRequest = request.path.toLowerCase().startsWith('/v1/images/');
+            const merged = this._config.injectJsonFields && !isImageRequest
+              ? deepMerge(transformed, this._config.injectJsonFields)
+              : transformed;
+
+            swappedRequest = { ...swappedRequest, body: new TextEncoder().encode(JSON.stringify(merged)) };
+          } catch {
+            // Not JSON — leave body unchanged
           }
-
-          const isImageRequest = request.path.toLowerCase().startsWith('/v1/images/');
-          const merged = this._config.injectJsonFields && !isImageRequest
-            ? deepMerge(transformed, this._config.injectJsonFields)
-            : transformed;
-
-          swappedRequest = { ...swappedRequest, body: new TextEncoder().encode(JSON.stringify(merged)) };
-        } catch {
-          // Not JSON — leave body unchanged
         }
       }
 

--- a/plugins/provider-anthropic/package.json
+++ b/plugins/provider-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-anthropic",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "Anthropic API key provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/provider-claude-code/package.json
+++ b/plugins/provider-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-claude-code",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "Claude Code keychain provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/provider-claude-oauth/package.json
+++ b/plugins/provider-claude-oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-claude-oauth",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "description": "Third-party Anthropic Claude provider with OAuth authentication",
   "type": "module",
   "files": [

--- a/plugins/provider-local-llm/package.json
+++ b/plugins/provider-local-llm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-local-llm",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "description": "Local LLM provider plugin for Antseed",
   "type": "module",
   "files": [

--- a/plugins/provider-openai-responses/package.json
+++ b/plugins/provider-openai-responses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-openai-responses",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "OpenAI Responses provider plugin for Antseed via Codex backend auth",
   "type": "module",
   "files": [

--- a/plugins/provider-openai/package.json
+++ b/plugins/provider-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/provider-openai",
-  "version": "0.2.45",
+  "version": "0.2.46",
   "description": "OpenAI-compatible provider plugin for Antseed",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Description

Fixes image-edit requests from Desktop losing their selected model when the multipart request crosses the buyer and seller relays. The buyer now extracts and forwards the multipart model as internal routing metadata, while the seller restores and rewrites the multipart `model` field before calling the upstream Images API.

The Desktop loading state now keys off the explicit image generation/editing phase, so the shimmer appears on the first prompt as well as follow-up edits and the header picker remains image-only while either request is running.

## Release Notes

- Fixed follow-up image edits failing with `model is required`.
- Show the image generation shimmer for both initial generations and later edits.
- Keep the active model picker limited to image models during image requests.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
- [x] I have updated `CHANGELOG.md` for this user-facing fix

## Testing

- `pnpm -C packages/provider-core exec vitest run src/http-relay.test.ts`
- `pnpm -C apps/cli run build`
- `node --test --test-name-pattern="extractRequestedService reads the model from multipart image edits" apps/cli/dist/proxy/buyer-proxy.test.js`
- `pnpm -C apps/desktop exec vitest run src/renderer/ui/components/chat/ImageGenerationPlaceholder.test.tsx`
- `pnpm -C apps/desktop run typecheck:renderer`


## Deployment Impact

This fix must ship on both sides of the relay. The PR includes the complete selective patch-release cascade required by the exact npm pins:

- `@antseed/provider-core@0.2.54`
- `@antseed/cli@0.1.151`
- `@antseed/provider-anthropic@0.1.48`
- `@antseed/provider-claude-code@0.1.48`
- `@antseed/provider-claude-oauth@0.1.51`
- `@antseed/provider-local-llm@0.1.48`
- `@antseed/provider-openai@0.2.46`
- `@antseed/provider-openai-responses@0.1.38`

Desktop v0.2.16 predates conversational image editing and is not affected as a released UI.

## Publish Validation

- Full monorepo build passes.
- Selective `pnpm publish --dry-run` passes for all eight packages.
- Packed provider plugins and CLI resolve `@antseed/provider-core` exactly to `0.2.54`.
- No packed manifest contains a `workspace:*` dependency.
- Tarballs contain only the declared package metadata and built `dist/` files.


## Desktop Routing Follow-up

Downloaded Desktop logs confirmed that a model-page seller pin was dropped during “Use in chat”: Venice.ai Proxy (`9e8f…`) was shown as pinned, but the image request carried `pin-peer=none` and auto-selected another seller (`73b4…`). The handoff now preserves the seller displayed as pinned, and remembered image pins are restored defensively when applying an image model.

The same test session also showed Venice returning HTTP 404 for `/v1/images/edits`. Its service metadata advertises `inputs: ["text"]`, so it is generation-only. Desktop now sends follow-up edits only to routes advertising `image` input; a pinned generation-only seller receives no edit request and the user sees an actionable message instead. Seller rows distinguish “Image generation only” from “Image generation + editing.”

Image generation/edit phases are now sticky for the duration of the image request, so payment negotiation logs cannot replace the shimmer with the normal text loader.
