### PR TITLE
fix(desktop): Bound model discovery phases so slow machines still get rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ## Unreleased
 
+### Fixed
+
+- Desktop model discovery no longer stalls forever on slow machines or connections. The discovery pipeline previously did unbounded network work (per-peer metering, seller-domain metadata, a ~400KB network-stats download on every cycle) and could exceed the UI's 12s cutoff on every refresh, leaving "No models discovered yet" / "Loading models…" while the runtime was healthy. Each phase now has a hard time budget with graceful degradation, network-wide seller stats come from the Antscan explorer API (~20KB, cached 60s, aggregator fallback), and the UI cutoff is a generous 30s backstop. Discovery failures, recoveries, and slow-cycle phase timings are now written to the system log so exported logs capture this failure mode.
+
 ### Changed
 
 - Desktop Help now explains the Virtual Private Router as a VPN for AI and adds practical guidance for built-in chat, connected apps, per-conversation model and seller selection, floating-window controls, routing, credits, rewards, the local API, and troubleshooting. Each subject links to a new comprehensive VPR guide or relevant supporting source.

--- a/apps/desktop/src/main/chat/engine.ts
+++ b/apps/desktop/src/main/chat/engine.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { getNetworkStats } from '../runtime/fetch-network-stats.js';
+import { raceBudget } from './race-budget.js';
 import { type ChatStreamStopReason } from './stream-stop.js';
 import {
   normalizeChatPeerSelectionRequest,
@@ -443,24 +444,6 @@ export function registerPiChatHandlers({
     totalOutputTokens: number;
     firstSessionAt: number | null;
     lastSessionAt: number | null;
-  };
-
-  /**
-   * Hard time budget immune to stuck I/O: resolves with the task's result when
-   * it lands inside budgetMs, otherwise with fallback(). Unlike an
-   * AbortController cap this cannot be defeated by a fetch that ignores its
-   * abort signal (e.g. a DNS lookup wedged on the libuv threadpool) — the
-   * task keeps running in the background and later cycles pick up whatever
-   * it cached.
-   */
-  const raceBudget = <T>(task: Promise<T>, budgetMs: number, fallback: () => T): Promise<T> => {
-    return new Promise<T>((resolve) => {
-      const timer = setTimeout(() => { resolve(fallback()); }, budgetMs);
-      task.then(
-        (value) => { clearTimeout(timer); resolve(value); },
-        () => { clearTimeout(timer); resolve(fallback()); },
-      );
-    });
   };
 
   // Phase budgets for the discover-rows pipeline. The renderer drops the IPC

--- a/apps/desktop/src/main/chat/engine.ts
+++ b/apps/desktop/src/main/chat/engine.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
-import { fetchNetworkStats } from '../runtime/fetch-network-stats.js';
+import { getNetworkStats } from '../runtime/fetch-network-stats.js';
 import { type ChatStreamStopReason } from './stream-stop.js';
 import {
   normalizeChatPeerSelectionRequest,
@@ -312,9 +312,12 @@ export function registerPiChatHandlers({
     }
 
     serviceCatalogRefreshPromise = (async () => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 5_000);
+      let port = 0;
       try {
-        const port = await resolveProxyPort(configPath);
-        const response = await fetch(`${LOCALHOST_URL}:${port}/v1/models`);
+        port = await resolveProxyPort(configPath);
+        const response = await fetch(`${LOCALHOST_URL}:${port}/v1/models`, { signal: controller.signal });
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const entries = buildChatServiceCatalogFromNetworkModels(await response.json());
         const limited = limitChatServiceCatalogEntries(entries);
@@ -325,11 +328,13 @@ export function registerPiChatHandlers({
         lastServiceCatalogEntries = resolved;
         return resolved;
       } catch (error) {
-        appendSystemLog(`Desktop model catalog refresh failed: ${asErrorMessage(error)}`);
+        appendSystemLog(`Desktop model catalog refresh failed (proxy :${String(port)}/v1/models): ${asErrorMessage(error)}`);
         if (lastServiceCatalogEntries.length > 0) return lastServiceCatalogEntries;
         const persisted = await loadPersistedServiceCatalog();
         lastServiceCatalogEntries = persisted;
         return persisted;
+      } finally {
+        clearTimeout(timer);
       }
     })().finally(() => { serviceCatalogRefreshPromise = null; });
 
@@ -431,33 +436,89 @@ export function registerPiChatHandlers({
     }
   });
 
+  type PeerMeteringStats = {
+    totalSessions: number;
+    totalRequests: number;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    firstSessionAt: number | null;
+    lastSessionAt: number | null;
+  };
+
+  /**
+   * Hard time budget immune to stuck I/O: resolves with the task's result when
+   * it lands inside budgetMs, otherwise with fallback(). Unlike an
+   * AbortController cap this cannot be defeated by a fetch that ignores its
+   * abort signal (e.g. a DNS lookup wedged on the libuv threadpool) — the
+   * task keeps running in the background and later cycles pick up whatever
+   * it cached.
+   */
+  const raceBudget = <T>(task: Promise<T>, budgetMs: number, fallback: () => T): Promise<T> => {
+    return new Promise<T>((resolve) => {
+      const timer = setTimeout(() => { resolve(fallback()); }, budgetMs);
+      task.then(
+        (value) => { clearTimeout(timer); resolve(value); },
+        () => { clearTimeout(timer); resolve(fallback()); },
+      );
+    });
+  };
+
+  // Phase budgets for the discover-rows pipeline. The renderer drops the IPC
+  // result after 30s (CHAT_SERVICE_LIST_TIMEOUT_MS) — the sum of these plus
+  // the local file reads must stay comfortably under that, or the model list
+  // never populates while the runtime looks healthy. Generous enough for a
+  // slow machine or connection to finish each phase; a phase that still
+  // overruns is skipped for this cycle, not fatal.
+  const CATALOG_PHASE_BUDGET_MS = 8_000;
+  const METERING_FETCH_TIMEOUT_MS = 4_000;
+  const METERING_PHASE_BUDGET_MS = 5_000;
+  const ENRICHMENT_BUDGET_MS = 4_000;
+  const NETWORK_STATS_BUDGET_MS = 8_000;
+  const DISCOVER_ROWS_SLOW_MS = 3_000;
+  /** Last successful per-peer metering, reused when a cycle's fetch times out. */
+  const lastMeteringStats = new Map<string, PeerMeteringStats>();
+  let discoverRowsEverSucceeded = false;
+
   ipcMain.handle('chat:ai-list-discover-rows', async () => {
+    const startedAt = Date.now();
+    const phaseMs: Array<[string, number]> = [];
+    let phaseStartedAt = startedAt;
+    const endPhase = (name: string): void => {
+      const now = Date.now();
+      phaseMs.push([name, now - phaseStartedAt]);
+      phaseStartedAt = now;
+    };
     try {
       const buyerMaxPricing = await loadBuyerMaxPricingDefaults(configPath);
-      const entries = (await refreshServiceCatalogFromNetwork())
-        .filter((entry) => isCatalogEntryAllowedByBuyerMax(entry, buyerMaxPricing));
+      const entries = (await raceBudget(
+        refreshServiceCatalogFromNetwork(),
+        CATALOG_PHASE_BUDGET_MS,
+        () => lastServiceCatalogEntries,
+      )).filter((entry) => isCatalogEntryAllowedByBuyerMax(entry, buyerMaxPricing));
+      endPhase('catalog');
 
       const buyerPort = await resolveProxyPort(configPath);
-      const statsMap = new Map<string, {
-        totalSessions: number;
-        totalRequests: number;
-        totalInputTokens: number;
-        totalOutputTokens: number;
-        firstSessionAt: number | null;
-        lastSessionAt: number | null;
-      }>();
+      const statsMap = new Map<string, PeerMeteringStats>();
       // Per-peer lifetime metering. The buyer-proxy exposes
       // /_antseed/metering/<peerId>; fetch in parallel for every catalog peer.
       const uniqueCatalogPeerIds = Array.from(new Set(
         entries.map((e) => e.peerId ?? '').filter((p) => p.length > 0)
       ));
-      await Promise.all(uniqueCatalogPeerIds.map(async (peerId) => {
+      await raceBudget(Promise.all(uniqueCatalogPeerIds.map(async (peerId) => {
         try {
-          const resp = await fetch(
-            `${LOCALHOST_URL}:${buyerPort}/_antseed/metering/${encodeURIComponent(peerId)}`,
-          );
-          if (!resp.ok) return;
-          const body = await resp.json() as Record<string, unknown> | null;
+          const controller = new AbortController();
+          const timer = setTimeout(() => controller.abort(), METERING_FETCH_TIMEOUT_MS);
+          let body: Record<string, unknown> | null;
+          try {
+            const resp = await fetch(
+              `${LOCALHOST_URL}:${buyerPort}/_antseed/metering/${encodeURIComponent(peerId)}`,
+              { signal: controller.signal },
+            );
+            if (!resp.ok) return;
+            body = await resp.json() as Record<string, unknown> | null;
+          } finally {
+            clearTimeout(timer);
+          }
           if (!body || typeof body !== 'object') return;
           const sessions = Number(body.lifetimeSessions) || 0;
           const reqs = Number(body.lifetimeRequests) || 0;
@@ -466,18 +527,24 @@ export function registerPiChatHandlers({
           const firstAt = typeof body.lifetimeFirstSessionAt === 'number' ? body.lifetimeFirstSessionAt : null;
           const lastAt = typeof body.lifetimeLastSessionAt === 'number' ? body.lifetimeLastSessionAt : null;
           if (sessions === 0 && reqs === 0 && inTok === 0 && outTok === 0 && firstAt == null && lastAt == null) return;
-          statsMap.set(peerId, {
+          const stats: PeerMeteringStats = {
             totalSessions: sessions,
             totalRequests: reqs,
             totalInputTokens: inTok,
             totalOutputTokens: outTok,
             firstSessionAt: firstAt,
             lastSessionAt: lastAt,
-          });
+          };
+          statsMap.set(peerId, stats);
+          lastMeteringStats.set(peerId, stats);
         } catch {
-          // Ignore — peer simply has no metering info
+          // Timed out or unreachable — reuse the last known values so a slow
+          // cycle doesn't blank the lifetime columns.
+          const previous = lastMeteringStats.get(peerId);
+          if (previous) statsMap.set(peerId, previous);
         }
-      }));
+      })), METERING_PHASE_BUDGET_MS, () => []);
+      endPhase('metering');
 
       let discoveredPeersMap: Record<string, BuyerStateDiscoveredPeer> = {};
       let peerHealthMap: Record<string, RawPeerHealth> = {};
@@ -519,13 +586,18 @@ export function registerPiChatHandlers({
             );
           }
         }
-        await Promise.all(enrichmentTasks);
+        // Budgeted: already-cached domains resolve instantly; first-seen
+        // domains keep resolving in the background and land in the
+        // per-domain cache for the next cycle.
+        await raceBudget(Promise.all(enrichmentTasks), ENRICHMENT_BUDGET_MS, () => []);
       } catch {
         // No state file yet
       }
+      endPhase('enrichment');
 
-      // Network-wide stats from @antseed/network-stats. On non-mainnet chains and on any
-      // failure this returns an empty map and buildDiscoverRows falls back to local stats.
+      // Network-wide stats from the chain explorer (aggregator fallback). On
+      // non-mainnet chains and on any failure this returns an empty map and
+      // buildDiscoverRows falls back to local stats.
       const networkStats = await (async () => {
         try {
           const raw = await readFile(configPath, 'utf8');
@@ -536,11 +608,15 @@ export function registerPiChatHandlers({
             ? overrides.chainId
             : 'base-mainnet';
           const cc = resolveChainConfig({ chainId: selectedChain });
-          return await fetchNetworkStats(cc.networkStatsUrl);
+          return await getNetworkStats({
+            explorerApiUrl: cc.explorerApiUrl,
+            networkStatsUrl: cc.networkStatsUrl,
+          }, { budgetMs: NETWORK_STATS_BUDGET_MS });
         } catch {
           return new Map<number, { requests: bigint; inputTokens: bigint; outputTokens: bigint }>();
         }
       })();
+      endPhase('network-stats');
 
       const rows = (await buildDiscoverRows(entries, statsMap, discoveredPeersMap, networkStats, peerHealthMap))
         .filter((row) => isPriceAllowedByBuyerMax(
@@ -549,8 +625,20 @@ export function registerPiChatHandlers({
           row.cachedInputUsdPerMillion,
           buyerMaxPricing,
         ));
+      endPhase('build');
+
+      const totalMs = Date.now() - startedAt;
+      if (totalMs >= DISCOVER_ROWS_SLOW_MS) {
+        const breakdown = phaseMs.map(([name, ms]) => `${name}=${String(ms)}ms`).join(' ');
+        appendSystemLog(`Service discovery slow: ${String(totalMs)}ms (${breakdown}) — ${String(rows.length)} row(s) from ${String(entries.length)} service(s)`);
+      }
+      if (!discoverRowsEverSucceeded) {
+        discoverRowsEverSucceeded = true;
+        appendSystemLog(`Service discovery ready: ${String(rows.length)} row(s) from ${String(entries.length)} service(s) in ${String(totalMs)}ms`);
+      }
       return { ok: true, data: rows };
     } catch (error) {
+      appendSystemLog(`Service discovery failed after ${String(Date.now() - startedAt)}ms: ${asErrorMessage(error)}`);
       return { ok: false, data: [] as DiscoverRowEntry[], error: asErrorMessage(error) };
     }
   });

--- a/apps/desktop/src/main/chat/race-budget.test.ts
+++ b/apps/desktop/src/main/chat/race-budget.test.ts
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { raceBudget } from './race-budget.js';
+
+test('resolves with the task value when it finishes inside the budget', async () => {
+  const out = await raceBudget(Promise.resolve('fast'), 1_000, () => 'fallback');
+  assert.equal(out, 'fast');
+});
+
+test('resolves with the fallback when the task never settles', async () => {
+  const never = new Promise<string>(() => {});
+  const startedAt = Date.now();
+  const out = await raceBudget(never, 50, () => 'fallback');
+  assert.equal(out, 'fallback');
+  assert.ok(Date.now() - startedAt < 1_000, 'must return around the budget, not hang');
+});
+
+test('resolves with the fallback when the task rejects', async () => {
+  const out = await raceBudget(Promise.reject(new Error('boom')), 1_000, () => 'fallback');
+  assert.equal(out, 'fallback');
+});
+
+test('a slow task still settles in the background after the fallback fired', async () => {
+  let resolveTask: (value: string) => void = () => {};
+  const task = new Promise<string>((resolve) => { resolveTask = resolve; });
+  const out = await raceBudget(task, 20, () => 'fallback');
+  assert.equal(out, 'fallback');
+  // The caller moved on, but the underlying work is not cancelled — a later
+  // completion (feeding some cache) must not throw or unhandled-reject.
+  resolveTask('late');
+  assert.equal(await task, 'late');
+});

--- a/apps/desktop/src/main/chat/race-budget.ts
+++ b/apps/desktop/src/main/chat/race-budget.ts
@@ -1,0 +1,17 @@
+/**
+ * Hard time budget immune to stuck I/O: resolves with the task's result when
+ * it lands inside budgetMs, otherwise with fallback(). Unlike an
+ * AbortController cap this cannot be defeated by a fetch that ignores its
+ * abort signal (e.g. a DNS lookup wedged on the libuv threadpool) — the
+ * task keeps running in the background and later cycles pick up whatever
+ * it cached. A rejected task also resolves to fallback().
+ */
+export function raceBudget<T>(task: Promise<T>, budgetMs: number, fallback: () => T): Promise<T> {
+  return new Promise<T>((resolve) => {
+    const timer = setTimeout(() => { resolve(fallback()); }, budgetMs);
+    task.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      () => { clearTimeout(timer); resolve(fallback()); },
+    );
+  });
+}

--- a/apps/desktop/src/main/runtime/fetch-network-stats.test.ts
+++ b/apps/desktop/src/main/runtime/fetch-network-stats.test.ts
@@ -270,6 +270,34 @@ test('getNetworkStats: falls back to the aggregator when the explorer returns no
   }
 });
 
+test('getNetworkStats: concurrent calls for different chains do not share in-flight state or cooldown', async () => {
+  resetNetworkStatsCache();
+  globalThis.fetch = async (url: string | URL | Request) => {
+    const u = String(url);
+    if (u.startsWith('https://down.example')) {
+      throw new Error('network down');
+    }
+    return {
+      ok: true,
+      json: async () => ([{ agentId: '5', requestCount: '50', inputTokens: '51', outputTokens: '52' }]),
+    } as unknown as Response;
+  };
+  try {
+    // First chain fails (both sources unreachable) and enters its cooldown…
+    const bad = await getNetworkStats({ explorerApiUrl: 'https://down.example', networkStatsUrl: 'https://down.example' });
+    assert.equal(bad.size, 0);
+    // …which must not block or contaminate a healthy chain queried right after.
+    const good = await getNetworkStats({ explorerApiUrl: 'https://up.example', networkStatsUrl: 'https://up.example' });
+    assert.equal(good.get(5)?.requests, 50n);
+    // And the failed chain still serves empty (cooldown), not the other chain's map.
+    const badAgain = await getNetworkStats({ explorerApiUrl: 'https://down.example', networkStatsUrl: 'https://down.example' });
+    assert.equal(badAgain.size, 0);
+  } finally {
+    resetNetworkStatsCache();
+    restoreFetch();
+  }
+});
+
 test('getNetworkStats: both sources failing with no prior cache returns empty', async () => {
   resetNetworkStatsCache();
   globalThis.fetch = async () => { throw new Error('network down'); };

--- a/apps/desktop/src/main/runtime/fetch-network-stats.test.ts
+++ b/apps/desktop/src/main/runtime/fetch-network-stats.test.ts
@@ -1,6 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchNetworkStats } from './fetch-network-stats.js';
+import {
+  fetchNetworkStats,
+  fetchNetworkStatsFromExplorer,
+  getNetworkStats,
+  resetNetworkStatsCache,
+} from './fetch-network-stats.js';
 
 // Helper to make a mock fetch that returns a resolved response object
 function mockFetch(response: unknown): typeof globalThis.fetch {
@@ -164,6 +169,115 @@ test('peer with malformed numeric string is skipped, others remain', async () =>
     assert.equal(entry.inputTokens, 888n);
     assert.equal(entry.outputTokens, 777n);
   } finally {
+    restoreFetch();
+  }
+});
+
+test('explorer: returns empty when URL is undefined', async () => {
+  let called = false;
+  globalThis.fetch = async () => { called = true; return null as unknown as Response; };
+  try {
+    const out = await fetchNetworkStatsFromExplorer(undefined);
+    assert.equal(out.size, 0);
+    assert.equal(called, false);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test('explorer: maps /api/sellers rows to bigint stats, skipping null agentIds', async () => {
+  const calls: string[] = [];
+  globalThis.fetch = async (url: string | URL | Request) => {
+    calls.push(String(url));
+    return {
+      ok: true,
+      json: async () => ([
+        { agentId: '53008', requestCount: '2111335', inputTokens: '6120535493', outputTokens: '1169883968' },
+        { agentId: null, requestCount: '0', inputTokens: '0', outputTokens: '0' },
+        { agentId: '10', requestCount: 'not-a-number', inputTokens: '0', outputTokens: '0' },
+      ]),
+    } as unknown as Response;
+  };
+  try {
+    const out = await fetchNetworkStatsFromExplorer('https://antscan.example/');
+    assert.equal(calls[0], 'https://antscan.example/api/sellers');
+    assert.equal(out.size, 1);
+    const entry = out.get(53008);
+    assert.ok(entry, 'expected entry for agentId 53008');
+    assert.equal(entry.requests, 2111335n);
+    assert.equal(entry.inputTokens, 6120535493n);
+    assert.equal(entry.outputTokens, 1169883968n);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test('explorer: non-array payload returns empty map', async () => {
+  globalThis.fetch = mockFetch({ ok: true, json: async () => ({ sellers: [] }) });
+  try {
+    const out = await fetchNetworkStatsFromExplorer('https://antscan.example');
+    assert.equal(out.size, 0);
+  } finally {
+    restoreFetch();
+  }
+});
+
+test('getNetworkStats: explorer result is cached — second call does not refetch', async () => {
+  resetNetworkStatsCache();
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return {
+      ok: true,
+      json: async () => ([{ agentId: '7', requestCount: '1', inputTokens: '2', outputTokens: '3' }]),
+    } as unknown as Response;
+  };
+  try {
+    const urls = { explorerApiUrl: 'https://antscan.example', networkStatsUrl: 'https://stats.example' };
+    const first = await getNetworkStats(urls);
+    const second = await getNetworkStats(urls);
+    assert.equal(calls, 1);
+    assert.equal(first, second);
+    assert.equal(first.get(7)?.requests, 1n);
+  } finally {
+    resetNetworkStatsCache();
+    restoreFetch();
+  }
+});
+
+test('getNetworkStats: falls back to the aggregator when the explorer returns nothing', async () => {
+  resetNetworkStatsCache();
+  const calls: string[] = [];
+  globalThis.fetch = async (url: string | URL | Request) => {
+    calls.push(String(url));
+    if (String(url).includes('/api/sellers')) {
+      return { ok: false, status: 503, statusText: 'down' } as unknown as Response;
+    }
+    return {
+      ok: true,
+      json: async () => ({
+        peers: [{ peerId: 'p', onChainStats: { agentId: 9, totalRequests: '4', totalInputTokens: '5', totalOutputTokens: '6' } }],
+      }),
+    } as unknown as Response;
+  };
+  try {
+    const out = await getNetworkStats({ explorerApiUrl: 'https://antscan.example', networkStatsUrl: 'https://stats.example' });
+    assert.deepEqual(calls, ['https://antscan.example/api/sellers', 'https://stats.example/stats']);
+    assert.equal(out.get(9)?.requests, 4n);
+  } finally {
+    resetNetworkStatsCache();
+    restoreFetch();
+  }
+});
+
+test('getNetworkStats: both sources failing with no prior cache returns empty', async () => {
+  resetNetworkStatsCache();
+  globalThis.fetch = async () => { throw new Error('network down'); };
+  try {
+    const out = await getNetworkStats({ explorerApiUrl: 'https://antscan.example', networkStatsUrl: 'https://stats.example' });
+    assert.equal(out.size, 0);
+  } finally {
+    resetNetworkStatsCache();
     restoreFetch();
   }
 });

--- a/apps/desktop/src/main/runtime/fetch-network-stats.ts
+++ b/apps/desktop/src/main/runtime/fetch-network-stats.ts
@@ -55,15 +55,17 @@ export async function fetchNetworkStatsFromExplorer(
 
 const NETWORK_STATS_TTL_MS = 60_000;
 const NETWORK_STATS_FAILURE_COOLDOWN_MS = 30_000;
-let networkStatsCache: { key: string; fetchedAtMs: number; map: NetworkStatsMap } | null = null;
-let networkStatsInFlight: Promise<NetworkStatsMap> | null = null;
-let networkStatsLastFailureAt = 0;
+// All state is keyed by the URL pair so a chain-config switch mid-fetch can't
+// serve the previous chain's stats or inherit its failure cooldown.
+const networkStatsCache = new Map<string, { fetchedAtMs: number; map: NetworkStatsMap }>();
+const networkStatsInFlight = new Map<string, Promise<NetworkStatsMap>>();
+const networkStatsLastFailureAt = new Map<string, number>();
 
 /** Test-only: drop the module-level cache so runs don't leak into each other. */
 export function resetNetworkStatsCache(): void {
-  networkStatsCache = null;
-  networkStatsInFlight = null;
-  networkStatsLastFailureAt = 0;
+  networkStatsCache.clear();
+  networkStatsInFlight.clear();
+  networkStatsLastFailureAt.clear();
 }
 
 /**
@@ -85,32 +87,34 @@ export async function getNetworkStats(urls: {
   networkStatsUrl?: string;
 }, opts: { budgetMs?: number } = {}): Promise<NetworkStatsMap> {
   const key = `${urls.explorerApiUrl ?? ''}|${urls.networkStatsUrl ?? ''}`;
-  const stale = (): NetworkStatsMap => (networkStatsCache?.key === key ? networkStatsCache.map : new Map());
-  if (networkStatsCache && networkStatsCache.key === key
-    && Date.now() - networkStatsCache.fetchedAtMs < NETWORK_STATS_TTL_MS) {
-    return networkStatsCache.map;
+  const stale = (): NetworkStatsMap => networkStatsCache.get(key)?.map ?? new Map();
+  const cached = networkStatsCache.get(key);
+  if (cached && Date.now() - cached.fetchedAtMs < NETWORK_STATS_TTL_MS) {
+    return cached.map;
   }
 
-  if (!networkStatsInFlight) {
-    if (Date.now() - networkStatsLastFailureAt < NETWORK_STATS_FAILURE_COOLDOWN_MS) {
+  let inFlight = networkStatsInFlight.get(key);
+  if (!inFlight) {
+    if (Date.now() - (networkStatsLastFailureAt.get(key) ?? 0) < NETWORK_STATS_FAILURE_COOLDOWN_MS) {
       return stale();
     }
-    networkStatsInFlight = (async () => {
+    inFlight = (async () => {
       let map = await fetchNetworkStatsFromExplorer(urls.explorerApiUrl);
       if (map.size === 0) map = await fetchNetworkStats(urls.networkStatsUrl);
       if (map.size > 0) {
-        networkStatsCache = { key, fetchedAtMs: Date.now(), map };
+        networkStatsCache.set(key, { fetchedAtMs: Date.now(), map });
         return map;
       }
-      networkStatsLastFailureAt = Date.now();
+      networkStatsLastFailureAt.set(key, Date.now());
       return stale();
-    })().finally(() => { networkStatsInFlight = null; });
+    })().finally(() => { networkStatsInFlight.delete(key); });
+    networkStatsInFlight.set(key, inFlight);
   }
 
-  if (opts.budgetMs === undefined) return networkStatsInFlight;
+  if (opts.budgetMs === undefined) return inFlight;
   return new Promise<NetworkStatsMap>((resolve) => {
     const timer = setTimeout(() => { resolve(stale()); }, opts.budgetMs);
-    networkStatsInFlight?.then(
+    inFlight.then(
       (map) => { clearTimeout(timer); resolve(map); },
       () => { clearTimeout(timer); resolve(stale()); },
     );

--- a/apps/desktop/src/main/runtime/fetch-network-stats.ts
+++ b/apps/desktop/src/main/runtime/fetch-network-stats.ts
@@ -1,3 +1,122 @@
+export type NetworkStatsMap = Map<number, { requests: bigint; inputTokens: bigint; outputTokens: bigint }>;
+
+/**
+ * Fetches per-seller on-chain stats from the chain explorer (Antscan).
+ * GET {explorerApiUrl}/api/sellers returns every settled seller with
+ * agentId/requestCount/inputTokens/outputTokens — ~20KB vs the ~400KB
+ * aggregator snapshot. Same failure contract as fetchNetworkStats: any
+ * problem returns an empty map.
+ */
+export async function fetchNetworkStatsFromExplorer(
+  explorerApiUrl: string | undefined,
+): Promise<NetworkStatsMap> {
+  const empty: NetworkStatsMap = new Map();
+  if (!explorerApiUrl) return empty;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5_000);
+
+  try {
+    const res = await fetch(`${explorerApiUrl.replace(/\/+$/, '')}/api/sellers`, {
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      console.warn(`[pi-chat] explorer sellers ${res.status} ${res.statusText}`);
+      return empty;
+    }
+    const body = (await res.json()) as Array<Record<string, unknown>>;
+    if (!Array.isArray(body)) {
+      console.warn('[pi-chat] explorer sellers: unexpected payload shape');
+      return empty;
+    }
+
+    const out: NetworkStatsMap = new Map();
+    for (const seller of body) {
+      const agentId = Number(seller['agentId']);
+      if (!Number.isFinite(agentId) || agentId <= 0) continue;
+      try {
+        out.set(agentId, {
+          requests: BigInt(String(seller['requestCount'])),
+          inputTokens: BigInt(String(seller['inputTokens'])),
+          outputTokens: BigInt(String(seller['outputTokens'])),
+        });
+      } catch {
+        // malformed numeric string — skip this seller, don't poison the whole map
+      }
+    }
+    return out;
+  } catch (err) {
+    console.warn('[pi-chat] explorer sellers fetch failed:', err);
+    return empty;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const NETWORK_STATS_TTL_MS = 60_000;
+const NETWORK_STATS_FAILURE_COOLDOWN_MS = 30_000;
+let networkStatsCache: { key: string; fetchedAtMs: number; map: NetworkStatsMap } | null = null;
+let networkStatsInFlight: Promise<NetworkStatsMap> | null = null;
+let networkStatsLastFailureAt = 0;
+
+/** Test-only: drop the module-level cache so runs don't leak into each other. */
+export function resetNetworkStatsCache(): void {
+  networkStatsCache = null;
+  networkStatsInFlight = null;
+  networkStatsLastFailureAt = 0;
+}
+
+/**
+ * Cached network stats: explorer (Antscan /api/sellers) first, the
+ * network-stats aggregator as fallback. Lifetime counters move slowly, so a
+ * fresh result is reused for 60s and concurrent callers share one fetch —
+ * the service-discovery refresh cycle no longer pays for this on every pass.
+ * When both sources fail, the last good map is served stale rather than
+ * blanking the stats, and no refresh is retried for 30s so an unreachable
+ * network doesn't tax every cycle.
+ *
+ * opts.budgetMs puts a hard cap on how long the caller waits: past it the
+ * best available map (stale or empty) is returned while the refresh keeps
+ * running in the background for the next call. The cap holds even when a
+ * fetch ignores its abort signal.
+ */
+export async function getNetworkStats(urls: {
+  explorerApiUrl?: string;
+  networkStatsUrl?: string;
+}, opts: { budgetMs?: number } = {}): Promise<NetworkStatsMap> {
+  const key = `${urls.explorerApiUrl ?? ''}|${urls.networkStatsUrl ?? ''}`;
+  const stale = (): NetworkStatsMap => (networkStatsCache?.key === key ? networkStatsCache.map : new Map());
+  if (networkStatsCache && networkStatsCache.key === key
+    && Date.now() - networkStatsCache.fetchedAtMs < NETWORK_STATS_TTL_MS) {
+    return networkStatsCache.map;
+  }
+
+  if (!networkStatsInFlight) {
+    if (Date.now() - networkStatsLastFailureAt < NETWORK_STATS_FAILURE_COOLDOWN_MS) {
+      return stale();
+    }
+    networkStatsInFlight = (async () => {
+      let map = await fetchNetworkStatsFromExplorer(urls.explorerApiUrl);
+      if (map.size === 0) map = await fetchNetworkStats(urls.networkStatsUrl);
+      if (map.size > 0) {
+        networkStatsCache = { key, fetchedAtMs: Date.now(), map };
+        return map;
+      }
+      networkStatsLastFailureAt = Date.now();
+      return stale();
+    })().finally(() => { networkStatsInFlight = null; });
+  }
+
+  if (opts.budgetMs === undefined) return networkStatsInFlight;
+  return new Promise<NetworkStatsMap>((resolve) => {
+    const timer = setTimeout(() => { resolve(stale()); }, opts.budgetMs);
+    networkStatsInFlight?.then(
+      (map) => { clearTimeout(timer); resolve(map); },
+      () => { clearTimeout(timer); resolve(stale()); },
+    );
+  });
+}
+
 /**
  * Fetches network-wide per-agent stats from the @antseed/network-stats aggregator.
  * On any failure (unset URL, timeout, non-2xx, JSON parse error, unexpected shape),

--- a/apps/desktop/src/renderer/modules/chat/controller.ts
+++ b/apps/desktop/src/renderer/modules/chat/controller.ts
@@ -1550,7 +1550,7 @@ export function initChatModule({
   }
 
   async function refreshChatServiceOptions(): Promise<void> {
-    // Skip if a fetch is already in-flight — the 12s timeout outlasts the 5s poll
+    // Skip if a fetch is already in-flight — the 30s timeout outlasts the 5s poll
     // cycle, so without this guard every result gets a stale token and is dropped.
     if (serviceRefreshInProgress) return;
     serviceRefreshInProgress = true;

--- a/apps/desktop/src/renderer/modules/chat/controller.ts
+++ b/apps/desktop/src/renderer/modules/chat/controller.ts
@@ -192,7 +192,11 @@ export function initChatModule({
   const CHAT_SERVICE_REFRESH_INTERVAL_MS = 60_000;
   // Faster retry during first-run setup while no services have been found yet.
   const CHAT_SERVICE_SETUP_REFRESH_INTERVAL_MS = 2_000;
-  const CHAT_SERVICE_LIST_TIMEOUT_MS = 12_000;
+  // Last-resort backstop only: the main-process handler bounds itself to
+  // ~26s worst case via per-phase budgets, so on a healthy machine this never
+  // fires. Generous so slow machines/connections still get their rows late
+  // rather than never.
+  const CHAT_SERVICE_LIST_TIMEOUT_MS = 30_000;
 
   // ---------------------------------------------------------------------------
   // Module-local state
@@ -1522,6 +1526,29 @@ export function initChatModule({
     }
   }
 
+  // Service-discovery failures (notably the 12s IPC timeout above) used to be
+  // invisible in exported logs — the runtime looked healthy while the model
+  // list stayed empty. Log the first failure, then one summary per minute,
+  // plus the recovery, so a log export tells the story.
+  let discoverFailureStreak = 0;
+  let discoverFailureLogAt = 0;
+  function noteDiscoverFailure(message: string): void {
+    discoverFailureStreak += 1;
+    const now = Date.now();
+    if (discoverFailureStreak === 1 || now - discoverFailureLogAt >= 60_000) {
+      discoverFailureLogAt = now;
+      appendSystemLog(discoverFailureStreak === 1
+        ? `Service discovery failed: ${message}`
+        : `Service discovery still failing (${String(discoverFailureStreak)} consecutive): ${message}`);
+    }
+  }
+  function noteDiscoverSuccess(rowCount: number): void {
+    if (discoverFailureStreak === 0) return;
+    appendSystemLog(`Service discovery recovered after ${String(discoverFailureStreak)} failure(s): ${String(rowCount)} row(s)`);
+    discoverFailureStreak = 0;
+    discoverFailureLogAt = 0;
+  }
+
   async function refreshChatServiceOptions(): Promise<void> {
     // Skip if a fetch is already in-flight — the 12s timeout outlasts the 5s poll
     // cycle, so without this guard every result gets a stale token and is dropped.
@@ -1548,6 +1575,7 @@ export function initChatModule({
       if (!result.ok || !Array.isArray(result.data)) {
         uiState.chatDiscoverRowsLoaded = false;
         updateChatServiceOptions(fallback);
+        noteDiscoverFailure(result.error || 'Service catalog unavailable.');
         setRuntimeActivity('warn', result.error || 'Service catalog unavailable.');
         notifyUiStateChanged();
         return;
@@ -1560,6 +1588,7 @@ export function initChatModule({
       uiState.discoverRows = rows;
       uiState.vprRoutableRows = filterRoutableVprRoutes(rows, uiState.vprRoutingPreferences);
       uiState.chatDiscoverRowsLoaded = true;
+      noteDiscoverSuccess(rows.length);
       // Guard on the raw discovery result, not the projection: an allowlist
       // that excludes every discovered seller must empty the catalog, while a
       // transient empty discovery snapshot must leave the last one standing.
@@ -1621,6 +1650,7 @@ export function initChatModule({
       uiState.chatDiscoverRowsLoaded = false;
       updateChatServiceOptions(fallback);
       const message = toErrorMessage(error, 'Failed to load services');
+      noteDiscoverFailure(message);
       setRuntimeActivity('bad', message);
     } finally {
       serviceRefreshInProgress = false;

--- a/packages/node/src/payments/chain-config.ts
+++ b/packages/node/src/payments/chain-config.ts
@@ -29,6 +29,8 @@ export interface ChainConfig {
   statsDeployBlock?: number;
   /** Public URL of the @antseed/network-stats aggregator that indexes the stats contract for this chain. */
   networkStatsUrl?: string;
+  /** Public REST API of the chain explorer (Antscan). Serves per-seller on-chain stats at /api/sellers. */
+  explorerApiUrl?: string;
   /** AntseedDepositRelay contract for gasless USDC sweeps from buyer hot wallets. */
   depositRelayAddress?: string;
 }
@@ -72,6 +74,7 @@ const CHAIN_CONFIGS: Record<ChainId, ChainConfig> = {
     statsContractAddress: '0x15649ff076bfa5e37e24ee3154a00503149954fd',
     statsDeployBlock: 44469557,
     networkStatsUrl: 'https://network.antseed.com',
+    explorerApiUrl: 'https://antscan.co',
     depositRelayAddress: '0x34a44542e76f9b4cff3a31902eDF14AbF2C3B3DD',
   },
   'base-sepolia': {


### PR DESCRIPTION
## Description

The desktop's model-discovery pipeline did unbounded network work (per-peer metering, seller-domain metadata, a ~400KB stats download every cycle) and on slow machines exceeded the UI's 12s cutoff on every refresh — the model list stayed at "No models discovered yet" / "Loading models…" forever while the runtime looked healthy, with no trace in exported logs.

## Changes

- Hard per-phase time budgets in the discover-rows handler (catalog 8s, metering 5s, enrichment 4s, network stats 8s) with graceful degradation — a slow phase is skipped for the cycle, not fatal. Budgets hold even if a fetch ignores its abort signal.
- Network-wide seller stats now come from the Antscan explorer API (~20KB) instead of the ~400KB aggregator snapshot, cached 60s with a 30s failure cooldown and aggregator fallback. New `explorerApiUrl` in chain config.
- UI cutoff raised 12s → 30s as a last-resort backstop above the ~26s worst case.
- Discovery failures, recoveries, and slow-cycle phase timings are logged to the system log so exported logs capture this failure mode.

CHANGELOG.md updated (user-facing desktop fix).