### PR TITLE
fix(desktop): Remove ox alpha from free model lineup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Changed
 
+- Ox Alpha is no longer part of the desktop's curated free model lineup (first-run default and free-first model lists).
+
 - Desktop Connected Apps now includes Droid. Connecting adds and selects an `AntSeed Auto` custom model in the live-reloaded Factory settings shared by Droid CLI and Factory Desktop, routes it through the local VPR, refuses to overwrite an existing `antseed` custom model, and restores the user's previous default model on disconnect.
 
 - Desktop installers are dramatically smaller. The Windows installer drops from ~424 MB to roughly a third of that: it previously packed both an x64 and an arm64 app into one universal installer — and the arm64 half shipped x64 native modules, so it could not have started anyway. Windows now ships x64 only (Windows-on-ARM runs it under emulation). All platforms additionally shed the bundled ~74 MB Whisper Tiny voice model (see below), dead transitive code that was never reachable at runtime (an OCR engine and PDF-rendering backends pulled in by the document-attachment parser, which only extracts text with OCR disabled), duplicate minified/sandbox/browser builds, other platforms' Whisper binaries, and sourcemaps/type declarations across the app and the bundled plugin runtime.

--- a/apps/desktop/src/renderer/modules/catalog/model-catalog.test.ts
+++ b/apps/desktop/src/renderer/modules/catalog/model-catalog.test.ts
@@ -549,15 +549,14 @@ test('sortFreeModelsByPriority leads with priority-slot models, keeps availabili
     discoverRow({ serviceId: 'minimax-m2.7', peerId: 'a3' }),
     discoverRow({ serviceId: 'random-free-model', peerId: 'b1' }),
     discoverRow({ serviceId: 'random-free-model', peerId: 'b2' }),
-    discoverRow({ serviceId: 'ox-alpha', peerId: 'c1' }),
     discoverRow({ serviceId: 'deepseek-v4-flash', peerId: 'd1' }),
   ]);
 
   assert.deepEqual(
     sortFreeModelsByPriority(catalog).map((entry) => entry.serviceId),
-    // deepseek (slot 1) and ox-alpha (slot 2) lead despite having the fewest
-    // sellers; minimax follows in its slot; unslotted models keep the
-    // incoming availability order at the tail.
-    ['deepseek-v4-flash', 'ox-alpha', 'minimax-m2.7', 'random-free-model'],
+    // deepseek (slot 1) leads despite having the fewest sellers; minimax
+    // follows in its slot; unslotted models keep the incoming availability
+    // order at the tail.
+    ['deepseek-v4-flash', 'minimax-m2.7', 'random-free-model'],
   );
 });

--- a/apps/desktop/src/renderer/modules/catalog/model-catalog.ts
+++ b/apps/desktop/src/renderer/modules/catalog/model-catalog.ts
@@ -150,8 +150,6 @@ export function projectRowsToVprModelCatalog(
  *  entry wins. */
 export const FREE_MODEL_PRIORITY: ReadonlyArray<RegExp> = [
   /deep-?seek.*flash/,
-  // "ox-alpha" / "ox alpha", not the tail of e.g. "fox-alpha".
-  /(^|[^a-z])ox[-\s]?alpha/,
   /gpt[-\s]?oss[-\s]?120b/,
   /minimax[-\s]?m?[-\s]?3/,
   /minimax[-\s]?m?[-\s]?2\.7/,


### PR DESCRIPTION
## Description

Removes the ox-alpha slot from `FREE_MODEL_PRIORITY` in the desktop model catalog, so it is no longer prioritized in the first-run free model default or the free-first surfaces (Home dropdown lead, Models recommended frame). Updates the affected sort test and adds a CHANGELOG entry.

## Testing

- `model-catalog.test.ts` — 28 tests pass
- Renderer typecheck clean