### PR TITLE
feat(desktop): Simplify connected apps UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Changed
 
+- Desktop Connected Apps now opens directly to the complete app list without the redundant search field at the top; application-picker searches remain available when choosing an installed app. The Home notice for apps that need restarting can now be dismissed for the current app launch and returns after Desktop is relaunched.
 - Desktop Connected Apps now includes GooeyPi, configures its Pi harness through `~/.pi/agent/models.json`, auto-detects the installed desktop app, and stamps distinct `originator` headers for Pi and GooeyPi so VPR conversations are attributed to the correct client instead of the underlying OpenAI SDK.
 - Buyer request and streaming duration limits are now configurable through `buyer.requestTimeoutMs` and `buyer.maxStreamDurationMs`, allowing slow or long-running generations to exceed the previous fixed five-minute cap.
 - The default streaming duration cap was raised from 5 to 30 minutes. Streams longer than the cap were cancelled mid-response, which surfaced in OpenAI Responses clients (e.g. Codex CLI) as `stream disconnected before completion: stream closed before response.completed` on long agentic turns. The cap can also be set via the `ANTSEED_BUYER_MAX_STREAM_DURATION_MS` environment variable.

--- a/apps/desktop/src/renderer/ui/components/views/VprHomeView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/VprHomeView.module.scss
@@ -374,21 +374,34 @@
 }
 
 .restartBanner {
+  position: relative;
   width: 100%;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 12px 14px;
+  gap: 4px;
+  padding: 4px;
   border: 1px solid rgba(245, 158, 11, 0.35);
   border-radius: 14px;
   background: rgba(245, 158, 11, 0.1);
   color: #f59e0b;
+}
+
+.restartBannerBody {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 38px 8px 10px;
+  border: none;
+  background: transparent;
+  color: inherit;
   font: inherit;
   text-align: left;
   cursor: pointer;
 }
 
-.restartBanner > span {
+.restartBannerBody > span {
   flex: 1 1 auto;
   min-width: 0;
   display: grid;
@@ -405,6 +418,27 @@
   color: var(--text-secondary);
   font-size: 11px;
   line-height: 16px;
+}
+
+.restartBannerClose {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: none;
+  border-radius: 9px;
+  background: transparent;
+  color: rgba(245, 158, 11, 0.72);
+  cursor: pointer;
+}
+
+.restartBannerClose:hover {
+  background: rgba(245, 158, 11, 0.12);
+  color: #f59e0b;
 }
 
 .balanceBanner {

--- a/apps/desktop/src/renderer/ui/components/views/VprHomeView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprHomeView.tsx
@@ -43,6 +43,7 @@ import styles from './VprHomeView.module.scss';
 type Props = { onSelectView?: (view: ViewName) => void };
 
 const ADD_BALANCE_DISMISSED_KEY = 'antseed.desktop.vpr.addBalanceDismissed';
+const RESTART_NOTICE_DISMISSED_KEY = 'antseed.desktop.vpr.restartNoticeDismissed';
 const MODEL_CHANGE_NOTICE_MS = 4_000;
 /* Rows in the model dropdown (Figma) — the full catalog lives on Models. */
 const DROPDOWN_MODEL_COUNT = 5;
@@ -83,6 +84,13 @@ export function VprHomeView({ onSelectView }: Props) {
   const [addBalanceDismissed, setAddBalanceDismissed] = useState(() => {
     try {
       return localStorage.getItem(ADD_BALANCE_DISMISSED_KEY) === '1';
+    } catch {
+      return false;
+    }
+  });
+  const [restartNoticeDismissed, setRestartNoticeDismissed] = useState(() => {
+    try {
+      return sessionStorage.getItem(RESTART_NOTICE_DISMISSED_KEY) === '1';
     } catch {
       return false;
     }
@@ -256,6 +264,13 @@ export function VprHomeView({ onSelectView }: Props) {
     setAddBalanceDismissed(true);
     try {
       localStorage.setItem(ADD_BALANCE_DISMISSED_KEY, '1');
+    } catch { /* private mode */ }
+  }
+
+  function dismissRestartNotice(): void {
+    setRestartNoticeDismissed(true);
+    try {
+      sessionStorage.setItem(RESTART_NOTICE_DISMISSED_KEY, '1');
     } catch { /* private mode */ }
   }
 
@@ -469,15 +484,24 @@ export function VprHomeView({ onSelectView }: Props) {
           <div className={styles.connectedGroup}>
             {/* Connected apps live on the Apps page — home leads with the
                 chats themselves. */}
-            {restartProfiles.length > 0 ? (
-              <button type="button" className={styles.restartBanner} onClick={() => onSelectView?.('tools')}>
-                <HugeiconsIcon icon={ArrowReloadHorizontalIcon} size={18} strokeWidth={2} />
-                <span>
-                  <strong>{restartProfiles.length === 1 ? restartProfiles[0]!.displayName : `${restartProfiles.length} apps`} need a restart</strong>
-                  <small>Restart to apply the VPR connection.</small>
-                </span>
-                <HugeiconsIcon icon={ArrowRight02Icon} size={16} strokeWidth={2} />
-              </button>
+            {restartProfiles.length > 0 && !restartNoticeDismissed ? (
+              <div className={styles.restartBanner}>
+                <button type="button" className={styles.restartBannerBody} onClick={() => onSelectView?.('tools')}>
+                  <HugeiconsIcon icon={ArrowReloadHorizontalIcon} size={18} strokeWidth={2} />
+                  <span>
+                    <strong>{restartProfiles.length === 1 ? restartProfiles[0]!.displayName : `${restartProfiles.length} apps`} need a restart</strong>
+                    <small>Restart to apply the VPR connection.</small>
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className={styles.restartBannerClose}
+                  onClick={dismissRestartNotice}
+                  aria-label="Dismiss app restart notice"
+                >
+                  <HugeiconsIcon icon={Cancel01Icon} size={16} strokeWidth={2} />
+                </button>
+              </div>
             ) : null}
 
             {reminderCard}

--- a/apps/desktop/src/renderer/ui/components/views/VprToolsView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprToolsView.tsx
@@ -58,7 +58,6 @@ export function VprToolsView() {
   const [guiTest, setGuiTest] = useState<GuiTestResult | null>(null);
   const [trustBusy, setTrustBusy] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
-  const [search, setSearch] = useState('');
   const [addOpen, setAddOpen] = useState(false);
   const [addUrl, setAddUrl] = useState('');
   const [addBusy, setAddBusy] = useState(false);
@@ -467,18 +466,12 @@ export function VprToolsView() {
     }
   }, [activeProfileNames, disconnect, refresh, startProfiles]);
 
-  const visibleProfiles = useMemo(() => {
-    const query = search.trim().toLowerCase();
-    const filtered = query
-      ? profiles.filter((profile) => profile.displayName.toLowerCase().includes(query) || profile.name.toLowerCase().includes(query))
-      : profiles;
+  const orderedProfiles = useMemo(() => {
     // Connected apps float to the top; the sort is stable, so each group keeps
     // its original order.
     const isConnected = (name: string): boolean => activeProfiles?.has(name) ?? false;
-    return [...filtered].sort((a, b) => Number(isConnected(b.name)) - Number(isConnected(a.name)));
-  }, [profiles, search, activeProfiles]);
-
-  const telegramVisible = !search.trim() || 'telegram bot'.includes(search.trim().toLowerCase());
+    return [...profiles].sort((a, b) => Number(isConnected(b.name)) - Number(isConnected(a.name)));
+  }, [profiles, activeProfiles]);
 
   // Certificate trust presentation. A live probe failure (certTrustError) or a
   // stale/absent keychain state all mean the same thing to the user: press
@@ -498,17 +491,11 @@ export function VprToolsView() {
     <section className={`view view-vpr-tools view-pinned-header ${styles.view}`} role="tabpanel">
       <VprPage title="Connected apps" backFallback="home">
       <div className={styles.stack}>
-
-        <VprSearch value={search} onChange={setSearch} placeholder="Search app" />
-
         {message ? <p className={styles.note} role="status">{message}</p> : null}
 
-        {visibleProfiles.length === 0 && !telegramVisible ? (
-          <div className={styles.empty}>{profiles.length === 0 ? 'No tool profiles configured' : 'No apps match your search'}</div>
-        ) : (
-          <div className={styles.appList}>
-            {telegramVisible ? <TelegramBotCard /> : null}
-            {visibleProfiles.map((profile) => {
+        <div className={styles.appList}>
+          <TelegramBotCard />
+          {orderedProfiles.map((profile) => {
               const connected = activeProfiles?.has(profile.name) ?? false;
               const setupComplete = setupProfiles.has(profile.name);
               const canRestart = connected && profile.canRestart === true;
@@ -609,9 +596,8 @@ export function VprToolsView() {
 
                 </div>
               );
-            })}
-          </div>
-        )}
+          })}
+        </div>
 
         <button
           type="button"


### PR DESCRIPTION
## Description

Simplifies the Desktop connected-app experience in two places. The Connected Apps screen now always shows the complete app list without a redundant top-level search, while the Home restart notice gains a separate close action that hides it for the current Desktop launch.

Search remains available inside the installed-application pickers used by app settings and the custom-app flow. The restart notice's main area still opens Connected Apps, and its dismissal uses launch-scoped session storage so the reminder returns after Desktop is relaunched.

## Release Notes

- Removed the redundant search field from the top of Connected Apps.
- Connected Apps now opens directly to the complete app list.
- Added an `X` to dismiss the apps-needing-restart notice until the next Desktop launch.
- Installed-application picker searches remain unchanged.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
- [x] I have updated the changelog for this user-facing change

## Validation

- `pnpm -C apps/desktop run typecheck:renderer`
- `pnpm -C apps/desktop run build:renderer`
- `git diff --check`

The renderer build completes with the repository's existing CSS nesting and bundle-size warnings.
