### PR TITLE
fix(seller): pause advertising and warn when wallet runs out of gas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Fixed
 
+- Sellers now monitor their wallet's ETH balance while running (`seller.gasCheck`, enabled by default in payments mode). When the wallet can no longer fund on-chain settlement, the seller pauses advertising — instead of staying discoverable while rejecting every buyer — and prints a console notice with the wallet address to fund; `antseed seller status` shows the same warning. Advertising resumes automatically once the wallet is topped up.
 - Seller startup now warns when `seller.publicAddress` is missing or non-public, and `antseed seller doctor` classifies and locally probes the announced endpoint with explicit NAT guidance. The `/docs/transport/` guide now covers port forwarding, firewalls, and VPS/reverse-tunnel deployments.
 - CLI identity loading now fails safely when the data directory contains an app-encrypted, unreadable, or malformed identity instead of silently generating a second wallet and overwriting or competing with the existing signer.
 - Fixed Desktop image chats dropping an explicitly selected seller when moving from a model page into chat. Image follow-ups use true edits only with sellers that advertise image input support; generation-only sellers instead generate a new image from the cumulative prompt history, and payment progress no longer replaces the image shimmer with the text loader.

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -8,9 +8,14 @@ import { loadConfig } from '../../../config/loader.js'
 import {
   AntseedNode,
   ModelHealthChecker,
+  GasHealthMonitor,
   CONNECTION_CAPABILITY_MODEL_HEALTH_V1,
   DEFAULT_HEALTH_CHECK_INTERVAL_MS,
   DEFAULT_HEALTH_CHECK_FAILURE_THRESHOLD,
+  DEFAULT_GAS_CHECK_INTERVAL_MS,
+  DEFAULT_MIN_GAS_BALANCE_WEI,
+  formatEther,
+  parseEther,
   type Provider,
   type Prover,
   type ConfigField,
@@ -579,6 +584,12 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
       }
       const healthCheckCfg = effectiveSellerConfig.healthCheck
       const healthCheckEnabled = healthCheckCfg?.enabled !== false
+      const gasCheckCfg = effectiveSellerConfig.gasCheck
+      const gasCheckEnabled = paymentsEnabled && Boolean(config.payments.crypto) && gasCheckCfg?.enabled !== false
+      const gasCheckIntervalMs = gasCheckCfg?.intervalMs ?? DEFAULT_GAS_CHECK_INTERVAL_MS
+      const minGasBalanceWei = gasCheckCfg?.minBalanceEth !== undefined
+        ? parseEther(String(gasCheckCfg.minBalanceEth))
+        : DEFAULT_MIN_GAS_BALANCE_WEI
 
       console.log(chalk.bold('Effective seller settings:'))
       console.log(chalk.dim(`  providers: ${selectedProviderNames.join(', ')}`))
@@ -614,6 +625,9 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
         console.log(chalk.dim(`  model health checks: every ${Math.round(intervalMs / 1000)}s, unadvertise after ${failureThreshold} consecutive failures`))
       } else {
         console.log(chalk.dim('  model health checks: disabled'))
+      }
+      if (gasCheckEnabled) {
+        console.log(chalk.dim(`  gas checks: every ${Math.round(gasCheckIntervalMs / 1000)}s, pause advertising below ${formatEther(minGasBalanceWei)} ETH`))
       }
       const maxUploadBodyBytes = parseOptionalPositiveIntegerEnv(process.env['ANTSEED_MAX_UPLOAD_BODY_BYTES'])
         ?? effectiveSellerConfig.maxUploadBodyBytes
@@ -800,6 +814,10 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
         healthChecker.start()
       }
 
+      // Operator-facing notices surfaced via daemon.state.json (seller status
+      // command and desktop). Currently only the out-of-gas notice.
+      let gasNotice: string | null = null
+
       // Write daemon state so dashboard and connect can discover this seeder
       const startedAt = Date.now()
       const syntheticSessionStarts = new Map<string, number>()
@@ -917,6 +935,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
           earningsToday: '0',
           tokensToday: 0,
           uptime: formatUptime(),
+          notices: gasNotice ? [gasNotice] : [],
           updatedAt: now,
           proxyPort: null,
         }
@@ -954,8 +973,44 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
         await writeDaemonState().catch(() => {})
       }, 1_000)
 
+      // Periodic seller-wallet gas checks: a seller whose wallet cannot fund
+      // reserve/settle/close transactions rejects every buyer that connects,
+      // so pause advertising (and say so) until the wallet is funded again.
+      let gasMonitor: GasHealthMonitor | null = null
+      if (gasCheckEnabled && node.identity) {
+        const gasWalletAddress = node.identity.wallet.address
+        try {
+          const gasStakingClient = createStakingClient(config, { rpcUrl: baseRpcUrlOverride })
+          gasMonitor = new GasHealthMonitor({
+            address: gasWalletAddress,
+            getBalance: (address) => gasStakingClient.provider.getBalance(address),
+            intervalMs: gasCheckIntervalMs,
+            minBalanceWei: minGasBalanceWei,
+            onChange: (event) => {
+              const balanceSummary = `wallet ${event.address} holds ${formatEther(event.balanceWei)} ETH (minimum ${formatEther(event.minBalanceWei)} ETH)`
+              if (event.status === 'depleted') {
+                gasNotice = `Out of gas: ${balanceSummary}. Advertising is paused; send ETH to ${event.address} to resume.`
+                console.log(chalk.yellow.bold('\nSeller out of gas — advertising paused.'))
+                console.log(chalk.yellow(`  On-chain settlement would fail and buyers would be rejected: ${balanceSummary}.`))
+                console.log(chalk.cyan(`  Send ETH to ${event.address} — advertising resumes automatically once funded.`))
+                void node.pauseAdvertising('out-of-gas').catch(() => {})
+              } else {
+                gasNotice = null
+                console.log(chalk.green(`Gas balance restored (${formatEther(event.balanceWei)} ETH) — advertising resumed.`))
+                node.resumeAdvertising()
+              }
+              scheduleDaemonStateWrite()
+            },
+          })
+          gasMonitor.start()
+        } catch (err) {
+          console.log(chalk.dim(`  gas checks unavailable: ${(err as Error).message}`))
+        }
+      }
+
       setupShutdownHandler(async () => {
         healthChecker?.stop()
+        gasMonitor?.stop()
         clearInterval(stateInterval)
         node.off('connection', scheduleDaemonStateWrite)
         node.off('session:updated', scheduleDaemonStateWrite)

--- a/apps/cli/src/cli/commands/seller/status.ts
+++ b/apps/cli/src/cli/commands/seller/status.ts
@@ -52,6 +52,7 @@ export function registerSellerStatusCommand(sellerCmd: Command): void {
             activeChannels: status.activeChannels,
             uptime: status.uptime,
             walletAddress,
+            notices: status.notices,
             providers: providerSummary,
           }, null, 2));
           return;
@@ -64,6 +65,9 @@ export function registerSellerStatusCommand(sellerCmd: Command): void {
         };
         const colorFn = stateColors[status.state] ?? chalk.white;
         console.log(chalk.bold('Seller Status: ') + colorFn(status.state.toUpperCase()));
+        for (const notice of status.notices) {
+          console.log(chalk.yellow(`⚠ ${notice}`));
+        }
         console.log('');
 
         const table = new Table({

--- a/apps/cli/src/config/loader.test.ts
+++ b/apps/cli/src/config/loader.test.ts
@@ -673,6 +673,52 @@ test('loadConfig rejects invalid seller healthCheck failureThreshold', async () 
   );
 });
 
+test('loadConfig preserves seller gasCheck setting', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      seller: {
+        gasCheck: { enabled: false, intervalMs: 30_000, minBalanceEth: 0.0001 },
+      },
+    }),
+    async (configPath) => {
+      const config = await loadConfig(configPath);
+      assert.deepEqual(config.seller.gasCheck, { enabled: false, intervalMs: 30_000, minBalanceEth: 0.0001 });
+    }
+  );
+});
+
+test('loadConfig rejects invalid seller gasCheck intervalMs', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      seller: {
+        gasCheck: { intervalMs: 1_000 },
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        async () => loadConfig(configPath),
+        /seller\.gasCheck\.intervalMs/
+      );
+    }
+  );
+});
+
+test('loadConfig rejects invalid seller gasCheck minBalanceEth', async () => {
+  await withTempConfig(
+    JSON.stringify({
+      seller: {
+        gasCheck: { minBalanceEth: -1 },
+      },
+    }),
+    async (configPath) => {
+      await assert.rejects(
+        async () => loadConfig(configPath),
+        /seller\.gasCheck\.minBalanceEth/
+      );
+    }
+  );
+});
+
 test('loadConfig preserves seller agentDir setting', async () => {
   await withTempConfig(
     JSON.stringify({

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -308,6 +308,35 @@ function normalizeSellerHealthCheck(
   };
 }
 
+function cloneSellerGasCheck(
+  value: AntseedConfig['seller']['gasCheck'],
+): AntseedConfig['seller']['gasCheck'] {
+  if (!value) return undefined;
+  return {
+    ...(value.enabled !== undefined ? { enabled: value.enabled } : {}),
+    ...(value.intervalMs !== undefined ? { intervalMs: value.intervalMs } : {}),
+    ...(value.minBalanceEth !== undefined ? { minBalanceEth: value.minBalanceEth } : {}),
+  };
+}
+
+function normalizeSellerGasCheck(
+  value: unknown,
+  fallback?: AntseedConfig['seller']['gasCheck'],
+): { gasCheck: NonNullable<AntseedConfig['seller']['gasCheck']> } | Record<string, never> {
+  if (!isRecord(value)) {
+    const cloned = cloneSellerGasCheck(fallback);
+    return cloned ? { gasCheck: cloned } : {};
+  }
+  // Keep user-supplied values (even malformed) so validateConfig reports them.
+  return {
+    gasCheck: {
+      ...(value['enabled'] !== undefined ? { enabled: value['enabled'] as boolean } : {}),
+      ...(value['intervalMs'] !== undefined ? { intervalMs: toFiniteOrNaN(value['intervalMs']) } : {}),
+      ...(value['minBalanceEth'] !== undefined ? { minBalanceEth: toFiniteOrNaN(value['minBalanceEth']) } : {}),
+    },
+  };
+}
+
 function mergeSellerConfig(
   defaults: AntseedConfig['seller'],
   value: unknown
@@ -322,6 +351,7 @@ function mergeSellerConfig(
       ...(defaults.agentDir ? { agentDir: defaults.agentDir } : {}),
       ...(normalizeVerifications(undefined, defaults.verifications)),
       ...(normalizeSellerHealthCheck(undefined, defaults.healthCheck)),
+      ...(normalizeSellerGasCheck(undefined, defaults.gasCheck)),
     };
   }
 
@@ -344,6 +374,7 @@ function mergeSellerConfig(
         : {}),
     ...(normalizeAgentDir(value['agentDir'], defaults.agentDir)),
     ...(normalizeSellerHealthCheck(value['healthCheck'], defaults.healthCheck)),
+    ...(normalizeSellerGasCheck(value['gasCheck'], defaults.gasCheck)),
   };
 }
 

--- a/apps/cli/src/config/types.ts
+++ b/apps/cli/src/config/types.ts
@@ -119,6 +119,18 @@ export interface SellerHealthCheckCLIConfig {
 }
 
 /**
+ * Periodic seller-wallet gas balance check settings.
+ */
+export interface SellerGasCheckCLIConfig {
+  /** Enable periodic ETH balance checks while payments are enabled. Default: true. */
+  enabled?: boolean;
+  /** Milliseconds between balance checks. Default: 60000 (1 minute). */
+  intervalMs?: number;
+  /** Minimum wallet balance in ETH before advertising is paused. Default: 0.00005. */
+  minBalanceEth?: number;
+}
+
+/**
  * Seller-specific configuration within the Antseed config.
  */
 export interface SellerCLIConfig {
@@ -159,6 +171,12 @@ export interface SellerCLIConfig {
    * are unadvertised until they recover. Set `enabled: false` to opt out.
    */
   healthCheck?: SellerHealthCheckCLIConfig;
+  /**
+   * Periodic seller-wallet ETH balance checks (payments mode only). Enabled by
+   * default; when the wallet cannot fund on-chain settlement the seller stops
+   * advertising until it is funded again. Set `enabled: false` to opt out.
+   */
+  gasCheck?: SellerGasCheckCLIConfig;
 }
 
 /**

--- a/apps/cli/src/config/validation.ts
+++ b/apps/cli/src/config/validation.ts
@@ -397,6 +397,25 @@ export function validateConfig(config: AntseedConfig): string[] {
     }
   }
 
+  if (config.seller.gasCheck !== undefined) {
+    const gasCheck = config.seller.gasCheck;
+    if (gasCheck.enabled !== undefined && typeof gasCheck.enabled !== 'boolean') {
+      errors.push('seller.gasCheck.enabled must be a boolean');
+    }
+    if (
+      gasCheck.intervalMs !== undefined &&
+      (!Number.isInteger(gasCheck.intervalMs) || gasCheck.intervalMs < 10_000)
+    ) {
+      errors.push('seller.gasCheck.intervalMs must be an integer >= 10000 (10 seconds)');
+    }
+    if (
+      gasCheck.minBalanceEth !== undefined &&
+      (typeof gasCheck.minBalanceEth !== 'number' || !Number.isFinite(gasCheck.minBalanceEth) || gasCheck.minBalanceEth < 0)
+    ) {
+      errors.push('seller.gasCheck.minBalanceEth must be a finite number >= 0');
+    }
+  }
+
   validateVerifications('seller.verifications', config.seller.verifications, errors);
 
   if (config.relayer !== undefined) {

--- a/apps/cli/src/status/node-status.ts
+++ b/apps/cli/src/status/node-status.ts
@@ -17,6 +17,8 @@ export interface NodeStatus {
   capacityUsedPercent: number;
   daemonPid: number | null;
   daemonAlive: boolean;
+  /** Operator-facing warnings from the running daemon (e.g. out of gas). */
+  notices: string[];
 }
 
 /** Stale threshold: 30 seconds */
@@ -121,6 +123,9 @@ function sellerStatus(
     capacityUsedPercent: typeof state.capacityUsedPercent === 'number' ? state.capacityUsedPercent : 0,
     daemonPid: pid,
     daemonAlive: alive,
+    notices: Array.isArray(state.notices)
+      ? state.notices.filter((notice): notice is string => typeof notice === 'string')
+      : [],
   };
 }
 
@@ -149,6 +154,7 @@ function buyerStatus(
     capacityUsedPercent: 0,
     daemonPid: pid,
     daemonAlive: alive,
+    notices: [],
   };
 }
 
@@ -165,5 +171,6 @@ function idleStatus(config: AntseedConfig, pid: number | null): NodeStatus {
     capacityUsedPercent: 0,
     daemonPid: pid,
     daemonAlive: false,
+    notices: [],
   };
 }

--- a/packages/node/src/health/gas-health-monitor.ts
+++ b/packages/node/src/health/gas-health-monitor.ts
@@ -1,0 +1,159 @@
+import { formatEther } from 'ethers';
+import { debugLog, debugWarn } from '../utils/debug.js';
+
+/** Default balance poll interval. Each poll is a single eth_getBalance call. */
+export const DEFAULT_GAS_CHECK_INTERVAL_MS = 60_000;
+/**
+ * Default minimum wallet balance before the seller is treated as out of gas.
+ * 0.00005 ETH covers several reserve/settle/close transactions on Base; below
+ * that the next on-chain call is likely to fail with "insufficient funds",
+ * which rejects every buyer while the peer keeps looking discoverable.
+ */
+export const DEFAULT_MIN_GAS_BALANCE_WEI = 50_000_000_000_000n;
+
+export interface GasHealthEvent {
+  status: 'depleted' | 'restored';
+  /** Wallet that pays gas for seller transactions (the peer identity wallet). */
+  address: string;
+  balanceWei: bigint;
+  minBalanceWei: bigint;
+}
+
+export interface GasHealthSnapshot {
+  address: string;
+  depleted: boolean;
+  lastBalanceWei: bigint | null;
+  lastCheckedAt: number | null;
+  minBalanceWei: bigint;
+}
+
+export interface GasHealthMonitorConfig {
+  /** Wallet that pays gas for seller transactions (the peer identity wallet). */
+  address: string;
+  /** Reads the wallet's current balance in wei (e.g. `provider.getBalance`). */
+  getBalance: (address: string) => Promise<bigint>;
+  intervalMs?: number;
+  minBalanceWei?: bigint;
+  /**
+   * Invoked when the wallet crosses the threshold in either direction.
+   * Callers should pause/resume advertising here (e.g.
+   * `node.pauseAdvertising(...)` / `node.resumeAdvertising()`).
+   */
+  onChange?: (event: GasHealthEvent) => void | Promise<void>;
+}
+
+/**
+ * Periodically reads the seller wallet's ETH balance and reports when it drops
+ * below the minimum needed to fund on-chain settlement. A seller with no gas
+ * cannot reserve, settle, or close payment channels — every buyer that finds
+ * it gets rejected — so the operator hook should unadvertise the peer until
+ * the wallet is funded again.
+ *
+ * A balance read is authoritative (unlike a model probe there is nothing flaky
+ * to debounce), so a single reading below the threshold flips to `depleted`
+ * and a single reading at or above it flips back to `restored`. RPC errors are
+ * inconclusive and leave the current state untouched.
+ */
+export class GasHealthMonitor {
+  private readonly _address: string;
+  private readonly _getBalance: (address: string) => Promise<bigint>;
+  private readonly _intervalMs: number;
+  private readonly _minBalanceWei: bigint;
+  private readonly _onChange: GasHealthMonitorConfig['onChange'];
+  private _timer: ReturnType<typeof setInterval> | null = null;
+  private _checkInFlight: Promise<void> | null = null;
+  private _depleted = false;
+  private _lastBalanceWei: bigint | null = null;
+  private _lastCheckedAt: number | null = null;
+
+  constructor(config: GasHealthMonitorConfig) {
+    this._address = config.address;
+    this._getBalance = config.getBalance;
+    this._intervalMs = config.intervalMs ?? DEFAULT_GAS_CHECK_INTERVAL_MS;
+    this._minBalanceWei = config.minBalanceWei ?? DEFAULT_MIN_GAS_BALANCE_WEI;
+    this._onChange = config.onChange;
+  }
+
+  /** Start periodic checks. The first check runs immediately (async). */
+  start(): void {
+    if (this._timer) return;
+    void this.checkNow();
+    this._timer = setInterval(() => {
+      void this.checkNow();
+    }, this._intervalMs);
+    // Never keep the process alive just for gas checks.
+    this._timer.unref?.();
+  }
+
+  stop(): void {
+    if (this._timer) {
+      clearInterval(this._timer);
+      this._timer = null;
+    }
+  }
+
+  /** Whether the last successful reading was below the threshold. */
+  get depleted(): boolean {
+    return this._depleted;
+  }
+
+  getSnapshot(): GasHealthSnapshot {
+    return {
+      address: this._address,
+      depleted: this._depleted,
+      lastBalanceWei: this._lastBalanceWei,
+      lastCheckedAt: this._lastCheckedAt,
+      minBalanceWei: this._minBalanceWei,
+    };
+  }
+
+  /** Read the balance once and emit a change event on a threshold crossing. */
+  async checkNow(): Promise<void> {
+    if (this._checkInFlight) return this._checkInFlight;
+    this._checkInFlight = this._check().finally(() => {
+      this._checkInFlight = null;
+    });
+    return this._checkInFlight;
+  }
+
+  private async _check(): Promise<void> {
+    let balanceWei: bigint;
+    try {
+      balanceWei = await this._getBalance(this._address);
+    } catch (err) {
+      // Can't tell anything from an unreachable RPC — keep the current state.
+      debugWarn(`[GasHealth] Balance check failed for ${this._address}: ${err instanceof Error ? err.message : err}`);
+      return;
+    }
+    this._lastBalanceWei = balanceWei;
+    this._lastCheckedAt = Date.now();
+
+    const depleted = balanceWei < this._minBalanceWei;
+    if (depleted === this._depleted) return;
+    this._depleted = depleted;
+    this._emitChange({
+      status: depleted ? 'depleted' : 'restored',
+      address: this._address,
+      balanceWei,
+      minBalanceWei: this._minBalanceWei,
+    });
+  }
+
+  private _emitChange(event: GasHealthEvent): void {
+    debugLog(
+      `[GasHealth] ${event.address} ${event.status} `
+      + `(${formatEther(event.balanceWei)} ETH, minimum ${formatEther(event.minBalanceWei)} ETH)`,
+    );
+    if (!this._onChange) return;
+    try {
+      const result = this._onChange(event);
+      if (result && typeof (result as Promise<void>).catch === 'function') {
+        (result as Promise<void>).catch((err) => {
+          debugWarn(`[GasHealth] onChange failed: ${err instanceof Error ? err.message : err}`);
+        });
+      }
+    } catch (err) {
+      debugWarn(`[GasHealth] onChange failed: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+}

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -22,6 +22,17 @@ export {
   type ModelHealthTarget,
   type ServiceHealthSnapshot,
 } from './health/model-health-checker.js';
+export {
+  GasHealthMonitor,
+  DEFAULT_GAS_CHECK_INTERVAL_MS,
+  DEFAULT_MIN_GAS_BALANCE_WEI,
+  type GasHealthMonitorConfig,
+  type GasHealthEvent,
+  type GasHealthSnapshot,
+} from './health/gas-health-monitor.js';
+// Re-exported so CLI callers can format/parse gas balances without depending
+// on ethers directly.
+export { formatEther, parseEther } from 'ethers';
 export type { Router } from './interfaces/buyer-router.js';
 
 // Types (re-export everything)

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -328,6 +328,8 @@ export class AntseedNode extends EventEmitter {
   private _router: Router | null = null;
   private _started = false;
   private _announcer: PeerAnnouncer | null = null;
+  /** Set while advertising is paused (e.g. seller wallet out of gas). */
+  private _advertisingPausedReason: string | null = null;
   private _peerLookup: PeerLookup | null = null;
   private _muxes = new Map<PeerId, ProxyMux>();
   private _decoders = new Map<PeerId, FrameDecoder>();
@@ -410,6 +412,31 @@ export class AntseedNode extends EventEmitter {
    */
   async refreshSellerMetadata(): Promise<void> {
     await this._announcer?.refreshMetadata();
+  }
+
+  /**
+   * Stop announcing this seller to the DHT and re-sign the metadata snapshot
+   * with zero providers, so buyers stop discovering a peer that cannot
+   * actually serve (e.g. its wallet has no ETH to fund settlement). The
+   * `/metadata` endpoint reflects the pause immediately; already-published
+   * DHT entries age out on the buyer's staleness cutoff.
+   */
+  async pauseAdvertising(reason: string): Promise<void> {
+    this._advertisingPausedReason = reason;
+    this._announcer?.stopPeriodicAnnounce();
+    await this._announcer?.refreshMetadata();
+  }
+
+  /** Resume DHT announcements after `pauseAdvertising` (announces immediately). */
+  resumeAdvertising(): void {
+    if (this._advertisingPausedReason === null) return;
+    this._advertisingPausedReason = null;
+    this._announcer?.startPeriodicAnnounce();
+  }
+
+  /** Why advertising is currently paused, or null when advertising normally. */
+  get advertisingPausedReason(): string | null {
+    return this._advertisingPausedReason;
   }
 
   /** Register an embedded verifier prover (serves reserved attestation requests). */
@@ -1568,7 +1595,7 @@ export class AntseedNode extends EventEmitter {
           ...(p.serviceUnitBillingModels ? { serviceUnitBillingModels: { ...p.serviceUnitBillingModels } } : {}),
           ...(p.serviceCapabilities ? { serviceCapabilities: { ...p.serviceCapabilities } } : {}),
           maxConcurrency: p.maxConcurrency,
-          isAvailable: () => p.healthCheckAvailable !== false,
+          isAvailable: () => this._advertisingPausedReason === null && p.healthCheckAvailable !== false,
           pricing: {
             defaults: {
               inputUsdPerMillion: p.pricing.defaults.inputUsdPerMillion,

--- a/packages/node/tests/gas-health-monitor.test.ts
+++ b/packages/node/tests/gas-health-monitor.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_MIN_GAS_BALANCE_WEI,
+  GasHealthMonitor,
+  type GasHealthEvent,
+} from '../src/health/gas-health-monitor.js';
+
+const ADDRESS = '0x1111111111111111111111111111111111111111';
+
+function makeMonitor(
+  balances: Array<bigint | Error>,
+  overrides: { minBalanceWei?: bigint; intervalMs?: number } = {},
+): { monitor: GasHealthMonitor; events: GasHealthEvent[]; calls: string[] } {
+  const events: GasHealthEvent[] = [];
+  const calls: string[] = [];
+  const monitor = new GasHealthMonitor({
+    address: ADDRESS,
+    getBalance: async (address) => {
+      calls.push(address);
+      const next = balances.length > 1 ? balances.shift()! : balances[0]!;
+      if (next instanceof Error) throw next;
+      return next;
+    },
+    ...overrides,
+    onChange: (event) => {
+      events.push(event);
+    },
+  });
+  return { monitor, events, calls };
+}
+
+describe('GasHealthMonitor', () => {
+  it('stays quiet while the balance is at or above the threshold', async () => {
+    const { monitor, events } = makeMonitor([DEFAULT_MIN_GAS_BALANCE_WEI]);
+    await monitor.checkNow();
+    expect(monitor.depleted).toBe(false);
+    expect(events).toEqual([]);
+  });
+
+  it('emits depleted once when the balance drops below the threshold', async () => {
+    const { monitor, events } = makeMonitor([0n]);
+    await monitor.checkNow();
+    await monitor.checkNow();
+    expect(monitor.depleted).toBe(true);
+    expect(events).toEqual([{
+      status: 'depleted',
+      address: ADDRESS,
+      balanceWei: 0n,
+      minBalanceWei: DEFAULT_MIN_GAS_BALANCE_WEI,
+    }]);
+  });
+
+  it('emits restored when the wallet is funded again', async () => {
+    const { monitor, events } = makeMonitor([0n, DEFAULT_MIN_GAS_BALANCE_WEI * 2n]);
+    await monitor.checkNow();
+    await monitor.checkNow();
+    expect(monitor.depleted).toBe(false);
+    expect(events.map((event) => event.status)).toEqual(['depleted', 'restored']);
+    expect(events[1]!.balanceWei).toBe(DEFAULT_MIN_GAS_BALANCE_WEI * 2n);
+  });
+
+  it('respects a custom threshold', async () => {
+    const { monitor, events } = makeMonitor([5n], { minBalanceWei: 10n });
+    await monitor.checkNow();
+    expect(events[0]!.status).toBe('depleted');
+    expect(events[0]!.minBalanceWei).toBe(10n);
+  });
+
+  it('treats RPC errors as inconclusive and keeps the current state', async () => {
+    const { monitor, events } = makeMonitor([0n, new Error('rpc down'), 1_000_000_000_000_000n]);
+    await monitor.checkNow();
+    expect(monitor.depleted).toBe(true);
+    await monitor.checkNow(); // RPC error — still depleted, no new event
+    expect(monitor.depleted).toBe(true);
+    expect(events).toHaveLength(1);
+    await monitor.checkNow();
+    expect(monitor.depleted).toBe(false);
+    expect(events.map((event) => event.status)).toEqual(['depleted', 'restored']);
+  });
+
+  it('coalesces concurrent checks into one balance read', async () => {
+    const { monitor, calls } = makeMonitor([DEFAULT_MIN_GAS_BALANCE_WEI]);
+    await Promise.all([monitor.checkNow(), monitor.checkNow(), monitor.checkNow()]);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('polls on the configured interval and stops cleanly', async () => {
+    vi.useFakeTimers();
+    try {
+      const { monitor, events, calls } = makeMonitor([0n], { intervalMs: 1_000 });
+      monitor.start();
+      await vi.advanceTimersByTimeAsync(0); // initial check
+      expect(calls).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(calls).toHaveLength(3);
+      expect(events).toHaveLength(1); // only the first crossing emits
+      monitor.stop();
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(calls).toHaveLength(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports a snapshot of the last reading', async () => {
+    const { monitor } = makeMonitor([7n], { minBalanceWei: 10n });
+    expect(monitor.getSnapshot()).toMatchObject({
+      address: ADDRESS,
+      depleted: false,
+      lastBalanceWei: null,
+      lastCheckedAt: null,
+    });
+    await monitor.checkNow();
+    const snapshot = monitor.getSnapshot();
+    expect(snapshot.depleted).toBe(true);
+    expect(snapshot.lastBalanceWei).toBe(7n);
+    expect(snapshot.lastCheckedAt).not.toBeNull();
+  });
+
+  it('does not let an onChange failure break the check loop', async () => {
+    const balances = [0n, DEFAULT_MIN_GAS_BALANCE_WEI];
+    const events: string[] = [];
+    const monitor = new GasHealthMonitor({
+      address: ADDRESS,
+      getBalance: async () => balances.shift() ?? DEFAULT_MIN_GAS_BALANCE_WEI,
+      onChange: (event) => {
+        events.push(event.status);
+        throw new Error('handler blew up');
+      },
+    });
+    await monitor.checkNow();
+    await monitor.checkNow();
+    expect(events).toEqual(['depleted', 'restored']);
+  });
+});


### PR DESCRIPTION
## Description

A seller whose wallet ran out of ETH kept advertising itself on the DHT while every buyer got rejected (reserve/settle/close transactions fail without gas, and the errors were swallowed into debug logs). The only gas check ran once at startup.

This adds a runtime gas guard:

- New `GasHealthMonitor` in `packages/node` (mirrors `ModelHealthChecker`): polls the seller wallet's ETH balance (default every 60s) and reports `depleted`/`restored` crossings of a minimum threshold (default 0.00005 ETH). RPC errors are inconclusive and never flap state.
- New `AntseedNode.pauseAdvertising(reason)` / `resumeAdvertising()`: stops the DHT re-announce loop and re-signs metadata with zero providers, so `/metadata` stops offering services immediately; stale DHT entries age out on the buyer staleness cutoff.
- `antseed seller start` wires the monitor when payments are enabled: on depletion it prints a notice with the wallet address to fund and pauses advertising; on refund it resumes automatically. The notice is written to `daemon.state.json` (`notices`) and rendered by `antseed seller status` (table and `--json`).
- New config: `seller.gasCheck { enabled, intervalMs, minBalanceEth }`, on by default in payments mode.

## Testing

- 9 new vitest tests for `GasHealthMonitor` (threshold crossings, RPC-error handling, interval polling, concurrent-check coalescing, onChange failure isolation)
- Full workspace build + typecheck clean; `packages/node` (993) and `apps/cli` (433) suites pass

## Changelog

Updated `CHANGELOG.md` (Unreleased → Fixed).