### PR TITLE
feat(website): Add all-platforms download modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- Website download buttons now offer an "All platforms & versions" link that opens a modal listing every installer (macOS Apple Silicon/Intel, Windows x64, Linux AppImage x86_64/ARM64) as direct `download.antseed.com` links, with older versions and `.deb` packages linked to the GitHub releases page. This gives visitors whose OS was detected wrong — privacy browsers that spoof a Windows user agent on Linux, for example — a way to pick the right installer without leaving the page.
 - Desktop installer downloads from the website now go through `download.antseed.com` (a new Cloudflare Worker, `apps/download-proxy`) instead of linking GitHub release assets directly. The proxy resolves the latest release server-side — so download buttons have a direct per-platform URL without any client-side GitHub API call — streams the installer, and reports download started/completed/aborted telemetry to GA4 alongside the existing `download_vpr` click event, giving full click → download-finished funnel visibility. Website-driven downloads are now also cleanly separated from electron-updater traffic, which keeps fetching from GitHub directly. Unresolvable requests (unknown platform, partial releases) fall back to the GitHub releases page as before.
 
 ### Fixed

--- a/apps/website/src/css/custom.css
+++ b/apps/website/src/css/custom.css
@@ -1753,6 +1753,15 @@ html[data-theme='light'] .blog-wrapper .pagination-nav__link:hover {
   font-weight: 400;
   color: var(--as-text-3);
 }
+.vprVersionsDetected {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--as-green-deep);
+  background: rgba(16, 185, 129, 0.12);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
 .vprVersionsFooter {
   display: block;
   text-align: center;

--- a/apps/website/src/css/custom.css
+++ b/apps/website/src/css/custom.css
@@ -1683,6 +1683,8 @@ html[data-theme='light'] .blog-wrapper .pagination-nav__link:hover {
   padding: 24px;
 }
 .vprVersionsModal {
+  /* The trigger sits in centered CTA blocks — don't inherit their alignment. */
+  text-align: left;
   background: #FFFEFB;
   color: var(--as-text);
   border-radius: 16px;
@@ -1753,6 +1755,7 @@ html[data-theme='light'] .blog-wrapper .pagination-nav__link:hover {
 }
 .vprVersionsFooter {
   display: block;
+  text-align: center;
   margin-top: 12px;
   padding-top: 12px;
   border-top: 1px solid rgba(0, 30, 18, 0.08);

--- a/apps/website/src/css/custom.css
+++ b/apps/website/src/css/custom.css
@@ -1646,6 +1646,125 @@ html[data-theme='light'] .blog-wrapper .pagination-nav__link:hover {
 
 @keyframes downloadSpin { to { transform: rotate(360deg); } }
 
+/* "All platforms & versions" — text-link trigger under download CTAs plus
+   the modal it opens (AllVersionsLink.tsx). The modal commits to the site's
+   light card look on every page, including dark closing bands. */
+.vprAllVersions {
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 500;
+  color: var(--as-text-3);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+.vprAllVersions:hover {
+  color: var(--as-green-deep);
+}
+.vprAllVersionsLight {
+  color: rgba(255, 255, 255, 0.75);
+}
+.vprAllVersionsLight:hover {
+  color: #FFFFFF;
+}
+
+.vprVersionsOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(0, 30, 18, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.vprVersionsModal {
+  background: #FFFEFB;
+  color: var(--as-text);
+  border-radius: 16px;
+  box-shadow: 0 24px 64px rgba(0, 30, 18, 0.25);
+  width: 100%;
+  max-width: 420px;
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  padding: 20px;
+}
+.vprVersionsHead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.vprVersionsTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--as-text);
+}
+.vprVersionsClose {
+  margin-left: auto;
+  background: none;
+  border: none;
+  padding: 0 4px;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--as-text-3);
+  cursor: pointer;
+}
+.vprVersionsClose:hover {
+  color: var(--as-text);
+}
+.vprVersionsList {
+  display: flex;
+  flex-direction: column;
+}
+.vprVersionsRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 8px;
+  border-radius: 10px;
+  color: var(--as-text);
+  text-decoration: none;
+}
+.vprVersionsRow:hover {
+  background: rgba(16, 185, 129, 0.08);
+  color: var(--as-text);
+  text-decoration: none;
+}
+.vprVersionsIcon {
+  display: inline-flex;
+  color: var(--as-text);
+}
+.vprVersionsName {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 18px;
+}
+.vprVersionsSub {
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--as-text-3);
+}
+.vprVersionsFooter {
+  display: block;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(0, 30, 18, 0.08);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--as-text-3);
+}
+.vprVersionsFooter:hover {
+  color: var(--as-green-deep);
+  text-decoration: none;
+}
+
 @media (max-width: 640px) {
   .vprLabelDesktop {
     display: none;
@@ -1658,5 +1777,10 @@ html[data-theme='light'] .blog-wrapper .pagination-nav__link:hover {
   }
   .vprBtn {
     padding-left: 20px !important;
+  }
+  /* Phone CTAs read "Get Started" and reroute — a desktop-installer list
+     below them would be noise. */
+  .vprAllVersions {
+    display: none;
   }
 }

--- a/apps/website/src/lib/AllVersionsLink.tsx
+++ b/apps/website/src/lib/AllVersionsLink.tsx
@@ -1,5 +1,7 @@
 import React, {useCallback, useEffect, useState} from 'react';
+import {createPortal} from 'react-dom';
 import {DesktopDownloadIcon} from './DesktopDownloadIcon';
+import {LinuxIcon} from '../components/ui';
 import {
   ALL_VERSIONS_URL,
   DOWNLOAD_BASE_URL,
@@ -51,7 +53,12 @@ function AllVersionsModal({onClose}: {onClose: () => void}) {
     };
   }, [onClose]);
 
-  return (
+  // Portal to <body>: the CTA blocks sit inside Reveal wrappers whose
+  // `will-change: transform` makes them the containing block for
+  // position:fixed descendants — rendered in place, the overlay anchors to
+  // the wrong box and the card lands off-screen. Only mounted after a click,
+  // so document.body is always available (no SSR concern).
+  return createPortal(
     <div className="vprVersionsOverlay" onClick={onClose} role="presentation">
       <div
         className="vprVersionsModal"
@@ -74,7 +81,12 @@ function AllVersionsModal({onClose}: {onClose: () => void}) {
               href={`${DOWNLOAD_BASE_URL}/vpr/${row.target}`}
             >
               <span className="vprVersionsIcon">
-                <DesktopDownloadIcon platform={row.platform} size={20} />
+                {/* DesktopDownloadIcon has no Tux — reuse the CTA button's. */}
+                {row.platform === 'linux' ? (
+                  <LinuxIcon />
+                ) : (
+                  <DesktopDownloadIcon platform={row.platform} size={20} />
+                )}
               </span>
               <span className="vprVersionsName">
                 {row.label}
@@ -83,11 +95,17 @@ function AllVersionsModal({onClose}: {onClose: () => void}) {
             </a>
           ))}
         </div>
-        <a className="vprVersionsFooter" href={ALL_VERSIONS_URL}>
+        <a
+          className="vprVersionsFooter"
+          href={ALL_VERSIONS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Older versions &amp; .deb packages →
         </a>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }
 

--- a/apps/website/src/lib/AllVersionsLink.tsx
+++ b/apps/website/src/lib/AllVersionsLink.tsx
@@ -5,6 +5,7 @@ import {LinuxIcon} from '../components/ui';
 import {
   ALL_VERSIONS_URL,
   DOWNLOAD_BASE_URL,
+  useLatestDesktopDownload,
   type DesktopPlatform,
 } from './useLatestDesktopDownload';
 
@@ -40,6 +41,12 @@ const TARGET_ROWS: TargetRow[] = [
 ];
 
 function AllVersionsModal({onClose}: {onClose: () => void}) {
+  // Badge the row matching the visitor's detected OS/arch — the same
+  // detection the main CTA uses, so a wrong guess (UA-spoofing privacy
+  // browser) is visible at a glance and explains what the button would do.
+  const {platform, arch} = useLatestDesktopDownload();
+  const detectedTarget = platform === 'unknown' ? null : `${platform}-${arch}`;
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
@@ -92,6 +99,9 @@ function AllVersionsModal({onClose}: {onClose: () => void}) {
                 {row.label}
                 <span className="vprVersionsSub">{row.sub}</span>
               </span>
+              {row.target === detectedTarget && (
+                <span className="vprVersionsDetected">Detected</span>
+              )}
             </a>
           ))}
         </div>

--- a/apps/website/src/lib/AllVersionsLink.tsx
+++ b/apps/website/src/lib/AllVersionsLink.tsx
@@ -1,0 +1,109 @@
+import React, {useCallback, useEffect, useState} from 'react';
+import {DesktopDownloadIcon} from './DesktopDownloadIcon';
+import {
+  ALL_VERSIONS_URL,
+  DOWNLOAD_BASE_URL,
+  type DesktopPlatform,
+} from './useLatestDesktopDownload';
+
+/**
+ * "All platforms & versions" — an escape hatch under the download CTAs for
+ * visitors whose platform detection guessed wrong (privacy browsers spoof a
+ * Windows UA on Linux, so the CTA offers the .exe) or who want a different
+ * installer. Opens a modal listing every installer as download.antseed.com
+ * links, so these downloads carry the same started/completed telemetry as
+ * the main CTA.
+ *
+ * The list is hardcoded: the proxy always resolves /vpr/<target> to the
+ * latest release server-side, so the links never go stale, and a target
+ * missing from a partial release 302s to the GitHub releases page rather
+ * than 404ing. Older versions and .deb packages stay on the GitHub releases
+ * page, linked in the modal footer. Hidden on phone viewports, where the
+ * CTAs become "Get Started".
+ */
+
+interface TargetRow {
+  target: string;
+  platform: DesktopPlatform;
+  label: string;
+  sub: string;
+}
+
+const TARGET_ROWS: TargetRow[] = [
+  {target: 'mac-arm64', platform: 'mac', label: 'macOS', sub: 'Apple Silicon'},
+  {target: 'mac-x64', platform: 'mac', label: 'macOS', sub: 'Intel'},
+  {target: 'win-x64', platform: 'win', label: 'Windows', sub: 'x64 installer'},
+  {target: 'linux-x64', platform: 'linux', label: 'Linux', sub: 'AppImage · x86_64'},
+  {target: 'linux-arm64', platform: 'linux', label: 'Linux', sub: 'AppImage · ARM64'},
+];
+
+function AllVersionsModal({onClose}: {onClose: () => void}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [onClose]);
+
+  return (
+    <div className="vprVersionsOverlay" onClick={onClose} role="presentation">
+      <div
+        className="vprVersionsModal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="All download versions"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="vprVersionsHead">
+          <span className="vprVersionsTitle">Download AntSeed VPR</span>
+          <button className="vprVersionsClose" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+        <div className="vprVersionsList">
+          {TARGET_ROWS.map(row => (
+            <a
+              key={row.target}
+              className="vprVersionsRow"
+              href={`${DOWNLOAD_BASE_URL}/vpr/${row.target}`}
+            >
+              <span className="vprVersionsIcon">
+                <DesktopDownloadIcon platform={row.platform} size={20} />
+              </span>
+              <span className="vprVersionsName">
+                {row.label}
+                <span className="vprVersionsSub">{row.sub}</span>
+              </span>
+            </a>
+          ))}
+        </div>
+        <a className="vprVersionsFooter" href={ALL_VERSIONS_URL}>
+          Older versions &amp; .deb packages →
+        </a>
+      </div>
+    </div>
+  );
+}
+
+export function AllVersionsLink({light}: {light?: boolean}) {
+  const [open, setOpen] = useState(false);
+  const close = useCallback(() => setOpen(false), []);
+  return (
+    <>
+      <button
+        type="button"
+        className={`vprAllVersions${light ? ' vprAllVersionsLight' : ''}`}
+        onClick={() => setOpen(true)}
+      >
+        All platforms &amp; versions
+      </button>
+      {open && <AllVersionsModal onClose={close} />}
+    </>
+  );
+}

--- a/apps/website/src/lib/analytics.ts
+++ b/apps/website/src/lib/analytics.ts
@@ -28,14 +28,17 @@ export function track(event: string, params: Record<string, unknown> = {}): void
 
 /**
  * Any link that points at our download proxy (download.antseed.com, see
- * apps/download-proxy) or GitHub releases counts as a VPR download — the
- * proxy URL is the normal per-platform CTA target, and the releases-page
- * fallback is what `useLatestDesktopDownload` returns when detection fails.
+ * apps/download-proxy), a release asset, or the latest-release fallback
+ * counts as a VPR download — the proxy URL is the normal per-platform CTA
+ * target, and /releases/latest is what `useLatestDesktopDownload` returns
+ * when detection fails. The bare /releases list (the "all platforms &
+ * versions" escape hatch) is deliberately excluded: browsing versions is not
+ * a download conversion, and it tracks as a plain outbound click.
  */
 export function isDownloadUrl(href: string): boolean {
   return (
     /^https?:\/\/download\.antseed\.com(\/|$)/i.test(href) ||
-    /^https?:\/\/(www\.)?github\.com\/AntSeed\/antseed\/releases(\/|$)/i.test(href)
+    /^https?:\/\/(www\.)?github\.com\/AntSeed\/antseed\/releases\/(latest|download)(\/|$)/i.test(href)
   );
 }
 

--- a/apps/website/src/lib/useLatestDesktopDownload.ts
+++ b/apps/website/src/lib/useLatestDesktopDownload.ts
@@ -36,6 +36,8 @@ import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 export const DOWNLOAD_BASE_URL = 'https://download.antseed.com';
 export const RELEASES_URL = 'https://github.com/AntSeed/antseed/releases/latest';
+/** Full releases list — every platform, arch, and past version. */
+export const ALL_VERSIONS_URL = 'https://github.com/AntSeed/antseed/releases';
 
 export type DesktopPlatform = 'mac' | 'win' | 'linux' | 'unknown';
 export type DesktopArch = 'arm64' | 'x64';

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -440,8 +440,8 @@ function DownloadCta({caption, size = 'lg'}: {caption?: string; size?: 'md' | 'l
         <span className="vprLabelDesktop">Download VPR</span>
         <span className="vprLabelMobile">Get Started<ArrowRight /></span>
       </Button>
-      {caption && <span className={styles.ctaCaption}>{caption}</span>}
       <AllVersionsLink />
+      {caption && <span className={styles.ctaCaption}>{caption}</span>}
     </div>
   );
 }
@@ -1315,8 +1315,8 @@ function FinalCta() {
         <p className={styles.finalSub}>Every Model, No Middleman. Anonymous and Always On.</p>
         <div className={styles.ctaBlock}>
           <FinalCtaButton />
-          <span className={styles.ctaCaptionLight}>No account needed. Just start.</span>
           <AllVersionsLink light />
+          <span className={styles.ctaCaptionLight}>No account needed. Just start.</span>
         </div>
       </Reveal>
     </section>

--- a/apps/website/src/pages/index.tsx
+++ b/apps/website/src/pages/index.tsx
@@ -5,6 +5,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import styles from './index.module.css';
 import {useLatestDesktopDownload} from '../lib/useLatestDesktopDownload';
+import {AllVersionsLink} from '../lib/AllVersionsLink';
 import {useMobileGetStarted} from '../lib/useMobileGetStarted';
 import {useNetworkStats} from '../lib/useNetworkStats';
 import {useMarketplaceShowcase} from '../lib/useMarketplacePrices';
@@ -440,6 +441,7 @@ function DownloadCta({caption, size = 'lg'}: {caption?: string; size?: 'md' | 'l
         <span className="vprLabelMobile">Get Started<ArrowRight /></span>
       </Button>
       {caption && <span className={styles.ctaCaption}>{caption}</span>}
+      <AllVersionsLink />
     </div>
   );
 }
@@ -1314,6 +1316,7 @@ function FinalCta() {
         <div className={styles.ctaBlock}>
           <FinalCtaButton />
           <span className={styles.ctaCaptionLight}>No account needed. Just start.</span>
+          <AllVersionsLink light />
         </div>
       </Reveal>
     </section>


### PR DESCRIPTION
## Description

A Linux user was served the Windows installer: privacy-hardened browsers (e.g. Firefox with `resistFingerprinting`) spoof a Windows user agent, so platform detection picks the `.exe` and there was no visible way to choose another installer.

This adds an **"All platforms & versions"** text link under the homepage download CTAs (hero, mid-page CTA, and the closing band — with a light variant for the dark background) that opens a modal listing every installer with OS icons:

- macOS — Apple Silicon / Intel (`.dmg`)
- Windows — x64 installer (`.exe`)
- Linux — AppImage x86_64 / ARM64

All rows are direct `download.antseed.com/vpr/<target>` links, so downloads from the modal carry the same started/completed/aborted telemetry as the main CTA. The list is hardcoded — the proxy resolves "latest" server-side, so the links never go stale, and a target missing from a partial release 302s to the releases page rather than 404ing. The modal footer links **older versions & .deb packages** to the GitHub releases page.

Analytics change: the bare `/releases` list URL no longer counts as a `download_vpr` conversion (browsing versions isn't a download — it now tracks as an outbound click); `/releases/latest` and release asset URLs still count. The modal trigger is hidden on phone viewports, where the CTAs become "Get Started".

No worker changes — the proxy is untouched.

## Changelog

Updated `CHANGELOG.md` (Unreleased → Added).

## Test plan
- Website typecheck and production build pass
- Modal behavior: opens from trigger, closes on backdrop click / × / Escape, body scroll locked while open
- Links verified against the live proxy earlier today (all five targets serve the correct installers)