### PR TITLE
ci: build the Nix CLI package on PRs; add lockfile hash convention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,3 +114,29 @@ jobs:
 
       - name: Typecheck
         run: pnpm run typecheck
+
+  nix-build:
+    name: Nix build (antseed CLI)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pinned SHA — DeterminateSystems/nix-installer-action @main as of 2026-08-31
+      - uses: DeterminateSystems/nix-installer-action@33c9ab3ef95cd57c164d9d6eb1f9a46338538d41
+
+      # First build fetches each dependency tarball individually; keep the
+      # store between runs so lockfile churn only fetches what changed.
+      # Pinned SHA — DeterminateSystems/magic-nix-cache-action @main as of 2026-08-31
+      - uses: DeterminateSystems/magic-nix-cache-action@55718cd9ebf1737a061487d5ada21abf31e99a98
+
+      # Fails when the pnpmDeps fixed-output hash in flake.nix is stale —
+      # after touching pnpm-lock.yaml, regenerate with
+      # ./scripts/update-nix-hash.sh (see NIX-PNPM-HASH in flake.nix).
+      - name: Build antseed CLI
+        run: nix build .#
+
+      - name: Smoke test
+        run: |
+          ./result/bin/antseed --version
+          ./result/bin/antseed --help > /dev/null

--- a/flake.nix
+++ b/flake.nix
@@ -143,7 +143,11 @@
               inherit pnpm;
               fetcherVersion = 3;
               pnpmWorkspaces = [ "@antseed/cli..." ];
-              hash = "sha256-EHNc17gKwWQSrrd/XVzxfnTpdG1IzJ0z2q+8exMYn6c=";
+              # NIX-PNPM-HASH: this fixed-output hash goes stale on every
+              # pnpm-lock.yaml change (the store no longer matches). After
+              # touching the lockfile, regenerate it with:
+              #   ./scripts/update-nix-hash.sh
+              hash = "sha256-KB45hE4jNhXvVnzy0N9wHY/ei/5ggKx591DbxvbHAV4=";
             };
 
             pnpmWorkspaces = [ "@antseed/cli..." ];

--- a/scripts/update-nix-hash.sh
+++ b/scripts/update-nix-hash.sh
@@ -19,11 +19,9 @@ EMPTY='sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
 
 # The pnpmDeps hash is the only literal `hash = "sha256-..."` assignment in
 # flake.nix (the native prebuild hashes live in per-system attrsets), so the
-# first match is the right one. sed -i.bak works with both GNU and BSD sed.
-# `|` delimiters because base64 hashes contain `/`.
+# first match is the right one. Perl is available on both macOS and NixOS.
 if ! grep -q "hash = \"$EMPTY\";" "$FLAKE"; then
-  sed -i.bak -E '0,\|hash = "sha256-[A-Za-z0-9+/=]+";|s||hash = "'"$EMPTY"'";|' "$FLAKE"
-  rm -f "$FLAKE.bak"
+  perl -0pi -e 's/hash = "sha256-[A-Za-z0-9+\/=]+";/hash = "'"$EMPTY"'";/' "$FLAKE"
 fi
 
 echo "Building with a placeholder hash to compute the real one..."
@@ -37,8 +35,7 @@ if [ -z "$got" ]; then
   exit 1
 fi
 
-sed -i.bak -E '0,\|hash = "sha256-[A-Za-z0-9+/=]+";|s||hash = "'"$got"'";|' "$FLAKE"
-rm -f "$FLAKE.bak"
+perl -0pi -e 's/hash = "sha256-[A-Za-z0-9+\/=]+";/hash = "'"$got"'";/' "$FLAKE"
 echo "Updated pnpmDeps hash in $FLAKE: $got"
 
 echo "Verifying with a full build..."

--- a/scripts/update-nix-hash.sh
+++ b/scripts/update-nix-hash.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Regenerate the pnpmDeps fixed-output hash in flake.nix.
+#
+# Run this after any change to pnpm-lock.yaml (dependency bumps, new
+# workspace packages, lockfile regeneration):
+#
+#   ./scripts/update-nix-hash.sh
+#
+# It blanks the hash, lets `nix build` fail with a mismatch that reports
+# the correct fixed-output hash, writes that value back, and rebuilds to
+# verify.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+FLAKE=flake.nix
+EMPTY='sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA='
+
+# The pnpmDeps hash is the only literal `hash = "sha256-..."` assignment in
+# flake.nix (the native prebuild hashes live in per-system attrsets), so the
+# first match is the right one. sed -i.bak works with both GNU and BSD sed.
+# `|` delimiters because base64 hashes contain `/`.
+if ! grep -q "hash = \"$EMPTY\";" "$FLAKE"; then
+  sed -i.bak -E '0,\|hash = "sha256-[A-Za-z0-9+/=]+";|s||hash = "'"$EMPTY"'";|' "$FLAKE"
+  rm -f "$FLAKE.bak"
+fi
+
+echo "Building with a placeholder hash to compute the real one..."
+echo "(this fetches every npm dependency — a few minutes on a cold cache)"
+got="$(nix build .# 2>&1 | grep -Eo 'got: +sha256-[A-Za-z0-9+/=]+' | grep -oE 'sha256-[A-Za-z0-9+/=]+' | tail -1 || true)"
+
+if [ -z "$got" ]; then
+  echo "error: could not read the correct hash from the nix build output." >&2
+  echo "$FLAKE still holds the empty placeholder — restore it from git" >&2
+  echo "(git checkout -- $FLAKE) and investigate the build failure." >&2
+  exit 1
+fi
+
+sed -i.bak -E '0,\|hash = "sha256-[A-Za-z0-9+/=]+";|s||hash = "'"$got"'";|' "$FLAKE"
+rm -f "$FLAKE.bak"
+echo "Updated pnpmDeps hash in $FLAKE: $got"
+
+echo "Verifying with a full build..."
+nix build .#
+echo "OK — smoke test:"
+./result/bin/antseed --version


### PR DESCRIPTION
## What
Regenerates the hash for the current lockfile and adds a script for updating the hash.
Aslo adds a nix-build CI job (nix build .# + smoke test) so a stale pnpmDeps fixed-output hash fails the build on any PR touching pnpm-lock.yaml. This is an alternative to #948 




