### PR TITLE
blog: LLM APIs Without an Account: What Each One Actually Asks For

### DIFF
--- a/apps/website/blog/2026-08-18-llm-api-without-account.mdx
+++ b/apps/website/blog/2026-08-18-llm-api-without-account.mdx
@@ -1,0 +1,213 @@
+---
+slug: llm-api-without-account
+title: "LLM APIs Without an Account: What Each One Actually Asks For"
+authors: [antseed]
+tags: [privacy, API, no signup, developer tools, AI infrastructure, P2P]
+description: "Which LLM APIs really work without an account? We checked ten, from Pollinations to AntSeed, and recorded exactly what each one asks you to hand over instead."
+keywords: [llm api without account, ai api no signup, llm api no api key, free ai api without registration, openai compatible api no account, anonymous ai api, chatgpt api alternative no account]
+image: /og-image.jpg
+date: 2026-08-18
+---
+
+import Head from '@docusaurus/Head';
+
+export const llmApiFaqLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: [
+    {
+      '@type': 'Question',
+      name: 'Can I use an LLM API without any account at all?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: "Yes, but the list is short. Pollinations' original text endpoint and LLM7 (using the literal string \"unused\" as your key) both return completions with no registration step. Almost everything else marketed as \"no signup\" turns out to need a Google, GitHub, or Cloudflare account before your first real call.",
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Is a keyless API the same as an anonymous AI API?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: "No. Keyless means you didn't create an account. Anonymous means the provider can't tie your requests back to you at all. A keyless endpoint still sees your IP address and can bucket your usage by it, which is an identifier in every practical sense, even without a login form.",
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Is there a production-ready option that never identifies me?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: "Not a free one, and be skeptical of anyone claiming otherwise. Production-grade privacy from identification generally means paying with something other than an identity — a funded wallet rather than a login — which is a different tradeoff than a free keyless endpoint, not the same thing with better branding.",
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'Do I need crypto to use AntSeed?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'Yes. AntSeed swaps an account for a funded wallet: you pre-deposit USDC on Base mainnet before your first request. There is no free tier and no trial. That is real friction, just a different kind than an email signup, and we are not going to pretend it is free.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: "Are no-account LLM APIs against the model providers' terms?",
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: 'It depends on the layer. Gateways like Pollinations and LLM7 sit in front of upstream models and publish their own terms for the proxy itself; they are not the same agreement as the upstream provider you never directly signed with. Read each gateway\'s own terms before routing production traffic through one, since "free" and "unrestricted" are not the same claim.',
+      },
+    },
+    {
+      '@type': 'Question',
+      name: 'What happens to my prompts on a no-account API?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: "It varies by provider and is rarely spelled out for free tiers. Absence of a login does not imply absence of logging — your IP, request bodies, and timing can still be retained. Check the specific provider's privacy policy rather than assuming \"no account\" means \"no record.\"",
+      },
+    },
+  ],
+};
+
+<Head>
+  <script type="application/ld+json">{JSON.stringify(llmApiFaqLd)}</script>
+</Head>
+
+A handful of LLM APIs work with no account at all: you send an HTTP request and get a completion back, with no email, no dashboard, and no API key. The list is much shorter than the marketing suggests, and most of what gets called "no signup" turns out to swap the signup for something else — an IP-based rate limit, a browser fingerprint, or in a couple of cases, a wallet.
+
+This is a search for an **LLM API without an account**, not a search for a free one — those are different questions, and conflating them is how most of these roundups go wrong. We checked ten options, sorted them by actual friction rather than marketing copy, and recorded what each one asks you to hand over instead of an email address.
+
+<!-- truncate -->
+
+## The short answer
+
+Two providers need zero account for basic use: Pollinations' original text endpoint and LLM7, which accepts the literal string `unused` as an API key. AntSeed needs no personal identity but does need a funded wallet before your first call. Puter needs no key from the developer, but the end user gets prompted to log into a Puter account to cover the cost. Everything else on this list — OpenRouter's free tier, Google AI Studio, Groq, Cloudflare Workers AI, GitHub Models, and Hugging Face's Inference API — markets itself as easy and free, and every one of them requires an account before you get a real completion.
+
+## How we checked this
+
+Checked 18 August 2026. "No account" here means a request that returns a real completion with no email confirmation, no OAuth redirect, and no dashboard visit — not a homepage claim. Every entry below is checked against that provider's current, primary documentation or quickstart, linked so you can verify it yourself and rerun the same request. The AntSeed section is our own product's documented flow, cross-checked here against our install and payments docs directly. We did not load-test any of these or measure uptime over time; this is about the signup step, not throughput.
+
+Say the quiet part plainly: AntSeed is ours, and we placed it by the actual friction it has — a funded wallet, not an account, which is neither free nor invisible. A roundup that flatters its own product doesn't survive a reader with a terminal open.
+
+## The comparison table
+
+Sorted by ascending friction, not alphabetically. "What you hand over instead" is never "nothing" — everyone collects something, whether it's named or not.
+
+| Provider | Account required | What you hand over instead | Payment | OpenAI-compatible | The real catch |
+|---|---|---|---|---|---|
+| [Pollinations](https://github.com/pollinations/pollinations/blob/main/APIDOCS.md) (text endpoint) | No | IP address, no persistent ID | Free | Partial (simple GET endpoint) | Their newer `/v1` endpoint now wants a bearer key |
+| [LLM7](https://github.com/chigwell/llm7.io) | No (`unused` as key) | IP address, shared rate bucket | Free | Yes | 30 RPM anonymous; email gets you 120 RPM |
+| [AntSeed](/docs/guides/payments) | No (funded wallet instead) | A public, pseudonymous wallet address | USDC pre-deposit, no free tier | Yes | No account, but real money up front |
+| [Puter](https://developer.puter.com/tutorials/free-llm-api/) | No for the developer | The end user's own Puter login | End user pays via their account | No (custom SDK) | The "no account" is yours, not your users' |
+| [OpenRouter](https://openrouter.ai) free tier | Yes (email, GitHub, or Google) | An email or federated identity | Free, rate-limited | Yes | 20 req/min, 1,000/day; no card needed |
+| [Groq](https://console.groq.com) | Yes (email, verified) | A verified email address | Free tier, no card | Yes | Email verification step before first key |
+| [Hugging Face Inference](https://huggingface.co/docs/hub/security-tokens) | Yes | Account + a scoped access token | Free tier | No (native SDK) | Token is technically optional, then you get throttled hard |
+| [GitHub Models](https://docs.github.com/en/github-models) | Yes (GitHub account) | Your existing GitHub identity | Free, rate-limited | Yes | Needs a PAT scoped to `models:read` |
+| [Google AI Studio](https://ai.google.dev/gemini-api/docs/api-key) | Yes (Google account) | A Google account + linked Cloud project | Free tier, no billing required | No (native SDK, OpenAI-compat layer exists separately) | ToS acceptance creates a Cloud project behind the scenes |
+| [Cloudflare Workers AI](https://developers.cloudflare.com/workers-ai/) | Yes (Cloudflare account) | Account, verified email, Account ID | 10,000 neurons/day free | No (native SDK) | Most setup steps of the group: signup, verify, token, ID |
+
+## Tier 1: genuinely no account
+
+### Pollinations
+
+Pollinations is an open-source, Berlin-based gen-AI gateway that has run a keyless text endpoint since its early releases. The classic form is a plain GET request:
+
+```bash
+curl "https://text.pollinations.ai/What%20is%202%2B2%3F%20Answer%20in%20one%20word."
+```
+
+No header, no key, no account. The real limit is that this simple endpoint gives you a single default model and a text response, not a structured chat API. Pollinations also runs a newer OpenAI-compatible endpoint at `gen.pollinations.ai/v1/chat/completions`, and their own API docs now state a bearer key is required there unless the specific route documents `?key=` support — so the "no account" claim holds for the classic endpoint, not uniformly across the whole product. Get a key at `enter.pollinations.ai` if you want the newer endpoint or higher limits.
+
+### LLM7
+
+LLM7 is an OpenAI-compatible gateway that fronts a rotating set of open and closed models. It genuinely accepts an unregistered caller:
+
+```bash
+curl https://api.llm7.io/v1/chat/completions \
+  -H "content-type: application/json" \
+  -H "Authorization: Bearer unused" \
+  -d '{"model": "gpt-4.1-nano-2025-04-14", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+The word `unused` in the Authorization header is not a placeholder you're supposed to replace — it's the documented anonymous key. That tier gets you 30 requests per minute. Trade an email address at `token.llm7.io` and the ceiling rises to 120 RPM. Either way, nobody asks who you are.
+
+## Tier 2: no account, but you fund a wallet
+
+### AntSeed
+
+This is where the honesty has to be sharper, because it's our product. AntSeed doesn't ask for an account. It asks for a funded wallet, which is a different kind of friction, not an absent one.
+
+Install:
+
+```bash
+npm install -g @antseed/cli
+```
+
+Node.js 20+, macOS, Linux, or Windows via WSL. On first run the CLI generates a secp256k1 key at `~/.antseed/identity.key` — or you supply one via `ANTSEED_IDENTITY_HEX`. That one key is your peer ID, your signing identity, and your wallet, all at once. There's no separate signup screen anywhere in this flow.
+
+The buyer proxy runs locally and speaks the standard OpenAI shape:
+
+```bash
+curl http://localhost:8377/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{
+    "model": "deepseek-v4-flash",
+    "messages": [{"role": "user", "content": "Hello"}]
+  }'
+```
+
+No API key header is checked by the local proxy. Tools that insist on sending one can send any placeholder string and it will be ignored.
+
+Payment is USDC on Base mainnet: [install the AntSeed CLI](/docs/install), then pre-deposit before your first paid request, since [how USDC settlement works](/docs/guides/payments) confirms there's no free tier and no trial credit. Prices are quoted per provider as `inputUsdPerMillion` and `outputUsdPerMillion`. One detail worth knowing: any address can fund a node's deposit — a team treasury, a hardware wallet, an exchange withdrawal — without that funding source ever touching the node's private key.
+
+State the cost of admission plainly: you need real, funded USDC before AntSeed does anything for you. That's the trade for not needing a login.
+
+## Tier 3: "no signup" that is actually a signup
+
+### Puter
+
+Puter's pitch is real but easy to misread. As a developer embedding Puter.js, you write no API key and manage no billing — Puter calls this the "User-Pays" model, and it genuinely removes your integration cost. But somebody's account is still in the loop: the person using your app is the one who ends up authenticating to Puter to cover their own usage. "No account" describes your side of the integration, not the end user's session.
+
+### OpenRouter, Groq, Hugging Face, GitHub Models, Google AI Studio, Cloudflare Workers AI
+
+None of these are dishonest about requiring a signup — that's not the complaint. The complaint is with roundups that file them under "no account needed" because the free tier doesn't ask for a credit card. A free tier is not a no-account tier. Every one of these needs an identity of some kind before your first real request: an email for OpenRouter or Groq, a Google account for AI Studio, a GitHub account and scoped token for GitHub Models, an account and access token for Hugging Face, and — the heaviest of the group — a verified Cloudflare account, an API token, and an Account ID for Workers AI. If your actual requirement is "no signup screen," these all fail it, whatever the pricing page says. If [AntSeed compared to OpenRouter](/vs/openrouter) is the tradeoff you're weighing, note that OpenRouter's friction is an account; AntSeed's is a wallet.
+
+## Keyless isn't the same as an anonymous AI API
+
+An API can drop the login form entirely and still not give you that property, because the provider sees your IP address on every request and can bucket, log, or throttle you by it — that's an identifier, it's just not labeled "account." We've written at length about [the difference between privacy and not being identified](/blog/anonymous-vs-private-ai); the short version is that neither property follows automatically from the other, and "no signup" tells you nothing about which one, if either, you're actually getting.
+
+## Which one should you actually use
+
+- **Prototyping and throwaway scripts** — Pollinations or LLM7. Zero setup, and the rate limits won't bother a script you run twice.
+- **CI, where you can't store a secret** — LLM7's `unused` key or AntSeed with a funded wallet, since neither needs a stored credential that can leak.
+- **Work you don't want tied to a corporate identity** — AntSeed, because the wallet is pseudonymous by default and isn't linked to a company Google Workspace or GitHub org.
+- **Production traffic** — honestly, most of this list is the wrong tool. Keyless gateways don't publish SLAs, and free tiers from the big providers throttle exactly when you need them not to. Pay someone, one way or another.
+
+That last one matters more than it sounds. A roundup that recommends its own product for every row isn't one you should trust, and we're not going to be that roundup.
+
+## FAQ
+
+### Can I use an LLM API without any account at all?
+
+Yes, but the list is short. Pollinations' original text endpoint and LLM7 (using the literal string "unused" as your key) both return completions with no registration step. Almost everything else marketed as "no signup" turns out to need a Google, GitHub, or Cloudflare account before your first real call.
+
+### Is a keyless API the same as an anonymous AI API?
+
+No. Keyless means you didn't create an account. Anonymous means the provider can't tie your requests back to you at all. A keyless endpoint still sees your IP address and can bucket your usage by it, which is an identifier in every practical sense, even without a login form.
+
+### Is there a production-ready option that never identifies me?
+
+Not a free one, and be skeptical of anyone claiming otherwise. Production-grade privacy from identification generally means paying with something other than an identity — a funded wallet rather than a login — which is a different tradeoff than a free keyless endpoint, not the same thing with better branding.
+
+### Do I need crypto to use AntSeed?
+
+Yes. AntSeed swaps an account for a funded wallet: you pre-deposit USDC on Base mainnet before your first request. There is no free tier and no trial. That is real friction, just a different kind than an email signup, and we are not going to pretend it is free.
+
+### Are no-account LLM APIs against the model providers' terms?
+
+It depends on the layer. Gateways like Pollinations and LLM7 sit in front of upstream models and publish their own terms for the proxy itself; that is not the same agreement as the upstream provider you never directly signed with. Read each gateway's own terms before routing production traffic through one, since "free" and "unrestricted" are not the same claim.
+
+### What happens to my prompts on a no-account API?
+
+It varies by provider and is rarely spelled out for free tiers. Absence of a login does not imply absence of logging — your IP, request bodies, and timing can still be retained. Check the specific provider's privacy policy rather than assuming "no account" means "no record."
+
+---
+
+Nobody on this list is giving you anonymity for free. Every option, including ours, has you hand something over — an IP address, a rate-limit bucket, a browser session, or a funded wallet. The honest way to pick one is to decide which of those you'd rather give up, not to keep searching for the option that asks for nothing, because it doesn't exist. If a funded wallet and no login is the trade you'd take, [get started](/get-started) with AntSeed.


### PR DESCRIPTION
New post comparing ten LLM APIs on signup friction instead of price: which ones genuinely need no account, which ones swap the account for something else (a wallet, an end user's login), and which ones market "no signup" but still require one.

Covers Pollinations, LLM7, AntSeed, Puter, OpenRouter, Groq, Hugging Face Inference, GitHub Models, Google AI Studio, and Cloudflare Workers AI, with a comparison table sorted by ascending friction and a "what you hand over instead" column for each.