### PR TITLE
fix(desktop): Enforce image moderation routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Changed
 
-- Desktop image chats now request `moderation: "low"` for image models whose selected seller, or every eligible auto-routed seller, advertises support for that parameter, disabling provider-side Safe Mode blurring without sending unsupported fields.
+- Desktop image chats now require sellers that advertise `moderation` support and send `moderation: "low"`, preventing automatic fallback to sellers that would silently restore provider-side Safe Mode blurring. Model lists show reviewed tags such as **Uncensored**, **Coding**, **Reasoning**, **Vision**, **Web search**, and **Open weights** from a versioned declarative registry covering maintained OpenRouter and Venice catalogs with per-model provenance, instead of trusting seller-announced categories. Seller rows identify offers with **Moderation control**, and requests fail clearly when no compatible seller is available.
 - The AntSeed X (Twitter) account moved from `@antseedai` to `@antseed`; all website, desktop help, and brand guideline links now point to https://x.com/antseed.
 
 - Desktop Connected Apps now opens directly to the complete app list without the redundant search field at the top; application-picker searches remain available when choosing an installed app. The Home notice for apps that need restarting can now be dismissed for the current app launch and returns after Desktop is relaunched.

--- a/apps/cli/src/proxy/buyer-proxy.test.ts
+++ b/apps/cli/src/proxy/buyer-proxy.test.ts
@@ -601,6 +601,114 @@ test('model-only request routes to the highest-ranked canonical service match', 
   assert.equal(selectedBody?.['model'], 'opus-5')
 })
 
+test('required parameters filter automatic routes and are stripped before seller dispatch', async () => {
+  const unsupported = makePeer('a', ['openai'])
+  unsupported.reputationScore = 99
+  unsupported.providerServiceApiProtocols = {
+    openai: { services: { 'venice-sd35': ['openai-images'] } },
+  }
+  unsupported.providerServiceCapabilities = {
+    openai: { services: { 'venice-sd35': { outputs: ['image'] } } },
+  }
+  const supported = makePeer('b', ['openai'])
+  supported.reputationScore = 70
+  supported.providerServiceApiProtocols = {
+    openai: { services: { 'venice-sd35': ['openai-images'] } },
+  }
+  supported.providerServiceCapabilities = {
+    openai: {
+      services: {
+        'venice-sd35': { outputs: ['image'], supportedParameters: ['moderation'] },
+      },
+    },
+  }
+  const proxy = makeBuyerProxyWithPeers(
+    [unsupported, supported],
+    [unsupported, supported],
+    permissiveRouter(),
+  )
+  let selectedPeerId = ''
+  let forwardedHeaders: Record<string, string> = {}
+  ;(proxy as any)._node.sendRequest = async (
+    peer: PeerInfo,
+    request: { requestId: string; headers: Record<string, string> },
+  ) => {
+    selectedPeerId = peer.peerId
+    forwardedHeaders = request.headers
+    return {
+      requestId: request.requestId,
+      statusCode: 200,
+      headers: { 'content-type': 'application/json' },
+      body: Buffer.from(JSON.stringify({ data: [{ b64_json: 'image' }] })),
+    }
+  }
+
+  const res = await invokeProxy(proxy, makeProxyRequest({
+    path: '/v1/images/generations',
+    headers: { 'x-antseed-required-parameters': 'moderation' },
+    body: { model: 'venice-sd35', prompt: 'a landscape', moderation: 'low' },
+  }))
+
+  assert.equal(res.statusCode, 200)
+  assert.equal(selectedPeerId, supported.peerId)
+  assert.equal(forwardedHeaders['x-antseed-required-parameters'], undefined)
+})
+
+test('required parameters fail clearly when no automatic route advertises support', async () => {
+  const peer = makePeer('a', ['openai'])
+  peer.providerServiceApiProtocols = {
+    openai: { services: { 'venice-sd35': ['openai-images'] } },
+  }
+  peer.providerServiceCapabilities = {
+    openai: { services: { 'venice-sd35': { outputs: ['image'] } } },
+  }
+  const proxy = makeBuyerProxyWithPeers([peer], [peer], permissiveRouter())
+  let dispatches = 0
+  ;(proxy as any)._node.sendRequest = async () => {
+    dispatches += 1
+    throw new Error('must not dispatch')
+  }
+
+  const res = await invokeProxy(proxy, makeProxyRequest({
+    path: '/v1/images/generations',
+    headers: { 'x-antseed-required-parameters': 'moderation' },
+    body: { model: 'venice-sd35', prompt: 'a landscape', moderation: 'low' },
+  }))
+
+  assert.equal(res.statusCode, 422)
+  assert.equal(JSON.parse(res.body).error.code, 'required_capability_unavailable')
+  assert.equal(dispatches, 0)
+})
+
+test('pinned routes fail clearly when the seller lacks a required parameter', async () => {
+  const peer = makePeer('a', ['openai'])
+  peer.providerServiceApiProtocols = {
+    openai: { services: { 'venice-sd35': ['openai-images'] } },
+  }
+  peer.providerServiceCapabilities = {
+    openai: { services: { 'venice-sd35': { outputs: ['image'] } } },
+  }
+  const proxy = makeBuyerProxyWithPeers([peer], [peer], permissiveRouter())
+  let dispatches = 0
+  ;(proxy as any)._node.sendRequest = async () => {
+    dispatches += 1
+    throw new Error('must not dispatch')
+  }
+
+  const res = await invokeProxy(proxy, makeProxyRequest({
+    path: '/v1/images/generations',
+    headers: {
+      'x-antseed-pin-peer': peer.peerId,
+      'x-antseed-required-parameters': 'moderation',
+    },
+    body: { model: 'venice-sd35', prompt: 'a landscape', moderation: 'low' },
+  }))
+
+  assert.equal(res.statusCode, 422)
+  assert.equal(JSON.parse(res.body).error.code, 'required_capability_unavailable')
+  assert.equal(dispatches, 0)
+})
+
 test('conversation routing keeps the actual peer as a soft preference and fails over when needed', async () => {
   const preferred = makePeer('c', ['openai'])
   preferred.reputationScore = 70

--- a/apps/cli/src/proxy/buyer-proxy.ts
+++ b/apps/cli/src/proxy/buyer-proxy.ts
@@ -60,10 +60,13 @@ import {
   parseModelTypeFilter,
 } from './network-models.js'
 import {
+  findMissingRequiredParameters,
   findUnannouncedRequestParameters,
   findAdvertisedServiceOffer,
   getExplicitProviderOverride,
   getExplicitPeerIdOverride,
+  parseRequiredParametersHeader,
+  REQUIRED_PARAMETERS_HEADER,
   resolvePeerRoutePlan,
   selectCandidatePeersForRouting,
   type CandidatePeerRouteSelection,
@@ -2128,6 +2131,21 @@ export class BuyerProxy {
       headers,
       body: new Uint8Array(body),
     }
+    const requiredParameters = parseRequiredParametersHeader(
+      serializedReq.headers[REQUIRED_PARAMETERS_HEADER],
+    )
+    if (requiredParameters === null) {
+      res.writeHead(400, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({
+        error: {
+          type: 'invalid_request_error',
+          code: 'invalid_required_parameters',
+          message: `${REQUIRED_PARAMETERS_HEADER} must contain at most 16 comma-separated parameter names.`,
+          param: REQUIRED_PARAMETERS_HEADER,
+        },
+      }))
+      return
+    }
 
     // Snapshot the session overrides before any await so a concurrent
     // _reloadSessionOverrides() cannot change routing mid-request.
@@ -2344,6 +2362,21 @@ export class BuyerProxy {
           if (!plan?.serviceId) return null
           const offer = findAdvertisedServiceOffer(peer, plan.provider, plan.serviceId)
           if (!offer) return null
+          const missingRequired = plan.selection?.requiresTransform
+            ? requiredParameters
+            : findMissingRequiredParameters(
+                peer,
+                plan.provider,
+                plan.serviceId,
+                requiredParameters,
+              )
+          if (missingRequired.length > 0) {
+            log(
+              `Capability filter: peer ${peer.peerId.slice(0, 12)}... service="${plan.serviceId}" `
+              + `missing required parameter(s): ${missingRequired.join(', ')}`,
+            )
+            return null
+          }
           const requestForPolicy = withRoutedModel(serializedReq, plan.serviceId)
           if (!peerAllowedByPolicy(policyRouter, requestForPolicy, peer)) return null
           return {
@@ -2398,14 +2431,22 @@ export class BuyerProxy {
         }
       }
       if (candidates.length === 0) {
-        res.writeHead(502, { 'content-type': 'application/json' })
+        const capabilityRequired = requiredParameters.length > 0
+        res.writeHead(capabilityRequired ? 422 : 502, { 'content-type': 'application/json' })
         res.end(JSON.stringify({
-          error: {
-            type: 'model_not_found',
-            code: 'model_not_found',
-            message: `No policy-allowed peer currently serves model "${requestedService}".`,
-            param: 'model',
-          },
+          error: capabilityRequired
+            ? {
+                type: 'required_capability_unavailable',
+                code: 'required_capability_unavailable',
+                message: `No policy-allowed seller for model "${requestedService}" advertises required parameter(s): ${requiredParameters.join(', ')}.`,
+                param: REQUIRED_PARAMETERS_HEADER,
+              }
+            : {
+                type: 'model_not_found',
+                code: 'model_not_found',
+                message: `No policy-allowed peer currently serves model "${requestedService}".`,
+                param: 'model',
+              },
         }))
         return
       }
@@ -2614,6 +2655,26 @@ export class BuyerProxy {
     const selectedPlan = routingPlans.get(selectedPeer.peerId)
       ?? resolvePeerRoutePlan(selectedPeer, requestProtocol, requestedService, explicitProvider, 'lenient')
     const pinnedServiceId = selectedPlan?.serviceId ?? requestedService
+    const missingRequired = selectedPlan && !selectedPlan.selection?.requiresTransform
+      ? findMissingRequiredParameters(
+          selectedPeer,
+          selectedPlan.provider,
+          pinnedServiceId,
+          requiredParameters,
+        )
+      : requiredParameters
+    if (missingRequired.length > 0) {
+      res.writeHead(422, { 'content-type': 'application/json' })
+      res.end(JSON.stringify({
+        error: {
+          type: 'required_capability_unavailable',
+          code: 'required_capability_unavailable',
+          message: `Pinned seller does not advertise required parameter(s) for model "${pinnedServiceId ?? requestedService ?? 'unknown'}": ${missingRequired.join(', ')}.`,
+          param: REQUIRED_PARAMETERS_HEADER,
+        },
+      }))
+      return
+    }
     const pinnedRequest = pinnedServiceId ? withRoutedModel(serializedReq, pinnedServiceId) : serializedReq
     if (!peerAllowedByPolicy(policyRouter, pinnedRequest, selectedPeer)) {
       log(`Pinned peer ${selectedPeer.peerId.slice(0, 12)}... filtered out by buyer routing policy`)
@@ -2802,6 +2863,7 @@ export class BuyerProxy {
     const {
       'x-antseed-pin-peer': _pinPeer,
       'x-antseed-prefer-peer': _preferPeer,
+      [REQUIRED_PARAMETERS_HEADER]: _requiredParameters,
       'x-vpr-session-id': _vprSession,
       // Legacy desktop builds (pre AntStation → VPR rename) still send this.
       'x-antstation-session-id': _antstationSession,

--- a/apps/cli/src/proxy/routing-parameters.test.ts
+++ b/apps/cli/src/proxy/routing-parameters.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import type { PeerInfo } from '@antseed/node'
-import { findUnannouncedRequestParameters } from './routing.js'
+import {
+  findMissingRequiredParameters,
+  findUnannouncedRequestParameters,
+  parseRequiredParametersHeader,
+} from './routing.js'
 
 const encode = (value: unknown): Uint8Array => new TextEncoder().encode(JSON.stringify(value))
 
@@ -35,6 +39,28 @@ const imagePeer = makePeer({
       },
     },
   },
+})
+
+test('parses normalized required-parameter constraints and rejects malformed values', () => {
+  assert.deepEqual(parseRequiredParametersHeader(undefined), [])
+  assert.deepEqual(parseRequiredParametersHeader(' Moderation,moderation,output_format '), ['moderation', 'output_format'])
+  assert.equal(parseRequiredParametersHeader('moderation,not valid'), null)
+  assert.equal(parseRequiredParametersHeader(Array.from({ length: 17 }, (_, index) => `p${index}`).join(',')), null)
+})
+
+test('strict required parameters reject absent metadata and accept announced support', () => {
+  assert.deepEqual(
+    findMissingRequiredParameters(imagePeer, 'openai', 'gpt-image-1', ['quality', 'moderation']),
+    ['moderation'],
+  )
+  assert.deepEqual(
+    findMissingRequiredParameters(imagePeer, 'OpenAI', 'GPT Image 1', ['OUTPUT_FORMAT']),
+    [],
+  )
+  assert.deepEqual(
+    findMissingRequiredParameters(makePeer(), 'openai', 'gpt-image-1', ['moderation']),
+    ['moderation'],
+  )
 })
 
 test('flags parameters outside the announced list plus protocol baseline', () => {

--- a/apps/cli/src/proxy/routing.ts
+++ b/apps/cli/src/proxy/routing.ts
@@ -26,6 +26,52 @@ export type CandidatePeerRouteSelection = {
   routePlanByPeerId: Map<string, PeerProtocolRoutePlan>
 }
 
+export const REQUIRED_PARAMETERS_HEADER = 'x-antseed-required-parameters'
+const REQUIRED_PARAMETER_PATTERN = /^[a-z][a-z0-9_.-]{0,63}$/
+const MAX_REQUIRED_PARAMETERS = 16
+
+/**
+ * Parse an internal buyer routing constraint. An empty array means no
+ * constraint; null means the caller supplied a malformed header.
+ */
+export function parseRequiredParametersHeader(value: string | undefined): string[] | null {
+  if (value === undefined || value.trim() === '') return []
+  if (value.length > 1_024) return null
+  const parameters = [...new Set(value.split(',').map((entry) => entry.trim().toLowerCase()))]
+  if (
+    parameters.length === 0
+    || parameters.length > MAX_REQUIRED_PARAMETERS
+    || parameters.some((parameter) => !REQUIRED_PARAMETER_PATTERN.test(parameter))
+  ) {
+    return null
+  }
+  return parameters
+}
+
+/** Required parameters are strict: missing capability metadata is unsupported. */
+export function findMissingRequiredParameters(
+  peer: PeerInfo,
+  provider: string,
+  requestedService: string | null,
+  requiredParameters: readonly string[],
+): string[] {
+  if (requiredParameters.length === 0) return []
+  const service = requestedService?.trim()
+  if (!service) return [...requiredParameters]
+
+  const providerKey = Object.keys(peer.providerServiceCapabilities ?? {})
+    .find((key) => key.toLowerCase() === provider.toLowerCase())
+  const services = providerKey ? peer.providerServiceCapabilities?.[providerKey]?.services : undefined
+  const serviceKey = services
+    ? Object.keys(services).find((key) => isRequestedServiceMatch(key, service))
+    : undefined
+  const announced = serviceKey ? services?.[serviceKey]?.supportedParameters : undefined
+  if (!announced) return [...requiredParameters]
+
+  const supported = new Set(announced.map((parameter) => parameter.trim().toLowerCase()))
+  return requiredParameters.filter((parameter) => !supported.has(parameter.toLowerCase()))
+}
+
 // `strict` drops peers that don't advertise the requested service; `lenient`
 // falls back to the provider's protocol set so a pinned peer still dispatches
 // and surfaces the seller's real upstream error.
@@ -297,8 +343,11 @@ export function findUnannouncedRequestParameters(
 
   const fields = extractRequestBodyFields(request.headers, request.body)
   if (!fields) return []
-  const allowed = new Set<string>([...announced, ...(PROTOCOL_BASELINE_FIELDS[requestProtocol] ?? [])])
-  return Object.keys(fields).filter((key) => !allowed.has(key))
+  const allowed = new Set<string>(
+    [...announced, ...(PROTOCOL_BASELINE_FIELDS[requestProtocol] ?? [])]
+      .map((parameter) => parameter.toLowerCase()),
+  )
+  return Object.keys(fields).filter((key) => !allowed.has(key.toLowerCase()))
 }
 
 export function pickProviderForPeer(peer: PeerInfo, request: SerializedHttpRequest): string {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "ensure:cli-dist": "pnpm -C ../../packages/api-adapter build && pnpm -C ../../packages/protocol build && pnpm -C ../../packages/buyer-core build && pnpm -C ../../packages/router-core build && pnpm -C ../../plugins/router-local build && pnpm -C ../../packages/node build && pnpm -C ../payments build:server && pnpm -C ../cli build",
     "brand:electron-dev": "node ./scripts/brand-electron-dev.mjs",
+    "models:update-metadata": "pnpm -C ../../packages/node build && node ./scripts/update-model-metadata.mjs",
     "ensure:native": "npm run ensure:runtime-native",
     "ensure:runtime-native": "node ./scripts/ensure-runtime-native-modules.mjs",
     "prebuild": "npm run ensure:cli-dist && npm run brand:electron-dev && npm run ensure:native && node ../../scripts/remove-paths.mjs dist",

--- a/apps/desktop/scripts/update-model-metadata.mjs
+++ b/apps/desktop/scripts/update-model-metadata.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+import { writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { canonicalModelKey } from '../../../packages/node/dist/model-identity.js';
+
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1/models';
+const VENICE_URL = 'https://api.venice.ai/api/v1/models?type=all';
+const OUTPUT_URL = new URL('../src/renderer/modules/catalog/model-metadata.json', import.meta.url);
+const TAG_ORDER = [
+  'Uncensored',
+  'Coding',
+  'Reasoning',
+  'Vision',
+  'Web search',
+  'Audio input',
+  'Video input',
+  'Roleplay',
+  'Anime',
+  'Fast',
+  'Open weights',
+];
+
+async function fetchCatalog(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`);
+  const payload = await response.json();
+  if (!Array.isArray(payload?.data)) throw new Error(`Invalid model catalog from ${url}`);
+  return payload.data;
+}
+
+function explicitlyOpenWeights(description) {
+  return typeof description === 'string'
+    && !/\bproprietary\b/i.test(description)
+    && /\b(open[- ]source(?:d)?|open[- ]weights?|open[- ]weight(?:ed)?)\b/i.test(description);
+}
+
+function tagsFromOpenRouter(model) {
+  const tags = new Set();
+  const name = model.name ?? model.id;
+  if (model.reasoning) tags.add('Reasoning');
+  if (model.architecture?.input_modalities?.includes('image')) tags.add('Vision');
+  if (/\b(sonar|search)\b/i.test(name)
+    && (model.pricing?.web_search != null || model.supported_parameters?.includes('web_search_options'))) {
+    tags.add('Web search');
+  }
+  if (/\b(codex|coder|codestral|code[- ]?audit)\b/i.test(name)) tags.add('Coding');
+  if (/\brole[- ]?play\b/i.test(name)) tags.add('Roleplay');
+  if (/\b(fast|flash|turbo|lightning|spark|highspeed)\b/i.test(name)) tags.add('Fast');
+  if (explicitlyOpenWeights(model.description)) tags.add('Open weights');
+  return tags;
+}
+
+function tagsFromVenice(model) {
+  const tags = new Set();
+  const spec = model.model_spec ?? {};
+  const capabilities = spec.capabilities ?? {};
+  const name = spec.name ?? model.id;
+  if (spec.uncensored === true) tags.add('Uncensored');
+  if (capabilities.optimizedForCode === true) tags.add('Coding');
+  if (capabilities.supportsReasoning === true) tags.add('Reasoning');
+  if (capabilities.supportsVision === true) tags.add('Vision');
+  if (/\b(sonar|search)\b/i.test(name)
+    && (capabilities.supportsWebSearch === true || spec.supportsWebSearch === true)) tags.add('Web search');
+  if (capabilities.supportsAudioInput === true) tags.add('Audio input');
+  if (capabilities.supportsVideoInput === true) tags.add('Video input');
+  if (/\brole[- ]?play\b/i.test(name)) tags.add('Roleplay');
+  if (/\banime\b/i.test(name)) tags.add('Anime');
+  if (spec.traits?.includes('fastest') || /\b(fast|flash|turbo|lightning|spark|highspeed)\b/i.test(name)) {
+    tags.add('Fast');
+  }
+  if (explicitlyOpenWeights(spec.description)) tags.add('Open weights');
+  return tags;
+}
+
+function preferredOpenRouterId(id) {
+  const slash = id.lastIndexOf('/');
+  return slash >= 0 ? id.slice(slash + 1) : id;
+}
+
+function isCanonicalOpenRouterModel(model) {
+  return typeof model.id === 'string'
+    && !model.id.startsWith('openrouter/')
+    && !model.id.startsWith('~')
+    && !model.id.includes(':');
+}
+
+function mergeModel(byCanonicalKey, id, source, sourceId, tags) {
+  const key = canonicalModelKey(id);
+  if (!key) return;
+  const entry = byCanonicalKey.get(key) ?? { id, tags: new Set(), sources: {} };
+  for (const tag of tags) entry.tags.add(tag);
+  const sourceIds = entry.sources[source] ?? new Set();
+  sourceIds.add(sourceId);
+  entry.sources[source] = sourceIds;
+  byCanonicalKey.set(key, entry);
+}
+
+async function main() {
+  const [openRouter, venice] = await Promise.all([
+    fetchCatalog(OPENROUTER_URL),
+    fetchCatalog(VENICE_URL),
+  ]);
+  const byCanonicalKey = new Map();
+
+  // Prefer OpenRouter's unqualified slug as the registry key when both
+  // maintained catalogs describe the same canonical model.
+  for (const model of openRouter) {
+    if (!isCanonicalOpenRouterModel(model)) continue;
+    mergeModel(byCanonicalKey, preferredOpenRouterId(model.id), 'openrouter', model.id, tagsFromOpenRouter(model));
+  }
+  for (const model of venice) {
+    mergeModel(byCanonicalKey, model.id, 'venice', model.id, tagsFromVenice(model));
+  }
+
+  const aliasesByModel = {
+    'e2ee-gemma-4-26b-a4b-uncensored-p': ['gemma-4-26b-uncensored-p'],
+    'e2ee-qwen3-6-35b-a3b-uncensored-p': ['qwen3.6-35b-uncensored-p'],
+    'olafangensan-glm-4.7-flash-heretic': ['glm-4.7-flash-heretic'],
+    'qwen3.6-plus': ['qwen3.6-plus-uncensored'],
+    'venice-uncensored-role-play': ['venice-role-play-uncensored'],
+  };
+  for (const [modelId, aliases] of Object.entries(aliasesByModel)) {
+    const entry = byCanonicalKey.get(canonicalModelKey(modelId));
+    if (entry) entry.aliases = aliases;
+  }
+
+  const models = {};
+  for (const entry of [...byCanonicalKey.values()].sort((a, b) => a.id.localeCompare(b.id))) {
+    const sources = {};
+    if (entry.sources.openrouter) sources.openrouter = [...entry.sources.openrouter].sort();
+    if (entry.sources.venice) sources.venice = [...entry.sources.venice].sort();
+    models[entry.id] = {
+      tags: TAG_ORDER.filter((tag) => entry.tags.has(tag)),
+      ...(entry.aliases ? { aliases: entry.aliases } : {}),
+      sources,
+    };
+  }
+
+  const registry = {
+    version: 2,
+    reviewedAt: new Date().toISOString().slice(0, 10),
+    sources: {
+      openrouter: { label: 'OpenRouter model catalog', url: OPENROUTER_URL },
+      venice: { label: 'Venice model catalog', url: VENICE_URL },
+    },
+    tagDefinitions: {
+      Uncensored: 'The maintained upstream catalog explicitly marks the model uncensored.',
+      Coding: 'The upstream catalog identifies the model as code-optimized or its official model name is code-specific.',
+      Reasoning: 'The upstream catalog explicitly identifies reasoning support.',
+      Vision: 'The upstream catalog explicitly identifies image input support.',
+      'Web search': 'The upstream catalog identifies a search-specialized model with integrated web search.',
+      'Audio input': 'The upstream catalog explicitly identifies audio input support.',
+      'Video input': 'The upstream catalog explicitly identifies video input support.',
+      Roleplay: 'The official model name identifies a roleplay specialization.',
+      Anime: 'The official model name identifies an anime image specialization.',
+      Fast: 'The official model name or maintained upstream trait identifies a speed-optimized variant.',
+      'Open weights': 'A maintained upstream description explicitly identifies the model as open-source or open-weight.',
+    },
+    models,
+  };
+
+  await writeFile(OUTPUT_URL, `${JSON.stringify(registry, null, 2)}\n`);
+  const taggedCount = Object.values(models).filter((entry) => entry.tags.length > 0).length;
+  console.log(`Updated ${fileURLToPath(OUTPUT_URL)} with ${Object.keys(models).length} models (${taggedCount} tagged).`);
+}
+
+await main();

--- a/apps/desktop/src/main/chat/image-generation.test.ts
+++ b/apps/desktop/src/main/chat/image-generation.test.ts
@@ -6,10 +6,14 @@ import { convertAssistantMessageForUi } from './message-projection.js';
 
 test('generateChatImage uses model-only routing and persists the peer selected by the proxy', async () => {
   const originalFetch = globalThis.fetch;
-  const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const calls: Array<{ url: string; headers: Headers; body: Record<string, unknown> }> = [];
   const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
   globalThis.fetch = (async (input, init) => {
-    calls.push({ url: String(input), body: JSON.parse(String(init?.body)) as Record<string, unknown> });
+    calls.push({
+      url: String(input),
+      headers: new Headers(init?.headers),
+      body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+    });
     return new Response(JSON.stringify({ data: [{ b64_json: png.toString('base64') }] }), {
       status: 200,
       headers: {
@@ -57,6 +61,7 @@ test('generateChatImage uses model-only routing and persists the peer selected b
     assert.deepEqual(calls[0]?.body, {
       model: 'image-model', prompt: 'A tiny ant astronaut', n: 1, response_format: 'b64_json', moderation: 'low',
     });
+    assert.equal(calls[0]?.headers.get('x-antseed-required-parameters'), 'moderation');
     assert.equal(persistedPrompt, 'A tiny ant astronaut');
     assert.equal(persistedPeerId, 'routed-peer');
     assert.equal(persistedService, 'image-model-v2');
@@ -162,6 +167,7 @@ test('generateChatImage edits a prior generated image with multipart routing', a
     assert.equal(requestUrl, 'http://127.0.0.1:8377/v1/images/edits');
     assert.equal(requestHeaders.get('authorization'), 'Bearer antseed-desktop');
     assert.equal(requestHeaders.get('x-antseed-pin-peer'), 'image-peer');
+    assert.equal(requestHeaders.get('x-antseed-required-parameters'), 'moderation');
     assert.equal(requestHeaders.has('content-type'), false);
     assert.equal(loadedAttachmentId, 'source-image');
     assert.ok(requestBody instanceof FormData);

--- a/apps/desktop/src/main/chat/image-generation.ts
+++ b/apps/desktop/src/main/chat/image-generation.ts
@@ -193,7 +193,10 @@ export async function generateChatImage(
   try {
     let endpoint = '/v1/images/generations';
     let body: string | FormData;
-    const headers: Record<string, string> = { authorization: 'Bearer antseed-desktop' };
+    const headers: Record<string, string> = {
+      authorization: 'Bearer antseed-desktop',
+      ...(request.moderation ? { 'x-antseed-required-parameters': 'moderation' } : {}),
+    };
     if (sourceImageAttachmentId) {
       const source = await (dependencies.loadSourceAttachment ?? loadSourceAttachment)(conversationId, sourceImageAttachmentId);
       if (source.bytes.length === 0 || source.bytes.length > MAX_GENERATED_IMAGE_BYTES) {

--- a/apps/desktop/src/renderer/modules/catalog/model-capabilities.ts
+++ b/apps/desktop/src/renderer/modules/catalog/model-capabilities.ts
@@ -21,6 +21,14 @@ export function supportsImageEdits(row: DiscoverRow): boolean {
   return row.capabilities?.inputs?.some((input) => input.trim().toLowerCase() === 'image') ?? false;
 }
 
+export function supportsServiceParameter(row: DiscoverRow, parameter: string): boolean {
+  const normalized = parameter.trim().toLowerCase();
+  return normalized.length > 0 && (
+    row.capabilities?.supportedParameters
+      ?.some((supported) => supported.trim().toLowerCase() === normalized) ?? false
+  );
+}
+
 export function formatTokenCount(value: number): string {
   if (value >= 1_000_000) {
     const millions = value / 1_000_000;
@@ -33,15 +41,15 @@ export function formatTokenCount(value: number): string {
   return value.toLocaleString('en-US');
 }
 
-export function modelCapabilitySummary(entry: VprModelCatalogEntry): string[] {
-  return entry.kind === 'image' ? ['Image generation only'] : [];
+export function modelCapabilitySummary(_entry: VprModelCatalogEntry): string[] {
+  return [];
 }
 
 export function peerCapabilitySummary(row: DiscoverRow): string[] {
   const capabilities = row.capabilities;
   const summary: string[] = [];
-  if (serviceModelKind(row.protocol, capabilities) === 'image') {
-    summary.push(supportsImageEdits(row) ? 'Image generation + editing' : 'Image generation only');
+  if (serviceModelKind(row.protocol, capabilities) === 'image' && supportsImageEdits(row)) {
+    summary.push('Image editing');
   }
   if (capabilities?.contextWindow) summary.push(`${formatTokenCount(capabilities.contextWindow)} context`);
   if (capabilities?.maxOutputTokens) summary.push(`${formatTokenCount(capabilities.maxOutputTokens)} max output`);

--- a/apps/desktop/src/renderer/modules/catalog/model-metadata.json
+++ b/apps/desktop/src/renderer/modules/catalog/model-metadata.json
@@ -1,0 +1,5745 @@
+{
+  "version": 2,
+  "reviewedAt": "2026-08-17",
+  "sources": {
+    "openrouter": {
+      "label": "OpenRouter model catalog",
+      "url": "https://openrouter.ai/api/v1/models"
+    },
+    "venice": {
+      "label": "Venice model catalog",
+      "url": "https://api.venice.ai/api/v1/models?type=all"
+    }
+  },
+  "tagDefinitions": {
+    "Uncensored": "The maintained upstream catalog explicitly marks the model uncensored.",
+    "Coding": "The upstream catalog identifies the model as code-optimized or its official model name is code-specific.",
+    "Reasoning": "The upstream catalog explicitly identifies reasoning support.",
+    "Vision": "The upstream catalog explicitly identifies image input support.",
+    "Web search": "The upstream catalog identifies a search-specialized model with integrated web search.",
+    "Audio input": "The upstream catalog explicitly identifies audio input support.",
+    "Video input": "The upstream catalog explicitly identifies video input support.",
+    "Roleplay": "The official model name identifies a roleplay specialization.",
+    "Anime": "The official model name identifies an anime image specialization.",
+    "Fast": "The official model name or maintained upstream trait identifies a speed-optimized variant.",
+    "Open weights": "A maintained upstream description explicitly identifies the model as open-source or open-weight."
+  },
+  "models": {
+    "ace-step-15": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "ace-step-15"
+        ]
+      }
+    },
+    "aion-2.0": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "aion-labs/aion-2.0"
+        ]
+      }
+    },
+    "aion-3.0": {
+      "tags": [
+        "Uncensored",
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "aion-labs/aion-3.0"
+        ],
+        "venice": [
+          "aion-labs-aion-3-0"
+        ]
+      }
+    },
+    "aion-3.0-mini": {
+      "tags": [
+        "Uncensored",
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "aion-labs/aion-3.0-mini"
+        ],
+        "venice": [
+          "aion-labs-aion-3-0-mini"
+        ]
+      }
+    },
+    "aion-rp-llama-3.1-8b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "aion-labs/aion-rp-llama-3.1-8b"
+        ]
+      }
+    },
+    "bria-bg-remover": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "bria-bg-remover"
+        ]
+      }
+    },
+    "chroma": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "chroma"
+        ]
+      }
+    },
+    "claude-3-haiku": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-3-haiku"
+        ]
+      }
+    },
+    "claude-fable-5": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-fable-5"
+        ],
+        "venice": [
+          "claude-fable-5"
+        ]
+      }
+    },
+    "claude-haiku-4.5": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-haiku-4.5"
+        ]
+      }
+    },
+    "claude-opus-4": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-opus-4"
+        ]
+      }
+    },
+    "claude-opus-4.1": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-opus-4.1"
+        ]
+      }
+    },
+    "claude-opus-4.5": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-opus-4.5"
+        ],
+        "venice": [
+          "claude-opus-4-5"
+        ]
+      }
+    },
+    "claude-opus-4.6": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-opus-4.6"
+        ],
+        "venice": [
+          "claude-opus-4-6"
+        ]
+      }
+    },
+    "claude-opus-4.7": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-opus-4.7"
+        ],
+        "venice": [
+          "claude-opus-4-7"
+        ]
+      }
+    },
+    "claude-opus-4.7-fast": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-opus-4.7-fast"
+        ]
+      }
+    },
+    "claude-opus-4.8": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-opus-4.8"
+        ],
+        "venice": [
+          "claude-opus-4-8"
+        ]
+      }
+    },
+    "claude-opus-4.8-fast": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-opus-4.8-fast"
+        ],
+        "venice": [
+          "claude-opus-4-8-fast"
+        ]
+      }
+    },
+    "claude-opus-5": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-opus-5"
+        ],
+        "venice": [
+          "claude-opus-5"
+        ]
+      }
+    },
+    "claude-opus-5-fast": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-opus-5-fast"
+        ],
+        "venice": [
+          "claude-opus-5-fast"
+        ]
+      }
+    },
+    "claude-sonnet-4": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-sonnet-4"
+        ]
+      }
+    },
+    "claude-sonnet-4.5": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-sonnet-4.5"
+        ],
+        "venice": [
+          "claude-sonnet-4-5"
+        ]
+      }
+    },
+    "claude-sonnet-4.6": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-sonnet-4.6"
+        ],
+        "venice": [
+          "claude-sonnet-4-6"
+        ]
+      }
+    },
+    "claude-sonnet-5": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "anthropic/claude-sonnet-5"
+        ],
+        "venice": [
+          "claude-sonnet-5"
+        ]
+      }
+    },
+    "codestral-2508": {
+      "tags": [
+        "Coding"
+      ],
+      "sources": {
+        "openrouter": [
+          "mistralai/codestral-2508"
+        ]
+      }
+    },
+    "cogito-v2.1-671b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "deepcogito/cogito-v2.1-671b"
+        ]
+      }
+    },
+    "command-a": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "cohere/command-a"
+        ]
+      }
+    },
+    "command-r-08-2024": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "cohere/command-r-08-2024"
+        ]
+      }
+    },
+    "command-r-plus-08-2024": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "cohere/command-r-plus-08-2024"
+        ]
+      }
+    },
+    "command-r7b-12-2024": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "cohere/command-r7b-12-2024"
+        ]
+      }
+    },
+    "cydonia-24b-v4.1": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "thedrummer/cydonia-24b-v4.1"
+        ]
+      }
+    },
+    "deepseek-chat": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-chat"
+        ]
+      }
+    },
+    "deepseek-chat-v3-0324": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-chat-v3-0324"
+        ]
+      }
+    },
+    "deepseek-chat-v3.1": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-chat-v3.1"
+        ]
+      }
+    },
+    "deepseek-r1": {
+      "tags": [
+        "Reasoning",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-r1"
+        ]
+      }
+    },
+    "deepseek-r1-0528": {
+      "tags": [
+        "Reasoning",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-r1-0528"
+        ]
+      }
+    },
+    "deepseek-r1-distill-llama-70b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-r1-distill-llama-70b"
+        ]
+      }
+    },
+    "deepseek-v3.1-terminus": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-v3.1-terminus"
+        ]
+      }
+    },
+    "deepseek-v3.2": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-v3.2"
+        ],
+        "venice": [
+          "deepseek-v3.2"
+        ]
+      }
+    },
+    "deepseek-v3.2-exp": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-v3.2-exp"
+        ]
+      }
+    },
+    "deepseek-v4-flash": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-v4-flash"
+        ],
+        "venice": [
+          "deepseek-v4-flash"
+        ]
+      }
+    },
+    "deepseek-v4-flash-0731": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-v4-flash-0731"
+        ],
+        "venice": [
+          "deepseek-v4-flash-0731"
+        ]
+      }
+    },
+    "deepseek-v4-flash-0731-fast": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "deepseek-v4-flash-0731-fast"
+        ]
+      }
+    },
+    "deepseek-v4-pro": {
+      "tags": [
+        "Coding",
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-v4-pro"
+        ],
+        "venice": [
+          "deepseek-v4-pro"
+        ]
+      }
+    },
+    "deepseek-v4-pro-0813": {
+      "tags": [
+        "Coding",
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "deepseek/deepseek-v4-pro-0813"
+        ],
+        "venice": [
+          "deepseek-v4-pro-0813"
+        ]
+      }
+    },
+    "dolphin-mistral-24b-venice-edition": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "cognitivecomputations/dolphin-mistral-24b-venice-edition"
+        ]
+      }
+    },
+    "e2ee-deepseek-v4-flash": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "e2ee-deepseek-v4-flash"
+        ]
+      }
+    },
+    "e2ee-gemma-3-27b-p": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "e2ee-gemma-3-27b-p"
+        ]
+      }
+    },
+    "e2ee-gemma-4-26b-a4b-uncensored-p": {
+      "tags": [
+        "Uncensored"
+      ],
+      "aliases": [
+        "gemma-4-26b-uncensored-p"
+      ],
+      "sources": {
+        "venice": [
+          "e2ee-gemma-4-26b-a4b-uncensored-p"
+        ]
+      }
+    },
+    "e2ee-gemma-4-31b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "venice": [
+          "e2ee-gemma-4-31b"
+        ]
+      }
+    },
+    "e2ee-glm-5-1": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "venice": [
+          "e2ee-glm-5-1"
+        ]
+      }
+    },
+    "e2ee-glm-5-2-p": {
+      "tags": [
+        "Coding",
+        "Reasoning"
+      ],
+      "sources": {
+        "venice": [
+          "e2ee-glm-5-2-p"
+        ]
+      }
+    },
+    "e2ee-gpt-oss-120b-p": {
+      "tags": [
+        "Reasoning",
+        "Open weights"
+      ],
+      "sources": {
+        "venice": [
+          "e2ee-gpt-oss-120b-p"
+        ]
+      }
+    },
+    "e2ee-gpt-oss-20b-p": {
+      "tags": [
+        "Reasoning",
+        "Open weights"
+      ],
+      "sources": {
+        "venice": [
+          "e2ee-gpt-oss-20b-p"
+        ]
+      }
+    },
+    "e2ee-qwen-2-5-7b-p": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "e2ee-qwen-2-5-7b-p"
+        ]
+      }
+    },
+    "e2ee-qwen3-6-27b": {
+      "tags": [
+        "Coding",
+        "Reasoning"
+      ],
+      "sources": {
+        "venice": [
+          "e2ee-qwen3-6-27b"
+        ]
+      }
+    },
+    "e2ee-qwen3-6-35b-a3b": {
+      "tags": [
+        "Coding",
+        "Reasoning"
+      ],
+      "sources": {
+        "venice": [
+          "e2ee-qwen3-6-35b-a3b"
+        ]
+      }
+    },
+    "e2ee-qwen3-6-35b-a3b-uncensored-p": {
+      "tags": [
+        "Uncensored"
+      ],
+      "aliases": [
+        "qwen3.6-35b-uncensored-p"
+      ],
+      "sources": {
+        "venice": [
+          "e2ee-qwen3-6-35b-a3b-uncensored-p"
+        ]
+      }
+    },
+    "e2ee-qwen3-vl-30b-a3b-p": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "venice": [
+          "e2ee-qwen3-vl-30b-a3b-p"
+        ]
+      }
+    },
+    "elevenlabs-music": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "elevenlabs-music"
+        ]
+      }
+    },
+    "elevenlabs-sound-effects-v2": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "elevenlabs-sound-effects-v2"
+        ]
+      }
+    },
+    "elevenlabs-tts-multilingual-v2": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "elevenlabs-tts-multilingual-v2"
+        ]
+      }
+    },
+    "elevenlabs-tts-v3": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "elevenlabs-tts-v3"
+        ]
+      }
+    },
+    "elevenlabs/scribe-v2": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "elevenlabs/scribe-v2"
+        ]
+      }
+    },
+    "ernie-4.5-vl-424b-a47b": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "baidu/ernie-4.5-vl-424b-a47b"
+        ]
+      }
+    },
+    "fal-ai/wizper": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "fal-ai/wizper"
+        ]
+      }
+    },
+    "firered-image-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "firered-image-edit"
+        ]
+      }
+    },
+    "flux-2-max": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "flux-2-max"
+        ]
+      }
+    },
+    "flux-2-max-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "flux-2-max-edit"
+        ]
+      }
+    },
+    "flux-2-pro": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "flux-2-pro"
+        ]
+      }
+    },
+    "flux-3-first-last-frame-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "flux-3-first-last-frame-to-video"
+        ]
+      }
+    },
+    "flux-3-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "flux-3-image-to-video"
+        ]
+      }
+    },
+    "flux-3-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "flux-3-text-to-video"
+        ]
+      }
+    },
+    "fugu-ultra": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "sakana/fugu-ultra"
+        ]
+      }
+    },
+    "gemini-2.5-flash": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-2.5-flash"
+        ]
+      }
+    },
+    "gemini-2.5-flash-image": {
+      "tags": [
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-2.5-flash-image"
+        ]
+      }
+    },
+    "gemini-2.5-flash-lite": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-2.5-flash-lite"
+        ]
+      }
+    },
+    "gemini-2.5-pro": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-2.5-pro"
+        ]
+      }
+    },
+    "gemini-2.5-pro-preview": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-2.5-pro-preview"
+        ]
+      }
+    },
+    "gemini-2.5-pro-preview-05-06": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-2.5-pro-preview-05-06"
+        ]
+      }
+    },
+    "gemini-3-flash-preview": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Audio input",
+        "Video input",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3-flash-preview"
+        ],
+        "venice": [
+          "gemini-3-flash-preview"
+        ]
+      }
+    },
+    "gemini-3-pro-image": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3-pro-image"
+        ]
+      }
+    },
+    "gemini-3-pro-image-preview": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3-pro-image-preview"
+        ]
+      }
+    },
+    "gemini-3.1-flash-image": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3.1-flash-image"
+        ]
+      }
+    },
+    "gemini-3.1-flash-image-preview": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3.1-flash-image-preview"
+        ]
+      }
+    },
+    "gemini-3.1-flash-lite": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3.1-flash-lite"
+        ]
+      }
+    },
+    "gemini-3.1-flash-lite-image": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3.1-flash-lite-image"
+        ]
+      }
+    },
+    "gemini-3.1-flash-lite-preview": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3.1-flash-lite-preview"
+        ]
+      }
+    },
+    "gemini-3.1-pro-preview": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Audio input",
+        "Video input"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3.1-pro-preview"
+        ],
+        "venice": [
+          "gemini-3-1-pro-preview"
+        ]
+      }
+    },
+    "gemini-3.1-pro-preview-customtools": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3.1-pro-preview-customtools"
+        ]
+      }
+    },
+    "gemini-3.5-flash": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Audio input",
+        "Video input",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3.5-flash"
+        ],
+        "venice": [
+          "gemini-3-5-flash"
+        ]
+      }
+    },
+    "gemini-3.5-flash-lite": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Audio input",
+        "Video input",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3.5-flash-lite"
+        ],
+        "venice": [
+          "gemini-3-5-flash-lite"
+        ]
+      }
+    },
+    "gemini-3.6-flash": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Audio input",
+        "Video input",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3.6-flash"
+        ],
+        "venice": [
+          "gemini-3-6-flash"
+        ]
+      }
+    },
+    "gemini-3.7-flash": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Audio input",
+        "Video input",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemini-3.7-flash"
+        ],
+        "venice": [
+          "gemini-3-7-flash"
+        ]
+      }
+    },
+    "gemini-embedding-2-preview": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "gemini-embedding-2-preview"
+        ]
+      }
+    },
+    "gemini-omni-flash-image-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "gemini-omni-flash-image-to-video"
+        ]
+      }
+    },
+    "gemini-omni-flash-reference-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "gemini-omni-flash-reference-to-video"
+        ]
+      }
+    },
+    "gemini-omni-flash-text-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "gemini-omni-flash-text-to-video"
+        ]
+      }
+    },
+    "gemma-2-27b-it": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "google/gemma-2-27b-it"
+        ]
+      }
+    },
+    "gemma-3-12b-it": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemma-3-12b-it"
+        ]
+      }
+    },
+    "gemma-3-27b-it": {
+      "tags": [
+        "Vision",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemma-3-27b-it"
+        ],
+        "venice": [
+          "google-gemma-3-27b-it"
+        ]
+      }
+    },
+    "gemma-3-4b-it": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemma-3-4b-it"
+        ]
+      }
+    },
+    "gemma-3n-e4b-it": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "google/gemma-3n-e4b-it"
+        ]
+      }
+    },
+    "gemma-4-26b-a4b-it": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Video input"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemma-4-26b-a4b-it"
+        ],
+        "venice": [
+          "google-gemma-4-26b-a4b-it"
+        ]
+      }
+    },
+    "gemma-4-31b-it": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Video input"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/gemma-4-31b-it"
+        ],
+        "venice": [
+          "google-gemma-4-31b-it"
+        ]
+      }
+    },
+    "gemma-4-uncensored": {
+      "tags": [
+        "Uncensored",
+        "Vision"
+      ],
+      "sources": {
+        "venice": [
+          "gemma-4-uncensored"
+        ]
+      }
+    },
+    "glm-4.5": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "z-ai/glm-4.5"
+        ]
+      }
+    },
+    "glm-4.5-air": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "z-ai/glm-4.5-air"
+        ]
+      }
+    },
+    "glm-4.5v": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "z-ai/glm-4.5v"
+        ]
+      }
+    },
+    "glm-4.6": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "z-ai/glm-4.6"
+        ],
+        "venice": [
+          "zai-org-glm-4.6"
+        ]
+      }
+    },
+    "glm-4.6v": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "z-ai/glm-4.6v"
+        ]
+      }
+    },
+    "glm-4.7": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "z-ai/glm-4.7"
+        ],
+        "venice": [
+          "zai-org-glm-4.7"
+        ]
+      }
+    },
+    "glm-4.7-flash": {
+      "tags": [
+        "Reasoning",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "z-ai/glm-4.7-flash"
+        ],
+        "venice": [
+          "zai-org-glm-4.7-flash"
+        ]
+      }
+    },
+    "glm-5": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "z-ai/glm-5"
+        ],
+        "venice": [
+          "zai-org-glm-5"
+        ]
+      }
+    },
+    "glm-5-turbo": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "z-ai/glm-5-turbo"
+        ],
+        "venice": [
+          "z-ai-glm-5-turbo"
+        ]
+      }
+    },
+    "glm-5.1": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "z-ai/glm-5.1"
+        ],
+        "venice": [
+          "zai-org-glm-5-1"
+        ]
+      }
+    },
+    "glm-5.2": {
+      "tags": [
+        "Coding",
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "z-ai/glm-5.2"
+        ],
+        "venice": [
+          "zai-org-glm-5-2"
+        ]
+      }
+    },
+    "glm-5v-turbo": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "z-ai/glm-5v-turbo"
+        ],
+        "venice": [
+          "z-ai-glm-5v-turbo"
+        ]
+      }
+    },
+    "gpt-3.5-turbo": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-3.5-turbo"
+        ]
+      }
+    },
+    "gpt-3.5-turbo-0613": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-3.5-turbo-0613"
+        ]
+      }
+    },
+    "gpt-3.5-turbo-16k": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-3.5-turbo-16k"
+        ]
+      }
+    },
+    "gpt-3.5-turbo-instruct": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-3.5-turbo-instruct"
+        ]
+      }
+    },
+    "gpt-4": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-4"
+        ]
+      }
+    },
+    "gpt-4-turbo": {
+      "tags": [
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-4-turbo"
+        ]
+      }
+    },
+    "gpt-4-turbo-preview": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-4-turbo-preview"
+        ]
+      }
+    },
+    "gpt-4.1": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-4.1"
+        ]
+      }
+    },
+    "gpt-4.1-mini": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-4.1-mini"
+        ]
+      }
+    },
+    "gpt-4.1-nano": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-4.1-nano"
+        ]
+      }
+    },
+    "gpt-4o-2024-11-20": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-4o",
+          "openai/gpt-4o-2024-05-13",
+          "openai/gpt-4o-2024-08-06",
+          "openai/gpt-4o-2024-11-20"
+        ],
+        "venice": [
+          "openai-gpt-4o-2024-11-20"
+        ]
+      }
+    },
+    "gpt-4o-mini": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-4o-mini",
+          "openai/gpt-4o-mini-2024-07-18"
+        ],
+        "venice": [
+          "openai-gpt-4o-mini-2024-07-18"
+        ]
+      }
+    },
+    "gpt-5": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5"
+        ]
+      }
+    },
+    "gpt-5-image": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5-image"
+        ]
+      }
+    },
+    "gpt-5-image-mini": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5-image-mini"
+        ]
+      }
+    },
+    "gpt-5-mini": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5-mini"
+        ]
+      }
+    },
+    "gpt-5-nano": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5-nano"
+        ]
+      }
+    },
+    "gpt-5-pro": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5-pro"
+        ]
+      }
+    },
+    "gpt-5.1": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.1"
+        ]
+      }
+    },
+    "gpt-5.1-codex": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.1-codex"
+        ]
+      }
+    },
+    "gpt-5.1-codex-max": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.1-codex-max"
+        ]
+      }
+    },
+    "gpt-5.1-codex-mini": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.1-codex-mini"
+        ]
+      }
+    },
+    "gpt-5.2": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.2"
+        ],
+        "venice": [
+          "openai-gpt-52"
+        ]
+      }
+    },
+    "gpt-5.2-chat": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.2-chat"
+        ]
+      }
+    },
+    "gpt-5.2-codex": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.2-codex"
+        ],
+        "venice": [
+          "openai-gpt-52-codex"
+        ]
+      }
+    },
+    "gpt-5.2-pro": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.2-pro"
+        ]
+      }
+    },
+    "gpt-5.3-codex": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.3-codex"
+        ],
+        "venice": [
+          "openai-gpt-53-codex"
+        ]
+      }
+    },
+    "gpt-5.4": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.4"
+        ],
+        "venice": [
+          "openai-gpt-54"
+        ]
+      }
+    },
+    "gpt-5.4-image-2": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.4-image-2"
+        ]
+      }
+    },
+    "gpt-5.4-mini": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.4-mini"
+        ],
+        "venice": [
+          "openai-gpt-54-mini"
+        ]
+      }
+    },
+    "gpt-5.4-nano": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.4-nano"
+        ]
+      }
+    },
+    "gpt-5.4-pro": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.4-pro"
+        ],
+        "venice": [
+          "openai-gpt-54-pro"
+        ]
+      }
+    },
+    "gpt-5.5": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.5"
+        ],
+        "venice": [
+          "openai-gpt-55"
+        ]
+      }
+    },
+    "gpt-5.5-pro": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.5-pro"
+        ],
+        "venice": [
+          "openai-gpt-55-pro"
+        ]
+      }
+    },
+    "gpt-5.6-luna": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.6-luna"
+        ],
+        "venice": [
+          "openai-gpt-56-luna"
+        ]
+      }
+    },
+    "gpt-5.6-luna-pro": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.6-luna-pro"
+        ],
+        "venice": [
+          "openai-gpt-56-luna-pro"
+        ]
+      }
+    },
+    "gpt-5.6-sol": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.6-sol"
+        ],
+        "venice": [
+          "openai-gpt-56-sol"
+        ]
+      }
+    },
+    "gpt-5.6-sol-pro": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.6-sol-pro"
+        ],
+        "venice": [
+          "openai-gpt-56-sol-pro"
+        ]
+      }
+    },
+    "gpt-5.6-terra": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.6-terra"
+        ],
+        "venice": [
+          "openai-gpt-56-terra"
+        ]
+      }
+    },
+    "gpt-5.6-terra-pro": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-5.6-terra-pro"
+        ],
+        "venice": [
+          "openai-gpt-56-terra-pro"
+        ]
+      }
+    },
+    "gpt-audio": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-audio"
+        ]
+      }
+    },
+    "gpt-audio-mini": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-audio-mini"
+        ]
+      }
+    },
+    "gpt-chat-latest": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-chat-latest"
+        ]
+      }
+    },
+    "gpt-image-1-5": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "gpt-image-1-5"
+        ]
+      }
+    },
+    "gpt-image-1-5-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "gpt-image-1-5-edit"
+        ]
+      }
+    },
+    "gpt-image-2": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "gpt-image-2"
+        ]
+      }
+    },
+    "gpt-image-2-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "gpt-image-2-edit"
+        ]
+      }
+    },
+    "gpt-oss-120b": {
+      "tags": [
+        "Reasoning",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-oss-120b"
+        ],
+        "venice": [
+          "openai-gpt-oss-120b"
+        ]
+      }
+    },
+    "gpt-oss-20b": {
+      "tags": [
+        "Reasoning",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-oss-20b"
+        ]
+      }
+    },
+    "gpt-oss-safeguard-20b": {
+      "tags": [
+        "Reasoning",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/gpt-oss-safeguard-20b"
+        ]
+      }
+    },
+    "granite-4.0-h-micro": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "ibm-granite/granite-4.0-h-micro"
+        ]
+      }
+    },
+    "granite-4.1-8b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "ibm-granite/granite-4.1-8b"
+        ]
+      }
+    },
+    "grok-4.20": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "x-ai/grok-4.20"
+        ],
+        "venice": [
+          "grok-4-20"
+        ]
+      }
+    },
+    "grok-4.20-multi-agent": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "x-ai/grok-4.20-multi-agent"
+        ],
+        "venice": [
+          "grok-4-20-multi-agent"
+        ]
+      }
+    },
+    "grok-4.3": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "x-ai/grok-4.3"
+        ],
+        "venice": [
+          "grok-4-3"
+        ]
+      }
+    },
+    "grok-4.5": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "x-ai/grok-4.5"
+        ],
+        "venice": [
+          "grok-4-5"
+        ]
+      }
+    },
+    "grok-4.6": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "x-ai/grok-4.6"
+        ],
+        "venice": [
+          "grok-4-6"
+        ]
+      }
+    },
+    "grok-build-0.1": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "x-ai/grok-build-0.1"
+        ],
+        "venice": [
+          "grok-build-0-1"
+        ]
+      }
+    },
+    "grok-imagine-1-5-image-to-video-private": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-1-5-image-to-video-private"
+        ]
+      }
+    },
+    "grok-imagine-1-5-reference-to-video-private": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-1-5-reference-to-video-private"
+        ]
+      }
+    },
+    "grok-imagine-1-5-text-to-video-private": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-1-5-text-to-video-private"
+        ]
+      }
+    },
+    "grok-imagine-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-edit"
+        ]
+      }
+    },
+    "grok-imagine-image": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-image"
+        ]
+      }
+    },
+    "grok-imagine-image-2-0": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-image-2-0"
+        ]
+      }
+    },
+    "grok-imagine-image-2-0-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-image-2-0-edit"
+        ]
+      }
+    },
+    "grok-imagine-image-quality": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-image-quality"
+        ]
+      }
+    },
+    "grok-imagine-image-to-video-private": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-image-to-video-private"
+        ]
+      }
+    },
+    "grok-imagine-quality-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-quality-edit"
+        ]
+      }
+    },
+    "grok-imagine-reference-to-video-private": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-reference-to-video-private"
+        ]
+      }
+    },
+    "grok-imagine-text-to-video-private": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-text-to-video-private"
+        ]
+      }
+    },
+    "grok-imagine-video-to-video-private": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "grok-imagine-video-to-video-private"
+        ]
+      }
+    },
+    "happyhorse-1-0-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "happyhorse-1-0-image-to-video"
+        ]
+      }
+    },
+    "happyhorse-1-0-reference-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "happyhorse-1-0-reference-to-video"
+        ]
+      }
+    },
+    "happyhorse-1-0-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "happyhorse-1-0-text-to-video"
+        ]
+      }
+    },
+    "happyhorse-1-0-video-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "happyhorse-1-0-video-to-video"
+        ]
+      }
+    },
+    "happyhorse-1-1-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "happyhorse-1-1-image-to-video"
+        ]
+      }
+    },
+    "happyhorse-1-1-reference-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "happyhorse-1-1-reference-to-video"
+        ]
+      }
+    },
+    "happyhorse-1-1-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "happyhorse-1-1-text-to-video"
+        ]
+      }
+    },
+    "hermes-3-llama-3.1-405b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "nousresearch/hermes-3-llama-3.1-405b"
+        ],
+        "venice": [
+          "hermes-3-llama-3.1-405b"
+        ]
+      }
+    },
+    "hermes-3-llama-3.1-70b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "nousresearch/hermes-3-llama-3.1-70b"
+        ]
+      }
+    },
+    "hermes-4-405b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "nousresearch/hermes-4-405b"
+        ]
+      }
+    },
+    "hermes-4-70b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "nousresearch/hermes-4-70b"
+        ]
+      }
+    },
+    "hunyuan-a13b-instruct": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "tencent/hunyuan-a13b-instruct"
+        ]
+      }
+    },
+    "hunyuan-image-v3": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "hunyuan-image-v3"
+        ]
+      }
+    },
+    "hy3": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "tencent/hy3"
+        ]
+      }
+    },
+    "hy3-preview": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "tencent/hy3-preview"
+        ]
+      }
+    },
+    "ideogram-v4": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "ideogram-v4"
+        ]
+      }
+    },
+    "imagineart-1.5-pro": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "imagineart-1.5-pro"
+        ]
+      }
+    },
+    "inkling": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Audio input",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "thinkingmachines/inkling"
+        ],
+        "venice": [
+          "inkling"
+        ]
+      }
+    },
+    "inkling-small": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "thinkingmachines/inkling-small"
+        ]
+      }
+    },
+    "jamba-large-1.7": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "ai21/jamba-large-1.7"
+        ]
+      }
+    },
+    "kat-coder-air-v2.5": {
+      "tags": [
+        "Coding"
+      ],
+      "sources": {
+        "openrouter": [
+          "kwaipilot/kat-coder-air-v2.5"
+        ]
+      }
+    },
+    "kat-coder-pro-v2": {
+      "tags": [
+        "Coding"
+      ],
+      "sources": {
+        "openrouter": [
+          "kwaipilot/kat-coder-pro-v2"
+        ]
+      }
+    },
+    "kat-coder-pro-v2.5": {
+      "tags": [
+        "Coding"
+      ],
+      "sources": {
+        "openrouter": [
+          "kwaipilot/kat-coder-pro-v2.5"
+        ]
+      }
+    },
+    "kimi-k2": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "moonshotai/kimi-k2"
+        ]
+      }
+    },
+    "kimi-k2-0905": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "moonshotai/kimi-k2-0905"
+        ]
+      }
+    },
+    "kimi-k2-thinking": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "moonshotai/kimi-k2-thinking"
+        ]
+      }
+    },
+    "kimi-k2.5": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "moonshotai/kimi-k2.5"
+        ],
+        "venice": [
+          "kimi-k2-5"
+        ]
+      }
+    },
+    "kimi-k2.6": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "moonshotai/kimi-k2.6"
+        ],
+        "venice": [
+          "kimi-k2-6"
+        ]
+      }
+    },
+    "kimi-k2.7-code": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "moonshotai/kimi-k2.7-code"
+        ],
+        "venice": [
+          "kimi-k2-7-code"
+        ]
+      }
+    },
+    "kimi-k3": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "moonshotai/kimi-k3"
+        ],
+        "venice": [
+          "kimi-k3"
+        ]
+      }
+    },
+    "kimi-k3-fast-api": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Fast",
+        "Open weights"
+      ],
+      "sources": {
+        "venice": [
+          "kimi-k3-fast-api"
+        ]
+      }
+    },
+    "kling-2.5-turbo-pro-image-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "kling-2.5-turbo-pro-image-to-video"
+        ]
+      }
+    },
+    "kling-2.5-turbo-pro-text-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "kling-2.5-turbo-pro-text-to-video"
+        ]
+      }
+    },
+    "kling-2.6-pro-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-2.6-pro-image-to-video"
+        ]
+      }
+    },
+    "kling-2.6-pro-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-2.6-pro-text-to-video"
+        ]
+      }
+    },
+    "kling-o3-4k-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-o3-4k-image-to-video"
+        ]
+      }
+    },
+    "kling-o3-4k-reference-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-o3-4k-reference-to-video"
+        ]
+      }
+    },
+    "kling-o3-4k-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-o3-4k-text-to-video"
+        ]
+      }
+    },
+    "kling-o3-pro-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-o3-pro-image-to-video"
+        ]
+      }
+    },
+    "kling-o3-pro-reference-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-o3-pro-reference-to-video"
+        ]
+      }
+    },
+    "kling-o3-pro-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-o3-pro-text-to-video"
+        ]
+      }
+    },
+    "kling-o3-standard-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-o3-standard-image-to-video"
+        ]
+      }
+    },
+    "kling-o3-standard-reference-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-o3-standard-reference-to-video"
+        ]
+      }
+    },
+    "kling-o3-standard-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-o3-standard-text-to-video"
+        ]
+      }
+    },
+    "kling-v3-4k-reference-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-v3-4k-reference-to-video"
+        ]
+      }
+    },
+    "kling-v3-4k-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-v3-4k-text-to-video"
+        ]
+      }
+    },
+    "kling-v3-pro-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-v3-pro-image-to-video"
+        ]
+      }
+    },
+    "kling-v3-pro-motion-control": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-v3-pro-motion-control"
+        ]
+      }
+    },
+    "kling-v3-pro-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-v3-pro-text-to-video"
+        ]
+      }
+    },
+    "kling-v3-standard-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-v3-standard-image-to-video"
+        ]
+      }
+    },
+    "kling-v3-standard-motion-control": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-v3-standard-motion-control"
+        ]
+      }
+    },
+    "kling-v3-standard-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "kling-v3-standard-text-to-video"
+        ]
+      }
+    },
+    "kling-v3-turbo-pro-image-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "kling-v3-turbo-pro-image-to-video"
+        ]
+      }
+    },
+    "kling-v3-turbo-pro-text-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "kling-v3-turbo-pro-text-to-video"
+        ]
+      }
+    },
+    "kling-v3-turbo-standard-image-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "kling-v3-turbo-standard-image-to-video"
+        ]
+      }
+    },
+    "kling-v3-turbo-standard-text-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "kling-v3-turbo-standard-text-to-video"
+        ]
+      }
+    },
+    "krea-2-turbo": {
+      "tags": [
+        "Uncensored",
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "krea-2-turbo"
+        ]
+      }
+    },
+    "krea-v2-large": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "krea-v2-large"
+        ]
+      }
+    },
+    "krea-v2-medium": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "krea-v2-medium"
+        ]
+      }
+    },
+    "l3-lunaris-8b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "sao10k/l3-lunaris-8b"
+        ]
+      }
+    },
+    "l3.1-euryale-70b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "sao10k/l3.1-euryale-70b"
+        ]
+      }
+    },
+    "l3.3-euryale-70b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "sao10k/l3.3-euryale-70b"
+        ]
+      }
+    },
+    "laguna-s-2.1": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "poolside/laguna-s-2.1"
+        ]
+      }
+    },
+    "laguna-xs-2.1": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "poolside/laguna-xs-2.1"
+        ]
+      }
+    },
+    "ling-2.6-1t": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "inclusionai/ling-2.6-1t"
+        ]
+      }
+    },
+    "ling-2.6-flash": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "inclusionai/ling-2.6-flash"
+        ]
+      }
+    },
+    "ling-3.0-flash": {
+      "tags": [
+        "Reasoning",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "inclusionai/ling-3.0-flash"
+        ]
+      }
+    },
+    "llama-3.1-70b-instruct": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "meta-llama/llama-3.1-70b-instruct"
+        ]
+      }
+    },
+    "llama-3.1-8b-instruct": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "meta-llama/llama-3.1-8b-instruct"
+        ]
+      }
+    },
+    "llama-3.2-1b-instruct": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "meta-llama/llama-3.2-1b-instruct"
+        ]
+      }
+    },
+    "llama-3.2-3b": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "llama-3.2-3b"
+        ]
+      }
+    },
+    "llama-3.2-3b-instruct": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "meta-llama/llama-3.2-3b-instruct"
+        ]
+      }
+    },
+    "llama-3.3-70b": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "llama-3.3-70b"
+        ]
+      }
+    },
+    "llama-3.3-70b-instruct": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "meta-llama/llama-3.3-70b-instruct"
+        ]
+      }
+    },
+    "llama-4-maverick": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "meta-llama/llama-4-maverick"
+        ]
+      }
+    },
+    "llama-4-scout": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "meta-llama/llama-4-scout"
+        ]
+      }
+    },
+    "llama-guard-4-12b": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "meta-llama/llama-guard-4-12b"
+        ]
+      }
+    },
+    "longcat-2.0": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "meituan/longcat-2.0"
+        ]
+      }
+    },
+    "longcat-distilled-image-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "longcat-distilled-image-to-video"
+        ]
+      }
+    },
+    "longcat-distilled-text-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "longcat-distilled-text-to-video"
+        ]
+      }
+    },
+    "longcat-image-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "longcat-image-to-video"
+        ]
+      }
+    },
+    "longcat-text-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "longcat-text-to-video"
+        ]
+      }
+    },
+    "ltx-2-5-fast-image-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "ltx-2-5-fast-image-to-video"
+        ]
+      }
+    },
+    "ltx-2-5-fast-text-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "ltx-2-5-fast-text-to-video"
+        ]
+      }
+    },
+    "ltx-2-5-pro-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "ltx-2-5-pro-image-to-video"
+        ]
+      }
+    },
+    "ltx-2-5-pro-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "ltx-2-5-pro-text-to-video"
+        ]
+      }
+    },
+    "ltx-2-v2-3-fast-image-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "ltx-2-v2-3-fast-image-to-video"
+        ]
+      }
+    },
+    "ltx-2-v2-3-fast-text-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "ltx-2-v2-3-fast-text-to-video"
+        ]
+      }
+    },
+    "ltx-2-v2-3-full-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "ltx-2-v2-3-full-image-to-video"
+        ]
+      }
+    },
+    "ltx-2-v2-3-full-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "ltx-2-v2-3-full-text-to-video"
+        ]
+      }
+    },
+    "luma-uni-1": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "luma-uni-1"
+        ]
+      }
+    },
+    "luma-uni-1-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "luma-uni-1-edit"
+        ]
+      }
+    },
+    "luma-uni-1-max": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "luma-uni-1-max"
+        ]
+      }
+    },
+    "luma-uni-1-max-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "luma-uni-1-max-edit"
+        ]
+      }
+    },
+    "lustify-sdxl": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "lustify-sdxl"
+        ]
+      }
+    },
+    "lustify-v7": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "lustify-v7"
+        ]
+      }
+    },
+    "lustify-v8": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "lustify-v8"
+        ]
+      }
+    },
+    "lyria-3-clip-preview": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/lyria-3-clip-preview"
+        ]
+      }
+    },
+    "lyria-3-pro": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "lyria-3-pro"
+        ]
+      }
+    },
+    "lyria-3-pro-preview": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "google/lyria-3-pro-preview"
+        ]
+      }
+    },
+    "magnum-v4-72b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "anthracite-org/magnum-v4-72b"
+        ]
+      }
+    },
+    "mercury-2": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "inception/mercury-2"
+        ],
+        "venice": [
+          "mercury-2"
+        ]
+      }
+    },
+    "mimo-v2.5": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "xiaomi/mimo-v2.5"
+        ]
+      }
+    },
+    "mimo-v2.5-pro": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "xiaomi/mimo-v2.5-pro"
+        ]
+      }
+    },
+    "minimax-01": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "minimax/minimax-01"
+        ]
+      }
+    },
+    "minimax-h3-enhanced-reference-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "minimax-h3-enhanced-reference-to-video"
+        ]
+      }
+    },
+    "minimax-h3-enhanced-text-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "minimax-h3-enhanced-text-to-video"
+        ]
+      }
+    },
+    "minimax-h3-image-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "minimax-h3-image-to-video"
+        ]
+      }
+    },
+    "minimax-h3-reference-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "minimax-h3-reference-to-video"
+        ]
+      }
+    },
+    "minimax-h3-text-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "minimax-h3-text-to-video"
+        ]
+      }
+    },
+    "minimax-m1": {
+      "tags": [
+        "Reasoning",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "minimax/minimax-m1"
+        ]
+      }
+    },
+    "minimax-m2": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "minimax/minimax-m2"
+        ]
+      }
+    },
+    "minimax-m2-her": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "minimax/minimax-m2-her"
+        ]
+      }
+    },
+    "minimax-m2.1": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "minimax/minimax-m2.1"
+        ]
+      }
+    },
+    "minimax-m2.5": {
+      "tags": [
+        "Coding",
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "minimax/minimax-m2.5"
+        ],
+        "venice": [
+          "minimax-m25"
+        ]
+      }
+    },
+    "minimax-m2.7": {
+      "tags": [
+        "Coding",
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "minimax/minimax-m2.7"
+        ],
+        "venice": [
+          "minimax-m27"
+        ]
+      }
+    },
+    "minimax-m3": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "minimax/minimax-m3"
+        ]
+      }
+    },
+    "minimax-m3-preview": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Video input"
+      ],
+      "sources": {
+        "venice": [
+          "minimax-m3-preview"
+        ]
+      }
+    },
+    "minimax-music-v2": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "minimax-music-v2"
+        ]
+      }
+    },
+    "minimax-music-v25": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "minimax-music-v25"
+        ]
+      }
+    },
+    "minimax-music-v26": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "minimax-music-v26"
+        ]
+      }
+    },
+    "ministral-14b-2512": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "mistralai/ministral-14b-2512"
+        ]
+      }
+    },
+    "ministral-3b-2512": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "mistralai/ministral-3b-2512"
+        ]
+      }
+    },
+    "ministral-8b-2512": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "mistralai/ministral-8b-2512"
+        ]
+      }
+    },
+    "mistral-large": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "mistralai/mistral-large"
+        ]
+      }
+    },
+    "mistral-large-2407": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "mistralai/mistral-large-2407"
+        ]
+      }
+    },
+    "mistral-large-2512": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "mistralai/mistral-large-2512"
+        ]
+      }
+    },
+    "mistral-medium-3": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "mistralai/mistral-medium-3"
+        ]
+      }
+    },
+    "mistral-medium-3-5": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "mistralai/mistral-medium-3-5"
+        ]
+      }
+    },
+    "mistral-medium-3.1": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "mistralai/mistral-medium-3.1"
+        ]
+      }
+    },
+    "mistral-nemo": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "mistralai/mistral-nemo"
+        ]
+      }
+    },
+    "mistral-saba": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "mistralai/mistral-saba"
+        ]
+      }
+    },
+    "mistral-small-24b-instruct-2501": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "mistralai/mistral-small-24b-instruct-2501"
+        ]
+      }
+    },
+    "mistral-small-2603": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "mistralai/mistral-small-2603"
+        ],
+        "venice": [
+          "mistral-small-2603"
+        ]
+      }
+    },
+    "mistral-small-3.1-24b-instruct": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "mistralai/mistral-small-3.1-24b-instruct"
+        ]
+      }
+    },
+    "mistral-small-3.2-24b-instruct": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "mistralai/mistral-small-3.2-24b-instruct"
+        ],
+        "venice": [
+          "mistral-small-3-2-24b-instruct"
+        ]
+      }
+    },
+    "mixtral-8x22b-instruct": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "mistralai/mixtral-8x22b-instruct"
+        ]
+      }
+    },
+    "mmaudio-v2-text-to-audio": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "mmaudio-v2-text-to-audio"
+        ]
+      }
+    },
+    "morph-v3-fast": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "morph/morph-v3-fast"
+        ]
+      }
+    },
+    "morph-v3-large": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "morph/morph-v3-large"
+        ]
+      }
+    },
+    "muse-glimmer-30b": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "meta/muse-glimmer-30b"
+        ]
+      }
+    },
+    "muse-spark-1.1": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "meta/muse-spark-1.1"
+        ]
+      }
+    },
+    "muse-spark-1.2": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "meta/muse-spark-1.2"
+        ]
+      }
+    },
+    "mythomax-l2-13b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "gryphe/mythomax-l2-13b"
+        ]
+      }
+    },
+    "nano-banana-2": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "nano-banana-2"
+        ]
+      }
+    },
+    "nano-banana-2-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "nano-banana-2-edit"
+        ]
+      }
+    },
+    "nano-banana-2-lite": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "nano-banana-2-lite"
+        ]
+      }
+    },
+    "nano-banana-2-lite-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "nano-banana-2-lite-edit"
+        ]
+      }
+    },
+    "nano-banana-pro": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "nano-banana-pro"
+        ]
+      }
+    },
+    "nano-banana-pro-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "nano-banana-pro-edit"
+        ]
+      }
+    },
+    "nemotron-3-nano-30b-a3b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "nvidia/nemotron-3-nano-30b-a3b"
+        ]
+      }
+    },
+    "nemotron-3-super-120b-a12b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "nvidia/nemotron-3-super-120b-a12b"
+        ]
+      }
+    },
+    "nemotron-3-ultra-550b-a55b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "nvidia/nemotron-3-ultra-550b-a55b"
+        ]
+      }
+    },
+    "nemotron-3.5-lightning": {
+      "tags": [
+        "Reasoning",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "nvidia/nemotron-3.5-lightning"
+        ]
+      }
+    },
+    "nex-n2-mini": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "nex-agi/nex-n2-mini"
+        ]
+      }
+    },
+    "nex-n2-pro": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "nex-agi/nex-n2-pro"
+        ]
+      }
+    },
+    "nova-2-lite-v1": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "amazon/nova-2-lite-v1"
+        ]
+      }
+    },
+    "nova-lite-v1": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "amazon/nova-lite-v1"
+        ]
+      }
+    },
+    "nova-micro-v1": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "amazon/nova-micro-v1"
+        ]
+      }
+    },
+    "nova-premier-v1": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "amazon/nova-premier-v1"
+        ]
+      }
+    },
+    "nova-pro-v1": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "amazon/nova-pro-v1"
+        ]
+      }
+    },
+    "nvidia-nemotron-3-5-lightning-30b-a3b": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "nvidia-nemotron-3-5-lightning-30b-a3b"
+        ]
+      }
+    },
+    "nvidia-nemotron-3-nano-30b-a3b": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "nvidia-nemotron-3-nano-30b-a3b"
+        ]
+      }
+    },
+    "nvidia-nemotron-3-ultra-550b-a55b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "venice": [
+          "nvidia-nemotron-3-ultra-550b-a55b"
+        ]
+      }
+    },
+    "nvidia/parakeet-tdt-0.6b-v3": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "nvidia/parakeet-tdt-0.6b-v3"
+        ]
+      }
+    },
+    "o1": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/o1"
+        ]
+      }
+    },
+    "o1-pro": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/o1-pro"
+        ]
+      }
+    },
+    "o3": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/o3"
+        ]
+      }
+    },
+    "o3-mini": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/o3-mini"
+        ]
+      }
+    },
+    "o3-mini-high": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/o3-mini-high"
+        ]
+      }
+    },
+    "o3-pro": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/o3-pro"
+        ]
+      }
+    },
+    "o4-mini": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/o4-mini"
+        ]
+      }
+    },
+    "o4-mini-high": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "openai/o4-mini-high"
+        ]
+      }
+    },
+    "olafangensan-glm-4.7-flash-heretic": {
+      "tags": [
+        "Uncensored",
+        "Reasoning",
+        "Fast"
+      ],
+      "aliases": [
+        "glm-4.7-flash-heretic"
+      ],
+      "sources": {
+        "venice": [
+          "olafangensan-glm-4.7-flash-heretic"
+        ]
+      }
+    },
+    "olmo-3-32b-think": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "allenai/olmo-3-32b-think"
+        ]
+      }
+    },
+    "openai/whisper-large-v3": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "openai/whisper-large-v3"
+        ]
+      }
+    },
+    "ovi-image-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "ovi-image-to-video"
+        ]
+      }
+    },
+    "palmyra-x5": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "writer/palmyra-x5"
+        ]
+      }
+    },
+    "perceptron-mk1": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "perceptron/perceptron-mk1"
+        ]
+      }
+    },
+    "phi-4": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "microsoft/phi-4"
+        ]
+      }
+    },
+    "pixverse-c1-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "pixverse-c1-image-to-video"
+        ]
+      }
+    },
+    "pixverse-c1-reference-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "pixverse-c1-reference-to-video"
+        ]
+      }
+    },
+    "pixverse-c1-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "pixverse-c1-text-to-video"
+        ]
+      }
+    },
+    "pixverse-c1-transition": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "pixverse-c1-transition"
+        ]
+      }
+    },
+    "pixverse-v5.6-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "pixverse-v5.6-image-to-video"
+        ]
+      }
+    },
+    "pixverse-v5.6-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "pixverse-v5.6-text-to-video"
+        ]
+      }
+    },
+    "pixverse-v5.6-transition": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "pixverse-v5.6-transition"
+        ]
+      }
+    },
+    "qwen-2.5-72b-instruct": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen-2.5-72b-instruct"
+        ]
+      }
+    },
+    "qwen-2.5-7b-instruct": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen-2.5-7b-instruct"
+        ]
+      }
+    },
+    "qwen-2.5-coder-32b-instruct": {
+      "tags": [
+        "Coding"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen-2.5-coder-32b-instruct"
+        ]
+      }
+    },
+    "qwen-edit-uncensored": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "qwen-edit-uncensored"
+        ]
+      }
+    },
+    "qwen-image": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "qwen-image"
+        ]
+      }
+    },
+    "qwen-image-2": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "qwen-image-2"
+        ]
+      }
+    },
+    "qwen-image-2-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "qwen-image-2-edit"
+        ]
+      }
+    },
+    "qwen-image-2-pro": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "qwen-image-2-pro"
+        ]
+      }
+    },
+    "qwen-image-2-pro-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "qwen-image-2-pro-edit"
+        ]
+      }
+    },
+    "qwen-image-3": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "qwen-image-3"
+        ]
+      }
+    },
+    "qwen-image-3-edit": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "qwen-image-3-edit"
+        ]
+      }
+    },
+    "qwen-image-3-pro": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "qwen-image-3-pro"
+        ]
+      }
+    },
+    "qwen-image-3-pro-edit": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "qwen-image-3-pro-edit"
+        ]
+      }
+    },
+    "qwen-plus-2025-07-28": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen-plus",
+          "qwen/qwen-plus-2025-07-28"
+        ]
+      }
+    },
+    "qwen2.5-vl-72b-instruct": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen2.5-vl-72b-instruct"
+        ]
+      }
+    },
+    "qwen3-14b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-14b"
+        ]
+      }
+    },
+    "qwen3-235b-a22b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-235b-a22b"
+        ]
+      }
+    },
+    "qwen3-235b-a22b-2507": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-235b-a22b-2507"
+        ]
+      }
+    },
+    "qwen3-235b-a22b-instruct-2507": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "qwen3-235b-a22b-instruct-2507"
+        ]
+      }
+    },
+    "qwen3-235b-a22b-thinking-2507": {
+      "tags": [
+        "Reasoning",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-235b-a22b-thinking-2507"
+        ],
+        "venice": [
+          "qwen3-235b-a22b-thinking-2507"
+        ]
+      }
+    },
+    "qwen3-30b-a3b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-30b-a3b"
+        ]
+      }
+    },
+    "qwen3-30b-a3b-instruct-2507": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-30b-a3b-instruct-2507"
+        ]
+      }
+    },
+    "qwen3-30b-a3b-thinking-2507": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-30b-a3b-thinking-2507"
+        ]
+      }
+    },
+    "qwen3-32b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-32b"
+        ]
+      }
+    },
+    "qwen3-8b": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-8b"
+        ]
+      }
+    },
+    "qwen3-coder": {
+      "tags": [
+        "Coding"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-coder"
+        ]
+      }
+    },
+    "qwen3-coder-30b-a3b-instruct": {
+      "tags": [
+        "Coding"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-coder-30b-a3b-instruct"
+        ]
+      }
+    },
+    "qwen3-coder-480b-a35b-instruct-turbo": {
+      "tags": [
+        "Coding",
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "qwen3-coder-480b-a35b-instruct-turbo"
+        ]
+      }
+    },
+    "qwen3-coder-flash": {
+      "tags": [
+        "Coding",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-coder-flash"
+        ]
+      }
+    },
+    "qwen3-coder-next": {
+      "tags": [
+        "Coding",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-coder-next"
+        ]
+      }
+    },
+    "qwen3-coder-plus": {
+      "tags": [
+        "Coding",
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-coder-plus"
+        ]
+      }
+    },
+    "qwen3-max": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-max"
+        ]
+      }
+    },
+    "qwen3-max-thinking": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-max-thinking"
+        ]
+      }
+    },
+    "qwen3-next-80b": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "qwen3-next-80b"
+        ]
+      }
+    },
+    "qwen3-next-80b-a3b-instruct": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-next-80b-a3b-instruct"
+        ]
+      }
+    },
+    "qwen3-next-80b-a3b-thinking": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-next-80b-a3b-thinking"
+        ]
+      }
+    },
+    "qwen3-vl-235b-a22b": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "venice": [
+          "qwen3-vl-235b-a22b"
+        ]
+      }
+    },
+    "qwen3-vl-235b-a22b-instruct": {
+      "tags": [
+        "Vision",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-vl-235b-a22b-instruct"
+        ]
+      }
+    },
+    "qwen3-vl-235b-a22b-thinking": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-vl-235b-a22b-thinking"
+        ]
+      }
+    },
+    "qwen3-vl-30b-a3b-instruct": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-vl-30b-a3b-instruct"
+        ]
+      }
+    },
+    "qwen3-vl-30b-a3b-thinking": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-vl-30b-a3b-thinking"
+        ]
+      }
+    },
+    "qwen3-vl-32b-instruct": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-vl-32b-instruct"
+        ]
+      }
+    },
+    "qwen3-vl-8b-instruct": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-vl-8b-instruct"
+        ]
+      }
+    },
+    "qwen3-vl-8b-thinking": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3-vl-8b-thinking"
+        ]
+      }
+    },
+    "qwen3.5-122b-a10b": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.5-122b-a10b"
+        ]
+      }
+    },
+    "qwen3.5-27b": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.5-27b"
+        ]
+      }
+    },
+    "qwen3.5-35b-a3b": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Video input"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.5-35b-a3b"
+        ],
+        "venice": [
+          "qwen3-5-35b-a3b"
+        ]
+      }
+    },
+    "qwen3.5-397b-a17b": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Video input"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.5-397b-a17b"
+        ],
+        "venice": [
+          "qwen3-5-397b-a17b"
+        ]
+      }
+    },
+    "qwen3.5-9b": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.5-9b"
+        ],
+        "venice": [
+          "qwen3-5-9b"
+        ]
+      }
+    },
+    "qwen3.5-flash-02-23": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.5-flash-02-23"
+        ]
+      }
+    },
+    "qwen3.5-plus-02-15": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.5-plus-02-15"
+        ]
+      }
+    },
+    "qwen3.5-plus-20260420": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.5-plus-20260420"
+        ]
+      }
+    },
+    "qwen3.6-27b": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Video input"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.6-27b"
+        ],
+        "venice": [
+          "qwen3-6-27b"
+        ]
+      }
+    },
+    "qwen3.6-35b-a3b": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.6-35b-a3b"
+        ],
+        "venice": [
+          "qwen3-6-35b-a3b"
+        ]
+      }
+    },
+    "qwen3.6-flash": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.6-flash"
+        ]
+      }
+    },
+    "qwen3.6-max-preview": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.6-max-preview"
+        ]
+      }
+    },
+    "qwen3.6-plus": {
+      "tags": [
+        "Uncensored",
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Video input"
+      ],
+      "aliases": [
+        "qwen3.6-plus-uncensored"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.6-plus"
+        ],
+        "venice": [
+          "qwen-3-6-plus"
+        ]
+      }
+    },
+    "qwen3.7-flash": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.7-flash"
+        ]
+      }
+    },
+    "qwen3.7-max": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Video input"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.7-max"
+        ],
+        "venice": [
+          "qwen-3-7-max"
+        ]
+      }
+    },
+    "qwen3.7-plus": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Video input"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.7-plus"
+        ],
+        "venice": [
+          "qwen-3-7-plus"
+        ]
+      }
+    },
+    "qwen3.8-2.4t-a95b": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.8-2.4t-a95b"
+        ],
+        "venice": [
+          "qwen-3-8-2-4t-a95b"
+        ]
+      }
+    },
+    "qwen3.8-27b": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.8-27b"
+        ]
+      }
+    },
+    "qwen3.8-max": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Video input"
+      ],
+      "sources": {
+        "openrouter": [
+          "qwen/qwen3.8-max"
+        ],
+        "venice": [
+          "qwen-3-8-max"
+        ]
+      }
+    },
+    "recraft-v4": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "recraft-v4"
+        ]
+      }
+    },
+    "recraft-v4-pro": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "recraft-v4-pro"
+        ]
+      }
+    },
+    "reka-edge": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "rekaai/reka-edge"
+        ]
+      }
+    },
+    "reka-flash-3": {
+      "tags": [
+        "Reasoning",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "rekaai/reka-flash-3"
+        ]
+      }
+    },
+    "relace-apply-3": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "relace/relace-apply-3"
+        ]
+      }
+    },
+    "relace-search": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "relace/relace-search"
+        ]
+      }
+    },
+    "remm-slerp-l2-13b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "undi95/remm-slerp-l2-13b"
+        ]
+      }
+    },
+    "ring-2.6-1t": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "inclusionai/ring-2.6-1t"
+        ]
+      }
+    },
+    "rocinante-12b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "thedrummer/rocinante-12b"
+        ]
+      }
+    },
+    "runway-gen4-5": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "runway-gen4-5"
+        ]
+      }
+    },
+    "runway-gen4-5-text": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "runway-gen4-5-text"
+        ]
+      }
+    },
+    "runway-gen4-turbo": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "runway-gen4-turbo"
+        ]
+      }
+    },
+    "sakana-namazu": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "sakana/sakana-namazu"
+        ]
+      }
+    },
+    "seed-1.6": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "bytedance-seed/seed-1.6"
+        ]
+      }
+    },
+    "seed-1.6-flash": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "bytedance-seed/seed-1.6-flash"
+        ]
+      }
+    },
+    "seed-2-1-turbo": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Video input",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "bytedance-seed/seed-2-1-turbo"
+        ],
+        "venice": [
+          "seed-2-1-turbo"
+        ]
+      }
+    },
+    "seed-2.0-code": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "bytedance-seed/seed-2.0-code"
+        ]
+      }
+    },
+    "seed-2.0-lite": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "bytedance-seed/seed-2.0-lite"
+        ]
+      }
+    },
+    "seed-2.0-mini": {
+      "tags": [
+        "Reasoning",
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "bytedance-seed/seed-2.0-mini"
+        ]
+      }
+    },
+    "seed-audio-1-0": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "seed-audio-1-0"
+        ]
+      }
+    },
+    "seedance-1-5-pro-image-to-video-basic": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "seedance-1-5-pro-image-to-video-basic"
+        ]
+      }
+    },
+    "seedance-1-5-pro-text-to-video-basic": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "seedance-1-5-pro-text-to-video-basic"
+        ]
+      }
+    },
+    "seedance-2-0-fast-image-to-video-basic": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "seedance-2-0-fast-image-to-video-basic"
+        ]
+      }
+    },
+    "seedance-2-0-fast-reference-to-video-basic": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "seedance-2-0-fast-reference-to-video-basic"
+        ]
+      }
+    },
+    "seedance-2-0-fast-text-to-video-basic": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "seedance-2-0-fast-text-to-video-basic"
+        ]
+      }
+    },
+    "seedance-2-0-image-to-video-basic": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "seedance-2-0-image-to-video-basic"
+        ]
+      }
+    },
+    "seedance-2-0-mini-image-to-video-basic": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "seedance-2-0-mini-image-to-video-basic"
+        ]
+      }
+    },
+    "seedance-2-0-mini-reference-to-video-basic": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "seedance-2-0-mini-reference-to-video-basic"
+        ]
+      }
+    },
+    "seedance-2-0-mini-text-to-video-basic": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "seedance-2-0-mini-text-to-video-basic"
+        ]
+      }
+    },
+    "seedance-2-0-reference-to-video-basic": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "seedance-2-0-reference-to-video-basic"
+        ]
+      }
+    },
+    "seedance-2-0-text-to-video-basic": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "seedance-2-0-text-to-video-basic"
+        ]
+      }
+    },
+    "seedance-2-5-image-to-video-basic": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "seedance-2-5-image-to-video-basic"
+        ]
+      }
+    },
+    "seedance-2-5-reference-to-video-basic": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "seedance-2-5-reference-to-video-basic"
+        ]
+      }
+    },
+    "seedance-2-5-text-to-video-basic": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "seedance-2-5-text-to-video-basic"
+        ]
+      }
+    },
+    "seedream-v4": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "seedream-v4"
+        ]
+      }
+    },
+    "seedream-v4-edit": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "seedream-v4-edit"
+        ]
+      }
+    },
+    "seedream-v5-lite": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "seedream-v5-lite"
+        ]
+      }
+    },
+    "seedream-v5-lite-edit": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "seedream-v5-lite-edit"
+        ]
+      }
+    },
+    "seedream-v5-pro": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "seedream-v5-pro"
+        ]
+      }
+    },
+    "seedream-v5-pro-edit": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "seedream-v5-pro-edit"
+        ]
+      }
+    },
+    "skyfall-36b-v2": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "thedrummer/skyfall-36b-v2"
+        ]
+      }
+    },
+    "solar-pro-3": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "upstage/solar-pro-3"
+        ]
+      }
+    },
+    "solar-pro4": {
+      "tags": [
+        "Reasoning"
+      ],
+      "sources": {
+        "openrouter": [
+          "upstage/solar-pro4"
+        ]
+      }
+    },
+    "sonar": {
+      "tags": [
+        "Vision",
+        "Web search"
+      ],
+      "sources": {
+        "openrouter": [
+          "perplexity/sonar"
+        ]
+      }
+    },
+    "sonar-deep-research": {
+      "tags": [
+        "Reasoning",
+        "Web search"
+      ],
+      "sources": {
+        "openrouter": [
+          "perplexity/sonar-deep-research"
+        ]
+      }
+    },
+    "sonar-pro": {
+      "tags": [
+        "Vision",
+        "Web search"
+      ],
+      "sources": {
+        "openrouter": [
+          "perplexity/sonar-pro"
+        ]
+      }
+    },
+    "sonar-pro-search": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Web search"
+      ],
+      "sources": {
+        "openrouter": [
+          "perplexity/sonar-pro-search"
+        ]
+      }
+    },
+    "sonar-reasoning-pro": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Web search"
+      ],
+      "sources": {
+        "openrouter": [
+          "perplexity/sonar-reasoning-pro"
+        ]
+      }
+    },
+    "sonilo-v1-1-music": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "sonilo-v1-1-music"
+        ]
+      }
+    },
+    "sonilo-v1-1-sound-effects": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "sonilo-v1-1-sound-effects"
+        ]
+      }
+    },
+    "sora-2-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "sora-2-image-to-video"
+        ]
+      }
+    },
+    "sora-2-pro-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "sora-2-pro-image-to-video"
+        ]
+      }
+    },
+    "sora-2-pro-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "sora-2-pro-text-to-video"
+        ]
+      }
+    },
+    "sora-2-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "sora-2-text-to-video"
+        ]
+      }
+    },
+    "stable-audio-25": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "stable-audio-25"
+        ]
+      }
+    },
+    "step-3.5-flash": {
+      "tags": [
+        "Reasoning",
+        "Fast",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "stepfun/step-3.5-flash"
+        ]
+      }
+    },
+    "step-3.7-flash": {
+      "tags": [
+        "Reasoning",
+        "Vision",
+        "Fast"
+      ],
+      "sources": {
+        "openrouter": [
+          "stepfun/step-3.7-flash"
+        ]
+      }
+    },
+    "stt-xai-v1": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "stt-xai-v1"
+        ]
+      }
+    },
+    "text-embedding-3-large": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "text-embedding-3-large"
+        ]
+      }
+    },
+    "text-embedding-3-small": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "text-embedding-3-small"
+        ]
+      }
+    },
+    "text-embedding-bge-en-icl": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "text-embedding-bge-en-icl"
+        ]
+      }
+    },
+    "text-embedding-bge-m3": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "text-embedding-bge-m3"
+        ]
+      }
+    },
+    "text-embedding-multilingual-e5-large-instruct": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "text-embedding-multilingual-e5-large-instruct"
+        ]
+      }
+    },
+    "text-embedding-nemotron-embed-vl-1b-v2": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "text-embedding-nemotron-embed-vl-1b-v2"
+        ]
+      }
+    },
+    "text-embedding-qwen3-0-6b": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "text-embedding-qwen3-0-6b"
+        ]
+      }
+    },
+    "text-embedding-qwen3-8b": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "text-embedding-qwen3-8b"
+        ]
+      }
+    },
+    "topaz-video-upscale": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "topaz-video-upscale"
+        ]
+      }
+    },
+    "trinity-large-thinking": {
+      "tags": [
+        "Reasoning",
+        "Open weights"
+      ],
+      "sources": {
+        "openrouter": [
+          "arcee-ai/trinity-large-thinking"
+        ]
+      }
+    },
+    "tts-chatterbox-hd": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "tts-chatterbox-hd"
+        ]
+      }
+    },
+    "tts-elevenlabs-turbo-v2-5": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "tts-elevenlabs-turbo-v2-5"
+        ]
+      }
+    },
+    "tts-gemini-3-1-flash": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "tts-gemini-3-1-flash"
+        ]
+      }
+    },
+    "tts-gradium-v1": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "tts-gradium-v1"
+        ]
+      }
+    },
+    "tts-inworld-1-5-max": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "tts-inworld-1-5-max"
+        ]
+      }
+    },
+    "tts-kokoro": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "tts-kokoro"
+        ]
+      }
+    },
+    "tts-minimax-speech-02-hd": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "tts-minimax-speech-02-hd"
+        ]
+      }
+    },
+    "tts-orpheus": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "tts-orpheus"
+        ]
+      }
+    },
+    "tts-qwen3-0-6b": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "tts-qwen3-0-6b"
+        ]
+      }
+    },
+    "tts-qwen3-1-7b": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "tts-qwen3-1-7b"
+        ]
+      }
+    },
+    "tts-xai-v1": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "tts-xai-v1"
+        ]
+      }
+    },
+    "ui-tars-1.5-7b": {
+      "tags": [
+        "Vision"
+      ],
+      "sources": {
+        "openrouter": [
+          "bytedance/ui-tars-1.5-7b"
+        ]
+      }
+    },
+    "unslopnemo-12b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "thedrummer/unslopnemo-12b"
+        ]
+      }
+    },
+    "upscaler": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "upscaler"
+        ]
+      }
+    },
+    "venice-sd35": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "venice-sd35"
+        ]
+      }
+    },
+    "venice-uncensored-1-2": {
+      "tags": [
+        "Uncensored",
+        "Vision"
+      ],
+      "sources": {
+        "venice": [
+          "venice-uncensored-1-2"
+        ]
+      }
+    },
+    "venice-uncensored-role-play": {
+      "tags": [
+        "Uncensored",
+        "Vision",
+        "Roleplay"
+      ],
+      "aliases": [
+        "venice-role-play-uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "venice-uncensored-role-play"
+        ]
+      }
+    },
+    "veo3-fast-image-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "veo3-fast-image-to-video"
+        ]
+      }
+    },
+    "veo3-fast-text-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "veo3-fast-text-to-video"
+        ]
+      }
+    },
+    "veo3-full-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "veo3-full-image-to-video"
+        ]
+      }
+    },
+    "veo3-full-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "veo3-full-text-to-video"
+        ]
+      }
+    },
+    "veo3.1-fast-image-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "veo3.1-fast-image-to-video"
+        ]
+      }
+    },
+    "veo3.1-fast-text-to-video": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "veo3.1-fast-text-to-video"
+        ]
+      }
+    },
+    "veo3.1-full-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "veo3.1-full-image-to-video"
+        ]
+      }
+    },
+    "veo3.1-full-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "veo3.1-full-text-to-video"
+        ]
+      }
+    },
+    "vidu-q3-image-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "vidu-q3-image-to-video"
+        ]
+      }
+    },
+    "vidu-q3-text-to-video": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "vidu-q3-text-to-video"
+        ]
+      }
+    },
+    "virtuoso-large": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "arcee-ai/virtuoso-large"
+        ]
+      }
+    },
+    "voxtral-small-24b-2507": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "mistralai/voxtral-small-24b-2507"
+        ]
+      }
+    },
+    "wai-Illustrious": {
+      "tags": [
+        "Uncensored",
+        "Anime"
+      ],
+      "sources": {
+        "venice": [
+          "wai-Illustrious"
+        ]
+      }
+    },
+    "wan-2-2-enhanced-image-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2-2-enhanced-image-to-video"
+        ]
+      }
+    },
+    "wan-2-7-enhanced-image-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2-7-enhanced-image-to-video"
+        ]
+      }
+    },
+    "wan-2-7-enhanced-text-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2-7-enhanced-text-to-video"
+        ]
+      }
+    },
+    "wan-2-7-image-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2-7-image-to-video"
+        ]
+      }
+    },
+    "wan-2-7-pro-edit": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "wan-2-7-pro-edit"
+        ]
+      }
+    },
+    "wan-2-7-pro-text-to-image": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "wan-2-7-pro-text-to-image"
+        ]
+      }
+    },
+    "wan-2-7-reference-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2-7-reference-to-video"
+        ]
+      }
+    },
+    "wan-2-7-text-to-image": {
+      "tags": [],
+      "sources": {
+        "venice": [
+          "wan-2-7-text-to-image"
+        ]
+      }
+    },
+    "wan-2-7-text-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2-7-text-to-video"
+        ]
+      }
+    },
+    "wan-2-7-video-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2-7-video-to-video"
+        ]
+      }
+    },
+    "wan-2.1-pro-image-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2.1-pro-image-to-video"
+        ]
+      }
+    },
+    "wan-2.2-a14b-text-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2.2-a14b-text-to-video"
+        ]
+      }
+    },
+    "wan-2.5-preview-image-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2.5-preview-image-to-video"
+        ]
+      }
+    },
+    "wan-2.5-preview-text-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2.5-preview-text-to-video"
+        ]
+      }
+    },
+    "wan-2.6-flash-image-to-video": {
+      "tags": [
+        "Uncensored",
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2.6-flash-image-to-video"
+        ]
+      }
+    },
+    "wan-2.6-image-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2.6-image-to-video"
+        ]
+      }
+    },
+    "wan-2.6-text-to-video": {
+      "tags": [
+        "Uncensored"
+      ],
+      "sources": {
+        "venice": [
+          "wan-2.6-text-to-video"
+        ]
+      }
+    },
+    "weaver": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "mancer/weaver"
+        ]
+      }
+    },
+    "wizardlm-2-8x22b": {
+      "tags": [],
+      "sources": {
+        "openrouter": [
+          "microsoft/wizardlm-2-8x22b"
+        ]
+      }
+    },
+    "xiaomi-mimo-v2-5": {
+      "tags": [
+        "Coding",
+        "Reasoning",
+        "Vision",
+        "Audio input",
+        "Video input"
+      ],
+      "sources": {
+        "venice": [
+          "xiaomi-mimo-v2-5"
+        ]
+      }
+    },
+    "z-image-turbo": {
+      "tags": [
+        "Fast"
+      ],
+      "sources": {
+        "venice": [
+          "z-image-turbo"
+        ]
+      }
+    }
+  }
+}

--- a/apps/desktop/src/renderer/modules/catalog/model-metadata.test.ts
+++ b/apps/desktop/src/renderer/modules/catalog/model-metadata.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { test } from 'vitest';
+import { modelMetadataFor, modelTagsFor } from './model-metadata.js';
+
+test('curated registry labels known models from maintained catalogs', () => {
+  assert.deepEqual(modelTagsFor('lustify-v8'), ['Uncensored']);
+  assert.deepEqual(modelTagsFor('Lustify V8'), ['Uncensored']);
+  assert.deepEqual(modelTagsFor('gpt-5.2-codex'), ['Coding', 'Reasoning', 'Vision']);
+  assert.deepEqual(modelTagsFor('sonar-pro'), ['Vision', 'Web search']);
+  assert.deepEqual(modelTagsFor('deepseek-r1'), ['Reasoning', 'Open weights']);
+});
+
+test('curated aliases resolve to the same reviewed model metadata', () => {
+  assert.deepEqual(modelTagsFor('glm-4.7-flash-heretic'), ['Uncensored', 'Reasoning', 'Fast']);
+  assert.deepEqual(modelTagsFor('venice-role-play-uncensored'), ['Uncensored', 'Vision', 'Roleplay']);
+});
+
+test('metadata retains provenance without trusting seller categories', () => {
+  const metadata = modelMetadataFor('lustify-v8');
+  assert.deepEqual(metadata?.sources, { venice: ['lustify-v8'] });
+  assert.deepEqual(modelTagsFor('totally-uncensored-model'), []);
+  assert.equal(modelMetadataFor('totally-uncensored-model'), null);
+});

--- a/apps/desktop/src/renderer/modules/catalog/model-metadata.test.ts
+++ b/apps/desktop/src/renderer/modules/catalog/model-metadata.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'vitest';
-import { modelMetadataFor, modelTagsFor } from './model-metadata.js';
+import { availableModelTags, modelMetadataFor, modelTagsFor } from './model-metadata.js';
 
 test('curated registry labels known models from maintained catalogs', () => {
   assert.deepEqual(modelTagsFor('lustify-v8'), ['Uncensored']);
@@ -13,6 +13,13 @@ test('curated registry labels known models from maintained catalogs', () => {
 test('curated aliases resolve to the same reviewed model metadata', () => {
   assert.deepEqual(modelTagsFor('glm-4.7-flash-heretic'), ['Uncensored', 'Reasoning', 'Fast']);
   assert.deepEqual(modelTagsFor('venice-role-play-uncensored'), ['Uncensored', 'Vision', 'Roleplay']);
+});
+
+test('available tags are deduplicated, sorted, and limited to supported UI capabilities', () => {
+  assert.deepEqual(
+    availableModelTags(['gpt-5.2-codex', 'sonar-pro', 'google/gemini-2.5-pro', 'totally-unknown']),
+    ['Coding', 'Reasoning', 'Vision', 'Web search'],
+  );
 });
 
 test('metadata retains provenance without trusting seller categories', () => {

--- a/apps/desktop/src/renderer/modules/catalog/model-metadata.ts
+++ b/apps/desktop/src/renderer/modules/catalog/model-metadata.ts
@@ -40,6 +40,17 @@ export function modelMetadataFor(serviceId: string): ModelMetadata | null {
   return metadataByCanonicalKey.get(canonicalModelKey(serviceId)) ?? null;
 }
 
+const HIDDEN_MODEL_TAGS = new Set(['Video input']);
+
 export function modelTagsFor(serviceId: string): string[] {
-  return [...(modelMetadataFor(serviceId)?.tags ?? [])];
+  return (modelMetadataFor(serviceId)?.tags ?? [])
+    .filter((tag) => !HIDDEN_MODEL_TAGS.has(tag));
+}
+
+export function availableModelTags(serviceIds: readonly string[]): string[] {
+  const tags = new Set<string>();
+  for (const serviceId of serviceIds) {
+    for (const tag of modelTagsFor(serviceId)) tags.add(tag);
+  }
+  return [...tags].sort((a, b) => a.localeCompare(b));
 }

--- a/apps/desktop/src/renderer/modules/catalog/model-metadata.ts
+++ b/apps/desktop/src/renderer/modules/catalog/model-metadata.ts
@@ -1,0 +1,45 @@
+import registry from './model-metadata.json';
+import { canonicalModelKey } from './model-identity';
+
+export type ModelMetadata = {
+  readonly tags: readonly string[];
+  readonly aliases?: readonly string[];
+  readonly sources: Readonly<Record<string, readonly string[]>>;
+};
+
+type ModelMetadataRegistry = {
+  version: number;
+  reviewedAt: string;
+  sources: Record<string, { label: string; url: string }>;
+  tagDefinitions: Record<string, string>;
+  models: Record<string, ModelMetadata>;
+};
+
+const modelMetadataRegistry = registry as ModelMetadataRegistry;
+if (modelMetadataRegistry.version !== 2) {
+  throw new Error(`Unsupported model metadata registry version: ${String(modelMetadataRegistry.version)}`);
+}
+
+const metadataByCanonicalKey = new Map<string, ModelMetadata>();
+for (const [registeredId, metadata] of Object.entries(modelMetadataRegistry.models)) {
+  for (const candidate of [registeredId, ...(metadata.aliases ?? [])]) {
+    const key = canonicalModelKey(candidate);
+    if (!key) throw new Error(`Invalid model metadata id: ${candidate}`);
+    const existing = metadataByCanonicalKey.get(key);
+    if (existing && existing !== metadata) {
+      throw new Error(`Duplicate canonical model metadata id: ${candidate}`);
+    }
+    metadataByCanonicalKey.set(key, metadata);
+  }
+}
+
+/** Reviewed model-level metadata from maintained upstream catalogs. Unlike
+ * discovery categories, this release-owned registry cannot be expanded by a
+ * seller. Route-level support must still come from service capabilities. */
+export function modelMetadataFor(serviceId: string): ModelMetadata | null {
+  return metadataByCanonicalKey.get(canonicalModelKey(serviceId)) ?? null;
+}
+
+export function modelTagsFor(serviceId: string): string[] {
+  return [...(modelMetadataFor(serviceId)?.tags ?? [])];
+}

--- a/apps/desktop/src/renderer/modules/catalog/view-models.test.ts
+++ b/apps/desktop/src/renderer/modules/catalog/view-models.test.ts
@@ -143,6 +143,24 @@ function catalogEntry(overrides: Partial<VprModelCatalogEntry> = {}): VprModelCa
   };
 }
 
+test('filters the catalog by reviewed model tag', () => {
+  const entries = [
+    catalogEntry({ serviceId: 'gpt-5.2-codex' }),
+    catalogEntry({ serviceId: 'sonar-pro' }),
+    catalogEntry({ serviceId: 'unregistered-model' }),
+  ];
+
+  assert.deepEqual(
+    filterVprCatalog(entries, { tags: ['Coding'] }).map((entry) => entry.serviceId),
+    ['gpt-5.2-codex'],
+  );
+  assert.deepEqual(
+    filterVprCatalog(entries, { tags: ['vision'] }).map((entry) => entry.serviceId),
+    ['gpt-5.2-codex', 'sonar-pro'],
+  );
+  assert.equal(filterVprCatalog(entries, { tags: [] }).length, 3);
+});
+
 test('filters the catalog by model family', () => {
   const entries = [
     catalogEntry({ serviceId: 'claude-opus', label: 'Claude Opus 4.8', provider: 'anthropic' }),
@@ -151,14 +169,14 @@ test('filters the catalog by model family', () => {
   ];
 
   assert.deepEqual(
-    filterVprCatalog(entries, { family: 'Anthropic' }).map((entry) => entry.serviceId),
+    filterVprCatalog(entries, { families: ['Anthropic'] }).map((entry) => entry.serviceId),
     ['claude-opus'],
   );
   assert.deepEqual(
-    filterVprCatalog(entries, { family: 'Z.ai' }).map((entry) => entry.serviceId),
+    filterVprCatalog(entries, { families: ['Z.ai'] }).map((entry) => entry.serviceId),
     ['glm-5-2'],
   );
-  assert.equal(filterVprCatalog(entries, { family: null }).length, 3);
+  assert.equal(filterVprCatalog(entries, { families: [] }).length, 3);
 });
 
 test('seller ordering matches effective reputation instead of raw trust', () => {

--- a/apps/desktop/src/renderer/modules/catalog/view-models.ts
+++ b/apps/desktop/src/renderer/modules/catalog/view-models.ts
@@ -7,6 +7,7 @@ import type {
 } from '../../core/state';
 import { sameCanonicalModel } from './model-identity';
 import { modelFamilyLabel } from './model-families';
+import { modelTagsFor } from './model-metadata';
 import { modelPinKey, vprModelPinFor, type VprModelPins } from '../routing/model-pins';
 import { chooseBestVprRoute } from '../routing/select';
 import { shortPeerId } from '../routing/tools';
@@ -43,6 +44,7 @@ function catalogSearchText(entry: VprModelCatalogEntry): string {
     entry.serviceId,
     entry.provider,
     ...entry.categories,
+    ...modelTagsFor(entry.serviceId),
     entry.kind === 'image' ? 'image generation image-only' : 'text chat',
   ].join(' ').toLowerCase();
 }

--- a/apps/desktop/src/renderer/modules/catalog/view-models.ts
+++ b/apps/desktop/src/renderer/modules/catalog/view-models.ts
@@ -19,8 +19,10 @@ export type VprCatalogFilterOptions = {
   search?: string;
   category?: string | null;
   kind?: VprModelKind | null;
-  /** Family display name from `availableModelFamilies` (e.g. "Anthropic"). */
-  family?: string | null;
+  kinds?: readonly VprModelKind[] | null;
+  tags?: readonly string[] | null;
+  /** Family display names from `availableModelFamilies` (e.g. "Anthropic"). */
+  families?: readonly string[] | null;
 };
 
 export type VprSelectedRouteModel = {
@@ -81,10 +83,19 @@ export function filterVprCatalog(
 ): VprModelCatalogEntry[] {
   const search = normalized(options.search ?? '');
   const category = normalized(options.category ?? '');
+  const kinds = new Set(options.kinds ?? []);
+  const tags = new Set((options.tags ?? []).map(normalized));
+  const families = new Set(options.families ?? []);
 
   return entries.filter((entry) => {
     if (options.kind && (entry.kind ?? 'text') !== options.kind) return false;
-    if (options.family && modelFamilyLabel(entry) !== options.family) return false;
+    if (kinds.size > 0 && !kinds.has(entry.kind ?? 'text')) return false;
+    if (tags.size > 0) {
+      const entryTags = new Set(modelTagsFor(entry.serviceId).map(normalized));
+      if (![...tags].every((tag) => entryTags.has(tag))) return false;
+    }
+    const family = modelFamilyLabel(entry);
+    if (families.size > 0 && (!family || !families.has(family))) return false;
     if (category && !entry.categories.some((candidate) => normalized(candidate) === category)) {
       return false;
     }

--- a/apps/desktop/src/renderer/modules/chat/controller.ts
+++ b/apps/desktop/src/renderer/modules/chat/controller.ts
@@ -3,7 +3,7 @@ import { LOCALHOST_URL } from '../../constants';
 import { notifyUiStateChanged, notifyUiStateChangedSync } from '../../core/store';
 import { normalizeDiscoverRow, projectRowsToChatServiceOptions } from '../catalog/discover-rows.js';
 import { resolveVprChatOption } from './projection.js';
-import { supportsImageEdits } from '../catalog/model-capabilities.js';
+import { supportsImageEdits, supportsServiceParameter } from '../catalog/model-capabilities.js';
 import { findCatalogEntry, projectRowsToVprModelCatalog, selectDefaultVprModel } from '../catalog/model-catalog.js';
 import { sameCanonicalModel } from '../catalog/model-identity.js';
 import { chooseBestVprRoute, filterRoutableVprRoutes, hasEligibleFreeVprRoute } from '../routing/select.js';
@@ -2338,31 +2338,28 @@ export function initChatModule({
     if (!model) return null;
     const routes = routesForSelectedModel(uiState.vprRoutableRows, model)
       .filter((row) => row.protocol === 'openai-images');
-    const supportsModeration = (row: DiscoverRow): boolean => row.capabilities?.supportedParameters
-      ?.some((parameter) => parameter.trim().toLowerCase() === 'moderation') ?? false;
     if (routes.length === 0) return null;
     if (selection.mode === 'pinned-peer' && selection.peerId) {
       const route = routes.find((row) => row.peerId === selection.peerId);
       if (!route || (requiresImageInput && !supportsImageEdits(route))) return null;
-      return {
-        service: route.serviceId,
-        peerId: route.peerId,
-        ...(supportsModeration(route) ? { moderation: 'low' as const } : {}),
-      };
+      return { service: route.serviceId, peerId: route.peerId, moderation: 'low' };
     }
     const eligibleRoutes = requiresImageInput ? routes.filter(supportsImageEdits) : routes;
-    const preferredRoute = eligibleRoutes.find((row) => row.peerId === preferredPeerId);
-    const route = preferredRoute ?? chooseBestVprRoute(eligibleRoutes, uiState.vprRoutingPreferences);
+    const moderationRoutes = eligibleRoutes.filter((row) => supportsServiceParameter(row, 'moderation'));
+    // Prefer capability-compatible sellers for requests that resolve to one
+    // concrete peer (image edits). If none advertise support, keep a route so
+    // the buyer proxy can fail with its explicit required-capability error.
+    const routingPool = moderationRoutes.length > 0 ? moderationRoutes : eligibleRoutes;
+    const preferredRoute = routingPool.find((row) => row.peerId === preferredPeerId);
+    const route = preferredRoute ?? chooseBestVprRoute(routingPool, uiState.vprRoutingPreferences);
     if (!route) return null;
     if (requiresImageInput) {
-      return {
-        service: route.serviceId,
-        peerId: route.peerId,
-        ...(supportsModeration(route) ? { moderation: 'low' as const } : {}),
-      };
+      return { service: route.serviceId, peerId: route.peerId, moderation: 'low' };
     }
-    const moderation = eligibleRoutes.every(supportsModeration) ? 'low' as const : undefined;
-    return { service: model.serviceId, ...(moderation ? { moderation } : {}) };
+    // Keep model-only routing for generation. The internal required-parameter
+    // header makes the buyer proxy filter fallback candidates to sellers that
+    // advertise moderation instead of silently dropping the field.
+    return { service: model.serviceId, moderation: 'low' };
   }
 
   function generateImage(prompt: string): void {

--- a/apps/desktop/src/renderer/modules/chat/peer-routing.test.ts
+++ b/apps/desktop/src/renderer/modules/chat/peer-routing.test.ts
@@ -432,7 +432,7 @@ test('new chat created while previous response is pending keeps its own model an
 });
 
 
-test('mixed-capability auto image routes omit moderation and appear immediately while generation is pending', async () => {
+test('mixed-capability auto image routes require moderation and appear immediately while generation is pending', async () => {
   installDomTimers();
 
   const uiState = createInitialUiState();
@@ -495,6 +495,7 @@ test('mixed-capability auto image routes omit moderation and appear immediately 
   assert.deepEqual(request, {
     conversationId: 'conv-a',
     prompt: 'A tiny ant astronaut',
+    moderation: 'low',
     service: 'image-model',
   });
 
@@ -716,14 +717,28 @@ test('switching image models edits through a seller serving the new model', asyn
     updatedAt: Date.now(),
     usage: { inputTokens: 0, outputTokens: 0 },
   }];
-  uiState.vprRoutableRows = [{
-    rowKey: 'new-image-peer:new-image-model',
-    peerId: 'new-image-peer',
-    serviceId: 'new-image-model',
-    protocol: 'openai-images',
-    capabilities: { inputs: ['text', 'image'], outputs: ['image'] },
-    effectiveReputationScore: 80,
-  } as DiscoverRow];
+  uiState.vprRoutableRows = [
+    {
+      rowKey: 'new-image-peer:new-image-model',
+      peerId: 'new-image-peer',
+      serviceId: 'new-image-model',
+      protocol: 'openai-images',
+      capabilities: { inputs: ['text', 'image'], outputs: ['image'] },
+      effectiveReputationScore: 80,
+    } as DiscoverRow,
+    {
+      rowKey: 'moderation-image-peer:new-image-model',
+      peerId: 'moderation-image-peer',
+      serviceId: 'new-image-model',
+      protocol: 'openai-images',
+      capabilities: {
+        inputs: ['text', 'image'],
+        outputs: ['image'],
+        supportedParameters: ['moderation'],
+      },
+      effectiveReputationScore: 70,
+    } as DiscoverRow,
+  ];
   uiState.chatImageRouteSelection = {
     model: { provider: 'openai', serviceId: 'new-image-model', label: 'New Image Model', categories: [] },
     mode: 'auto',
@@ -746,7 +761,8 @@ test('switching image models edits through a seller serving the new model', asyn
   assert.deepEqual(request, {
     conversationId: 'conv-a',
     prompt: 'Make it look like a watercolor',
-    peerId: 'new-image-peer',
+    peerId: 'moderation-image-peer',
+    moderation: 'low',
     service: 'new-image-model',
     sourceImageAttachmentId: 'generated-attachment',
   });
@@ -808,6 +824,7 @@ test('generation-only image sellers generate from cumulative prompt history', as
       'Return only the newly generated image.',
     ].join('\n'),
     peerId: 'venice-peer',
+    moderation: 'low',
     service: 'image-model',
   });
   assert.equal(uiState.chatMessages.at(-1)?.content, request?.prompt);
@@ -878,6 +895,7 @@ test('generation-only image prompt history grows without nesting prior cumulativ
     'Return only the newly generated image.',
   ].join('\n'));
   assert.equal(request?.prompt.match(/Generate a new image using/g)?.length, 1);
+  assert.equal(request?.moderation, 'low');
 
   generation.resolve({ ok: false, error: 'Request aborted' });
   await waitFor(() => !uiState.chatSending);

--- a/apps/desktop/src/renderer/ui/components/InfoTooltip.module.scss
+++ b/apps/desktop/src/renderer/ui/components/InfoTooltip.module.scss
@@ -49,6 +49,11 @@
   overflow-y: auto;
 }
 
+.tooltip-narrow {
+  width: max-content;
+  max-width: min(180px, calc(100vw - 24px));
+}
+
 .tooltip-interactive.tooltip-open {
   pointer-events: auto;
 }

--- a/apps/desktop/src/renderer/ui/components/InfoTooltip.tsx
+++ b/apps/desktop/src/renderer/ui/components/InfoTooltip.tsx
@@ -13,6 +13,7 @@ import {
   type ReactElement,
   type ReactNode,
 } from 'react';
+import { createPortal } from 'react-dom';
 import styles from './InfoTooltip.module.scss';
 
 /**
@@ -69,6 +70,8 @@ export type InfoTooltipProps = {
   align?: InfoTooltipAlign;
   /** Wider panel for structured content such as a balance breakdown. */
   wide?: boolean;
+  /** Narrow panel for short labels or compact lists. */
+  narrow?: boolean;
   /** Keep the panel usable on hover and allow click-to-pin behavior. */
   interactive?: boolean;
   /**
@@ -79,7 +82,7 @@ export type InfoTooltipProps = {
   children: ReactElement;
 };
 
-export function InfoTooltip({ content, align = 'right', wide = false, interactive = false, children }: InfoTooltipProps) {
+export function InfoTooltip({ content, align = 'right', wide = false, narrow = false, interactive = false, children }: InfoTooltipProps) {
   const triggerRef = useRef<HTMLElement | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   const closeTimerRef = useRef<number | null>(null);
@@ -123,8 +126,8 @@ export function InfoTooltip({ content, align = 'right', wide = false, interactiv
       window.clearTimeout(closeTimerRef.current);
       closeTimerRef.current = null;
     }
-    reposition();
     setOpen(true);
+    requestAnimationFrame(reposition);
   }, [reposition]);
 
   const hide = useCallback(() => {
@@ -231,23 +234,27 @@ export function InfoTooltip({ content, align = 'right', wide = false, interactiv
   return (
     <>
       {triggerNode}
-      <div
-        ref={tooltipRef}
-        id={tooltipId}
-        role={interactive ? 'dialog' : 'tooltip'}
-        className={[
-          styles.tooltip,
-          wide ? styles.tooltipWide : '',
-          interactive ? styles.tooltipInteractive : '',
-          open ? styles.tooltipOpen : '',
-        ].filter(Boolean).join(' ')}
-        style={style}
-        onMouseEnter={interactive ? show : undefined}
-        onMouseLeave={interactive ? scheduleHide : undefined}
-        onPointerDown={interactive ? (event: PointerEvent<HTMLDivElement>) => event.stopPropagation() : undefined}
-      >
-        {content}
-      </div>
+      {typeof document !== 'undefined' && createPortal(
+        <div
+          ref={tooltipRef}
+          id={tooltipId}
+          role={interactive ? 'dialog' : 'tooltip'}
+          className={[
+            styles.tooltip,
+            wide ? styles.tooltipWide : '',
+            narrow ? styles.tooltipNarrow : '',
+            interactive ? styles.tooltipInteractive : '',
+            open ? styles.tooltipOpen : '',
+          ].filter(Boolean).join(' ')}
+          style={style}
+          onMouseEnter={interactive ? show : undefined}
+          onMouseLeave={interactive ? scheduleHide : undefined}
+          onPointerDown={interactive ? (event: PointerEvent<HTMLDivElement>) => event.stopPropagation() : undefined}
+        >
+          {content}
+        </div>,
+        document.body,
+      )}
     </>
   );
 }

--- a/apps/desktop/src/renderer/ui/components/views/VprExploreView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/VprExploreView.module.scss
@@ -80,44 +80,17 @@
   }
 }
 
-/* ---------- Filter chips (Type / Family / Sort) ---------- */
+/* ---------- Filter dropdowns (Type / Capability / Family / Sort) ---------- */
 
 .filterRow {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   min-width: 0;
 }
 
-.filterPill {
-  display: inline-flex;
-  min-width: 0;
-  border-radius: 16px;
-  border: 1px solid var(--border);
-  background: var(--bg-card);
-}
-
-.filterPill select {
-  appearance: none;
-  -webkit-appearance: none;
-  min-width: 0;
-  max-width: 112px;
-  padding: 6px 22px 6px 9px;
-  border: none;
-  border-radius: 16px;
-  background:
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath d='M1 1l4 4 4-4' fill='none' stroke='%236b7570' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
-    right 8px center / 10px 6px no-repeat;
-  color: var(--text-primary);
-  font-size: 12px;
-  font-weight: 400;
-  line-height: 16px;
-  cursor: pointer;
-  outline: none;
-}
-
-.filterPillEnd {
+.filterEnd {
   margin-left: auto;
 }
 

--- a/apps/desktop/src/renderer/ui/components/views/VprExploreView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprExploreView.tsx
@@ -1,6 +1,26 @@
 import { useDeferredValue, useMemo, useState } from 'react';
-import { HugeiconsIcon } from '@hugeicons/react';
-import { StarIcon } from '@hugeicons/core-free-icons';
+import { HugeiconsIcon, type IconSvgElement } from '@hugeicons/react';
+import {
+  AiBrain01Icon,
+  AlphabetGreekIcon,
+  ChartUpIcon,
+  CodeIcon,
+  Dollar01Icon,
+  EyeIcon,
+  Globe02Icon,
+  HeadphonesIcon,
+  HierarchyIcon,
+  Image01Icon,
+  PaintBrush01Icon,
+  Shield01Icon,
+  Sorting01Icon,
+  SourceCodeIcon,
+  StarIcon,
+  Tag01Icon,
+  TextIcon,
+  TheaterIcon,
+  ZapIcon,
+} from '@hugeicons/core-free-icons';
 import type { VprModelKind } from '../../../core/state';
 import {
   filterVprCatalog,
@@ -12,6 +32,7 @@ import {
 import { findCatalogEntry } from '../../../modules/catalog/model-catalog';
 import { availableModelFamilies } from '../../../modules/catalog/model-families';
 import { loadFavoriteModels } from '../../../modules/catalog/favorites';
+import { availableModelTags } from '../../../modules/catalog/model-metadata';
 import { setVprModelPageTarget } from '../../../modules/catalog/model-page-target';
 import {
   catalogEntryKey,
@@ -22,6 +43,8 @@ import { shallowEqual, useUiSelector } from '../../hooks/useUiSelector';
 import { useActions } from '../../hooks/useActions';
 import { useRetainedState } from '../../hooks/useRetainedState';
 import type { ViewName } from '../../types';
+import { BrandIcon } from '../brand/BrandIcon';
+import { VprFilterDropdown, VprMultiFilterDropdown, type VprFilterOption } from '../vpr/VprFilterDropdown';
 import { VprModelRowList, VprSelectedModelCard } from '../vpr/VprModelRows';
 import { VprPage, VprSearch } from '../vpr/VprKit';
 import styles from './VprExploreView.module.scss';
@@ -30,13 +53,30 @@ type Props = { onSelectView?: (view: ViewName) => void };
 
 const RECOMMENDED_LIMIT = 18;
 
+function FilterIconView({ icon }: { icon: IconSvgElement }) {
+  return <HugeiconsIcon icon={icon} size={16} strokeWidth={1.8} />;
+}
+
+const TAG_ICONS: Readonly<Record<string, IconSvgElement>> = {
+  Anime: PaintBrush01Icon,
+  'Audio input': HeadphonesIcon,
+  Coding: CodeIcon,
+  Fast: ZapIcon,
+  'Open weights': SourceCodeIcon,
+  Reasoning: AiBrain01Icon,
+  Roleplay: TheaterIcon,
+  Uncensored: Shield01Icon,
+  Vision: EyeIcon,
+  'Web search': Globe02Icon,
+};
+
 // Renderer-lifetime cache: tab/search/filter/sort survive drilling into a
 // model page and back (ViewHost unmounts inactive views).
 const exploreViewCache = {
   tab: 'Recommended' as 'Recommended' | 'All',
   search: '',
-  kind: '' as VprModelKind | '',
-  family: '',
+  types: [] as string[],
+  families: [] as string[],
   sort: 'Popular' as VprCatalogSort,
 };
 
@@ -51,16 +91,16 @@ export function VprExploreView({ onSelectView }: Props) {
   }), shallowEqual);
   const [tab, setTab] = useRetainedState(exploreViewCache, 'tab');
   const [search, setSearch] = useRetainedState(exploreViewCache, 'search');
-  const [kind, setKind] = useRetainedState(exploreViewCache, 'kind');
-  const [family, setFamily] = useRetainedState(exploreViewCache, 'family');
+  const [types, setTypes] = useRetainedState(exploreViewCache, 'types');
+  const [families, setFamilies] = useRetainedState(exploreViewCache, 'families');
   const [sort, setSort] = useRetainedState(exploreViewCache, 'sort');
   // Tab/filter/search changes re-render the full model list — hundreds of
   // rows. Deriving the list from deferred values keeps the tapped control
   // responsive: the tab/pill paints its new state in the urgent render and
   // the list catches up in an interruptible background render.
   const listInputs = useDeferredValue(useMemo(
-    () => ({ tab, search, kind, family, sort }),
-    [family, kind, search, sort, tab],
+    () => ({ tab, search, types, families, sort }),
+    [families, search, sort, tab, types],
   ));
   // Starred on the model pages; fresh on every visit (the view remounts).
   const [favorites] = useState(loadFavoriteModels);
@@ -71,7 +111,35 @@ export function VprExploreView({ onSelectView }: Props) {
     [snap.discoverRows, snap.selection],
   );
 
-  const families = useMemo(() => availableModelFamilies(snap.catalog), [snap.catalog]);
+  const availableFamilies = useMemo(() => availableModelFamilies(snap.catalog), [snap.catalog]);
+  const tags = useMemo(
+    () => availableModelTags(snap.catalog.map((entry) => entry.serviceId)),
+    [snap.catalog],
+  );
+  const typeOptions = useMemo<readonly VprFilterOption<string>[]>(() => [
+    { value: 'kind:text', label: 'Text', description: 'Chat and language models', icon: <FilterIconView icon={TextIcon} /> },
+    { value: 'kind:image', label: 'Image', description: 'Image generation models', icon: <FilterIconView icon={Image01Icon} /> },
+    ...tags.map((modelTag) => ({
+      value: `tag:${modelTag}`,
+      label: modelTag,
+      description: `Models tagged ${modelTag}`,
+      icon: <FilterIconView icon={TAG_ICONS[modelTag] ?? Tag01Icon} />,
+    })),
+  ], [tags]);
+  const familyOptions = useMemo<readonly VprFilterOption<string>[]>(() => [
+    ...availableFamilies.map((modelFamily) => ({
+      value: modelFamily,
+      label: modelFamily,
+      description: `${modelFamily} models`,
+      icon: <BrandIcon name={modelFamily} hints={[modelFamily]} size={16} />,
+    })),
+  ], [availableFamilies]);
+  const sortOptions = useMemo<readonly VprFilterOption<VprCatalogSort>[]>(() => [
+    { value: 'Popular', label: 'Popular', description: 'Most available sellers first', icon: <FilterIconView icon={Sorting01Icon} /> },
+    { value: 'Price', label: 'Price', description: 'Lowest price first', icon: <FilterIconView icon={Dollar01Icon} /> },
+    { value: 'Savings', label: 'Savings', description: 'Largest savings first', icon: <FilterIconView icon={ChartUpIcon} /> },
+    { value: 'Name', label: 'Name', description: 'Alphabetical order', icon: <FilterIconView icon={AlphabetGreekIcon} /> },
+  ], []);
   const favoriteEntries = useMemo(
     () => (listInputs.tab === 'Recommended'
       ? filterVprCatalog(selectFavoriteVprCatalog(snap.catalog, favorites), { search: listInputs.search })
@@ -90,8 +158,13 @@ export function VprExploreView({ onSelectView }: Props) {
     return sortVprCatalog(
       filterVprCatalog(snap.catalog, {
         search: listInputs.search,
-        kind: listInputs.kind || null,
-        family: listInputs.family || null,
+        kinds: listInputs.types
+          .filter((value) => value.startsWith('kind:'))
+          .map((value) => value.slice(5) as VprModelKind),
+        tags: listInputs.types
+          .filter((value) => value.startsWith('tag:'))
+          .map((value) => value.slice(4)),
+        families: listInputs.families,
       }),
       listInputs.sort,
     );
@@ -165,41 +238,28 @@ export function VprExploreView({ onSelectView }: Props) {
 
         {tab === 'All' && (
           <div className={styles.filterRow}>
-            <label className={styles.filterPill}>
-              <select
-                value={kind}
-                onChange={(event) => setKind(event.currentTarget.value as VprModelKind | '')}
-                aria-label="Filter by model type"
-              >
-                <option value="">Model type</option>
-                <option value="image">Image</option>
-                <option value="text">Text</option>
-              </select>
-            </label>
-            <label className={styles.filterPill}>
-              <select
-                value={family}
-                onChange={(event) => setFamily(event.currentTarget.value)}
-                aria-label="Filter by model family"
-              >
-                <option value="">Model family</option>
-                {families.map((entry) => (
-                  <option key={entry} value={entry}>{entry}</option>
-                ))}
-              </select>
-            </label>
-            <label className={`${styles.filterPill} ${styles.filterPillEnd}`}>
-              <select
+            <VprMultiFilterDropdown
+              label="Type"
+              values={types}
+              options={typeOptions}
+              onChange={setTypes}
+            />
+            <VprMultiFilterDropdown
+              label="Family"
+              values={families}
+              options={familyOptions}
+              onChange={setFamilies}
+              emptyIcon={<FilterIconView icon={HierarchyIcon} />}
+            />
+            <div className={styles.filterEnd}>
+              <VprFilterDropdown
+                label="Sort models"
                 value={sort}
-                onChange={(event) => setSort(event.currentTarget.value as VprCatalogSort)}
-                aria-label="Sort models"
-              >
-                <option value="Popular">Popular</option>
-                <option value="Price">Price</option>
-                <option value="Savings">Savings</option>
-                <option value="Name">Name</option>
-              </select>
-            </label>
+                options={sortOptions}
+                onChange={setSort}
+                align="end"
+              />
+            </div>
           </div>
         )}
 

--- a/apps/desktop/src/renderer/ui/components/views/VprModelView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/VprModelView.module.scss
@@ -54,8 +54,6 @@
   line-height: 24px;
 }
 
-/* Always a single line: the "+N" chip absorbs the tail, and anything that
-   still doesn't fit is clipped rather than wrapped. */
 /* Checkmark marking the applied model on its own page. */
 .titleCheck {
   flex: 0 0 auto;
@@ -64,6 +62,8 @@
   color: var(--accent-green);
 }
 
+/* Always a single line: the "+N" chip absorbs the tail, and anything that
+   still doesn't fit is clipped rather than wrapped. */
 .badgeRow {
   display: flex;
   flex-wrap: nowrap;
@@ -76,9 +76,36 @@
   flex: 0 0 auto;
 }
 
-/* "+N" overflow chip: its title attribute names the collapsed categories. */
+.modelTag,
 .badgeMore {
   display: inline-flex;
+  align-items: center;
+  height: 20px;
+  border: 1px solid color-mix(in srgb, var(--text-secondary) 16%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-secondary) 6%, transparent);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 550;
+  line-height: 16px;
+  letter-spacing: 0.01em;
+}
+
+.modelTag {
+  padding: 0 7px;
+}
+
+.modelTagUncensored {
+  border-color: color-mix(in srgb, var(--accent-green) 24%, transparent);
+  background: color-mix(in srgb, var(--accent-green) 9%, transparent);
+  color: var(--accent-green);
+}
+
+/* "+N" overflow chip: its title attribute names the collapsed tags. */
+.badgeMore {
+  min-width: 24px;
+  justify-content: center;
+  padding: 0 6px;
   cursor: default;
 }
 
@@ -186,39 +213,6 @@
   outline: none;
   border-radius: 4px;
   box-shadow: 0 0 0 2px rgba(var(--brand-rgb), 0.4);
-}
-
-.capabilityNotice {
-  display: grid;
-  gap: 3px;
-  padding: 10px 12px;
-  border: 1px solid rgba(var(--brand-rgb), 0.25);
-  border-radius: 10px;
-  background: rgba(var(--brand-rgb), 0.07);
-  color: var(--text-secondary);
-  font-size: 12px;
-  line-height: 17px;
-}
-
-.capabilityNotice strong {
-  color: var(--text-primary);
-  font-size: 13px;
-}
-
-.capabilityList {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-}
-
-.capabilityList span {
-  padding: 3px 7px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--bg-card);
-  color: var(--text-secondary);
-  font-size: 11px;
-  line-height: 15px;
 }
 
 /* ---------- Auto select row ---------- */

--- a/apps/desktop/src/renderer/ui/components/views/VprModelView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprModelView.tsx
@@ -16,6 +16,7 @@ import { shallowEqual, useUiSelector } from '../../hooks/useUiSelector';
 import { useActions } from '../../hooks/useActions';
 import type { ViewName } from '../../types';
 import { BrandIcon } from '../brand/BrandIcon';
+import { InfoTooltip } from '../InfoTooltip';
 import { formatUsdShort, VprBadge, VprCard, VprPage, VprSettingRow, VprStatRow, VprStatTile, VprToggle } from '../vpr/VprKit';
 import styles from './VprModelView.module.scss';
 
@@ -356,9 +357,16 @@ function ModelTagBadges({ tags }: { tags: string[] }) {
         </span>
       ))}
       {(visibleCount === null || hiddenTags.length > 0) && (
-        <span className={styles.badgeMore} title={hiddenTags.join(' · ')}>
-          +{hiddenTags.length || tags.length}
-        </span>
+        <InfoTooltip
+          align="left"
+          narrow
+          interactive
+          content={<span>{hiddenTags.join(' · ')}</span>}
+        >
+          <span className={styles.badgeMore} role="button" tabIndex={0}>
+            +{hiddenTags.length || tags.length}
+          </span>
+        </InfoTooltip>
       )}
     </div>
   );

--- a/apps/desktop/src/renderer/ui/components/views/VprModelView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/VprModelView.tsx
@@ -4,14 +4,14 @@ import { Copy01Icon, PreferenceHorizontalIcon, StarIcon, Tick02Icon } from '@hug
 import { chooseBestVprRoute } from '../../../modules/routing/select';
 import { compareModelRoutesByReputation, routesForSelectedModel } from '../../../modules/catalog/view-models';
 import { findCatalogEntry } from '../../../modules/catalog/model-catalog';
-import { modelCapabilitySummary, peerCapabilitySummary } from '../../../modules/catalog/model-capabilities';
+import { peerCapabilitySummary, supportsServiceParameter } from '../../../modules/catalog/model-capabilities';
+import { modelTagsFor } from '../../../modules/catalog/model-metadata';
 import { buildImageModelSkillPrompt } from '../../../modules/chat/image-model-instructions';
 import { favoriteModelKey, loadFavoriteModels, toggleFavoriteModel } from '../../../modules/catalog/favorites';
 import { vprModelPageTarget } from '../../../modules/catalog/model-page-target';
 import { modelPinKey, vprModelPinFor } from '../../../modules/routing/model-pins';
 import { isFreeRoute, sellerMetaLabel, sellerReputationLabel } from '../../../modules/catalog/seller-format';
 import type { DiscoverRow } from '../../../core/state';
-import { formatCategoryLabel } from '../chat/discover-filter-util';
 import { shallowEqual, useUiSelector } from '../../hooks/useUiSelector';
 import { useActions } from '../../hooks/useActions';
 import type { ViewName } from '../../types';
@@ -90,7 +90,8 @@ export function VprModelView({ onSelectView }: Props) {
   const priceValue = imageOnly
     ? priceRange(entry.minImageUsdPerImage, entry.maxImageUsdPerImage)
     : priceTile(entry);
-  const capabilitySummary = modelCapabilitySummary(entry);
+  const modelTags = modelTagsFor(entry.serviceId);
+  const displayedModelTags = imageOnly ? ['Image generation', ...modelTags] : modelTags;
 
   const viewedModel = model;
   /** Make the browsed text model (and its previewed pin) the active route. */
@@ -134,8 +135,8 @@ export function VprModelView({ onSelectView }: Props) {
                 </span>
               )}
             </div>
-            {(entry.categories.length > 0 || imageOnly) && (
-              <CategoryBadges categories={imageOnly ? ['image-generation', ...entry.categories] : entry.categories} />
+            {displayedModelTags.length > 0 && (
+              <ModelTagBadges tags={displayedModelTags} />
             )}
           </div>
           <div className={styles.headActions}>
@@ -191,19 +192,6 @@ export function VprModelView({ onSelectView }: Props) {
             )}
           </div>
         </div>
-
-        {imageOnly && (
-          <div className={styles.capabilityNotice} role="note">
-            <strong>Image generation only</strong>
-            <span>Use it in the internal chat, or copy model-only instructions for a normal text agent. It cannot become the main text or connected-app route.</span>
-          </div>
-        )}
-
-        {capabilitySummary.length > 0 && !imageOnly && (
-          <div className={styles.capabilityList} aria-label="Model type">
-            {capabilitySummary.map((capability) => <span key={capability}>{capability}</span>)}
-          </div>
-        )}
 
         <VprStatRow>
           <VprStatTile
@@ -306,19 +294,20 @@ export function VprModelView({ onSelectView }: Props) {
 const BADGE_GAP = 2;
 
 /**
- * Category tags on a single line, always. The row measures itself before
+ * Curated model tags on a single line, always. The row measures itself before
  * paint and shows only as many tags as actually fit, collapsing the rest into
  * a "+N" chip whose title lists them — no wrapping, no clipped chips.
  */
-function CategoryBadges({ categories }: { categories: string[] }) {
+function ModelTagBadges({ tags }: { tags: string[] }) {
   const rowRef = useRef<HTMLDivElement | null>(null);
   // null = measuring pass: render every tag (plus a worst-case "+N" chip) so
   // their widths can be read; the fitted count replaces it before paint.
   const [visibleCount, setVisibleCount] = useState<number | null>(null);
+  const tagSignature = tags.join('\0');
 
   useLayoutEffect(() => {
     setVisibleCount(null);
-  }, [categories]);
+  }, [tagSignature]);
 
   // Refit when the row's width changes (window resize, layout shifts).
   useLayoutEffect(() => {
@@ -353,20 +342,22 @@ function CategoryBadges({ categories }: { categories: string[] }) {
       : fitted(max - BADGE_GAP - chip.offsetWidth));
   }, [visibleCount]);
 
-  const visible = visibleCount ?? categories.length;
-  const hiddenCategories = categories.slice(visible);
+  const visible = visibleCount ?? tags.length;
+  const hiddenTags = tags.slice(visible);
 
   return (
     <div className={styles.badgeRow} ref={rowRef}>
-      {categories.slice(0, visible).map((category) => (
-        <VprBadge key={category} tone="type">{formatCategoryLabel(category)}</VprBadge>
-      ))}
-      {(visibleCount === null || hiddenCategories.length > 0) && (
+      {tags.slice(0, visible).map((tag) => (
         <span
-          className={styles.badgeMore}
-          title={hiddenCategories.map(formatCategoryLabel).join(' · ')}
+          key={tag}
+          className={`${styles.modelTag}${tag === 'Uncensored' ? ` ${styles.modelTagUncensored}` : ''}`}
         >
-          <VprBadge tone="type">+{hiddenCategories.length || categories.length}</VprBadge>
+          {tag}
+        </span>
+      ))}
+      {(visibleCount === null || hiddenTags.length > 0) && (
+        <span className={styles.badgeMore} title={hiddenTags.join(' · ')}>
+          +{hiddenTags.length || tags.length}
         </span>
       )}
     </div>
@@ -383,7 +374,14 @@ function SellerRow({ route, active, auto, onClick }: {
 }) {
   const capabilities = peerCapabilitySummary(route);
   const parameters = route.capabilities?.supportedParameters ?? [];
-  const capabilityLabel = [...capabilities, ...parameters.map((parameter) => parameter.replaceAll('_', ' '))].join(' · ');
+  const hasModerationControl = route.protocol === 'openai-images'
+    && supportsServiceParameter(route, 'moderation');
+  const capabilityLabel = [
+    ...capabilities,
+    ...parameters
+      .filter((parameter) => parameter.trim().toLowerCase() !== 'moderation')
+      .map((parameter) => parameter.replaceAll('_', ' ')),
+  ].join(' · ');
   return (
     <button
       type="button"
@@ -399,6 +397,7 @@ function SellerRow({ route, active, auto, onClick }: {
           {route.peerDisplayName || route.peerLabel || route.peerId}
           {active && <VprBadge tone="primary">{auto ? '• Auto' : 'Pinned'}</VprBadge>}
           {isFreeRoute(route) && <VprBadge tone="green">Free</VprBadge>}
+          {hasModerationControl && <VprBadge tone="neutral">Moderation control</VprBadge>}
         </span>
         <span className={styles.sellerMeta}>
           {sellerMetaLabel(route)}

--- a/apps/desktop/src/renderer/ui/components/views/VprModelViews.test.ts
+++ b/apps/desktop/src/renderer/ui/components/views/VprModelViews.test.ts
@@ -6,7 +6,7 @@ import {
   routesForSelectedModel,
   sortVprCatalog,
 } from '../../../modules/catalog/view-models.js';
-import { peerCapabilitySummary } from '../../../modules/catalog/model-capabilities.js';
+import { peerCapabilitySummary, supportsServiceParameter } from '../../../modules/catalog/model-capabilities.js';
 
 function catalogEntry(overrides: Partial<VprModelCatalogEntry> = {}): VprModelCatalogEntry {
   return {
@@ -95,6 +95,11 @@ test('Explore search finds image-only models by their derived type', () => {
   assert.deepEqual(filterVprCatalog([image], { search: 'image generation' }), [image]);
 });
 
+test('Explore search finds curated model tags without seller categories', () => {
+  const image = catalogEntry({ serviceId: 'lustify-v8', label: 'Lustify V8', kind: 'image', categories: [] });
+  assert.deepEqual(filterVprCatalog([image], { search: 'uncensored' }), [image]);
+});
+
 test('Explore filters models by output type', () => {
   const text = catalogEntry({ serviceId: 'chat-model', label: 'Chat Model', kind: 'text' });
   const image = catalogEntry({ serviceId: 'art-model', label: 'Art Model', kind: 'image' });
@@ -138,6 +143,16 @@ test('Model route filtering excludes other service IDs but keeps canonical varia
   );
 });
 
+test('service parameter support is matched case-insensitively', () => {
+  const route = discoverRow({
+    protocol: 'openai-images',
+    capabilities: { outputs: ['image'], supportedParameters: ['MODERATION', 'output_format'] },
+  });
+
+  assert.equal(supportsServiceParameter(route, 'moderation'), true);
+  assert.equal(supportsServiceParameter(route, 'quality'), false);
+});
+
 test('image seller summaries distinguish generation-only routes from edit support', () => {
   const generationOnly = discoverRow({
     protocol: 'openai-images',
@@ -148,6 +163,6 @@ test('image seller summaries distinguish generation-only routes from edit suppor
     capabilities: { inputs: ['text', 'image'], outputs: ['image'] },
   });
 
-  assert.equal(peerCapabilitySummary(generationOnly)[0], 'Image generation only');
-  assert.equal(peerCapabilitySummary(editable)[0], 'Image generation + editing');
+  assert.equal(peerCapabilitySummary(generationOnly)[0], undefined);
+  assert.equal(peerCapabilitySummary(editable)[0], 'Image editing');
 });

--- a/apps/desktop/src/renderer/ui/components/vpr/VprFilterDropdown.module.scss
+++ b/apps/desktop/src/renderer/ui/components/vpr/VprFilterDropdown.module.scss
@@ -1,0 +1,191 @@
+.root {
+  position: relative;
+  min-width: 0;
+}
+
+.trigger {
+  height: 32px;
+  max-width: 132px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 9px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 0.12s ease, background 0.12s ease, color 0.12s ease, box-shadow 0.12s ease;
+}
+
+.trigger:hover,
+.triggerOpen {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.triggerActive {
+  border-color: color-mix(in srgb, var(--brand) 28%, var(--border));
+  color: var(--text-primary);
+}
+
+.trigger:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(var(--brand-rgb), 0.35);
+}
+
+.triggerIcon,
+.optionIcon {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  color: var(--text-muted);
+}
+
+.triggerActive .triggerIcon,
+.optionActive .optionIcon {
+  color: var(--brand);
+}
+
+.triggerLabel {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 550;
+  line-height: 16px;
+}
+
+.chevron {
+  flex: 0 0 auto;
+  margin-left: 1px;
+  transition: transform 0.14s ease;
+}
+
+.triggerOpen .chevron {
+  transform: rotate(180deg);
+}
+
+.menu {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 6px);
+  left: 0;
+  width: max-content;
+  min-width: 210px;
+  max-width: min(280px, calc(100vw - 32px));
+  max-height: min(280px, calc(100vh - 32px));
+  padding: 6px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--bg-card);
+  box-shadow: 0 14px 36px rgba(0, 0, 0, 0.18), var(--shadow-sm);
+  animation: menuEnter 0.12s ease-out;
+  scrollbar-width: thin;
+}
+
+.menuEnd {
+  right: 0;
+  left: auto;
+}
+
+.menuLabel {
+  padding: 5px 9px 7px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 650;
+  line-height: 14px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.option {
+  width: 100%;
+  min-height: 40px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 9px;
+  border: none;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.option:hover,
+.option:focus-visible {
+  outline: none;
+  background: var(--bg-hover);
+}
+
+.optionActive {
+  background: color-mix(in srgb, var(--brand) 7%, transparent);
+}
+
+.menuCompact {
+  max-height: min(240px, calc(100vh - 32px));
+}
+
+.optionCompact {
+  min-height: 32px;
+  padding-block: 5px;
+}
+
+.optionIcon {
+  width: 20px;
+}
+
+.optionText {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: grid;
+  gap: 1px;
+}
+
+.optionLabel {
+  font-size: 12px;
+  font-weight: 560;
+  line-height: 16px;
+}
+
+.optionDescription {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 10px;
+  line-height: 14px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.check {
+  flex: 0 0 auto;
+  color: var(--accent-green);
+}
+
+@keyframes menuEnter {
+  from {
+    opacity: 0;
+    transform: translateY(-3px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .menu {
+    animation: none;
+  }
+
+  .chevron {
+    transition: none;
+  }
+}

--- a/apps/desktop/src/renderer/ui/components/vpr/VprFilterDropdown.tsx
+++ b/apps/desktop/src/renderer/ui/components/vpr/VprFilterDropdown.tsx
@@ -1,0 +1,301 @@
+import { useEffect, useId, useRef, useState, type KeyboardEvent, type ReactNode } from 'react';
+import { HugeiconsIcon } from '@hugeicons/react';
+import { ArrowDown01Icon, Tick02Icon } from '@hugeicons/core-free-icons';
+import styles from './VprFilterDropdown.module.scss';
+
+export type VprFilterOption<Value extends string> = {
+  value: Value;
+  label: string;
+  description?: string;
+  icon: ReactNode;
+};
+
+type Props<Value extends string> = {
+  label: string;
+  value: Value;
+  options: readonly VprFilterOption<Value>[];
+  onChange: (value: Value) => void;
+  align?: 'start' | 'end';
+};
+
+type MultiProps<Value extends string> = {
+  label: string;
+  values: readonly Value[];
+  options: readonly VprFilterOption<Value>[];
+  onChange: (values: Value[]) => void;
+  emptyIcon?: ReactNode;
+};
+
+function useDropdownDismiss(open: boolean, rootRef: React.RefObject<HTMLDivElement | null>, close: () => void) {
+  useEffect(() => {
+    if (!open) return undefined;
+    const dismiss = (event: PointerEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) close();
+    };
+    window.addEventListener('pointerdown', dismiss);
+    return () => window.removeEventListener('pointerdown', dismiss);
+  }, [close, open, rootRef]);
+}
+
+function focusOption(root: HTMLDivElement | null, index: number): void {
+  const items = root?.querySelectorAll<HTMLButtonElement>('[role="option"]');
+  items?.[Math.max(0, Math.min(index, items.length - 1))]?.focus();
+}
+
+function handleOptionKeyDown(
+  event: KeyboardEvent<HTMLButtonElement>,
+  index: number,
+  optionCount: number,
+  root: HTMLDivElement | null,
+  closeAndFocus: () => void,
+): void {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeAndFocus();
+  } else if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    event.preventDefault();
+    focusOption(root, (index + (event.key === 'ArrowDown' ? 1 : -1) + optionCount) % optionCount);
+  } else if (event.key === 'Home' || event.key === 'End') {
+    event.preventDefault();
+    focusOption(root, event.key === 'Home' ? 0 : optionCount - 1);
+  }
+}
+
+export function VprFilterDropdown<Value extends string>({
+  label,
+  value,
+  options,
+  onChange,
+  align = 'start',
+}: Props<Value>) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const menuId = useId();
+  const selected = options.find((option) => option.value === value) ?? options[0];
+  const close = () => setOpen(false);
+  useDropdownDismiss(open, rootRef, close);
+
+  function closeAndFocus(): void {
+    close();
+    buttonRef.current?.focus();
+  }
+
+  function handleTriggerKeyDown(event: KeyboardEvent<HTMLButtonElement>): void {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+    event.preventDefault();
+    setOpen(true);
+    requestAnimationFrame(() => focusOption(rootRef.current, event.key === 'ArrowDown' ? 0 : options.length - 1));
+  }
+
+  return (
+    <div className={styles.root} ref={rootRef}>
+      <DropdownTrigger
+        buttonRef={buttonRef}
+        label={label}
+        displayLabel={selected.label}
+        icon={selected.icon}
+        active={Boolean(value)}
+        open={open}
+        menuId={menuId}
+        onClick={() => setOpen((current) => !current)}
+        onKeyDown={handleTriggerKeyDown}
+      />
+      {open && (
+        <DropdownMenu id={menuId} label={label} align={align}>
+          {options.map((option, index) => {
+            const active = option.value === value;
+            return (
+              <DropdownOption
+                key={option.value || '__all'}
+                option={option}
+                active={active}
+                onClick={() => {
+                  onChange(option.value);
+                  closeAndFocus();
+                }}
+                onKeyDown={(event) => handleOptionKeyDown(
+                  event, index, options.length, rootRef.current, closeAndFocus,
+                )}
+              />
+            );
+          })}
+        </DropdownMenu>
+      )}
+    </div>
+  );
+}
+
+export function VprMultiFilterDropdown<Value extends string>({
+  label,
+  values,
+  options,
+  onChange,
+  emptyIcon,
+}: MultiProps<Value>) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const menuId = useId();
+  const selected = new Set(values);
+  const firstOption = options[0];
+  const displayLabel = values.length === 0
+    ? label
+    : values.length === 1
+      ? options.find((option) => option.value === values[0])?.label ?? label
+      : `${values.length} selected`;
+  const close = () => setOpen(false);
+  useDropdownDismiss(open, rootRef, close);
+
+  function closeAndFocus(): void {
+    close();
+    buttonRef.current?.focus();
+  }
+
+  function toggle(value: Value): void {
+    onChange(selected.has(value)
+      ? values.filter((candidate) => candidate !== value)
+      : [...values, value]);
+  }
+
+  return (
+    <div className={styles.root} ref={rootRef}>
+      <DropdownTrigger
+        buttonRef={buttonRef}
+        label={label}
+        displayLabel={displayLabel}
+        icon={values.length === 1
+          ? options.find((option) => option.value === values[0])?.icon ?? emptyIcon ?? firstOption.icon
+          : emptyIcon ?? firstOption.icon}
+        active={values.length > 0}
+        open={open}
+        menuId={menuId}
+        onClick={() => setOpen((current) => !current)}
+        onKeyDown={(event) => {
+          if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+          event.preventDefault();
+          setOpen(true);
+          requestAnimationFrame(() => focusOption(rootRef.current, event.key === 'ArrowDown' ? 0 : options.length - 1));
+        }}
+      />
+      {open && (
+        <DropdownMenu id={menuId} label={label} compact>
+          {options.map((option, index) => {
+            const active = selected.has(option.value);
+            return (
+              <DropdownOption
+                key={option.value || '__all'}
+                option={option}
+                active={active}
+                compact
+                onClick={() => toggle(option.value)}
+                onKeyDown={(event) => handleOptionKeyDown(
+                  event, index, options.length, rootRef.current, closeAndFocus,
+                )}
+              />
+            );
+          })}
+        </DropdownMenu>
+      )}
+    </div>
+  );
+}
+
+function DropdownTrigger({
+  buttonRef,
+  label,
+  displayLabel,
+  icon,
+  active,
+  open,
+  menuId,
+  onClick,
+  onKeyDown,
+}: {
+  buttonRef: React.RefObject<HTMLButtonElement | null>;
+  label: string;
+  displayLabel: string;
+  icon: ReactNode;
+  active: boolean;
+  open: boolean;
+  menuId: string;
+  onClick: () => void;
+  onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
+}) {
+  return (
+    <button
+      ref={buttonRef}
+      type="button"
+      className={`${styles.trigger}${open ? ` ${styles.triggerOpen}` : ''}${active ? ` ${styles.triggerActive}` : ''}`}
+      aria-label={label}
+      aria-haspopup="listbox"
+      aria-expanded={open}
+      aria-controls={menuId}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+    >
+      <span className={styles.triggerIcon}>{icon}</span>
+      <span className={styles.triggerLabel}>{displayLabel}</span>
+      <HugeiconsIcon icon={ArrowDown01Icon} size={14} strokeWidth={1.8} className={styles.chevron} />
+    </button>
+  );
+}
+
+function DropdownMenu({
+  id,
+  label,
+  align = 'start',
+  compact = false,
+  children,
+}: {
+  id: string;
+  label: string;
+  align?: 'start' | 'end';
+  compact?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      id={id}
+      className={`${styles.menu}${align === 'end' ? ` ${styles.menuEnd}` : ''}${compact ? ` ${styles.menuCompact}` : ''}`}
+      role="listbox"
+      aria-label={label}
+      aria-multiselectable={compact || undefined}
+    >
+      <div className={styles.menuLabel}>{label}</div>
+      {children}
+    </div>
+  );
+}
+
+function DropdownOption<Value extends string>({
+  option,
+  active,
+  compact = false,
+  onClick,
+  onKeyDown,
+}: {
+  option: VprFilterOption<Value>;
+  active: boolean;
+  compact?: boolean;
+  onClick: () => void;
+  onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={active}
+      className={`${styles.option}${active ? ` ${styles.optionActive}` : ''}${compact ? ` ${styles.optionCompact}` : ''}`}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+    >
+      <span className={styles.optionIcon}>{option.icon}</span>
+      <span className={styles.optionText}>
+        <span className={styles.optionLabel}>{option.label}</span>
+        {!compact && option.description && <span className={styles.optionDescription}>{option.description}</span>}
+      </span>
+      {active && <HugeiconsIcon icon={Tick02Icon} size={16} strokeWidth={2} className={styles.check} />}
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/ui/components/vpr/VprModelRows.module.scss
+++ b/apps/desktop/src/renderer/ui/components/vpr/VprModelRows.module.scss
@@ -112,6 +112,47 @@
   line-height: 20px;
 }
 
+.modelTypeTag,
+.modelTag,
+.modelTagMore {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  border: 1px solid color-mix(in srgb, var(--text-secondary) 16%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--text-secondary) 6%, transparent);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 550;
+  line-height: 16px;
+  letter-spacing: 0.01em;
+}
+
+.modelTypeTag,
+.modelTag {
+  padding: 0 7px;
+}
+
+.modelTypeTag {
+  border-color: color-mix(in srgb, var(--brand) 18%, transparent);
+  background: color-mix(in srgb, var(--brand) 7%, transparent);
+  color: var(--brand);
+}
+
+.modelTagUncensored {
+  border-color: color-mix(in srgb, var(--accent-green) 24%, transparent);
+  background: color-mix(in srgb, var(--accent-green) 9%, transparent);
+  color: var(--accent-green);
+}
+
+.modelTagMore {
+  min-width: 24px;
+  justify-content: center;
+  padding: 0 6px;
+  cursor: default;
+}
+
 .favStar {
   flex: 0 0 auto;
   color: var(--accent-yellow);

--- a/apps/desktop/src/renderer/ui/components/vpr/VprModelRows.tsx
+++ b/apps/desktop/src/renderer/ui/components/vpr/VprModelRows.tsx
@@ -7,6 +7,7 @@ import { sameCanonicalModel } from '../../../modules/catalog/model-identity';
 import { modelCapabilitySummary } from '../../../modules/catalog/model-capabilities';
 import { modelTagsFor } from '../../../modules/catalog/model-metadata';
 import { BrandIcon } from '../brand/BrandIcon';
+import { InfoTooltip } from '../InfoTooltip';
 import { formatUsdShort, VprBadge } from './VprKit';
 import styles from './VprModelRows.module.scss';
 
@@ -151,9 +152,21 @@ function ModelRow({ entry, checked, favorite, badge, compact, chevron = true, pi
             </span>
           ))}
           {!compact && hiddenModelTags.length > 0 && (
-            <span className={styles.modelTagMore} title={hiddenModelTags.join(' · ')}>
-              +{hiddenModelTags.length}
-            </span>
+            <InfoTooltip
+              align="left"
+              narrow
+              interactive
+              content={<span>{hiddenModelTags.join(' · ')}</span>}
+            >
+              <span
+                className={styles.modelTagMore}
+                role="button"
+                tabIndex={0}
+                onClick={(event) => event.stopPropagation()}
+              >
+                +{hiddenModelTags.length}
+              </span>
+            </InfoTooltip>
           )}
           {favorite && (
             <HugeiconsIcon icon={StarIcon} size={13} strokeWidth={2} className={styles.favStar} />

--- a/apps/desktop/src/renderer/ui/components/vpr/VprModelRows.tsx
+++ b/apps/desktop/src/renderer/ui/components/vpr/VprModelRows.tsx
@@ -5,6 +5,7 @@ import type { VprModelCatalogEntry } from '../../../core/state';
 import { favoriteModelKey } from '../../../modules/catalog/favorites';
 import { sameCanonicalModel } from '../../../modules/catalog/model-identity';
 import { modelCapabilitySummary } from '../../../modules/catalog/model-capabilities';
+import { modelTagsFor } from '../../../modules/catalog/model-metadata';
 import { BrandIcon } from '../brand/BrandIcon';
 import { formatUsdShort, VprBadge } from './VprKit';
 import styles from './VprModelRows.module.scss';
@@ -90,6 +91,9 @@ function ModelRow({ entry, checked, favorite, badge, compact, chevron = true, pi
   // the second line runs the full row.
   const discount = onConfigure ? null : discountLabel(entry);
   const capabilities = modelCapabilitySummary(entry);
+  const modelTags = modelTagsFor(entry.serviceId);
+  const visibleModelTags = modelTags.slice(0, 1);
+  const hiddenModelTags = modelTags.slice(visibleModelTags.length);
 
   const priceParts = entry.kind === 'image' ? (
     entry.minImageUsdPerImage !== null ? (
@@ -128,16 +132,29 @@ function ModelRow({ entry, checked, favorite, badge, compact, chevron = true, pi
       aria-pressed={checked}
       onClick={onClick}
     >
-      <span className={styles.checkSlot} aria-hidden="true">
-        {checked && (
+      {checked && (
+        <span className={styles.checkSlot} aria-hidden="true">
           <HugeiconsIcon icon={Tick02Icon} size={16} strokeWidth={2} className={styles.check} />
-        )}
-      </span>
+        </span>
+      )}
       <span className={styles.rowMain}>
         <span className={styles.titleLine}>
           <BrandIcon name={entry.provider} hints={[entry.label]} size={16} className={styles.logo} />
           <span className={styles.label}>{entry.label}</span>
-          {entry.kind === 'image' && <VprBadge tone="type">Image</VprBadge>}
+          {entry.kind === 'image' && <span className={styles.modelTypeTag}>Image</span>}
+          {!compact && visibleModelTags.map((tag) => (
+            <span
+              key={tag}
+              className={`${styles.modelTag}${tag === 'Uncensored' ? ` ${styles.modelTagUncensored}` : ''}`}
+            >
+              {tag}
+            </span>
+          ))}
+          {!compact && hiddenModelTags.length > 0 && (
+            <span className={styles.modelTagMore} title={hiddenModelTags.join(' · ')}>
+              +{hiddenModelTags.length}
+            </span>
+          )}
           {favorite && (
             <HugeiconsIcon icon={StarIcon} size={13} strokeWidth={2} className={styles.favStar} />
           )}


### PR DESCRIPTION
## Description

Makes image routing capability-aware so moderation-sensitive requests only use sellers advertising moderation support, including retries and failover. Also adds a reviewed, provenance-backed model metadata registry and displays curated model tags across Desktop catalog surfaces.

## Release Notes

- Image requests requiring moderation control now route only through compatible sellers and fail clearly when none are available
- Model lists now show reviewed tags such as Uncensored, Coding, Reasoning, Vision, Web search, and Open weights
- Improved image-model presentation and seller capability details in Desktop

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes
