### PR TITLE
chore: bump versions for npm release

### DIFF
--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -45,7 +45,7 @@ Don't compute this by hand and hope — step 4 validates it mechanically.
 
 ### 3. Bump versions
 
-Ask the user patch/minor/major if it isn't obvious (patch for fixes, minor for features). Bump only the computed set:
+Use a patch bump by default for every package, including packages with feature changes. Only use a minor or major bump when the user explicitly requests it. Bump only the computed set:
 
 ```bash
 pnpm --filter @antseed/protocol \

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.153",
+  "version": "0.1.154",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@antseed/desktop",
   "productName": "AntSeed VPR",
-  "version": "0.2.25",
+  "version": "0.2.26",
   "private": true,
   "description": "Desktop app for AntSeed",
   "author": "AntSeed <hello@antseed.com>",

--- a/apps/payments/package.json
+++ b/apps/payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/payments",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "Buyer payments portal for AntSeed",
   "files": [
     "dist"

--- a/apps/relay/package.json
+++ b/apps/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/relay",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Web relay for AntSeed: seller discovery cache + WebSocket-to-TCP signaling bridge for browser buyers",
   "type": "module",
   "engines": {

--- a/apps/relay/package.json
+++ b/apps/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/relay",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "description": "Web relay for AntSeed: seller discovery cache + WebSocket-to-TCP signaling bridge for browser buyers",
   "type": "module",
   "engines": {

--- a/packages/buyer-core/package.json
+++ b/packages/buyer-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/buyer-core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Transport-agnostic AntSeed buyer machinery: request handling, payment negotiation, channel accounting. Portable — no Node-only dependencies",
   "type": "module",
   "files": [

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/node",
-  "version": "0.2.114",
+  "version": "0.2.115",
   "description": "Antseed Network protocol SDK — P2P inference marketplace",
   "type": "module",
   "files": [

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/web-sdk",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "description": "Browser buyer SDK for AntSeed: connect to sellers over WebRTC via a signaling relay, pay with in-browser EIP-712 signatures",
   "type": "module",
   "files": [

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/web-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Browser buyer SDK for AntSeed: connect to sellers over WebRTC via a signaling relay, pay with in-browser EIP-712 signatures",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Description

Bumps package versions for the next npm and desktop releases. Updates the publish skill to use patch bumps by default unless another bump level is explicitly requested.

## Version Bumps

**Changed directly**
- `@antseed/buyer-core` → `0.1.7`
- `@antseed/node` → `0.2.115`
- `@antseed/web-sdk` → `0.1.1`
- `@antseed/relay` → `0.1.1`
- `@antseed/cli` → `0.1.154`
- `@antseed/desktop` → `0.2.26`

**Cascade (exact pins)**
- `@antseed/payments` → `0.1.42`
- `@antseed/cli` → `0.1.154`

All other publishable packages are unchanged. `node scripts/npm-publish-plan.mjs` validates the release set with six packages marked for publishing.
