### PR TITLE
feat(desktop): add native VPR model tray picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- Desktop: added a native macOS status-bar model picker that extends the existing tray menu with up to eight favorite and recommended models, keeps the active model checked, and links to model management in the main app.
+
 - Desktop: added seller-assisted channel closing to Activity for sellers advertising `payments.cooperative-close.v1`, with clear rejection feedback and the existing wallet-based on-chain close retained as a permanent fallback.
 
 - Discovery metadata v12 widens service catalog and per-service map counts to support up to 512 services per provider. Metadata now allows 64 categories and 4 API protocols per service, a 128 KiB signed binary snapshot, and a bounded 256 KiB HTTP metadata response. Buyers remain compatible with v10/v11 sellers, while sellers validate the same limits before announcing.

--- a/apps/desktop/src/main/chat/engine-types.ts
+++ b/apps/desktop/src/main/chat/engine-types.ts
@@ -9,6 +9,7 @@ import type { IpcMain } from 'electron';
 import type { AgentSession } from '@mariozechner/pi-coding-agent';
 import type { ChatStreamStopReason } from './stream-stop.js';
 import type { NetworkPeerAddress } from './service-catalog.js';
+import type { ModelPickerSnapshot } from '../../shared/model-picker.js';
 
 export type RegisterPiChatHandlersOptions = {
   ipcMain: IpcMain;
@@ -18,6 +19,7 @@ export type RegisterPiChatHandlersOptions = {
   ensureBuyerRuntimeStarted?: () => Promise<boolean>;
   appendSystemLog: (line: string) => void;
   getNetworkPeers?: () => Promise<NetworkPeerAddress[]>;
+  onModelPickerChanged?: (snapshot: ModelPickerSnapshot) => void;
 };
 
 export type ChatStreamErrorPayload = {

--- a/apps/desktop/src/main/chat/engine.ts
+++ b/apps/desktop/src/main/chat/engine.ts
@@ -116,6 +116,7 @@ export function registerPiChatHandlers({
   ensureBuyerRuntimeStarted,
   appendSystemLog,
   getNetworkPeers,
+  onModelPickerChanged,
 }: RegisterPiChatHandlersOptions): PiChatEngine {
   void loadChatWorkspaceDir().catch(() => {});
   const store = new PiConversationStore();
@@ -317,7 +318,10 @@ export function registerPiChatHandlers({
   let modelPickerSnapshot: ModelPickerSnapshot | null = null;
   ipcMain.handle('chat:sync-model-picker', (_event, payload: unknown) => {
     const normalized = normalizeModelPickerSnapshot(payload);
-    if (normalized) modelPickerSnapshot = normalized;
+    if (normalized) {
+      modelPickerSnapshot = normalized;
+      onModelPickerChanged?.(normalized);
+    }
     return { ok: normalized != null };
   });
 

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -76,6 +76,11 @@ import { registerPaymentsIpc } from './ipc/payments.js';
 import { registerRuntimeIpc } from './ipc/runtime.js';
 import { registerSystemProxyIpc } from './ipc/system-proxy.js';
 import { registerTelegramIpc } from './ipc/telegram.js';
+import type { ModelPickerSnapshot, ModelPickerSelection } from '../shared/model-picker.js';
+import {
+  buildVprNativeMenuItems,
+  selectVprNativeMenuModel,
+} from './ui/vpr-native-menu.js';
 import {
   effectiveLaunchTarget,
 } from './connected-apps/profile-targets.js';
@@ -305,6 +310,8 @@ const processManager = new ProcessManager((mode, stream, line) => {
   appendLog(mode, stream, line);
 });
 
+let trayModelPicker: ModelPickerSnapshot | null = null;
+
 initSystemProxyRuntime({
   appName: APP_NAME,
   appendLog,
@@ -421,6 +428,10 @@ const piChatEngine = registerPiChatHandlers({
         && peer.port > 0
         && peer.port <= 65535);
   },
+  onModelPickerChanged: (snapshot) => {
+    trayModelPicker = snapshot;
+    refreshTrayMenu();
+  },
 });
 
 // ── Telegram bridge ──
@@ -514,11 +525,35 @@ app.whenReady().then(async () => {
     getMainWindow()?.webContents.send(running ? 'desktop:disconnect-main' : 'desktop:connect-main');
   };
 
+  const selectTrayModel = (selection: ModelPickerSelection) => {
+    trayModelPicker = selectVprNativeMenuModel(trayModelPicker, selection);
+    refreshTrayMenu();
+    getMainWindow()?.webContents.send('desktop:select-vpr-model', selection);
+  };
+
+  const showModelsOverview = () => {
+    showMainWindow();
+    const win = getMainWindow();
+    if (!win) return;
+    const navigate = () => win.webContents.send('desktop:navigate-view', 'explore');
+    if (win.webContents.isLoadingMainFrame()) {
+      win.webContents.once('did-finish-load', navigate);
+    } else {
+      navigate();
+    }
+  };
+
   createDesktopTray({
     appName: APP_NAME,
     iconPath: TRAY_ICON_PATH,
     onShow: showMainWindow,
-    buildMenu: () => buildSystemProxyTrayMenu(showMainWindow, showFloatingWindow, toggleMainConnection),
+    buildMenu: () => [
+      ...buildSystemProxyTrayMenu(showMainWindow, showFloatingWindow, toggleMainConnection),
+      ...buildVprNativeMenuItems(trayModelPicker, {
+        selectModel: selectTrayModel,
+        browseModels: showModelsOverview,
+      }),
+    ],
   });
   refreshTrayMenu();
 

--- a/apps/desktop/src/main/preload.cts
+++ b/apps/desktop/src/main/preload.cts
@@ -654,6 +654,11 @@ const api = {
     ipcRenderer.on('desktop:open-floating-window', listener);
     return () => ipcRenderer.off('desktop:open-floating-window', listener);
   },
+  onDesktopSelectVprModel(handler: (selection: unknown) => void): () => void {
+    const listener = (_: unknown, selection: unknown) => handler(selection);
+    ipcRenderer.on('desktop:select-vpr-model', listener);
+    return () => ipcRenderer.off('desktop:select-vpr-model', listener);
+  },
   onDesktopConnectMain(handler: () => void): () => void {
     const listener = () => handler();
     ipcRenderer.on('desktop:connect-main', listener);

--- a/apps/desktop/src/main/ui/vpr-native-menu.test.ts
+++ b/apps/desktop/src/main/ui/vpr-native-menu.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { MenuItemConstructorOptions } from 'electron';
+import type { ModelPickerEntry, ModelPickerSnapshot } from '../../shared/model-picker.js';
+import {
+  buildVprNativeMenuItems,
+  selectVprNativeMenuModel,
+  VPR_NATIVE_MODEL_LIMIT,
+} from './vpr-native-menu.js';
+
+function model(index: number): ModelPickerEntry {
+  return {
+    provider: `provider-${index}`,
+    serviceId: `model-${index}`,
+    label: `Model ${index}`,
+    favorite: index < 2,
+    routePeerId: `peer-${index}`,
+    routeServiceId: `model-${index}`,
+    routeProvider: `provider-${index}`,
+  };
+}
+
+function invoke(item: MenuItemConstructorOptions | undefined): void {
+  if (!item || typeof item.click !== 'function') {
+    assert.fail('Expected a clickable native menu item');
+  }
+  (item.click as () => void)();
+}
+
+test('native VPR menu promotes the active model, deduplicates, and caps rows', () => {
+  const models = Array.from({ length: 12 }, (_, index) => model(index));
+  models.push({ ...models[3]! });
+  const snapshot: ModelPickerSnapshot = {
+    models,
+    selected: { provider: 'provider-9', serviceId: 'model-9' },
+  };
+  const selections: string[] = [];
+  const menu = buildVprNativeMenuItems(snapshot, {
+    selectModel: (selection) => selections.push(selection.serviceId),
+    browseModels: () => selections.push('browse'),
+  });
+  const radioItems = menu.filter((item) => item.type === 'radio');
+
+  assert.equal(radioItems.length, VPR_NATIVE_MODEL_LIMIT);
+  assert.equal(radioItems[0]?.label, 'Model 9');
+  assert.equal(radioItems[0]?.checked, true);
+  assert.equal(new Set(radioItems.map((item) => item.label)).size, VPR_NATIVE_MODEL_LIMIT);
+
+  invoke(radioItems[1]);
+  invoke(menu.find((item) => item.label === 'Manage Models…'));
+  assert.deepEqual(selections, ['model-0', 'browse']);
+});
+
+test('native VPR menu updates its selected snapshot immediately', () => {
+  const snapshot: ModelPickerSnapshot = {
+    models: [model(0), model(1), model(2)],
+    selected: { provider: 'provider-0', serviceId: 'model-0' },
+  };
+  const selected = selectVprNativeMenuModel(snapshot, {
+    provider: 'provider-2',
+    serviceId: 'model-2',
+  });
+
+  assert.equal(selected?.selected?.serviceId, 'model-2');
+  assert.equal(selected?.models[0]?.serviceId, 'model-2');
+});
+
+test('native VPR menu shows no fallback model rows before catalog sync', () => {
+  const menu = buildVprNativeMenuItems(null, {
+    selectModel: () => {},
+    browseModels: () => {},
+  });
+
+  assert.deepEqual(menu.map((item) => item.label ?? item.type), [
+    'separator',
+    'Manage Models…',
+  ]);
+});

--- a/apps/desktop/src/main/ui/vpr-native-menu.ts
+++ b/apps/desktop/src/main/ui/vpr-native-menu.ts
@@ -1,0 +1,74 @@
+import type { MenuItemConstructorOptions } from 'electron';
+import type {
+  ModelPickerEntry,
+  ModelPickerSnapshot,
+  ModelPickerSelection,
+} from '../../shared/model-picker.js';
+
+export const VPR_NATIVE_MODEL_LIMIT = 8;
+
+export type VprNativeMenuActions = {
+  selectModel: (selection: ModelPickerSelection) => void;
+  browseModels: () => void;
+};
+
+function modelKey(model: Pick<ModelPickerEntry, 'provider' | 'serviceId'>): string {
+  return `${model.provider}\u0000${model.serviceId}`;
+}
+
+function quickModels(snapshot: ModelPickerSnapshot): ModelPickerEntry[] {
+  const selectedKey = snapshot.selected ? modelKey(snapshot.selected) : null;
+  const seen = new Set<string>();
+  const models: ModelPickerEntry[] = [];
+  const add = (model: ModelPickerEntry): void => {
+    const key = modelKey(model);
+    if (seen.has(key)) return;
+    seen.add(key);
+    models.push(model);
+  };
+
+  if (selectedKey) {
+    const selected = snapshot.models.find((model) => modelKey(model) === selectedKey);
+    if (selected) add(selected);
+  }
+  for (const model of snapshot.models) add(model);
+  return models.slice(0, VPR_NATIVE_MODEL_LIMIT);
+}
+
+export function selectVprNativeMenuModel(
+  snapshot: ModelPickerSnapshot | null,
+  selection: ModelPickerSelection,
+): ModelPickerSnapshot | null {
+  if (!snapshot) return null;
+  const selected = snapshot.models.find((model) => modelKey(model) === modelKey(selection));
+  if (!selected) return snapshot;
+  return {
+    models: [selected, ...snapshot.models.filter((model) => model !== selected)],
+    selected: selection,
+  };
+}
+
+export function buildVprNativeMenuItems(
+  snapshot: ModelPickerSnapshot | null,
+  actions: VprNativeMenuActions,
+): MenuItemConstructorOptions[] {
+  const items: MenuItemConstructorOptions[] = [{ type: 'separator' }];
+  if (snapshot?.models.length) {
+    const selectedKey = snapshot.selected ? modelKey(snapshot.selected) : null;
+    items.push(
+      { label: 'Models', enabled: false },
+      ...quickModels(snapshot).map((model) => ({
+        type: 'radio' as const,
+        label: model.label,
+        checked: modelKey(model) === selectedKey,
+        click: () => actions.selectModel({
+          provider: model.provider,
+          serviceId: model.serviceId,
+        }),
+      })),
+      { type: 'separator' },
+    );
+  }
+  items.push({ label: 'Manage Models…', click: actions.browseModels });
+  return items;
+}

--- a/apps/desktop/src/renderer/app.ts
+++ b/apps/desktop/src/renderer/app.ts
@@ -19,6 +19,7 @@ import {
   saveFloatShowRoutedPeer,
 } from './modules/app/float-settings';
 import { initModelPickerSync } from './modules/catalog/picker-sync';
+import { normalizeModelPickerSelection } from '../shared/model-picker.js';
 import { applyVprRouteToConnectedProxy } from './modules/routing/proxy-sync';
 import { findCatalogEntry } from './modules/catalog/model-catalog';
 import { resolveVprChatOption } from './modules/chat/projection';
@@ -682,6 +683,10 @@ registerActions({
 });
 
 bridge?.onDesktopOpenFloatingWindow?.(() => { void vprFloatApi.openFloat(); });
+bridge?.onDesktopSelectVprModel?.((raw) => {
+  const selection = normalizeModelPickerSelection(raw);
+  if (selection) actionSelectVprModel(selection.provider, selection.serviceId);
+});
 bridge?.onDesktopConnectMain?.(() => { void actionStartAll(); });
 bridge?.onDesktopDisconnectMain?.(() => { void actionStopAll(); });
 

--- a/apps/desktop/src/renderer/types/bridge.ts
+++ b/apps/desktop/src/renderer/types/bridge.ts
@@ -482,6 +482,7 @@ export type DesktopBridge = {
   onVprFloatClosed?: (handler: () => void) => () => void;
   onVprFloatAction?: (handler: (action: unknown) => void) => () => void;
   onDesktopOpenFloatingWindow?: (handler: () => void) => () => void;
+  onDesktopSelectVprModel?: (handler: (selection: unknown) => void) => () => void;
   onDesktopConnectMain?: (handler: () => void) => () => void;
   onDesktopDisconnectMain?: (handler: () => void) => () => void;
 };

--- a/apps/desktop/src/shared/model-picker.test.ts
+++ b/apps/desktop/src/shared/model-picker.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeModelPickerSelection } from './model-picker.js';
+
+test('model picker selection normalizes valid tray payloads', () => {
+  assert.deepEqual(
+    normalizeModelPickerSelection({ provider: ' openai ', serviceId: ' gpt-5 ' }),
+    { provider: 'openai', serviceId: 'gpt-5' },
+  );
+});
+
+test('model picker selection rejects incomplete tray payloads', () => {
+  assert.equal(normalizeModelPickerSelection({ provider: 'openai', serviceId: '' }), null);
+  assert.equal(normalizeModelPickerSelection({ provider: 'openai' }), null);
+  assert.equal(normalizeModelPickerSelection(null), null);
+});

--- a/apps/desktop/src/shared/model-picker.ts
+++ b/apps/desktop/src/shared/model-picker.ts
@@ -30,8 +30,22 @@ export type ModelPickerSnapshot = {
   /** Display order: favorites first, then recommended. */
   models: ModelPickerEntry[];
   /** The app's current model selection, for the ✓ mark. */
-  selected: { provider: string; serviceId: string } | null;
+  selected: ModelPickerSelection | null;
 };
+
+export type ModelPickerSelection = {
+  provider: string;
+  serviceId: string;
+};
+
+export function normalizeModelPickerSelection(raw: unknown): ModelPickerSelection | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
+  const selection = raw as Record<string, unknown>;
+  if (typeof selection.provider !== 'string' || typeof selection.serviceId !== 'string') return null;
+  const provider = selection.provider.trim();
+  const serviceId = selection.serviceId.trim();
+  return provider && serviceId ? { provider, serviceId } : null;
+}
 
 export function normalizeModelPickerSnapshot(raw: unknown): ModelPickerSnapshot | null {
   if (!raw || typeof raw !== 'object') return null;
@@ -56,10 +70,6 @@ export function normalizeModelPickerSnapshot(raw: unknown): ModelPickerSnapshot 
       routeProvider: asId(entry.routeProvider),
     });
   }
-  const selectedRaw = snapshot.selected as Record<string, unknown> | null | undefined;
-  const selected = selectedRaw && typeof selectedRaw === 'object'
-    && typeof selectedRaw.provider === 'string' && typeof selectedRaw.serviceId === 'string'
-    ? { provider: selectedRaw.provider, serviceId: selectedRaw.serviceId }
-    : null;
+  const selected = normalizeModelPickerSelection(snapshot.selected);
   return { models, selected };
 }


### PR DESCRIPTION
## What

Extend the existing native macOS status-bar menu with a focused VPR model picker.

- Show up to eight curated favorite and recommended models as native radio items.
- Keep the active model first and checked, with deduplication and immediate local selection updates.
- Route model changes through the existing VPR selection flow so the main UI and connected routing stay synchronized.
- Add a native **Manage Models…** action that opens the model overview in AntSeed.
- Preserve the existing **Show AntSeed VPR**, **Show Floating Window**, and connection actions.

## Why

The custom status-bar popover did not behave like a native macOS menu in fullscreen spaces and did not reliably dismiss when another menu-bar item opened. Extending the original native tray menu delegates focus, dismissal, fullscreen placement, keyboard behavior, and accessibility to macOS while keeping model selection fast and compact.

## Testing

- Added native-menu tests covering active-model promotion, radio checked state, deduplication, the eight-model cap, immediate selection updates, action callbacks, and the pre-catalog state.
- Added model-picker payload normalization tests.
- Ran `pnpm -C apps/desktop build:main`.
- Ran all compiled desktop main-process tests: 203 passed.
- Ran `pnpm -C apps/desktop typecheck:renderer`.
- Ran `pnpm -C apps/desktop build:renderer`.
- Revalidated the picker after merging the multi-instance development base, including its shared-buyer tests.

## Checklist

- [ ] `pnpm run build` passes
- [ ] `pnpm run test` passes
- [x] Breaking changes documented — no breaking changes; user-facing behavior is recorded in `CHANGELOG.md`.
