### PR TITLE
fix(desktop): Clarify chat list toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Changed
 
+- Desktop chat now uses a clear, lightweight **View chats** / **Hide chats** control with matching sidebar-state icons, replacing the ambiguous arrow-only conversation-list toggle.
+
 - Windows desktop installers are now Authenticode-signed with the AntSeed Foundation's code-signing certificate. The release build signs directly against the issuing CA's cloud HSM (the private key never exists outside it), with the credentials held in a reviewer-protected CI environment; local and fork builds without the signing secrets continue to produce unsigned installers unchanged.
 
 - Desktop image chats now require sellers that advertise `moderation` support and send `moderation: "low"`, preventing automatic fallback to sellers that would silently restore provider-side Safe Mode blurring. Model lists show reviewed tags such as **Uncensored**, **Coding**, **Reasoning**, **Vision**, **Web search**, and **Open weights** from a versioned declarative registry covering maintained OpenRouter and Venice catalogs with per-model provenance, instead of trusting seller-announced categories. Seller rows identify offers with **Moderation control**, and requests fail clearly when no compatible seller is available.

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed VPR",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.module.scss
@@ -32,24 +32,34 @@
   min-width: 0;
 }
 
-/* Bare icon button — the expand/collapse toggle carries no chrome of its
-   own, just the arrow glyph. */
 .panel-toggle {
   appearance: none;
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 4px;
+  gap: 6px;
+  min-height: 30px;
+  padding: 0 2px;
   border: none;
+  border-radius: 4px;
   background: none;
   color: var(--text-muted);
   cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  transition: color 0.15s;
 
-  &:hover,
+  &:hover {
+    color: var(--text-primary);
+  }
+
   &:focus-visible {
     color: var(--text-primary);
-    outline: none;
+    outline: 2px solid color-mix(in srgb, var(--text-muted) 45%, transparent);
+    outline-offset: 3px;
   }
 }
 

--- a/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
+++ b/apps/desktop/src/renderer/ui/components/views/ChatView.tsx
@@ -3,8 +3,6 @@ import type { KeyboardEvent } from 'react';
 import { HugeiconsIcon } from '@hugeicons/react';
 import {
   Add01Icon,
-  ArrowLeft03Icon,
-  ArrowRight03Icon,
   ArrowUp02Icon,
   ArrowRight01Icon,
   ArrowDown02Icon,
@@ -12,6 +10,8 @@ import {
   Cancel01Icon,
   Folder01Icon,
   Mic01Icon,
+  PanelLeftCloseIcon,
+  PanelLeftOpenIcon,
   Search01Icon,
   SecurityWarningIcon,
   Shield01Icon
@@ -1151,15 +1151,16 @@ export function ChatView({ onSelectView }: ChatViewProps) {
             type="button"
             className={styles.panelToggle}
             onClick={handleTogglePanelExpanded}
-            title={snap.chatPanelExpanded ? 'Collapse to the thin view' : 'Expand to show conversations'}
-            aria-label={snap.chatPanelExpanded ? 'Collapse to the thin view' : 'Expand to show conversations'}
+            title={snap.chatPanelExpanded ? 'Hide chats' : 'View chats'}
+            aria-label={snap.chatPanelExpanded ? 'Hide chats' : 'View chats'}
             aria-pressed={snap.chatPanelExpanded}
           >
             <HugeiconsIcon
-              icon={snap.chatPanelExpanded ? ArrowLeft03Icon : ArrowRight03Icon}
-              size={16}
+              icon={snap.chatPanelExpanded ? PanelLeftOpenIcon : PanelLeftCloseIcon}
+              size={17}
               strokeWidth={1.8}
             />
+            <span>{snap.chatPanelExpanded ? 'Hide chats' : 'View chats'}</span>
           </button>
           <div className={styles.serviceSwitcherAnchor}>
             <VprModelDropdown


### PR DESCRIPTION
## Description

Replaces the ambiguous arrow-only chat-list toggle with a lightweight labeled control using sidebar-state icons. Also bumps the Desktop app from 0.2.22 to 0.2.23 and documents the user-facing change.

## Release Notes

- Desktop chat now shows a clear **View chats** / **Hide chats** control for the conversation list.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation
- [x] I have validated the change with the full monorepo build
- [x] I have updated the Desktop version