### PR TITLE
docs: Deduplicate agent tunnel guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Changed
 
-- The Agents guide now focuses on agent-specific Hermes and OpenClaw configuration and links to the Public HTTPS Tunnels guide as the single reference for tunnel providers, authentication, routes, CLI setup, Cursor, and troubleshooting.
-
 - Desktop and CLI now expose the authenticated VPR model API through optional ngrok or Cloudflare HTTPS tunnels for Cursor, remote agents, servers, and OpenAI-compatible SDKs. Desktop manages provider credentials, generated API keys, connection details, and endpoint lifecycle in one shared modal that opens from **Agents**, **Connected apps**, **Preferences**, and **Help**. Connected apps includes a tunnel-gated Cursor card with the exact URL, API key, model, and native launch steps. The **Agents** view links maintained Hermes and OpenClaw integration pages and setup skills, while website docs and skills cover Hermes' current `providers:` schema, OpenClaw's required `authHeader: true` bearer authentication and current model commands, supported routes, Cursor setup, CLI usage, and troubleshooting.
 
 - Desktop Help now explains the Virtual Private Router as a VPN for AI and adds practical guidance for built-in chat, connected apps, per-conversation model and seller selection, floating-window controls, routing, credits, rewards, the local API, and troubleshooting. Each subject links to a new comprehensive VPR guide or relevant supporting source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Changed
 
+- The Agents guide now focuses on agent-specific Hermes and OpenClaw configuration and links to the Public HTTPS Tunnels guide as the single reference for tunnel providers, authentication, routes, CLI setup, Cursor, and troubleshooting.
+
 - Desktop and CLI now expose the authenticated VPR model API through optional ngrok or Cloudflare HTTPS tunnels for Cursor, remote agents, servers, and OpenAI-compatible SDKs. Desktop manages provider credentials, generated API keys, connection details, and endpoint lifecycle in one shared modal that opens from **Agents**, **Connected apps**, **Preferences**, and **Help**. Connected apps includes a tunnel-gated Cursor card with the exact URL, API key, model, and native launch steps. The **Agents** view links maintained Hermes and OpenClaw integration pages and setup skills, while website docs and skills cover Hermes' current `providers:` schema, OpenClaw's required `authHeader: true` bearer authentication and current model commands, supported routes, Cursor setup, CLI usage, and troubleshooting.
 
 - Desktop Help now explains the Virtual Private Router as a VPN for AI and adds practical guidance for built-in chat, connected apps, per-conversation model and seller selection, floating-window controls, routing, credits, rewards, the local API, and troubleshooting. Each subject links to a new comprehensive VPR guide or relevant supporting source.

--- a/apps/website/docs/guides/agents.md
+++ b/apps/website/docs/guides/agents.md
@@ -103,126 +103,17 @@ Add AntSeed under `models.providers` in `~/.openclaw/openclaw.json`:
 
 Then run `openclaw models set "antseed/kimi-k2.6"` followed by `openclaw gateway restart`. `authHeader: true` makes OpenClaw send the API key as `Authorization: Bearer <API_KEY>`, which is required by the public gateway and also works locally. See the [OpenClaw skill](https://github.com/AntSeed/antseed/tree/main/skills/openclaw-antseed) for the complete walkthrough and setup script.
 
-## Define your internet-accessible AntSeed endpoint
+## Connect a remote agent
 
-Use this only when the agent or hosted client cannot reach the VPR locally. Open **Agents** in the desktop app, then configure one tunnel provider under **Define your internet-accessible AntSeed endpoint**.
+When the agent cannot reach the VPR on `localhost`, first create an authenticated endpoint by following the [Public HTTPS Tunnels guide](/docs/guides/public-tunnels). That guide is the canonical reference for ngrok and Cloudflare setup, authentication, supported routes, CLI commands, Cursor, and troubleshooting.
 
-For provider setup, authentication details, supported routes, Cursor configuration, CLI commands, and troubleshooting, follow the unchanged [Public HTTPS Tunnels guide](/docs/guides/public-tunnels).
+After the endpoint starts, replace the local placeholder values in the configuration above with the values shown by the VPR:
 
-The VPR places a small authenticated gateway in front of the buyer API. It does not expose the desktop, the unrestricted local proxy, or port `8377` directly.
-
-:::warning Protect the API key
-Anyone with the public URL and API key can send requests through your VPR and spend its available AntSeed credits. Store the key as a secret, rotate the tunnel configuration if it is exposed, and stop the endpoint when it is not needed.
-:::
-
-### ngrok
-
-Use ngrok for a quick generated endpoint or an ngrok static domain.
-
-1. Install the ngrok CLI and copy your account authtoken.
-2. In **VPR → Agents → ngrok**, paste the authtoken.
-3. Leave **Public hostname** blank for a generated `ngrok-free.dev` URL, or enter your configured static ngrok domain.
-4. Select **Save and start**.
-
-### Cloudflare Tunnel
-
-Use Cloudflare when you want a stable hostname on a domain you control.
-
-1. Create a named tunnel in Cloudflare Zero Trust.
-2. Add a public hostname whose service points to `http://localhost:8379`.
-3. Copy the tunnel's run token.
-4. In **VPR → Agents → Cloudflare Tunnel**, paste the token and public `https://` hostname.
-5. Select **Save and start**.
-
-After the endpoint starts, the VPR displays:
-
-- **OpenAI base URL** — for example, `https://example.ngrok-free.dev/v1`.
-- **API key** — an AntSeed-generated secret beginning with `antseed_`.
-
-Set those exact values on the remote machine:
-
-```bash
-export ANTSEED_BASE_URL="https://your-endpoint.example/v1"
-export ANTSEED_API_KEY="antseed_your_generated_key"
-```
-
-The public gateway requires the key in the standard bearer header:
-
-```http
-Authorization: Bearer antseed_your_generated_key
-```
-
-Do not use the ngrok authtoken or Cloudflare tunnel token as the agent API key. The gateway does not accept `x-api-key`, query parameters, cookies, or a key embedded in the URL.
-
-Use the public values in the Hermes provider's `api` and `api_key` fields or the OpenClaw `baseUrl` and `apiKey` fields shown above. Keep OpenClaw's `authHeader: true` setting.
-
-## Use it with Cursor
-
-In Cursor's model settings:
-
-1. Enable the OpenAI API key option and paste the generated AntSeed API key.
-2. Enable **Override OpenAI Base URL** and paste the complete VPR value ending in `/v1`.
-3. Add or select a model ID returned by `GET /v1/models`.
-4. Run a small request and confirm it appears in the VPR or tunnel logs.
-
-Some Cursor requests originate from Cursor's infrastructure, so `localhost`, private LAN addresses, and hostnames that resolve only on your computer will not work for those flows.
-
-## Supported public routes
-
-The authenticated gateway intentionally allows only these routes:
-
-| Method | Route | Purpose |
+| Agent | Public endpoint field | AntSeed API key field |
 |---|---|---|
-| `GET` | `/v1/models` | List available models and routes |
-| `POST` | `/v1/messages` | Anthropic-compatible messages |
-| `POST` | `/v1/messages/count_tokens` | Anthropic-compatible token-count preflight |
-| `POST` | `/v1/chat/completions` | OpenAI-compatible chat completions |
-| `POST` | `/v1/responses` | OpenAI Responses API |
-| `POST` | `/v1/images/generations` | Image generation |
-| `POST` | `/v1/images/edits` | Image editing |
+| Hermes | `providers.antseed.api` | `providers.antseed.api_key` |
+| OpenClaw | `models.providers.antseed.baseUrl` | `models.providers.antseed.apiKey` |
 
-Other paths return `404 Not Found`. Requests without the exact bearer key return `401 Unauthorized`.
+Use the complete public base URL ending in `/v1`. For OpenClaw, keep `authHeader: true` so it sends the generated AntSeed key as a bearer token.
 
-## CLI endpoint setup
-
-For a headless VPR, start `antseed buyer start` and run the tunnel as a separate process.
-
-```bash
-# ngrok
-export NGROK_AUTHTOKEN="your_ngrok_authtoken"
-export ANTSEED_TUNNEL_API_KEY="antseed_generate_a_long_random_secret"
-antseed tunnel start --provider ngrok
-
-# Cloudflare
-export CLOUDFLARED_TUNNEL_TOKEN="your_named_tunnel_token"
-export ANTSEED_TUNNEL_PUBLIC_URL="https://llm.example.com"
-export ANTSEED_TUNNEL_API_KEY="antseed_generate_a_long_random_secret"
-antseed tunnel start --provider cloudflare
-```
-
-Use `antseed tunnel status` to inspect the active URL and `antseed tunnel stop` to stop it.
-
-## Troubleshooting
-
-### The endpoint receives no request
-
-- Confirm the client uses the complete public base URL ending in `/v1`.
-- Test `GET /v1/models` with `curl` from another network.
-- Confirm public DNS resolves and the selected tunnel is running.
-- Check whether the hosted client blocks free tunnel domains or displays an interstitial page.
-
-### `401 Invalid API key`
-
-- Send `Authorization: Bearer <API_KEY>` exactly.
-- Copy the AntSeed API key from **VPR → Agents**, not the tunnel provider credential.
-- Do not put the key in the URL.
-
-### `404 Not found`
-
-- Use one of the supported routes above.
-- Configure SDKs with the displayed base URL ending in `/v1`.
-- For a raw call, use a path such as `/v1/models` or `/v1/responses`.
-
-### `502 AntSeed buyer proxy is unavailable`
-
-The public endpoint is running, but the local buyer proxy is not accepting requests. Start the VPR router or `antseed buyer start`, then retry.
+For another agent, use its custom OpenAI- or Anthropic-compatible provider settings. See [Using the API](/docs/guides/using-the-api) for request formats and model routing.


### PR DESCRIPTION
## Description

Refocuses the Agents guide on Hermes, OpenClaw, and agent-specific local or remote configuration. Removes repeated tunnel-provider setup, authentication, Cursor, route, CLI, and troubleshooting sections and links to the Public HTTPS Tunnels guide as the canonical reference instead.

## Release Notes

- Simplified the Agents guide and removed duplicated public-tunnel instructions

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected)
- [x] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [ ] Lint and unit tests pass locally with my changes