### PR TITLE
chore(release): Bump npm package versions

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.154",
+  "version": "0.1.155",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [

--- a/apps/payments/package.json
+++ b/apps/payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/payments",
-  "version": "0.1.42",
+  "version": "0.1.43",
   "description": "Buyer payments portal for AntSeed",
   "files": [
     "dist"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/node",
-  "version": "0.2.115",
+  "version": "0.2.116",
   "description": "Antseed Network protocol SDK — P2P inference marketplace",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Description

Bumps the npm package versions needed to publish the merged public-tunnel functionality and pending node runtime fixes. The release set includes direct changes in `@antseed/cli` and `@antseed/node`, plus the required exact-pin cascade to `@antseed/payments`.

### Changed directly

- `@antseed/cli` → `0.1.155`: publishes ngrok and Cloudflare public tunnel commands, authenticated gateway support, and tunneled Anthropic token-count requests.
- `@antseed/node` → `0.2.116`: publishes the pending bounded model-discovery runtime fixes.

### Cascade (exact pins)

- `@antseed/payments` → `0.1.43`: exactly pins `@antseed/node` and must be republished with the new node version.

All other public npm packages are intentionally skipped. `node scripts/npm-publish-plan.mjs` validates exactly these three packages as `PUBLISH` with no cascade violations.

## Release Notes

- Added authenticated ngrok and Cloudflare HTTPS tunnels to the AntSeed CLI for Cursor, remote agents, servers, and OpenAI-compatible clients
- Added support for tunneled Anthropic token-count requests
- Included the latest bounded model-discovery runtime fixes

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [x] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Lint and unit tests pass locally with my changes