### PR TITLE
fix(blog): correct AntSeed payment claims, drop unverified FAQ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,24 @@ agents, fine-tuned models, managed products). Subscription-based plugins
 (provider-claude-code, provider-claude-oauth) are for testing/development only.
 Reselling subscription credentials violates upstream provider terms of service.
 
+**AntSeed is not a crypto company.** Settlement happens in USDC on Base, but
+buyers are not required to already hold or handle crypto: the desktop app
+offers a card checkout (Stripe-backed onramp, region-gated) alongside crypto
+funding, and USDC can be funded from an exchange withdrawal, another wallet,
+or a card on-ramp (see `apps/website/docs/guides/payments.md`,
+`apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx`, and
+`apps/cli/README.md`). Never describe AntSeed as crypto-only, wallet-only, or
+as requiring the user to already own cryptocurrency.
+
+**When writing marketing or blog content that states a fact about AntSeed**
+(pricing, payment flow, CLI behavior, protocol mechanics, what is or isn't
+free) — source it only from this repository (code, docs, CHANGELOG) or the
+live antseed.com website. Never state an AntSeed-specific fact from general
+knowledge, a web search, or inference from silence in a doc (e.g. "the doc
+doesn't mention a free tier, so there must not be one" is not a valid basis
+for a claim). If a fact can't be verified from those two sources, say so
+explicitly rather than asserting it.
+
 ## Repository Structure
 ```
 packages/           Core libraries (published to npm as @antseed/*)

--- a/apps/website/blog/2026-08-18-llm-api-without-account.mdx
+++ b/apps/website/blog/2026-08-18-llm-api-without-account.mdx
@@ -17,14 +17,6 @@ export const llmApiFaqLd = {
   mainEntity: [
     {
       '@type': 'Question',
-      name: 'Can I use an LLM API without any account at all?',
-      acceptedAnswer: {
-        '@type': 'Answer',
-        text: "Yes, but the list is short. Pollinations' original text endpoint and LLM7 (using the literal string \"unused\" as your key) both return completions with no registration step. Almost everything else marketed as \"no signup\" turns out to need a Google, GitHub, or Cloudflare account before your first real call.",
-      },
-    },
-    {
-      '@type': 'Question',
       name: 'Is a keyless API the same as an anonymous AI API?',
       acceptedAnswer: {
         '@type': 'Answer',
@@ -44,7 +36,7 @@ export const llmApiFaqLd = {
       name: 'Do I need crypto to use AntSeed?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: 'Yes. AntSeed swaps an account for a funded wallet: you pre-deposit USDC on Base mainnet before your first request. There is no free tier and no trial. That is real friction, just a different kind than an email signup, and we are not going to pretend it is free.',
+        text: "No — you don't need to already hold crypto. AntSeed settles in USDC on Base, but the desktop app has a card checkout (Stripe-backed, US region for now) that funds your balance from a card without you touching crypto directly, alongside the crypto-native path. AntSeed itself doesn't hand out free trial credit, though individual providers can and do price their own services at $0.",
       },
     },
     {
@@ -94,7 +86,7 @@ Sorted by ascending friction, not alphabetically. "What you hand over instead" i
 |---|---|---|---|---|---|
 | [Pollinations](https://github.com/pollinations/pollinations/blob/main/APIDOCS.md) (text endpoint) | No | IP address, no persistent ID | Free | Partial (simple GET endpoint) | Their newer `/v1` endpoint now wants a bearer key |
 | [LLM7](https://github.com/chigwell/llm7.io) | No (`unused` as key) | IP address, shared rate bucket | Free | Yes | 30 RPM anonymous; email gets you 120 RPM |
-| [AntSeed](/docs/guides/payments) | No (funded wallet instead) | A public, pseudonymous wallet address | USDC pre-deposit, no free tier | Yes | No account, but real money up front |
+| [AntSeed](/docs/guides/payments) | No (funded wallet instead) | A public, pseudonymous wallet address | USDC pre-deposit — card or crypto | Yes | No account, but real money up front |
 | [Puter](https://developer.puter.com/tutorials/free-llm-api/) | No for the developer | The end user's own Puter login | End user pays via their account | No (custom SDK) | The "no account" is yours, not your users' |
 | [OpenRouter](https://openrouter.ai) free tier | Yes (email, GitHub, or Google) | An email or federated identity | Free, rate-limited | Yes | 20 req/min, 1,000/day; no card needed |
 | [Groq](https://console.groq.com) | Yes (email, verified) | A verified email address | Free tier, no card | Yes | Email verification step before first key |
@@ -155,9 +147,9 @@ curl http://localhost:8377/v1/chat/completions \
 
 No API key header is checked by the local proxy. Tools that insist on sending one can send any placeholder string and it will be ignored.
 
-Payment is USDC on Base mainnet: [install the AntSeed CLI](/docs/install), then pre-deposit before your first paid request, since [how USDC settlement works](/docs/guides/payments) confirms there's no free tier and no trial credit. Prices are quoted per provider as `inputUsdPerMillion` and `outputUsdPerMillion`. One detail worth knowing: any address can fund a node's deposit — a team treasury, a hardware wallet, an exchange withdrawal — without that funding source ever touching the node's private key.
+Payment settles in USDC on Base mainnet: [install the AntSeed CLI](/docs/install), then pre-deposit before your first paid request. [How USDC settlement works](/docs/guides/payments) covers the crypto-native funding paths — exchange withdrawal, another wallet, a card on-ramp — and the desktop app separately offers a built-in card checkout that funds the same balance without you needing to already hold crypto. Prices are quoted per provider as `inputUsdPerMillion` and `outputUsdPerMillion`, and providers can set either to zero. One detail worth knowing: any address can fund a node's deposit — a team treasury, a hardware wallet, an exchange withdrawal — without that funding source ever touching the node's private key.
 
-State the cost of admission plainly: you need real, funded USDC before AntSeed does anything for you. That's the trade for not needing a login.
+State the cost of admission plainly: you need a funded balance — card or crypto — before AntSeed does anything for you. That's the trade for not needing a login.
 
 ## Tier 3: "no signup" that is actually a signup
 
@@ -184,10 +176,6 @@ That last one matters more than it sounds. A roundup that recommends its own pro
 
 ## FAQ
 
-### Can I use an LLM API without any account at all?
-
-Yes, but the list is short. Pollinations' original text endpoint and LLM7 (using the literal string "unused" as your key) both return completions with no registration step. Almost everything else marketed as "no signup" turns out to need a Google, GitHub, or Cloudflare account before your first real call.
-
 ### Is a keyless API the same as an anonymous AI API?
 
 No. Keyless means you didn't create an account. Anonymous means the provider can't tie your requests back to you at all. A keyless endpoint still sees your IP address and can bucket your usage by it, which is an identifier in every practical sense, even without a login form.
@@ -198,7 +186,7 @@ Not a free one, and be skeptical of anyone claiming otherwise. Production-grade 
 
 ### Do I need crypto to use AntSeed?
 
-Yes. AntSeed swaps an account for a funded wallet: you pre-deposit USDC on Base mainnet before your first request. There is no free tier and no trial. That is real friction, just a different kind than an email signup, and we are not going to pretend it is free.
+No — you don't need to already hold crypto. AntSeed settles in USDC on Base, but the desktop app has a card checkout (Stripe-backed, US region for now) that funds your balance from a card without you touching crypto directly, alongside the crypto-native path. AntSeed itself doesn't hand out free trial credit, though individual providers can and do price their own services at $0.
 
 ### Are no-account LLM APIs against the model providers' terms?
 


### PR DESCRIPTION
Corrects two factual errors flagged by the maintainer in the already-merged "LLM APIs Without an Account" post (#894):

1. **"Do I need crypto to use AntSeed?" answered "Yes" with "no free tier and no trial"** — wrong on both counts. AntSeed isn't crypto-only: the desktop app has a Stripe-backed card checkout (`apps/desktop/src/renderer/ui/components/views/VprDepositView.tsx`, region-gated to the US for now) that funds the same USDC balance without the user touching crypto directly. And "no free tier" was an inference from a doc's silence, not a stated fact — `plugins/provider-local-llm/README.md` documents that pricing defaults to $0, so provider-priced-free services genuinely exist. Fixed in the FAQ (schema + visible), the comparison table's Payment cell, and the AntSeed section body — same wrong claim appeared in three spots.
2. **FAQ claiming Pollinations and LLM7 have "no registration step"** — removed (schema + visible) rather than fixed. That claim rested on web-search-summary sourcing I couldn't verify live from this session's network-restricted environment, and one primary source I did fetch (Pollinations' own `APIDOCS.md`) already contradicts it for their `/v1` endpoint. I didn't touch the same claim where it appears in the post's Tier 1 body/table (out of scope of what was flagged) — flagging that here in case it's worth a follow-up.

Also adds a standing rule to `CLAUDE.md`: AntSeed-specific facts in any content must come only from this repo or the live site, never from inference-from-silence or general web search, and AntSeed must never be described as crypto-only.

No user-facing package/CLI/protocol behavior changed — content and contributor-guidance only, so no `CHANGELOG.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPmPrNp26Gvu2BZiscp46g)_