### PR TITLE
fix(identity): Prevent duplicate wallets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- CLI identity loading now fails safely when the data directory contains an app-encrypted, unreadable, or malformed identity instead of silently generating a second wallet and overwriting or competing with the existing signer.
 - Local-LLM providers now consume per-service pricing from seller configuration, so differently priced local models are advertised with their configured rates instead of inheriting the provider default.
 - CLI plugin installation now reports an actionable Node.js/npm requirement when `npm` is unavailable instead of exposing the raw `spawn npm ENOENT` process error.
 - CLI seller configuration now passes a configured `baseUrl` to the local-LLM plugin using its declared `LOCAL_LLM_BASE_URL` key instead of silently falling back to the default Ollama endpoint.

--- a/packages/node/src/p2p/identity.ts
+++ b/packages/node/src/p2p/identity.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { access, readFile, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { Wallet } from "ethers";
@@ -10,6 +10,7 @@ export { hexToBytes, bytesToHex };
 
 const CONFIG_DIR = join(homedir(), ".antseed");
 const PRIVATE_KEY_FILE = "identity.key";
+const ENCRYPTED_PRIVATE_KEY_FILE = "identity.enc";
 
 export interface Identity {
   peerId: PeerId;
@@ -32,26 +33,47 @@ export interface IdentityStore {
  */
 export class FileIdentityStore implements IdentityStore {
   private readonly keyPath: string;
+  private readonly encryptedKeyPath: string;
   private readonly dir: string;
 
   constructor(configDir?: string) {
     this.dir = configDir ?? CONFIG_DIR;
     this.keyPath = join(this.dir, PRIVATE_KEY_FILE);
+    this.encryptedKeyPath = join(this.dir, ENCRYPTED_PRIVATE_KEY_FILE);
   }
 
   async load(): Promise<string | null> {
     try {
       const hexKey = (await readFile(this.keyPath, "utf-8")).trim();
-      return hexKey.length > 0 ? hexKey : null;
-    } catch {
-      return null;
+      return hexKey;
+    } catch (error) {
+      if (!isMissingFileError(error)) {
+        throw new Error(`Unable to read identity at ${this.keyPath}; refusing to create a replacement identity.`, { cause: error });
+      }
     }
+
+    try {
+      await access(this.encryptedKeyPath);
+    } catch (error) {
+      if (isMissingFileError(error)) return null;
+      throw new Error(`Unable to inspect identity at ${this.encryptedKeyPath}; refusing to create a replacement identity.`, { cause: error });
+    }
+
+    throw new Error(
+      `An app-encrypted identity already exists at ${this.encryptedKeyPath}. ` +
+      'The CLI cannot decrypt Electron safeStorage identities and will not create a second wallet in the same data directory. ' +
+      'Back up the private key from VPR and import it for CLI use, launch the CLI through VPR, or choose a different --data-dir.',
+    );
   }
 
   async save(hexKey: string): Promise<void> {
     await mkdir(this.dir, { recursive: true });
     await writeFile(this.keyPath, hexKey, { mode: 0o600 });
   }
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT';
 }
 
 /** Environment variable for passing identity hex from a parent process (e.g. desktop → CLI). */
@@ -94,7 +116,10 @@ export async function loadOrCreateIdentity(configDirOrStore?: string | IdentityS
       : configDirOrStore;
 
   const existingHex = await store.load();
-  if (existingHex && existingHex.length === 64) {
+  if (existingHex !== null) {
+    if (existingHex.length !== 64) {
+      throw new Error(`Existing identity is invalid: expected 64 hex characters, found ${existingHex.length}. Refusing to replace it.`);
+    }
     return identityFromPrivateKeyHex(existingHex);
   }
 

--- a/packages/node/tests/identity.test.ts
+++ b/packages/node/tests/identity.test.ts
@@ -68,6 +68,26 @@ describe('loadOrCreateIdentity', () => {
     expect(bytesToHex(second.privateKey)).toBe(bytesToHex(first.privateKey));
     expect(second.wallet.address).toBe(first.wallet.address);
   });
+
+  it('refuses to create a second identity beside an app-encrypted identity', async () => {
+    const dir = tmpDir();
+    dirsToClean.push(dir);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'identity.enc'), randomBytes(64));
+
+    await expect(loadOrCreateIdentity(dir)).rejects.toThrow(/app-encrypted identity already exists/);
+    await expect(fs.access(path.join(dir, 'identity.key'))).rejects.toThrow();
+  });
+
+  it('refuses to replace an invalid existing plaintext identity', async () => {
+    const dir = tmpDir();
+    dirsToClean.push(dir);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, 'identity.key'), 'invalid');
+
+    await expect(loadOrCreateIdentity(dir)).rejects.toThrow(/Existing identity is invalid/);
+    expect(await fs.readFile(path.join(dir, 'identity.key'), 'utf8')).toBe('invalid');
+  });
 });
 
 describe('signData / verifySignature', () => {


### PR DESCRIPTION
## Description

Makes file-based identity loading fail closed when an app-encrypted identity is present or an existing plaintext identity is unreadable or malformed. The CLI now provides recovery guidance instead of silently creating a second wallet in the same data directory.

Fixes #844

## Release Notes

- CLI commands no longer generate a competing wallet when the selected data directory already contains a VPR-encrypted or damaged identity.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
- [x] I have updated the changelog for user-facing changes
