### PR TITLE
nix: build the CLI package with pnpm2nix-nzbr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,11 +122,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
 
-      # First build fetches each dependency tarball individually; keep the
-      # store between runs so lockfile churn only fetches what changed.
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      # Pinned SHA — DeterminateSystems/nix-installer-action @main as of 2026-08-31
+      - uses: DeterminateSystems/nix-installer-action@33c9ab3ef95cd57c164d9d6eb1f9a46338538d41
+
+      # Pinned SHA — DeterminateSystems/magic-nix-cache-action @main as of 2026-08-31
+      - uses: DeterminateSystems/magic-nix-cache-action@55718cd9ebf1737a061487d5ada21abf31e99a98
 
       - name: Build antseed CLI
         run: nix build .#

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,24 @@ jobs:
 
       - name: Typecheck
         run: pnpm run typecheck
+
+  nix-build:
+    name: Nix build (antseed CLI)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      # First build fetches each dependency tarball individually; keep the
+      # store between runs so lockfile churn only fetches what changed.
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Build antseed CLI
+        run: nix build .#
+
+      - name: Smoke test
+        run: |
+          ./result/bin/antseed --version
+          ./result/bin/antseed --help > /dev/null

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,11 @@ pnpm run clean        # Remove all dist/ directories
 `flake.nix` provides a dev shell (`nix develop`) and a buildable CLI package:
 `nix build .#` / `nix run .# -- <args>` produces/runs `antseed` from
 `apps/cli` (esbuild bundle + pinned native prebuilds for better-sqlite3,
-node-datachannel, keytar). The prebuild versions/hashes in `flake.nix` must be
-updated when those dependencies change in `pnpm-lock.yaml`.
+node-datachannel, keytar). Dependencies are fetched per-package via
+pnpm2nix-nzbr using the integrity hashes in `pnpm-lock.yaml`, so lockfile
+changes need no hash updates. The prebuild versions/hashes in `flake.nix` must
+still be updated when better-sqlite3/node-datachannel/keytar change in
+`pnpm-lock.yaml`.
 
 ## Build Order
 Build must respect: node -> provider-core/router-core -> plugins -> dashboard -> cli -> desktop.

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1779508470,
@@ -16,9 +34,46 @@
         "type": "github"
       }
     },
+    "pnpm2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784968304,
+        "narHash": "sha256-NPXKyp40QNCk9r6kavSwqi/zv7OcLgrSRtPmHW+e74w=",
+        "owner": "FliegendeWurst",
+        "repo": "pnpm2nix-nzbr",
+        "rev": "9b15300b711a50bb96e553b66aad5cad94df9c7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "FliegendeWurst",
+        "repo": "pnpm2nix-nzbr",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pnpm2nix": "pnpm2nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,13 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    pnpm2nix = {
+      url = "github:FliegendeWurst/pnpm2nix-nzbr";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, pnpm2nix }:
     let
       systems = [
         "aarch64-darwin"
@@ -93,12 +97,13 @@
 
       packages = forAllSystems (system:
         let
-          pkgs = import nixpkgs { inherit system; };
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ pnpm2nix.overlays.default ];
+          };
           inherit (pkgs) lib stdenv;
 
           nodejs = pkgs.nodejs_22;
-          pnpm = pkgs.pnpm_9;
-          inherit (nodejs) version;
 
           platform = platformInfo.${system};
 
@@ -111,8 +116,6 @@
               hash = info.hashes.${system};
             }
           ) prebuildInfo;
-
-          cliVersion = (lib.importJSON ./apps/cli/package.json).version;
 
           # Modules the bundle needs at runtime that cannot be inlined:
           # the native packages above plus their pure-JS runtime deps.
@@ -127,58 +130,31 @@
           ];
         in
         {
-          default = stdenv.mkDerivation (finalAttrs: {
+          # Built with pnpm2nix (FliegendeWurst/pnpm2nix-nzbr): dependencies
+          # are fetched per-package using the integrity hashes in
+          # pnpm-lock.yaml, so there is no single pnpmDeps hash to keep in
+          # sync when the lockfile changes.
+          default = pkgs.mkPnpmPackage {
             pname = "antseed-cli";
-            version = cliVersion;
+            version = (lib.importJSON ./apps/cli/package.json).version;
 
-            src = lib.cleanSourceWith {
-              src = ./.;
-              filter = path: type:
-                (type != "directory" || baseNameOf path != "node_modules")
-                && lib.cleanSourceFilter path type;
-            };
+            workspace = ./.;
+            components = [ "apps/cli" ];
+            nodejs = nodejs;
+            # pnpm 9: the lockfile is v9.0 and package.json's "pnpm" field
+            # (patchedDependencies) is only read by pnpm < 10.
+            pnpm = pkgs.pnpm_9;
 
-            pnpmDeps = pkgs.fetchPnpmDeps {
-              inherit (finalAttrs) pname version src;
-              inherit pnpm;
-              fetcherVersion = 3;
-              pnpmWorkspaces = [ "@antseed/cli..." ];
-              hash = "sha256-EHNc17gKwWQSrrd/XVzxfnTpdG1IzJ0z2q+8exMYn6c=";
-            };
-
-            pnpmWorkspaces = [ "@antseed/cli..." ];
-
-            nativeBuildInputs = [
-              nodejs
-              pnpm
-              pkgs.pnpmConfigHook
-              pkgs.esbuild
-              pkgs.makeWrapper
-              pkgs.writableTmpDirAsHomeHook
-            ] ++ lib.optionals stdenv.isLinux [
-              pkgs.autoPatchelfHook
-            ];
-
-            # Shared libraries for the prebuilt native binaries (Linux).
-            buildInputs = lib.optionals stdenv.isLinux [
-              pkgs.glib
-              pkgs.libsecret
-              stdenv.cc.cc.lib
-            ];
-
-            buildPhase = ''
-              runHook preBuild
-
-              # pnpm installs with --ignore-scripts, so replicate the install
-              # scripts the build actually depends on.
-
+            # pnpm install runs with --ignore-scripts, so replicate the
+            # install-time bits the build depends on before compiling.
+            preBuild = ''
               # 1. packages/node postinstall: patch ethers type declarations.
               node packages/node/scripts/patch-ethers.js
 
               # 2. Native modules: unpack the pinned prebuilds exactly the way
-              #    prebuild-install would (it checks ./prebuilds/<tarball> first).
-              #    The workspace uses node-linker=hoisted, so packages are real
-              #    directories directly under node_modules/.
+              #    prebuild-install would (it checks ./prebuilds/<tarball>
+              #    first). The workspace uses node-linker=hoisted, so packages
+              #    are real directories directly under node_modules/.
               pi_bin="$(readlink -f node_modules/prebuild-install)/bin.js"
 
               install_prebuild() {
@@ -202,44 +178,62 @@
                 "install_prebuild ${name} ${prebuildTarballs.${name}} ${file} ${lib.optionalString info.napi "-r napi"}"
               ) prebuildInfo)}
 
-              # 3. Type-check/build the workspace packages the CLI depends on.
-              #    The pnpmConfigHook's patchShebangs only covers the root
-              #    node_modules, but pnpm recreates .bin wrapper scripts in
-              #    per-package node_modules whose /usr/bin/env shebangs break
-              #    inside the sandbox — patch those too.
+              # .bin wrapper scripts carry /usr/bin/env shebangs that don't
+              # resolve inside the sandbox.
+              patchShebangs node_modules
               find apps packages plugins -type d -name node_modules | while read -r d; do
                 patchShebangs "$d"
               done
-              #    Native bin wrappers (esbuild) can lose their exec bit in
-              #    the pnpm store, so restore it before vite shells out to them.
               for f in node_modules/@esbuild/*/bin/esbuild node_modules/*/node_modules/@esbuild/*/bin/esbuild; do
                 [ -f "$f" ] && chmod +x "$f"
               done
+            '';
+
+            # Build the CLI's whole workspace subgraph, then bundle it into a
+            # single ESM file; native modules stay external and are shipped
+            # alongside (same as build:bundle). ESM output breaks CJS deps
+            # that call require(); the banner shims it.
+            scriptFull = ''
               pnpm --filter='@antseed/cli...' run build
 
-              # 4. Bundle the CLI into a single ESM file; native modules stay
-              #    external and are shipped alongside (same as build:bundle).
-              # ESM output breaks CJS deps that call require(); shim it.
+              mkdir -p apps/cli/dist
               esbuild apps/cli/src/cli/index.ts \
                 --bundle --platform=node --format=esm \
                 --outfile=apps/cli/dist/bundle.mjs \
                 --external:better-sqlite3 --external:node-datachannel \
                 --external:koffi --external:keytar \
                 '--banner:js=import { createRequire as __antseedCreateRequire } from "node:module"; var require = __antseedCreateRequire(import.meta.url);'
-
-              runHook postBuild
             '';
 
-            installPhase = ''
-              runHook preInstall
+            # Only the bundle and the dashboard assets are packaged; the final
+            # layout is assembled in postInstall.
+            distDirs = [
+              "apps/cli/dist"
+              "apps/payments/dist/web"
+            ];
 
+            extraNativeBuildInputs = [
+              pkgs.esbuild
+              pkgs.makeWrapper
+            ] ++ lib.optionals stdenv.isLinux [
+              pkgs.autoPatchelfHook
+            ];
+
+            # Shared libraries for the prebuilt native binaries (Linux).
+            extraBuildInputs = lib.optionals stdenv.isLinux [
+              pkgs.glib
+              pkgs.libsecret
+              stdenv.cc.cc.lib
+            ];
+
+            postInstall = ''
               mkdir -p "$out/libexec/antseed/node_modules" "$out/bin"
 
-              cp apps/cli/dist/bundle.mjs "$out/libexec/antseed/"
-
+              mv "$out/apps/cli/dist/bundle.mjs" "$out/libexec/antseed/"
               # Web dashboard assets; @antseed/payments resolves ./web relative
               # to import.meta.url, which is the bundle's directory once built.
-              cp -r apps/payments/dist/web "$out/libexec/antseed/web"
+              mv "$out/apps/payments/dist/web" "$out/libexec/antseed/web"
+              rm -rf "$out/apps"
 
               for pkg in ${lib.concatStringsSep " " runtimeNodeModules}; do
                 if [ -e "node_modules/$pkg" ]; then
@@ -259,8 +253,6 @@
               makeWrapper ${nodejs}/bin/node "$out/bin/antseed" \
                 --add-flags "$out/libexec/antseed/bundle.mjs" \
                 --prefix PATH : ${lib.makeBinPath [ nodejs ]}
-
-              runHook postInstall
             '';
 
             meta = {
@@ -270,7 +262,7 @@
               mainProgram = "antseed";
               platforms = systems;
             };
-          });
+          };
         });
 
       apps = forAllSystems (system: {


### PR DESCRIPTION
## Why

The prevous in nix package I submitted has the problem that whenever the lockfile changes we need to bump the hash in the package definition. 

## What

This gets around that by replacing fetchPnpmDeps + pnpmConfigHook with mkPnpmPackage from [FliegendeWurst/pnpm2nix-nzbr](https://github.com/FliegendeWurst/pnpm2nix-nzbr). Dependencies are fetched per-package using the integrity hashes in pnpm-lock.yaml (seeded into the pnpm store via pnpm store add), so pnpm-lock.yaml changes no longer require updating a fixed-output hash in flake.nix. The  down side is that the package is slower to build but it was not too noticeable to me.


