### PR TITLE
chore: bump versions for npm release

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.151",
+  "version": "0.1.152",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [

--- a/apps/payments/package.json
+++ b/apps/payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/payments",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "Buyer payments portal for AntSeed",
   "files": [
     "dist"

--- a/packages/api-adapter/package.json
+++ b/packages/api-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/api-adapter",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "HTTP-level format translation between LLM API protocols (Anthropic Messages, OpenAI Chat Completions, OpenAI Responses)",
   "type": "module",
   "files": [

--- a/packages/buyer-core/package.json
+++ b/packages/buyer-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/buyer-core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Transport-agnostic AntSeed buyer machinery: request handling, payment negotiation, channel accounting. Portable — no Node-only dependencies",
   "type": "module",
   "files": [

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/node",
-  "version": "0.2.112",
+  "version": "0.2.113",
   "description": "Antseed Network protocol SDK — P2P inference marketplace",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Description

Version bumps for the next npm release (all patch). Publishing happens in the `Publish npm packages` workflow after merge.

## Changed directly

- **@antseed/api-adapter 0.1.44 → 0.1.45** — fix Responses function IDs (#872-adjacent, `14dc7bff`)
- **@antseed/buyer-core 0.1.4 → 0.1.5** — configurable max stream duration, default raised 5 → 30 minutes (#880)
- **@antseed/node 0.2.112 → 0.2.113** — route sorting by price with trust as gate (#881), free sellers kept auto-routable, duplicate-wallet identity fix, plus the buyer-core/api-adapter changes above
- **@antseed/cli 0.1.151 → 0.1.152** — `seller doctor` reachability diagnostics (#876) + review fixes, buyer `requestTimeoutMs`/`maxStreamDurationMs` config (#874/#880), free-route eligibility fix

## Cascade (exact pins)

- **@antseed/payments 0.1.39 → 0.1.40** — pins `@antseed/node`

## Skipped (unchanged)

protocol, provider-core, router-core, ant-agent, all provider/router plugins, network-stats.

`node scripts/npm-publish-plan.mjs` validates the set: exactly these 5 packages report PUBLISH, no cascade violations.