### PR TITLE
fix(cli): enable ngrok pooling to prevent ERR_NGROK_334

### DIFF
--- a/apps/cli/src/cli/commands/tunnel/start.ts
+++ b/apps/cli/src/cli/commands/tunnel/start.ts
@@ -59,6 +59,7 @@ function ngrokArgs(gatewayPort: number, publicUrl: URL | null): string[] {
     'http',
     `http://127.0.0.1:${gatewayPort}`,
     ...(publicUrl ? ['--url', publicUrl.origin] : []),
+    '--pooling-enabled',
     '--log', 'stdout', '--log-format', 'json', '--log-level', 'info',
   ]
 }


### PR DESCRIPTION
## Problem
When a previous ngrok tunnel session exits without cleanly unregistering the endpoint, ngrok's cloud keeps the endpoint as "already online". Any subsequent attempt to start the tunnel with the same URL fails with:

```
ERR_NGROK_334: The endpoint 'https://...' is already online
```

This leaves users stuck — they can't start the tunnel and the error message doesn't tell them how to fix it.

## Fix
Add `--pooling-enabled` to the ngrok arguments in `tunnel start`. This allows multiple ngrok processes to share the same endpoint URL, making tunnel startup resilient to stale sessions.

## Testing
- Reproduced the stale endpoint scenario manually
- Verified tunnel starts successfully with `--pooling-enabled`
- Confirmed the desktop app can now expose the `/v1` API even when a stale session exists

## Changelog
- CLI: ngrok tunnels now use `--pooling-enabled` to tolerate stale endpoint sessions
