### PR TITLE
docs(skills): publish skill prepares bumps only, CI publishes

### DIFF
--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -1,179 +1,119 @@
 ---
 name: publish
-description: Publish AntSeed packages to npm, including version bumping, dry-run validation, and verification.
+description: Prepare an npm release — decide which @antseed/* packages need version bumps, apply them, validate the set, and open the bump PR. Publishing itself happens in CI.
 ---
 
-# Publish AntSeed Packages to npm
+# Prepare an npm Release (version bumps only)
 
-Publish all public `@antseed/*` packages to the npm registry. This skill handles version bumping, building, publishing, and verification.
+Decide which public `@antseed/*` packages need a release, bump their versions, and open a PR. **This skill never runs `pnpm publish`** — actual publishing happens in the `Publish npm packages` GitHub Actions workflow (`.github/workflows/npm-publish.yml`), which the user triggers manually from the Actions tab after the bump PR merges. The committed version bumps ARE the publish decision: the workflow publishes exactly the packages whose version is not on the registry yet and skips everything else.
 
 ## Prerequisites
 
-- Must be logged in to npm (`npm whoami` should return the org owner)
-- Working directory must be the monorepo root `/Users/shahafan/Development/antseed`
-- All changes should be committed before publishing
+- Working directory is the monorepo root; `git fetch origin main` first so the analysis runs against the merged state.
+- No npm login is needed — CI publishes with the `NPM_TOKEN` repo secret.
 
 ## Workflow
 
-### 1. Determine scope and version bump
+### 1. Find what changed since each package's last release
 
-**Scope** — decide whether to publish all packages or only what's needed:
-- **Full release**: bump and publish every public package together. Use this for coordinated feature releases or when you genuinely don't know which packages changed.
-- **Selective release**: bump and publish only the packages whose runtime behavior changed *plus* their pinned dependents on npm. Use this for targeted bug fixes (e.g. a fix in `@antseed/api-adapter` that needs to reach the seller stack).
-
-To compute the minimum publish set for a selective release:
-
-1. Identify the package(s) where the fix actually lives (the "source" set).
-2. For each candidate dependent (anything that imports the source package), inspect its **published** dependency pin: `npm view <pkg>@latest dependencies`. Workspace `workspace:*` refs are resolved at publish time to **exact** versions (no caret), so the published dependent will keep installing the old source forever unless it's republished too.
-3. Add every dependent whose published pin is exact to the publish set, recursively. Stop at packages that declare the source as a peer dep with a `>=` range (those don't need rebumping).
-
-Example — a fix in `@antseed/api-adapter`:
+For every public package, list commits touching it since its version was last bumped:
 
 ```bash
-npm view @antseed/node@latest dependencies | grep api-adapter
-# '@antseed/api-adapter': '0.1.36'   ← exact pin, must republish node
-npm view @antseed/cli@latest dependencies | grep -E "api-adapter|@antseed/node"
-# '@antseed/api-adapter': '0.1.36'
-# '@antseed/node': '0.2.75'          ← exact pin, must republish cli
+for p in packages/protocol packages/api-adapter packages/buyer-core packages/node \
+         packages/provider-core packages/router-core packages/ant-agent \
+         plugins/* apps/cli apps/payments apps/network-stats; do
+  bump=$(git log origin/main -1 --format=%H -G'"version": ' -- $p/package.json)
+  echo "=== $p"
+  git log --oneline --no-merges $bump..origin/main -- $p
+done
 ```
 
-→ Minimum set: `api-adapter`, `node`, `cli`. Other workspace consumers (`provider-core`, `router-core`, `ant-agent`) declare `@antseed/node >=0.1.0` and don't need republishing.
+Judgment call per package: test-only and docs-only commits don't warrant a release on their own (the cascade below may still force the package). Runtime behavior changes do.
 
-**Version bump** — ask the user what kind:
-- **patch** (0.1.1 -> 0.1.2) — bug fixes, packaging fixes
-- **minor** (0.1.2 -> 0.2.0) — new features, non-breaking changes
-- **major** (0.2.0 -> 1.0.0) — breaking changes
+### 2. Compute the bump set (direct changes + pin cascade)
 
-### 2. Bump versions
+pnpm resolves `workspace:*` **regular dependencies** to exact versions at publish time. If a package is republished but a public dependent that pins it is not, npm installs of the dependent keep the old version and the fix silently never ships. So the bump set is the closure:
 
-Use pnpm to bump versions in a single command. **Never edit each package.json manually.**
+1. Start with the packages that changed (step 1).
+2. Add every public dependent that declares one of them as a regular `workspace:` dependency, recursively.
+3. Peer dependencies with ranges (e.g. provider-core/router-core/ant-agent declare `@antseed/node >=0.1.0`) do NOT cascade.
 
-#### Selective bump (recommended for bug fixes)
+Known chains: cli + payments pin node; node pins protocol/buyer-core/api-adapter; all provider plugins pin provider-core; router-local pins router-core; cli also pins payments, api-adapter, ant-agent, provider-core.
 
-Pass each package explicitly:
+Don't compute this by hand and hope — step 4 validates it mechanically.
+
+### 3. Bump versions
+
+Ask the user patch/minor/major if it isn't obvious (patch for fixes, minor for features). Bump only the computed set:
 
 ```bash
-pnpm --filter @antseed/api-adapter \
+pnpm --filter @antseed/protocol \
      --filter @antseed/node \
      --filter @antseed/cli \
   exec npm version <patch|minor|major> --no-git-tag-version
 ```
 
-#### Full-release bump
-
-```bash
-# Bump all 15 publishable packages at once
-pnpm -r --filter './packages/*' \
-       --filter './plugins/*' \
-       --filter '@antseed/cli' \
-       --filter '@antseed/network-stats' \
-       --filter '@antseed/payments' \
-  exec npm version <patch|minor|major> --no-git-tag-version
-```
-
-This bumps everything under `packages/*` and `plugins/*`, plus the three publishable apps (`@antseed/cli`, `@antseed/network-stats`, `@antseed/payments`). Private packages (`e2e`, `@antseed/desktop`, `@antseed/website`, `@antseed/diem-staking`) are excluded.
-
-Before running, sanity-check which apps are public vs private (the set occasionally changes):
+Sanity-check which apps are public vs private if unsure (the set occasionally changes):
 
 ```bash
 for d in apps/*/; do node -e "const p=require('./$d/package.json'); console.log((p.private?'[PRIV]':'[PUB] ')+p.name+'@'+p.version)"; done
 ```
 
-If a new public app appears, add it to the filter list above and update this skill.
-
-Verify the bump worked:
+### 4. Validate the set
 
 ```bash
-pnpm -r --filter './packages/*' \
-       --filter './plugins/*' \
-       --filter '@antseed/cli' \
-       --filter '@antseed/network-stats' \
-       --filter '@antseed/payments' \
-  exec -- node -p 'require("./package.json").name + "@" + require("./package.json").version'
+node scripts/npm-publish-plan.mjs
 ```
 
-### 3. Build all packages
+This prints local vs registry versions with a PUBLISH/skip verdict per package and **hard-fails** on:
+- a to-be-published package whose exact-pin dependent has no bump (cascade violation), or
+- a local version behind npm latest (a previous release never committed its bumps).
+
+The PUBLISH rows must exactly match the intended set, exit code 0. The CI workflow runs this same script as a gate before publishing.
+
+### 5. Open the bump PR
+
+Never commit to main. Branch, commit the changed `package.json` files, push, open a PR:
 
 ```bash
-pnpm run build
+git checkout -b release/npm-bump-<YYYY-MM-DD> origin/main
+git add <changed package.json files>
+git commit -m "chore: bump versions for npm release"
+git push -u origin release/npm-bump-<YYYY-MM-DD>
 ```
 
-Build must succeed with zero errors before proceeding.
+PR body: list the bumped packages grouped as "changed directly" (with a one-line reason each) vs "cascade (exact pins)", name the skipped packages, and note that the plan script validated the set. See PR #869 as a template.
 
-### 4. Dry-run publish
+### 6. Hand off to CI — do not publish
 
-For a **selective release**, scope the publish to the same `--filter` set you bumped:
+After the PR merges, the **user** triggers the release from GitHub: Actions → `Publish npm packages` → Run workflow on `main` (optionally with `dry_run` first to see the plan in the logs). The workflow installs, re-validates the plan, bakes `ANTSEED_COMPARABLE_PRICES_URL` into the release artifacts, builds, runs the full test suite, and publishes with `pnpm publish`.
+
+Do not run `pnpm publish`, `npm publish`, or the workflow yourself.
+
+### 7. Verify after the workflow succeeds (read-only)
 
 ```bash
-pnpm --filter @antseed/api-adapter \
-     --filter @antseed/node \
-     --filter @antseed/cli \
-  publish --no-git-checks --access public --dry-run
+node scripts/npm-publish-plan.mjs        # should report 0 packages to publish
+tmpdir=$(mktemp -d) && cd "$tmpdir" && npm install @antseed/cli@latest --ignore-scripts \
+  && npm ls @antseed/node && cd - && rm -rf "$tmpdir"
 ```
 
-For a **full release**, use `-r`:
-
-```bash
-pnpm -r publish --no-git-checks --access public --dry-run
-```
-
-Verify in the output:
-- No `workspace:*` appears in any tarball's dependencies (pnpm resolves these automatically)
-- All package versions match the bump target
-- Each tarball only contains `dist/` files (not source `.ts` files)
-
-### 5. Publish for real
-
-Same `--filter` scope as the dry-run:
-
-```bash
-# selective
-pnpm --filter <...> publish --no-git-checks --access public
-
-# full
-pnpm -r publish --no-git-checks --access public
-```
-
-Packages publish in dependency order. If a package version already exists on npm, pnpm skips it gracefully.
-
-### 6. Verify installation
-
-Test that the CLI installs cleanly from npm in an isolated temp directory:
-
-```bash
-tmpdir=$(mktemp -d) && cd "$tmpdir" && npm install @antseed/cli@<NEW_VERSION> 2>&1 && npx antseed --version && rm -rf "$tmpdir"
-```
-
-Confirm:
-- `npm install` exits 0 with no workspace protocol errors
-- `antseed --version` runs and prints a version
-
-### 7. Commit the version bump
-
-Stage all changed `package.json` files and the lockfile, then commit:
-
-```
-chore: bump all packages to v<NEW_VERSION>
-```
+Confirm exactly ONE `@antseed/node` version appears (the 0.1.139 incident check), no `workspace:` specs in published manifests, and — if the cli was released — that `node_modules/@antseed/cli/dist/generated/baked-defaults.js` contains the comparable-prices URL.
 
 ## Important notes
 
-- **Always use `pnpm publish`**, never `npm publish`. Only pnpm knows how to resolve `workspace:*` references to real version numbers in the published tarball.
-- The root `package.json` has convenience scripts: `pnpm run publish:all` (build + publish) and `pnpm run publish:dry` (build + dry-run).
-- The `e2e`, `@antseed/desktop`, `@antseed/website`, and `@antseed/diem-staking` packages are private and are automatically skipped.
-- All publishable packages have `"files": ["dist"]` to keep tarballs clean.
-- The `@antseed/node` package includes `"files": ["dist", "scripts"]` for the postinstall patch script.
-- If the `pnpm run build` step fails inside `@antseed/desktop` (e.g. native-module rebuild OOM), it does NOT block publishing — desktop is private, and all publishable packages build in earlier tiers. Just confirm each publishable package has a fresh `dist/` before proceeding to dry-run.
+- The old flow (local `pnpm publish` from the `antseed-publish` worktree) is retired; CI owns publishing. If an emergency ever forces a local publish, it must be `pnpm publish` (never `npm publish`) and the version bumps must still land on main.
+- Private packages (`e2e`, `@antseed/desktop`, `@antseed/website`, `@antseed/diem-staking`, `@antseed/ui`) are never published; pnpm skips them automatically.
+- Update this skill and the workflow's `--filter` set if a new public package appears.
 
 ## Publishable packages (for reference)
 
 ```
-packages/*   @antseed/node, @antseed/api-adapter, @antseed/ant-agent,
+packages/*   @antseed/node, @antseed/protocol, @antseed/buyer-core,
+             @antseed/api-adapter, @antseed/ant-agent,
              @antseed/provider-core, @antseed/router-core
 plugins/*    provider-anthropic, provider-claude-code, provider-claude-oauth,
              provider-openai, provider-openai-responses, provider-local-llm,
              router-local
 apps/*       @antseed/cli, @antseed/network-stats, @antseed/payments
 ```
-
-Private (not published): `e2e`, `@antseed/desktop`, `@antseed/website`, `@antseed/diem-staking`.


### PR DESCRIPTION
Rewrites the `/publish` skill for the CI-based release flow introduced in #862: the skill now only decides and prepares the release — it never publishes.

- Scope reduced to: per-package change detection since last version bump, bump-set computation (direct changes + exact-pin cascade closure, with the known chains spelled out), version bumps via `pnpm exec npm version`, mechanical validation with `scripts/npm-publish-plan.mjs`, and opening the bump PR (template: #869).
- Removed: local build, dry-run publish, `pnpm publish`, npm-login prerequisite. Publishing is handed off to the `Publish npm packages` workflow, triggered manually from the Actions tab after the bump PR merges.
- Post-release verification kept as a read-only section (plan reports 0 to publish, fresh-install single-`@antseed/node` check, baked comparable-prices URL present).
- Refreshed the publishable-package reference list (was missing `@antseed/protocol` and `@antseed/buyer-core`); noted the `antseed-publish`-worktree flow as retired.

No user-facing package behavior change — agent-skill documentation only.
