### PR TITLE
feat(download-proxy): Retain logs and tag bot traffic

### DIFF
--- a/apps/download-proxy/src/events.test.ts
+++ b/apps/download-proxy/src/events.test.ts
@@ -8,6 +8,8 @@ const ctx: DownloadContext = {
   country: 'DE',
   partial: false,
   totalBytes: 200_000_000,
+  userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)',
+  botCategory: null,
 };
 
 describe('download events', () => {
@@ -45,6 +47,20 @@ describe('download events', () => {
   it('marks range responses as partial', () => {
     const event = startEvent({...ctx, partial: true});
     expect(event.params['partial']).toBe(1);
+  });
+
+  it('truncates the user agent to the GA4 param limit and tags verified bots', () => {
+    const longUa = 'x'.repeat(300);
+    const event = startEvent({...ctx, userAgent: longUa, botCategory: 'Search Engine Crawler'});
+    expect((event.params['user_agent'] as string).length).toBe(100);
+    expect(event.params['bot_category']).toBe('Search Engine Crawler');
+
+    const human = startEvent(ctx);
+    expect(human.params['user_agent']).toBe(ctx.userAgent);
+    expect(human.params['bot_category']).toBeUndefined();
+
+    const empty = startEvent({...ctx, userAgent: ''});
+    expect(empty.params['user_agent']).toBe('unknown');
   });
 
   it('builds unresolved events with a reason', () => {

--- a/apps/download-proxy/src/events.ts
+++ b/apps/download-proxy/src/events.ts
@@ -32,6 +32,10 @@ export interface DownloadContext {
   country: string;
   partial: boolean;
   totalBytes: number | null;
+  /** Client User-Agent — separates real browsers from bots and scripts. */
+  userAgent: string;
+  /** Cloudflare's verified-bot category (e.g. "Search Engine Crawler"), or null. */
+  botCategory: string | null;
 }
 
 function baseParams(ctx: DownloadContext): Record<string, string | number> {
@@ -42,7 +46,13 @@ function baseParams(ctx: DownloadContext): Record<string, string | number> {
     release_tag: ctx.tag ?? 'unknown',
     country: ctx.country,
     partial: ctx.partial ? 1 : 0,
+    // GA4 Measurement Protocol caps param values at 100 chars; a truncated
+    // UA still identifies the client family.
+    user_agent: ctx.userAgent.slice(0, 100) || 'unknown',
   };
+  if (ctx.botCategory) {
+    params['bot_category'] = ctx.botCategory;
+  }
   if (ctx.totalBytes !== null) {
     params['total_bytes'] = ctx.totalBytes;
   }

--- a/apps/download-proxy/src/index.ts
+++ b/apps/download-proxy/src/index.ts
@@ -120,6 +120,8 @@ export default {
       country: (request.cf?.country as string | undefined) ?? 'unknown',
       partial: origin.status === 206,
       totalBytes: contentLength ?? asset.size,
+      userAgent: request.headers.get('user-agent') ?? '',
+      botCategory: (request.cf?.verifiedBotCategory as string | undefined) || null,
     };
 
     emit(env, ctx, startEvent(downloadCtx));

--- a/apps/download-proxy/wrangler.toml
+++ b/apps/download-proxy/wrangler.toml
@@ -2,6 +2,12 @@ name = "antseed-download-proxy"
 main = "src/index.ts"
 compatibility_date = "2026-08-01"
 
+# Retain per-request logs (the JSON telemetry lines from events.ts) in
+# Workers Logs, queryable from the dashboard — without this, logs exist only
+# while someone runs `wrangler tail`.
+[observability]
+enabled = true
+
 # download.antseed.com must be a zone (or subdomain of a zone) on the same
 # Cloudflare account. Remove this block to deploy on the workers.dev subdomain
 # while DNS is being set up.


### PR DESCRIPTION
## Description

Follow-up to #947, driven by the first day of live data: hour-0 today showed 31 `download_started` / 18 full 266MB completions against 12 page views and 1 CTA click — near-certainly bot traffic (CT-log scanners find new subdomains fast, and crawlers that render the site see the download hrefs). The events couldn't be attributed because the worker kept no logs beyond `wrangler tail` and sent no client identity.

Changes:
- **Workers observability enabled** (`wrangler.toml`): per-request telemetry log lines are now retained and queryable in the Cloudflare dashboard.
- **`user_agent` param** on all download events (truncated to GA4's 100-char param value limit, `unknown` when absent).
- **`bot_category` param** from Cloudflare's `verifiedBotCategory` when present, so verified crawlers are filterable in GA4 directly.

Already deployed and verified live (`user_agent` confirmed flowing on real events).

No user-facing behavior change — telemetry/ops only, so no CHANGELOG entry.

## Test plan
- `pnpm --filter @antseed/download-proxy test` — 16 tests, including UA truncation / bot tagging / unknown-UA fallback
- `pnpm --filter @antseed/download-proxy typecheck`
- Live verification: tailed the deployed worker and confirmed `user_agent` + `country` on download_started/aborted events