### PR TITLE
chore: Bump versions for npm release

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.155",
+  "version": "0.1.156",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Description

Version bumps for the next npm release. The \`Publish npm packages\` workflow publishes exactly the packages whose version is not on the registry.

## Bumped

**Changed directly**

- \`@antseed/cli\` 0.1.155 → 0.1.156 — buyer proxy now fails over to the next seller on relayed upstream 401/403 auth failures (#957); Droid integration + duplicate-conversation/title-helper fixes; Cursor chat identification and tunnel persistence; ngrok endpoint pooling fix (ERR_NGROK_334); Claude Desktop third-party gateway support (#954).

**Cascade (exact pins)**

- None — nothing publishable pins \`@antseed/cli\`.

**Skipped** (no runtime changes since their last release): \`@antseed/node\`, \`@antseed/protocol\`, \`@antseed/buyer-core\`, \`@antseed/api-adapter\`, \`@antseed/ant-agent\`, \`@antseed/provider-core\`, \`@antseed/router-core\`, \`@antseed/web-sdk\`, all provider/router plugins, \`@antseed/network-stats\`, \`@antseed/payments\`, \`@antseed/relay\`.

## Validation

\`node scripts/npm-publish-plan.mjs\` passes: \`@antseed/cli 0.1.156\` is the only PUBLISH row against main, no cascade violations, no local version behind npm latest.

No user-facing behavior change in this PR itself (version metadata only); the released changes are covered by the existing Unreleased changelog entries.

After merge: trigger Actions → \`Publish npm packages\` on \`main\` (optionally \`dry_run\` first).