### PR TITLE
chore(release): Bump npm package versions

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.156",
+  "version": "0.1.157",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [

--- a/apps/payments/package.json
+++ b/apps/payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/payments",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "description": "Buyer payments portal for AntSeed",
   "files": [
     "dist"

--- a/packages/api-adapter/package.json
+++ b/packages/api-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/api-adapter",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "description": "HTTP-level format translation between LLM API protocols (Anthropic Messages, OpenAI Chat Completions, OpenAI Responses)",
   "type": "module",
   "files": [

--- a/packages/buyer-core/package.json
+++ b/packages/buyer-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/buyer-core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Transport-agnostic AntSeed buyer machinery: request handling, payment negotiation, channel accounting. Portable — no Node-only dependencies",
   "type": "module",
   "files": [

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/node",
-  "version": "0.2.116",
+  "version": "0.2.117",
   "description": "Antseed Network protocol SDK — P2P inference marketplace",
   "type": "module",
   "files": [

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/web-sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Browser buyer SDK for AntSeed: connect to sellers over WebRTC via a signaling relay, pay with in-browser EIP-712 signatures",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Description

Prepares the next npm release by patch-bumping the public packages affected by changes merged since the previous release. This PR contains version-only changes; the runtime behavior and changelog entries were already merged on `main`.

### Changed directly

- `@antseed/api-adapter` `0.1.45` → `0.1.46` — preserves Codex response phases during protocol translation.
- `@antseed/buyer-core` `0.1.7` → `0.1.8` — wraps seller and transport failures with consistent peer guidance and pinned-peer metadata.
- `@antseed/node` `0.2.116` → `0.2.117` — exposes the updated buyer-core peer failure behavior through the node SDK.
- `@antseed/cli` `0.1.156` → `0.1.157` — preserves normalized peer errors through protocol transforms and CLI/API proxy responses.

### Cascade (exact pins)

- `@antseed/web-sdk` `0.1.1` → `0.1.2` — pins the updated buyer-core release.
- `@antseed/payments` `0.1.43` → `0.1.44` — pins the updated node release.

### Skipped packages

`@antseed/ant-agent`, `@antseed/protocol`, `@antseed/provider-core`, `@antseed/router-core`, all provider plugins, `@antseed/router-local`, `@antseed/network-stats`, and `@antseed/relay` have no publishable runtime changes or required exact-pin cascade.

`node scripts/npm-publish-plan.mjs` validates exactly these six packages for publication with no cascade violations.

## Release Notes

- Improved peer failure responses across the buyer protocol, CLI, and API proxy, including pinned-peer handling and preserved seller response details.
- Preserved Codex response phases when requests are translated between supported API protocols.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [ ] Lint and unit tests pass locally with my changes
