### PR TITLE
feat(website): Attribute proxy downloads to GA sessions

### DIFF
--- a/apps/download-proxy/README.md
+++ b/apps/download-proxy/README.md
@@ -45,7 +45,15 @@ resumed byte ranges. The transfer runs through workerd's native pipe (a JS
 per-chunk pump would exceed the Workers CPU limit on installer-sized files),
 so per-chunk byte counting isn't possible: `download_completed` implies the
 full `total_bytes` were delivered (enforced by `FixedLengthStream`), while
-`download_aborted` delivered an unknown prefix and carries only `duration_ms`. Each proxy event uses a random Measurement Protocol
+`download_aborted` delivered an unknown prefix and carries only `duration_ms`.
+
+Session attribution: the website's click handler appends the visitor's GA
+ids to proxy links (`?cid=<_ga client id>&sid=<session id>`), and the worker
+sends events under that `client_id`/`session_id` — so downloads land inside
+the visitor's GA4 session and inherit source/campaign/landing-page. Ids are
+strictly validated (digits-and-dot shapes only) and dropped otherwise.
+Direct or shared links without ids still count, under a random client_id
+with `attributed: 0` in the console line. Each proxy event uses a random Measurement Protocol
 `client_id`, so GA4 sees them as standalone hits (fine for counting; joining
 to the website session would require passing the GA client id on the URL).
 

--- a/apps/download-proxy/src/events.test.ts
+++ b/apps/download-proxy/src/events.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {endEvent, startEvent, unresolvedEvent, type DownloadContext} from './events';
+import {endEvent, parseGaIds, startEvent, unresolvedEvent, type DownloadContext} from './events';
 
 const ctx: DownloadContext = {
   target: {platform: 'mac', arch: 'arm64'},
@@ -61,6 +61,17 @@ describe('download events', () => {
 
     const empty = startEvent({...ctx, userAgent: ''});
     expect(empty.params['user_agent']).toBe('unknown');
+  });
+
+  it('accepts well-formed GA attribution ids and rejects garbage', () => {
+    const good = parseGaIds(new URLSearchParams('cid=1234567890.1699999999&sid=1756223000'));
+    expect(good).toEqual({clientId: '1234567890.1699999999', sessionId: '1756223000'});
+
+    expect(parseGaIds(new URLSearchParams(''))).toEqual({clientId: null, sessionId: null});
+    expect(parseGaIds(new URLSearchParams('cid=GA1.1.123.456')).clientId).toBeNull();
+    expect(parseGaIds(new URLSearchParams('cid=<script>alert(1)</script>')).clientId).toBeNull();
+    expect(parseGaIds(new URLSearchParams('sid=abc')).sessionId).toBeNull();
+    expect(parseGaIds(new URLSearchParams('cid=123.456&sid=99')).clientId).toBeNull();
   });
 
   it('builds unresolved events with a reason', () => {

--- a/apps/download-proxy/src/events.ts
+++ b/apps/download-proxy/src/events.ts
@@ -95,25 +95,57 @@ export function unresolvedEvent(
 
 const GA4_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
 
+const GA_CLIENT_ID_RE = /^\d{5,15}\.\d{5,15}$/;
+const GA_SESSION_ID_RE = /^\d{8,12}$/;
+
+export interface GaIds {
+  clientId: string | null;
+  sessionId: string | null;
+}
+
 /**
- * Fire-and-forget delivery: console line always, GA4 when configured. The
- * Measurement Protocol requires a client_id; a random UUID per request means
- * each download appears as its own GA4 "user", which is fine for funnel
- * counting (joining to the website session is a possible later refinement by
- * passing the GA client id as a query param on the download URL).
+ * GA attribution ids the website appends to download URLs (?cid=...&sid=...),
+ * read from the visitor's first-party _ga cookies. Strictly validated — these
+ * arrive on a public URL, and anything malformed is dropped rather than
+ * forwarded to GA.
  */
-export async function deliverEvent(
-  event: DownloadEvent,
-  measurementId: string | undefined,
-  apiSecret: string | undefined,
-): Promise<void> {
-  console.log(JSON.stringify({event: event.name, ...event.params}));
-  if (!measurementId || !apiSecret) return;
+export function parseGaIds(params: URLSearchParams): GaIds {
+  const cid = params.get('cid');
+  const sid = params.get('sid');
+  return {
+    clientId: cid && GA_CLIENT_ID_RE.test(cid) ? cid : null,
+    sessionId: sid && GA_SESSION_ID_RE.test(sid) ? sid : null,
+  };
+}
+
+export interface Ga4Delivery {
+  measurementId?: string;
+  apiSecret?: string;
+  ids?: GaIds;
+}
+
+/**
+ * Fire-and-forget delivery: console line always, GA4 when configured. When
+ * the website passed the visitor's GA client id (see parseGaIds), the event
+ * is sent under that client_id — and session_id — so it lands inside the
+ * same GA4 user and session as the download_vpr click, inheriting source,
+ * campaign, and landing page. Without it (direct links, shared URLs), a
+ * random UUID keeps the event countable but unattributed.
+ */
+export async function deliverEvent(event: DownloadEvent, ga: Ga4Delivery): Promise<void> {
+  console.log(JSON.stringify({event: event.name, ...event.params, attributed: ga.ids?.clientId ? 1 : 0}));
+  if (!ga.measurementId || !ga.apiSecret) return;
+  const params = ga.ids?.sessionId
+    ? {...event.params, session_id: Number(ga.ids.sessionId)}
+    : event.params;
   const url =
-    `${GA4_ENDPOINT}?measurement_id=${encodeURIComponent(measurementId)}` +
-    `&api_secret=${encodeURIComponent(apiSecret)}`;
+    `${GA4_ENDPOINT}?measurement_id=${encodeURIComponent(ga.measurementId)}` +
+    `&api_secret=${encodeURIComponent(ga.apiSecret)}`;
   await fetch(url, {
     method: 'POST',
-    body: JSON.stringify({client_id: crypto.randomUUID(), events: [event]}),
+    body: JSON.stringify({
+      client_id: ga.ids?.clientId ?? crypto.randomUUID(),
+      events: [{name: event.name, params}],
+    }),
   }).catch(() => {});
 }

--- a/apps/download-proxy/src/index.ts
+++ b/apps/download-proxy/src/index.ts
@@ -26,10 +26,12 @@ import {trackedStream} from './stream';
 import {
   deliverEvent,
   endEvent,
+  parseGaIds,
   startEvent,
   unresolvedEvent,
   type DownloadContext,
   type DownloadEvent,
+  type GaIds,
 } from './events';
 
 export interface Env {
@@ -48,8 +50,14 @@ const PASSTHROUGH_HEADERS = [
   'accept-ranges',
 ];
 
-function emit(env: Env, ctx: ExecutionContext, event: DownloadEvent): void {
-  ctx.waitUntil(deliverEvent(event, env.GA4_MEASUREMENT_ID, env.GA4_API_SECRET));
+function emit(env: Env, ctx: ExecutionContext, event: DownloadEvent, ids?: GaIds): void {
+  ctx.waitUntil(
+    deliverEvent(event, {
+      measurementId: env.GA4_MEASUREMENT_ID,
+      apiSecret: env.GA4_API_SECRET,
+      ids,
+    }),
+  );
 }
 
 export default {
@@ -71,6 +79,9 @@ export default {
     if (!target) {
       return Response.redirect(releasesUrl, 302);
     }
+    // GA attribution ids appended by the website's click handler — joins the
+    // proxy's server-side events to the visitor's GA session (see events.ts).
+    const gaIds = parseGaIds(url.searchParams);
 
     const release = await getLatestRelease(env.GITHUB_REPO, env.GITHUB_TOKEN, ctx);
     const asset = release ? matchAsset(release.assets, target) : null;
@@ -79,6 +90,7 @@ export default {
         env,
         ctx,
         unresolvedEvent(target, release?.tag ?? null, release ? 'no_matching_asset' : 'release_lookup_failed'),
+        gaIds,
       );
       return Response.redirect(releasesUrl, 302);
     }
@@ -90,7 +102,7 @@ export default {
       redirect: 'follow',
     });
     if (origin.status !== 200 && origin.status !== 206) {
-      emit(env, ctx, unresolvedEvent(target, release?.tag ?? null, `origin_status_${origin.status}`));
+      emit(env, ctx, unresolvedEvent(target, release?.tag ?? null, `origin_status_${origin.status}`), gaIds);
       return Response.redirect(releasesUrl, 302);
     }
 
@@ -124,11 +136,15 @@ export default {
       botCategory: (request.cf?.verifiedBotCategory as string | undefined) || null,
     };
 
-    emit(env, ctx, startEvent(downloadCtx));
+    emit(env, ctx, startEvent(downloadCtx), gaIds);
     const {readable, done} = trackedStream(origin.body, contentLength);
     ctx.waitUntil(
       done.then(result =>
-        deliverEvent(endEvent(downloadCtx, result), env.GA4_MEASUREMENT_ID, env.GA4_API_SECRET),
+        deliverEvent(endEvent(downloadCtx, result), {
+          measurementId: env.GA4_MEASUREMENT_ID,
+          apiSecret: env.GA4_API_SECRET,
+          ids: gaIds,
+        }),
       ),
     );
     return new Response(readable, {status: origin.status, headers});

--- a/apps/website/src/lib/analytics.ts
+++ b/apps/website/src/lib/analytics.ts
@@ -11,6 +11,8 @@
  * loaded here.
  */
 
+import {DOWNLOAD_BASE_URL} from './useLatestDesktopDownload';
+
 type DataLayerEvent = Record<string, unknown> & {event: string};
 
 declare global {
@@ -57,6 +59,60 @@ export function platformFromUrl(href: string): string {
   if (/\.(exe|msi)(\?|$)/i.test(href)) return 'win';
   if (/\.(appimage|deb|rpm|tar\.gz)(\?|$)/i.test(href)) return 'linux';
   return 'releases_page';
+}
+
+/**
+ * GA client id from the first-party `_ga` cookie ("GA1.1.<A>.<B>" → "<A>.<B>").
+ * Null when GA hasn't set cookies (blocked, consent pending, SSR).
+ */
+export function gaClientId(): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = /(?:^|; )_ga=([^;]+)/.exec(document.cookie);
+  if (!match) return null;
+  const parts = decodeURIComponent(match[1]).split('.');
+  if (parts.length < 4 || !/^\d+$/.test(parts[2]) || !/^\d+$/.test(parts[3])) return null;
+  return `${parts[2]}.${parts[3]}`;
+}
+
+/**
+ * GA session id from the `_ga_<stream>` cookie. Two formats exist in the
+ * wild: "GS1.1.<sessionId>.<n>..." (dot-separated) and
+ * "GS2.1.s<sessionId>$o<n>$..." (dollar-separated).
+ */
+export function gaSessionId(): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = /(?:^|; )_ga_[A-Z0-9]+=([^;]+)/.exec(document.cookie);
+  if (!match) return null;
+  const value = decodeURIComponent(match[1]);
+  const gs2 = /\.s(\d+)/.exec(value);
+  if (gs2) return gs2[1];
+  const parts = value.split('.');
+  if (parts.length >= 3 && /^\d+$/.test(parts[2])) return parts[2];
+  return null;
+}
+
+/**
+ * Append the visitor's GA ids to a download-proxy URL (?cid=...&sid=...), so
+ * the proxy's server-side download_started/completed events land inside this
+ * visitor's GA session and inherit source/campaign attribution. Non-proxy
+ * URLs and already-attributed URLs pass through unchanged; without GA
+ * cookies (ad blockers) the plain URL still works — the download is then
+ * counted without session attribution, exactly as before.
+ */
+export function withGaAttribution(href: string): string {
+  try {
+    const url = new URL(href);
+    if (url.hostname !== new URL(DOWNLOAD_BASE_URL).hostname) return href;
+    if (url.searchParams.has('cid')) return href;
+    const cid = gaClientId();
+    if (!cid) return href;
+    url.searchParams.set('cid', cid);
+    const sid = gaSessionId();
+    if (sid) url.searchParams.set('sid', sid);
+    return url.toString();
+  } catch {
+    return href;
+  }
 }
 
 /**

--- a/apps/website/src/theme/Root.tsx
+++ b/apps/website/src/theme/Root.tsx
@@ -10,6 +10,7 @@ import {
   platformFromUrl,
   sectionOf,
   visibleLabel,
+  withGaAttribution,
 } from '../lib/analytics';
 import {MOBILE_GET_STARTED_QUERY} from '../lib/useMobileGetStarted';
 import {
@@ -111,7 +112,18 @@ function useClickTracking() {
           e.preventDefault();
           anchor.classList.add('downloadResolving');
           anchor.setAttribute('aria-busy', 'true');
-          resolveLatestDesktopDownload().then(url => window.location.assign(url ?? RELEASES_URL));
+          resolveLatestDesktopDownload().then(url =>
+            window.location.assign(url ? withGaAttribution(url) : RELEASES_URL),
+          );
+        } else {
+          // Attach the visitor's GA ids to proxy links just-in-time, so the
+          // server-side download events join this GA session and inherit
+          // source/campaign attribution. Rewriting href during the capture
+          // phase affects the navigation this same click performs.
+          const attributed = withGaAttribution(absolute);
+          if (attributed !== absolute) {
+            anchor.setAttribute('href', attributed);
+          }
         }
         // Conversion event. Marked as the key event in GA4.
         track('download_vpr', {


### PR DESCRIPTION
## Description

The proxy's server-side `download_started`/`download_completed`/`download_aborted` events were Measurement Protocol hits under random client ids — countable, but sessionless, so they had no source/campaign attribution. Questions like "which campaign drives completed installs" needed manual hour+country matching against click events.

Now:
- **Website** (`analytics.ts`, `Root.tsx`): the delegated click handler appends the visitor's GA ids to `download.antseed.com` links just-in-time (`?cid=` from the `_ga` cookie, `?sid=` from the `_ga_<stream>` cookie — both GS1 dot and GS2 dollar formats handled). Applied in the capture phase, so it covers every CTA and the all-versions modal without touching call sites; the early-click resolver path is covered too.
- **Worker** (`events.ts`, `index.ts`): `parseGaIds` strictly validates the ids (digit-and-dot shapes only — they arrive on a public URL) and `deliverEvent` sends under that `client_id` with `session_id` on the event params. Events now land inside the visitor's GA4 user/session and inherit source, medium, campaign, and landing page. Console lines carry an `attributed: 0|1` flag.
- Ad-blocked visitors and direct/shared links have no GA cookies — they keep working exactly as before, counted under a random client id.

Worker is already deployed and live-verified (valid ids → `attributed:1`, malformed ids rejected). GA-side effect starts when this website change deploys.

No user-facing behavior change — measurement/attribution internals only, so no CHANGELOG entry.

## Test plan
- Proxy: 17 tests incl. new `parseGaIds` validation cases (well-formed, empty, GA-prefixed, script injection, wrong digit counts); typecheck green
- Website: typecheck + production build green
- Live: curl with valid/bogus ids against deployed worker confirms accept/reject