### PR TITLE
feat: hot reload seller pricing without restarting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- Sellers automatically reload token pricing from their config file without restarting, refresh discovery prices, and preserve agreed channel rates (including cached-input prices) across requests and seller restarts. Updated buyers reject stale discovery quotes before opening a new payment channel.
 - Seller shutdown now stops new work and drains active requests, final payment authorizations, and outgoing transport buffers before closing connections. Configure the default 60-second drain budget with `antseed seller start --shutdown-drain-timeout-ms` or the SDK's `shutdownDrainTimeoutMs` option.
 
 - Desktop telemetry's `app_connect` / `app_disconnect` user actions now carry which app was connected, as an `app` property drawn from a fixed local taxonomy (the packaged profile names plus the Telegram bot); user-added custom apps report as `custom`, so raw app names never leave the device. Connect events are also attributed to the specific app being connected rather than firing on every profile-set restart (profile switches and custom-app removals no longer emit spurious `app_connect`).

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -272,6 +272,30 @@ antseed buyer start --disable-metadata-v2-services
 
 For production sellers, prefer a dedicated Base JSON-RPC endpoint over public defaults. You can set it durably with `payments.crypto.rpcUrl`, at runtime with `ANTSEED_BASE_RPC_URL`, or for one run with `antseed seller start --base-rpc-url <url>`.
 
+### Live seller prices
+
+`antseed seller start` watches its selected config file for changes to
+`seller.providers.<name>.defaults` and
+`seller.providers.<name>.services.<service>.pricing`. Valid token-price changes
+are applied without a restart and discovery metadata is refreshed. Atomic file
+replacement is supported, with a five-second polling fallback for missed file
+events. Invalid, incomplete, or missing files leave the working prices unchanged.
+
+Existing payment channels keep a saved snapshot of their agreed prices, including
+cached-input rates, until a new channel is negotiated. A response already running
+also keeps its original rates. New channels use the new price list. Updated buyers
+reject quotes that no longer match discovery rather than signing against stale
+prices; refresh discovery or route to another seller in that case. Upgrade buyers
+alongside sellers to get this stale-quote check; older buyers ignore the additional
+quote fields.
+
+Channels created before this upgrade are initialized with startup pricing because
+older sellers did not save a price snapshot.
+
+Runtime flag and environment-variable precedence remains the same as at startup.
+Only token pricing is reloaded: credentials, provider/service membership, agent
+configuration, and unit/image billing models still require a restart.
+
 ### Graceful seller shutdown
 
 On SIGINT or SIGTERM, the seller stops advertising and rejects new requests with

--- a/apps/cli/src/cli/commands/seller/price-reload.test.ts
+++ b/apps/cli/src/cli/commands/seller/price-reload.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtemp, readFile, rename, rm, unlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { watchSellerPrices } from './price-reload.js';
+import { loadConfig } from '../../../config/loader.js';
+
+async function waitFor(check: () => boolean): Promise<void> {
+  const deadline = Date.now() + 3000;
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for price reload');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+test('price watcher follows atomic file replacement, ignores invalid saves and stops cleanly', async (context) => {
+  const directory = await mkdtemp(join(tmpdir(), 'antseed-price-reload-'));
+  const path = join(directory, 'config.json');
+  const prices = (input: number) => ({ provider: { defaults: { inputUsdPerMillion: input, outputUsdPerMillion: input * 2 } } });
+  await writeFile(path, JSON.stringify(prices(1)));
+  let active = prices(1);
+  let reloads = 0;
+  const errors: unknown[] = [];
+  const watcher = watchSellerPrices(path, {
+    initialPricing: active, debounceMs: 10, pollIntervalMs: 50,
+    readPricing: async () => JSON.parse(await readFile(path, 'utf8')) as typeof active,
+    applyPricing: async (pricing) => { active = pricing as typeof active; },
+    onReload: () => { reloads++; }, onError: (error) => { errors.push(error); },
+  });
+  context.after(async () => { await watcher.close(); await rm(directory, { recursive: true, force: true }); });
+  await writeFile(join(directory, 'temporary.json'), JSON.stringify(prices(2)));
+  await rename(join(directory, 'temporary.json'), path);
+  await waitFor(() => reloads === 1);
+  assert.deepEqual(active, prices(2));
+  await writeFile(path, '{');
+  await waitFor(() => errors.length > 0);
+  assert.deepEqual(active, prices(2));
+  await unlink(path);
+  await writeFile(path, JSON.stringify(prices(3)));
+  await waitFor(() => reloads === 2);
+  assert.deepEqual(active, prices(3));
+  await writeFile(path, JSON.stringify(prices(3)));
+  await new Promise((resolve) => setTimeout(resolve, 80));
+  assert.equal(reloads, 2);
+  await watcher.close();
+  await writeFile(path, JSON.stringify(prices(4)));
+  await new Promise((resolve) => setTimeout(resolve, 80));
+  assert.equal(reloads, 2);
+});
+
+test('closing a price watcher prevents a pending read from applying changes', async (context) => {
+  const directory = await mkdtemp(join(tmpdir(), 'antseed-price-close-'));
+  const path = join(directory, 'config.json');
+  await writeFile(path, '{}');
+  let finishRead!: () => void;
+  let applied = false;
+  const watcher = watchSellerPrices(path, {
+    initialPricing: {}, debounceMs: 1,
+    readPricing: async () => {
+      await new Promise<void>((resolve) => { finishRead = resolve; });
+      return { provider: { defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 1 } } };
+    },
+    applyPricing: async () => { applied = true; }, onReload: () => {}, onError: () => {},
+  });
+  context.after(async () => { await watcher.close(); await rm(directory, { recursive: true, force: true }); });
+  await waitFor(() => Boolean(finishRead));
+  const closing = watcher.close();
+  finishRead();
+  await closing;
+  assert.equal(applied, false);
+});
+
+test('strict reload never substitutes startup defaults for unreadable or invalid configuration', async (context) => {
+  const directory = await mkdtemp(join(tmpdir(), 'antseed-price-config-'));
+  const path = join(directory, 'config.json');
+  context.after(() => rm(directory, { recursive: true, force: true }));
+  await assert.rejects(loadConfig(path, { strict: true }));
+  for (const invalid of ['{', 'null', '[]', JSON.stringify({ seller: { providers: { local: { plugin: 'local-llm', services: { model: { pricing: null } } } } } })]) {
+    await writeFile(path, invalid);
+    await assert.rejects(loadConfig(path, { strict: true }));
+  }
+});

--- a/apps/cli/src/cli/commands/seller/price-reload.ts
+++ b/apps/cli/src/cli/commands/seller/price-reload.ts
@@ -1,0 +1,82 @@
+import { watch, type FSWatcher } from 'node:fs';
+import { basename, dirname } from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
+import type { Provider } from '@antseed/node';
+import { resolveConfigPath } from '../../../config/loader.js';
+
+type Pricing = Record<string, Provider['pricing']>;
+
+export function watchSellerPrices(configPath: string, options: {
+  initialPricing: Pricing;
+  readPricing: () => Promise<Pricing>;
+  applyPricing: (pricing: Pricing) => Promise<void>;
+  onReload: () => void;
+  onError: (error: unknown) => void;
+  debounceMs?: number;
+  pollIntervalMs?: number;
+}): { close: () => Promise<void> } {
+  const path = resolveConfigPath(configPath);
+  let current = structuredClone(options.initialPricing);
+  let closed = false;
+  let dirty = false;
+  let running: Promise<void> | undefined;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let watcher: FSWatcher | undefined;
+  let lastFailure: string | undefined;
+
+  const reload = (): void => {
+    if (closed) return;
+    dirty = true;
+    if (running) return;
+    running = (async () => {
+      while (dirty && !closed) {
+        dirty = false;
+        try {
+          const pricing = await options.readPricing();
+          lastFailure = undefined;
+          if (closed || isDeepStrictEqual(current, pricing)) continue;
+          await options.applyPricing(pricing);
+          current = structuredClone(pricing);
+          options.onReload();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (!closed && message !== lastFailure) options.onError(error);
+          lastFailure = message;
+        }
+      }
+    })().finally(() => { running = undefined; });
+  };
+
+  const schedule = (): void => {
+    if (closed) return;
+    clearTimeout(timer);
+    timer = setTimeout(reload, options.debounceMs ?? 200);
+    timer.unref();
+  };
+
+  try {
+    watcher = watch(dirname(path), (_event, filename) => {
+      if (filename === null || filename.toString() === basename(path)) schedule();
+    });
+    watcher.on('error', (error) => {
+      options.onError(error);
+      watcher?.close();
+    });
+    watcher.unref();
+  } catch (error) {
+    options.onError(error);
+  }
+  const poll = setInterval(reload, options.pollIntervalMs ?? 5_000);
+  poll.unref();
+  schedule();
+
+  return {
+    async close() {
+      closed = true;
+      watcher?.close();
+      clearTimeout(timer);
+      clearInterval(poll);
+      await running;
+    },
+  };
+}

--- a/apps/cli/src/cli/commands/seller/start.test.ts
+++ b/apps/cli/src/cli/commands/seller/start.test.ts
@@ -12,7 +12,30 @@ import {
   mergeSellerRuntimeEnv,
   parseOptionalPositiveIntegerEnv,
   selectSellerProviderNames,
+  resolveReloadedSellerPricing,
 } from './start.js';
+
+test('price reload preserves runtime precedence, clears removed overrides, and ignores non-pricing settings', () => {
+  const config = createDefaultConfig();
+  config.seller.providers = {
+    first: { plugin: 'openai', defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 2 }, services: { model: { upstreamModel: 'original', pricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 4 } } } },
+  };
+  const next = structuredClone(config.seller);
+  next.providers.first!.defaults = { inputUsdPerMillion: 10, outputUsdPerMillion: 20, cachedInputUsdPerMillion: 5 };
+  next.providers.first!.services.model!.upstreamModel = 'changed';
+  delete next.providers.first!.services.model!.pricing;
+  next.providers.first!.services.added = { pricing: { inputUsdPerMillion: 100, outputUsdPerMillion: 200 } };
+  const sources = [{ providerName: 'first', baseConfig: { ANTSEED_INPUT_USD_PER_MILLION: '7' }, fallback: { inputUsdPerMillion: 9, outputUsdPerMillion: 9 } }];
+  const original = structuredClone(config.seller);
+  const prices = resolveReloadedSellerPricing(config.seller, next, sources, false);
+  assert.deepEqual(prices.first, { defaults: { inputUsdPerMillion: 7, outputUsdPerMillion: 20, cachedInputUsdPerMillion: 5 } });
+  assert.deepEqual(config.seller, original);
+  assert.equal(resolveReloadedSellerPricing(config.seller, next, sources, true).first!.defaults.inputUsdPerMillion, 10);
+  delete next.providers.first!.defaults;
+  assert.deepEqual(resolveReloadedSellerPricing(config.seller, next, sources, false).first!.defaults, { inputUsdPerMillion: 7, outputUsdPerMillion: 9 });
+  delete next.providers.first!.services.model;
+  assert.throws(() => resolveReloadedSellerPricing(config.seller, next, sources, false), /require a restart/);
+});
 
 test('seller start runtime overrides are runtime-only and win over env/config', () => {
   const config = createDefaultConfig();

--- a/apps/cli/src/cli/commands/seller/start.ts
+++ b/apps/cli/src/cli/commands/seller/start.ts
@@ -41,6 +41,8 @@ import { ensureDerivedIdentityDisplayName } from '../../../config/identity-displ
 import { AntAgentProvider, loadAntAgent, type AntAgentDefinition } from '@antseed/ant-agent'
 import { resolvePluginPackage } from '../../../plugins/registry.js'
 import { startupReachabilityWarning } from './reachability.js'
+import { watchSellerPrices } from './price-reload.js'
+import { parseServicePricingJson } from '@antseed/provider-core'
 
 function getStateFile(dataDir: string): string {
   return join(dataDir, 'daemon.state.json')
@@ -369,6 +371,48 @@ export function mergeSellerRuntimeEnv(
   return merged
 }
 
+export interface SellerPriceReloadSource {
+  providerName: string
+  baseConfig: Record<string, string>
+  fallback: Provider['pricing']['defaults']
+}
+
+export function resolveReloadedSellerPricing(
+  previousConfig: SellerCLIConfig,
+  nextConfig: SellerCLIConfig,
+  sources: SellerPriceReloadSource[],
+  forcePricingOverride: boolean,
+): Record<string, Provider['pricing']> {
+  const pricingOnly = structuredClone(previousConfig)
+  return Object.fromEntries(sources.map((source) => {
+    const previous = previousConfig.providers[source.providerName]!
+    const updated = nextConfig.providers[source.providerName]
+    if (!updated || updated.plugin !== previous.plugin
+      || Object.keys(previous.services).some((service) => !updated.services[service])) {
+      throw new Error(`Provider/service removal or plugin changes require a restart: ${source.providerName}`)
+    }
+    const target = pricingOnly.providers[source.providerName]!
+    if (updated.defaults) target.defaults = updated.defaults
+    else delete target.defaults
+    for (const [service, entry] of Object.entries(target.services)) {
+      const pricing = updated.services[service]?.pricing
+      if (pricing) entry.pricing = pricing
+      else delete entry.pricing
+    }
+    const merged = mergeSellerRuntimeEnv(source.baseConfig, buildSellerPluginRuntimeEnv(pricingOnly, source.providerName), { forcePricingOverride })
+    const services = parseServicePricingJson(merged['ANTSEED_SERVICE_PRICING_JSON'])
+    return [source.providerName, {
+      defaults: {
+        inputUsdPerMillion: Number(merged['ANTSEED_INPUT_USD_PER_MILLION'] ?? source.fallback.inputUsdPerMillion),
+        outputUsdPerMillion: Number(merged['ANTSEED_OUTPUT_USD_PER_MILLION'] ?? source.fallback.outputUsdPerMillion),
+        ...(merged['ANTSEED_CACHED_INPUT_USD_PER_MILLION'] !== undefined
+          ? { cachedInputUsdPerMillion: Number(merged['ANTSEED_CACHED_INPUT_USD_PER_MILLION']) } : {}),
+      },
+      ...(services ? { services } : {}),
+    }]
+  }))
+}
+
 export function registerSellerStartCommand(sellerCmd: Command): void {
   sellerCmd
     .command('start')
@@ -449,6 +493,7 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
       await ensurePluginsUpToDate(selectedProviderPackages)
 
       const providers: Provider[] = []
+      const priceReloadSources: SellerPriceReloadSource[] = []
       for (const providerName of selectedProviderNames) {
         const providerCfg = effectiveSellerConfig.providers[providerName]!
         const packageName = resolvePluginPackage(providerCfg.plugin)
@@ -470,6 +515,18 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
             await provider.init()
           }
           providers.push(provider)
+          const defaultValue = (key: string, fallback: number): number => {
+            const field = configFields.find((entry) => entry.key === key)
+            return field && 'default' in field && typeof field.default === 'number' ? field.default : fallback
+          }
+          priceReloadSources.push({
+            providerName,
+            baseConfig: { ...basePluginConfig },
+            fallback: {
+              inputUsdPerMillion: defaultValue('ANTSEED_INPUT_USD_PER_MILLION', provider.pricing.defaults.inputUsdPerMillion),
+              outputUsdPerMillion: defaultValue('ANTSEED_OUTPUT_USD_PER_MILLION', provider.pricing.defaults.outputUsdPerMillion),
+            },
+          })
           spinner.succeed(chalk.green(`Provider "${providerName}" loaded via ${packageName}`))
         } catch (err) {
           spinner.fail(chalk.red(`Failed to load provider "${providerName}": ${(err as Error).message}`))
@@ -1020,7 +1077,22 @@ export function registerSellerStartCommand(sellerCmd: Command): void {
         }
       }
 
+      const priceWatcher = watchSellerPrices(globalOpts.config, {
+        initialPricing: Object.fromEntries(providers.map((provider, index) => [selectedProviderNames[index]!, provider.pricing])),
+        readPricing: async () => {
+          const next = resolveEffectiveSellerConfig({
+            config: await loadConfig(globalOpts.config, { strict: true }),
+            sellerOverrides: runtimeOverrides,
+          })
+          return resolveReloadedSellerPricing(effectiveSellerConfig, next, priceReloadSources, forcePricingOverride)
+        },
+        applyPricing: (pricing) => node.updateSellerPricing(new Map(registeredProviders.map((provider, index) => [provider, pricing[selectedProviderNames[index]!]!]))),
+        onReload: () => console.log(chalk.green('Seller prices reloaded. Existing payment sessions keep their agreed rates. Other settings require a restart.')),
+        onError: (error) => console.warn(chalk.yellow(`Price reload failed; keeping current prices: ${error instanceof Error ? error.message : String(error)}`)),
+      })
+
       setupShutdownHandler(async () => {
+        await priceWatcher.close()
         healthChecker?.stop()
         gasMonitor?.stop()
         clearInterval(stateInterval)

--- a/apps/cli/src/config/loader.ts
+++ b/apps/cli/src/config/loader.ts
@@ -21,7 +21,7 @@ import { assertValidConfig } from './validation.js';
 /**
  * Resolve a config path, expanding ~ to the user's home directory.
  */
-function resolveConfigPath(configPath: string): string {
+export function resolveConfigPath(configPath: string): string {
   if (configPath.startsWith('~')) {
     return resolve(homedir(), configPath.slice(2));
   }
@@ -515,14 +515,14 @@ function normalizeBooleanConfigValue(value: unknown, defaultValue: boolean, path
  * Load configuration from a JSON file.
  * Returns default configuration if the file does not exist.
  */
-export async function loadConfig(configPath: string): Promise<AntseedConfig> {
+export async function loadConfig(configPath: string, options?: { strict?: boolean }): Promise<AntseedConfig> {
   const resolved = resolveConfigPath(configPath);
 
   let raw: string;
   try {
     raw = await readFile(resolved, 'utf-8');
   } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+    if (!options?.strict && (err as NodeJS.ErrnoException).code === 'ENOENT') {
       return createDefaultConfig();
     }
     throw err;
@@ -532,11 +532,34 @@ export async function loadConfig(configPath: string): Promise<AntseedConfig> {
   try {
     parsedRaw = JSON.parse(raw);
   } catch {
+    if (options?.strict) throw new Error(`Could not parse config at ${resolved}`);
     console.warn(`Warning: Could not parse config at ${resolved}. Using defaults.`);
     return createDefaultConfig();
   }
 
   const defaults = createDefaultConfig();
+  if (options?.strict && !isRecord(parsedRaw)) throw new Error('Config must be an object');
+  if (options?.strict && isRecord(parsedRaw) && isRecord(parsedRaw.seller) && isRecord(parsedRaw.seller.providers)) {
+    for (const provider of Object.values(parsedRaw.seller.providers)) {
+      if (!isRecord(provider)) throw new Error('Seller provider must be an object');
+      const prices = [provider.defaults];
+      if (isRecord(provider.services)) {
+        for (const service of Object.values(provider.services)) {
+          if (!isRecord(service)) throw new Error('Seller service must be an object');
+          prices.push(service.pricing);
+        }
+      }
+      for (const pricing of prices) {
+        if (pricing === undefined) continue;
+        if (!isRecord(pricing)) throw new Error('Seller pricing must be an object');
+        for (const field of ['inputUsdPerMillion', 'outputUsdPerMillion', 'cachedInputUsdPerMillion']) {
+          const rate = pricing[field];
+          if (field === 'cachedInputUsdPerMillion' && rate === undefined) continue;
+          if (typeof rate !== 'number' || !Number.isFinite(rate) || rate < 0) throw new Error(`Invalid seller pricing ${field}`);
+        }
+      }
+    }
+  }
   const parsed = isRecord(parsedRaw) ? parsedRaw : {};
 
   const merged: AntseedConfig = {

--- a/packages/buyer-core/src/buyer-payment-negotiator.test.ts
+++ b/packages/buyer-core/src/buyer-payment-negotiator.test.ts
@@ -4,6 +4,34 @@ import type { BuyerConnection, BuyerPeerView } from './interfaces.js';
 import { ConnectionState, toPeerId } from '@antseed/protocol';
 
 describe('BuyerPaymentNegotiator', () => {
+  it('rejects changed discovery prices before authorizing payment', async () => {
+    const negotiator = Object.create(BuyerPaymentNegotiator.prototype) as BuyerPaymentNegotiator;
+    Object.assign(negotiator, { _lockedPeers: new Set(), _bpm: { getActiveSession: () => null } });
+    const peer: BuyerPeerView = {
+      peerId: toPeerId('4'.repeat(40)),
+      providerPricing: { openai: { defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 2 } } },
+    };
+    const response = {
+      requestId: 'request', statusCode: 402, headers: {},
+      body: new TextEncoder().encode(JSON.stringify({
+        minBudgetPerRequest: '100', suggestedAmount: '1000',
+        providerPricing: { openai: { defaults: { inputUsdPerMillion: 10, outputUsdPerMillion: 20 } } },
+      })),
+    };
+    await expect(negotiator.handle402(response, peer, {} as BuyerConnection, { requestId: 'request', method: 'POST', path: '/', headers: {}, body: new Uint8Array() }))
+      .rejects.toMatchObject({ code: 'peer-pricing-changed' });
+  });
+
+  it('uses agreed session prices even when the newly selected route advertises different rates', () => {
+    const negotiator = Object.create(BuyerPaymentNegotiator.prototype) as BuyerPaymentNegotiator;
+    const trackRequestBilling = vi.fn();
+    const agreed = { inputUsdPerMillion: 1, outputUsdPerMillion: 2 };
+    Object.assign(negotiator, { _bpm: { getSessionPricing: () => agreed, trackRequestBilling } });
+    negotiator.trackRequestBillingContext({ requestId: 'request', method: 'POST', path: '/v1/chat/completions', headers: {}, body: new Uint8Array() }, 'model', {
+      sellerPeerId: '4'.repeat(40), provider: 'openai', service: 'model', serviceApiProtocol: 'openai-chat-completions', tokenPricing: { inputUsdPerMillion: 10, outputUsdPerMillion: 20 },
+    });
+    expect(trackRequestBilling).toHaveBeenCalledWith('request', expect.objectContaining({ tokenPricing: agreed }));
+  });
   it('decodes a browser-compatible external spending auth header', async () => {
     const payload = {
       channelId: `0x${'1'.repeat(64)}`,

--- a/packages/buyer-core/src/buyer-payment-negotiator.ts
+++ b/packages/buyer-core/src/buyer-payment-negotiator.ts
@@ -41,6 +41,7 @@ import {
   type FinalUnitBillingResult,
 } from './unit-billing.js';
 import { buyerFault, peerFault } from './errors.js';
+import { parseProviderPricing, snapshotProviderPricing, type ProviderPricingMatrixEntry } from '@antseed/protocol/peer-pricing';
 
 export interface BuyerNegotiatorConfig {
   /**
@@ -262,12 +263,17 @@ export class BuyerPaymentNegotiator {
     return this._muxes.get(peerId);
   }
 
+  getSessionPricing(peerId: string, service: string): ServicePricing | null {
+    return this._bpm.getSessionPricing(peerId, service);
+  }
+
   trackRequestBillingContext(
     request: SerializedHttpRequest,
     service: string,
     route: SelectedBillingRoute | null,
   ): void {
     if (route) {
+      const tokenPricing = this._bpm.getSessionPricing(route.sellerPeerId, service) ?? route.tokenPricing;
       const captured = captureUnitBillingContext({
         sellerPeerId: route.sellerPeerId,
         provider: route.provider,
@@ -279,7 +285,7 @@ export class BuyerPaymentNegotiator {
         context: captured.context,
         requestFacts: captured.requestFacts,
         ...(route.unitModel ? { unitModel: route.unitModel } : {}),
-        ...(route.tokenPricing ? { tokenPricing: route.tokenPricing } : {}),
+        ...(tokenPricing ? { tokenPricing } : {}),
       });
     } else {
       this._bpm.trackRequestService(request.requestId, service);
@@ -498,12 +504,16 @@ export class BuyerPaymentNegotiator {
         minBudgetPerRequest: String(directPaymentBody.minBudgetPerRequest ?? '10000'),
         suggestedAmount: String(directPaymentBody.suggestedAmount ?? '100000'),
         requestId: req.requestId,
+        ...(directPaymentBody.providerPricing !== undefined ? { providerPricing: parseProviderPricing(directPaymentBody.providerPricing) } : {}),
         ...(directPaymentBody.inputUsdPerMillion != null ? { inputUsdPerMillion: Number(directPaymentBody.inputUsdPerMillion) } : {}),
         ...(directPaymentBody.outputUsdPerMillion != null ? { outputUsdPerMillion: Number(directPaymentBody.outputUsdPerMillion) } : {}),
         ...(directPaymentBody.cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion: Number(directPaymentBody.cachedInputUsdPerMillion) } : {}),
       }
       : null;
     const paymentRequirements = buffered ?? bodyRequirements;
+    if (paymentRequirements?.providerPricing && !this._bpm.getActiveSession(peer.peerId)) {
+      this._validateQuotedPricing(peer, paymentRequirements.providerPricing);
+    }
 
     const requestedReserveAmount = (() => {
       if (!paymentRequirements) return null;
@@ -956,6 +966,25 @@ export class BuyerPaymentNegotiator {
     };
   }
 
+  private _validateQuotedPricing(peer: BuyerPeerView, quoted: Record<string, ProviderPricingMatrixEntry>): void {
+    const advertisedPricing = peer.metadata ? snapshotProviderPricing(peer.metadata.providers) : peer.providerPricing;
+    const samePrice = (left: ServicePricing, right: ServicePricing): boolean =>
+      left.inputUsdPerMillion === right.inputUsdPerMillion
+      && left.outputUsdPerMillion === right.outputUsdPerMillion
+      && (left.cachedInputUsdPerMillion ?? left.inputUsdPerMillion) === (right.cachedInputUsdPerMillion ?? right.inputUsdPerMillion);
+    if (!advertisedPricing || Object.keys(advertisedPricing).length === 0) {
+      throw peerFault('Seller pricing snapshot requires fresh discovery metadata', 'peer-pricing-changed');
+    }
+    for (const [provider, advertised] of Object.entries(advertisedPricing)) {
+      const pricing = quoted[provider];
+      if (!pricing || (!peer.metadata && !samePrice(pricing.defaults, advertised.defaults))
+        || Object.keys(advertised.services ?? {}).some((service) =>
+          !samePrice(pricing.services?.[service] ?? pricing.defaults, advertised.services?.[service] ?? advertised.defaults))) {
+        throw peerFault('Seller pricing changed since discovery; refresh the peer before opening a payment session', 'peer-pricing-changed');
+      }
+    }
+  }
+
   /**
    * Build the full pricing map from peer metadata (defaults + all per-service overrides).
    * This ensures the buyer knows pricing for every service the seller offers,
@@ -1028,6 +1057,7 @@ export class BuyerPaymentNegotiator {
     });
 
     debugLog(`[BuyerNegotiator] PaymentRequired from ${peer.peerId.slice(0, 12)}...: minBudgetPerRequest=${requirements.minBudgetPerRequest} suggested=${requirements.suggestedAmount}`);
+    if (requirements.providerPricing) this._validateQuotedPricing(peer, requirements.providerPricing);
 
     // Validate seller's per-request minimum
     const minBudgetPerRequest = BigInt(requirements.minBudgetPerRequest);
@@ -1084,14 +1114,25 @@ export class BuyerPaymentNegotiator {
 
     // Build full pricing map from peer metadata (defaults + all per-service overrides)
     const pricingMap = this._buildPricingMap(peer);
+    if (pricingMap && requirements.providerPricing) {
+      for (const entry of Object.values(requirements.providerPricing)) {
+        Object.assign(pricingMap.services, entry.services);
+      }
+    }
 
     try {
-      await this._bpm.authorizeSpending(peer.peerId, pmux, minBudgetPerRequest, amount, pricing, pricingMap, peer.metadata);
+      await this._bpm.authorizeSpending(peer.peerId, pmux, minBudgetPerRequest, amount, requirements.providerPricing ? undefined : pricing, pricingMap, peer.metadata);
       debugLog(`[BuyerNegotiator] SpendingAuth sent to seller ${peer.peerId.slice(0, 12)}..., waiting for AuthAck...`);
 
       await this._waitForLockConfirmation(peer.peerId, { requestedReserve: amount, minBudgetPerRequest });
       debugLog(`[BuyerNegotiator] AuthAck received from seller ${peer.peerId.slice(0, 12)}...`);
       this._lockedPeers.add(peer.peerId);
+
+      const billing = this._bpm.getRequestBilling?.(requirements.requestId);
+      if (billing) {
+        const tokenPricing = this._bpm.getSessionPricing(peer.peerId, billing.context.service);
+        if (tokenPricing) this._bpm.trackRequestBilling(requirements.requestId, { ...billing, tokenPricing });
+      }
 
       this._emit.emit('payment:signed', {
         peerId: peer.peerId,

--- a/packages/buyer-core/src/buyer-request-handler.ts
+++ b/packages/buyer-core/src/buyer-request-handler.ts
@@ -128,11 +128,13 @@ export class BuyerRequestHandler {
     const requestProtocol = options?.controlPlane ? null : detectRequestServiceApiProtocol(req);
     const adaptPeerResponse = (response: SerializedHttpResponse): SerializedHttpResponse =>
       adaptPeerFaultErrorResponse(response, requestProtocol, { pinned: options?.pinned });
-    const billingRoute = requestedService ? selectBillingRoute(peer, req, requestedService) : null;
+    const selectedRoute = requestedService ? selectBillingRoute(peer, req, requestedService) : null;
+    const sessionPricing = requestedService ? negotiator?.getSessionPricing?.(peer.peerId, requestedService) : null;
+    const billingRoute = selectedRoute && sessionPricing ? { ...selectedRoute, tokenPricing: sessionPricing } : selectedRoute;
     // Decide free vs paid from the resolved route (provider + protocol), mirroring
     // the seller's per-request gate so both sides classify the request the same way.
     const isFreeService = requestedService
-      ? (billingRoute ? isBillingRouteFree(billingRoute) : isPeerServiceFree(peer, requestedService))
+      ? (billingRoute ? isBillingRouteFree(billingRoute) : isPeerServiceFree(peer, requestedService, sessionPricing ?? undefined))
       : false;
     if (negotiator && requestedService) {
       if (isFreeService) {
@@ -679,7 +681,7 @@ function isBillingRouteFree(route: SelectedBillingRoute): boolean {
 }
 
 /** Fallback gate when no billing route could be resolved for the service. */
-function isPeerServiceFree(peer: BuyerPeerView, service: string): boolean {
+function isPeerServiceFree(peer: BuyerPeerView, service: string, sessionPricing?: SelectedBillingRoute['tokenPricing']): boolean {
   // Unit-billed services (e.g. images) can have zero token pricing but still
   // charge per unit — stay conservative when any announced model is paid.
   for (const providerModels of Object.values(peer.providerServiceUnitBillingModels ?? {})) {
@@ -689,7 +691,7 @@ function isPeerServiceFree(peer: BuyerPeerView, service: string): boolean {
       if (model && !isFreeUnitBillingModel(model)) return false;
     }
   }
-  const servicePricing = findPeerServicePricing(peer, service);
+  const servicePricing = sessionPricing ?? findPeerServicePricing(peer, service);
   if (!servicePricing) return false;
   return (servicePricing.inputUsdPerMillion ?? 0) === 0
     && (servicePricing.outputUsdPerMillion ?? 0) === 0

--- a/packages/buyer-core/src/errors.ts
+++ b/packages/buyer-core/src/errors.ts
@@ -13,6 +13,7 @@ export type AntseedErrorCode =
   | 'invalid-spending-auth-header'
   | 'chain-rpc-unavailable'
   | 'peer-not-authorized'
+  | 'peer-pricing-changed'
   | 'peer-protocol-violation';
 
 export interface AntseedRequestErrorOptions {

--- a/packages/node/src/discovery/announcer.ts
+++ b/packages/node/src/discovery/announcer.ts
@@ -1,6 +1,7 @@
 import type { Identity } from "../p2p/identity.js";
 import { signData } from "../p2p/identity.js";
 import type { DHTNode } from "./dht-node.js";
+import type { ProviderPricingMatrixEntry } from '@antseed/protocol/peer-pricing';
 import {
   ANTSEED_WILDCARD_TOPIC,
   capabilityTopic,
@@ -63,23 +64,14 @@ export interface AnnouncerConfig {
     /** Runtime availability predicate. Unavailable providers are omitted. */
     isAvailable?: () => boolean;
     /** Per-instance pricing. Takes precedence over the shared pricing Map. */
-    pricing?: {
-      defaults: { inputUsdPerMillion: number; outputUsdPerMillion: number };
-      services?: Record<string, { inputUsdPerMillion: number; outputUsdPerMillion: number }>;
-    };
+    pricing?: ProviderPricingMatrixEntry;
   }>;
   displayName?: string;
   publicAddress?: string;
   /** External ownership claims to include in signed metadata for client verification. */
   verifications?: PeerVerifications;
   region: string;
-  pricing: Map<
-    string,
-    {
-      defaults: { inputUsdPerMillion: number; outputUsdPerMillion: number };
-      services?: Record<string, { inputUsdPerMillion: number; outputUsdPerMillion: number }>;
-    }
-  >;
+  pricing: Map<string, ProviderPricingMatrixEntry>;
   offerings?: PeerOffering[];
   stakeAmountUSDC?: number;
   paymentsEnabled?: boolean;
@@ -116,13 +108,16 @@ export class PeerAnnouncer {
   private stopped = false;
   private readonly loadMap: Map<string, number> = new Map();
   private _latestMetadata: PeerMetadata | null = null;
+  private _metadataRevision = 0;
 
   constructor(config: AnnouncerConfig) {
     this.config = config;
   }
 
   async announce(): Promise<void> {
-    this._latestMetadata = await this._buildSignedMetadata(true);
+    const revision = ++this._metadataRevision;
+    const metadata = await this._buildSignedMetadata(true);
+    if (revision === this._metadataRevision) this._latestMetadata = metadata;
     if (this.stopped) return;
 
     const failures = await this._announceTopics();
@@ -139,7 +134,19 @@ export class PeerAnnouncer {
    * Useful for high-frequency fields like current provider load.
    */
   async refreshMetadata(): Promise<void> {
-    this._latestMetadata = await this._buildSignedMetadata(false);
+    const revision = ++this._metadataRevision;
+    const metadata = await this._buildSignedMetadata(false);
+    if (revision === this._metadataRevision) this._latestMetadata = metadata;
+  }
+
+  updatePricing(pricing: ProviderPricingMatrixEntry[]): void {
+    for (const [index, provider] of this.config.providers.entries()) {
+      const updated = pricing[index];
+      if (updated) {
+        provider.pricing = structuredClone(updated);
+        this.config.pricing.set(provider.provider, structuredClone(updated));
+      }
+    }
   }
 
   startPeriodicAnnounce(): void {

--- a/packages/node/src/node.ts
+++ b/packages/node/src/node.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "node:events";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { parseProviderPricing, snapshotProviderPricing } from '@antseed/protocol/peer-pricing';
 
 import type { Identity, IdentityStore } from "./p2p/identity.js";
 import { loadOrCreateIdentity } from "./p2p/identity.js";
@@ -328,6 +329,7 @@ export class AntseedNode extends EventEmitter {
   private _dht: DHTNode | null = null;
   private _connectionManager: ConnectionManager | null = null;
   private _providers: Provider[] = [];
+  private readonly _providerPricingServices = new Map<Provider, string[]>();
   private _provers: Prover[] = [];
   private _router: Router | null = null;
   private _started = false;
@@ -411,6 +413,7 @@ export class AntseedNode extends EventEmitter {
   }
 
   registerProvider(provider: Provider): void {
+    this._providerPricingServices.set(provider, [...provider.services]);
     this._providers.push(provider);
   }
 
@@ -422,6 +425,28 @@ export class AntseedNode extends EventEmitter {
    */
   async refreshSellerMetadata(): Promise<void> {
     await this._announcer?.refreshMetadata();
+  }
+
+  async updateSellerPricing(pricing: ReadonlyMap<Provider, Provider['pricing']>): Promise<void> {
+    if (this._stopPromise) throw new Error('Cannot reload prices during shutdown');
+    const updates = [...pricing].map(([provider, prices]) => {
+      if (!this._providers.includes(provider)) throw new Error(`Unknown provider: ${provider.name}`);
+      return { provider, pricing: parseProviderPricing({ prices }).prices! };
+    });
+    for (const { provider, pricing: updated } of updates) {
+      provider.pricing.defaults = updated.defaults;
+      if (updated.services) provider.pricing.services = updated.services;
+      else delete provider.pricing.services;
+    }
+    this._announcer?.updatePricing(this._providers.map((provider) => provider.pricing));
+    await this.refreshSellerMetadata().catch((err: unknown) => {
+      debugWarn(`[Node] Prices applied but metadata refresh failed; periodic announcement will retry: ${String(err)}`);
+    });
+    if (this._announcer && this._advertisingPausedReason === null && !this._stopPromise) {
+      void this._announcer.announce().catch((err: unknown) => {
+        debugWarn(`[Node] Price announcement failed; periodic announcement will retry: ${String(err)}`);
+      });
+    }
   }
 
   /**
@@ -1666,13 +1691,7 @@ export class AntseedNode extends EventEmitter {
           ...(p.serviceCapabilities ? { serviceCapabilities: { ...p.serviceCapabilities } } : {}),
           maxConcurrency: p.maxConcurrency,
           isAvailable: () => this._advertisingPausedReason === null && p.healthCheckAvailable !== false,
-          pricing: {
-            defaults: {
-              inputUsdPerMillion: p.pricing.defaults.inputUsdPerMillion,
-              outputUsdPerMillion: p.pricing.defaults.outputUsdPerMillion,
-            },
-            ...(p.pricing.services ? { services: { ...p.pricing.services } } : {}),
-          },
+          pricing: structuredClone(p.pricing),
         })),
         ...(this._config.displayName ? { displayName: this._config.displayName } : {}),
         ...(this._config.publicAddress ? { publicAddress: this._config.publicAddress } : {}),
@@ -2100,6 +2119,12 @@ export class AntseedNode extends EventEmitter {
     if (this._config.role === 'seller' && this._identity && this._channelStore &&
         payments.rpcUrl && payments.channelsAddress) {
       const sellerConfig: SellerPaymentConfig = {
+        getProviderPricing: () => snapshotProviderPricing(this._providers.map((provider) => ({
+          provider: provider.name,
+          services: [...new Set([...(this._providerPricingServices.get(provider) ?? provider.services), ...Object.keys(provider.pricing.services ?? {})])],
+          defaultPricing: provider.pricing.defaults,
+          ...(provider.pricing.services ? { servicePricing: provider.pricing.services } : {}),
+        }))),
         rpcUrl: payments.rpcUrl,
         ...(fallbackRpcUrls ? { fallbackRpcUrls } : {}),
         channelsContractAddress: payments.channelsAddress,

--- a/packages/node/src/payments/channel-store.ts
+++ b/packages/node/src/payments/channel-store.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { runMigrations } from '../storage/migrate.js';
 import { channelMigrations } from '../storage/migrations/channels/index.js';
 import type { SpendingAuthMetadata, SpendingAuthServiceMetadata } from './evm/signatures.js';
+import { parseProviderPricing, type ProviderPricingMatrixEntry } from '@antseed/protocol/peer-pricing';
 
 // Channel constants/types + BuyerChannelStore interface moved to @antseed/buyer-core.
 export {
@@ -67,6 +68,8 @@ export class ChannelStore {
   private readonly _commitAuthorizationTxn: (channel: StoredChannel, totals: StoredChannelServiceTotal[]) => void;
 
   private readonly _stmts: {
+    getSellerPricing: Database.Statement;
+    setSellerPricing: Database.Statement;
     upsert: Database.Statement;
     getById: Database.Statement;
     getActiveByPeer: Database.Statement;
@@ -129,6 +132,8 @@ export class ChannelStore {
 
   private _prepareStatements() {
     return {
+      getSellerPricing: this._db.prepare('SELECT seller_pricing_json FROM payment_channels WHERE session_id = ?'),
+      setSellerPricing: this._db.prepare('UPDATE payment_channels SET seller_pricing_json = COALESCE(seller_pricing_json, ?) WHERE session_id = ?'),
       upsert: this._db.prepare(`
         INSERT INTO payment_channels (
           session_id, peer_id, role, channel_kind, seller_evm_addr, buyer_evm_addr,
@@ -275,6 +280,19 @@ export class ChannelStore {
   getChannel(sessionId: string): StoredChannel | null {
     const row = this._stmts.getById.get(sessionId) as ChannelRow | undefined;
     return row ? rowToChannel(row) : null;
+  }
+
+  getSellerPricing(sessionId: string): Record<string, ProviderPricingMatrixEntry> | undefined {
+    const row = this._stmts.getSellerPricing.get(sessionId) as { seller_pricing_json: string | null } | undefined;
+    return row?.seller_pricing_json ? parseProviderPricing(JSON.parse(row.seller_pricing_json)) : undefined;
+  }
+
+  upsertChannelWithSellerPricing(channel: StoredChannel, pricing: Record<string, ProviderPricingMatrixEntry>): void {
+    const serialized = JSON.stringify(parseProviderPricing(pricing));
+    this._db.transaction(() => {
+      this.upsertChannel(channel);
+      this._stmts.setSellerPricing.run(serialized, channel.sessionId);
+    })();
   }
 
   getActiveChannelByPeer(peerId: string, role: ChannelRole, channelKind: ChannelKind = CHANNEL_KIND.PAID): StoredChannel | null {

--- a/packages/node/src/payments/seller-payment-manager.ts
+++ b/packages/node/src/payments/seller-payment-manager.ts
@@ -20,8 +20,10 @@ import { debugLog, debugWarn } from '../utils/debug.js';
 import { peerIdToAddress } from '../types/peer.js';
 import { ChannelStore, CHANNEL_ROLE, CHANNEL_STATUS, type StoredChannel } from './channel-store.js';
 import { classifyOnChainChannel, matchesChannelParties } from './channel-session-state.js';
+import type { ProviderPricing } from '../interfaces/seller-provider.js';
 
 export interface SellerPaymentConfig {
+  getProviderPricing?: () => Record<string, ProviderPricing>;
   rpcUrl: string;
   fallbackRpcUrls?: string[];
   channelsContractAddress: string;
@@ -88,6 +90,8 @@ interface LatestAuth {
  */
 export class SellerPaymentManager {
   private _draining = false;
+  private readonly _sessionProviderPricing = new Map<string, Record<string, ProviderPricing>>();
+  private readonly _quotedProviderPricing = new Map<string, Record<string, ProviderPricing>>();
   private readonly _signer: AbstractSigner;
   private readonly _channelsClient: ChannelsClient;
   private readonly _config: SellerPaymentConfig;
@@ -210,6 +214,11 @@ export class SellerPaymentManager {
     // Hydrate from persisted channels
     const activeChannels = this._channelStore.getActiveChannels(CHANNEL_ROLE.SELLER);
     for (const channel of activeChannels) {
+      if (config.getProviderPricing) {
+        const pricing = this._channelStore.getSellerPricing(channel.sessionId) ?? structuredClone(config.getProviderPricing());
+        this._channelStore.upsertChannelWithSellerPricing(channel, pricing);
+        this._sessionProviderPricing.set(channel.sessionId, pricing);
+      }
       this._activeBuyers.add(channel.peerId);
       this._hydratedChannelIds.add(channel.sessionId);
       this._acceptedCumulative.set(channel.sessionId, BigInt(channel.authMax));
@@ -304,6 +313,7 @@ export class SellerPaymentManager {
   ): void {
     this._channelStore.updateChannelStatus(channelId, status);
     this._acceptedCumulative.delete(channelId);
+    this._sessionProviderPricing.delete(channelId);
     this._spent.delete(channelId);
     this._latestAuth.delete(channelId);
     this._closeRetryCount.delete(channelId);
@@ -484,6 +494,7 @@ export class SellerPaymentManager {
     payload: SpendingAuthPayload,
     paymentMux: PaymentMux,
   ): Promise<'accepted' | 'reserved' | 'rejected'> {
+    const quotedPricing = this._quotedProviderPricing.get(buyerPeerId);
     const buyerEvmAddr = peerIdToAddress(buyerPeerId);
     try {
       const channelId = payload.channelId;
@@ -607,6 +618,7 @@ export class SellerPaymentManager {
             metadataHash: payload.metadataHash,
             metadata: payload.metadata,
           },
+          quotedPricing,
         );
 
         // Send AuthAck
@@ -1094,8 +1106,15 @@ export class SellerPaymentManager {
     reserveMaxAmount: bigint,
     spent: bigint,
     latestAuth: LatestAuth,
+    quotedPricing?: Record<string, ProviderPricing>,
   ): void {
-    this._channelStore.upsertChannel(session);
+    const pricing = this._channelStore.getSellerPricing(session.sessionId) ?? quotedPricing ?? this._config.getProviderPricing?.();
+    if (pricing) this._channelStore.upsertChannelWithSellerPricing(session, pricing);
+    else this._channelStore.upsertChannel(session);
+    if (pricing && !this._sessionProviderPricing.has(session.sessionId)) {
+      this._sessionProviderPricing.set(session.sessionId, structuredClone(pricing));
+    }
+    this._quotedProviderPricing.delete(buyerPeerId);
     this._hydratedChannelIds.delete(session.sessionId);
     this._acceptedCumulative.set(session.sessionId, cumulativeAmount);
     this._reserveMax.set(session.sessionId, reserveMaxAmount);
@@ -1215,6 +1234,7 @@ export class SellerPaymentManager {
    * touch persisted status — callers set that first (SETTLED / TIMEOUT).
    */
   private _forgetChannel(channelId: string, buyerPeerId: string): void {
+    this._sessionProviderPricing.delete(channelId);
     this._acceptedCumulative.delete(channelId);
     this._spent.delete(channelId);
     this._latestAuth.delete(channelId);
@@ -1261,6 +1281,7 @@ export class SellerPaymentManager {
   // ── Disconnect handling ───────────────────────────────────────
 
   onBuyerDisconnect(buyerPeerId: string): void {
+    this._quotedProviderPricing.delete(buyerPeerId);
     const session = this._channelStore.getActiveChannelByPeer(buyerPeerId, CHANNEL_ROLE.SELLER);
     if (!session) return;
 
@@ -1503,7 +1524,21 @@ export class SellerPaymentManager {
     requestId: string,
     buyerPeerId?: string,
     pricing?: { inputUsdPerMillion?: number; outputUsdPerMillion?: number; cachedInputUsdPerMillion?: number },
+    options?: { newSession?: boolean; provider?: string; service?: string },
   ): PaymentRequiredPayload {
+    const quote = buyerPeerId ? this._quotedProviderPricing.get(buyerPeerId) : undefined;
+    let providerPricing = options?.newSession
+      ? quote
+      : this._getProviderPricing(buyerPeerId);
+    if (!providerPricing && buyerPeerId && this._config.getProviderPricing) {
+      if (this._quotedProviderPricing.size >= 1024) {
+        throw new Error('Too many pending seller price quotes');
+      }
+      providerPricing = structuredClone(this._config.getProviderPricing());
+      this._quotedProviderPricing.set(buyerPeerId, providerPricing);
+    }
+    const selected = options?.provider ? providerPricing?.[options.provider] : undefined;
+    if (selected) pricing = (options?.service ? selected.services?.[options.service] : undefined) ?? selected.defaults;
     const minBudgetPerRequest = this._config.minBudgetPerRequest ?? DEFAULT_MIN_BUDGET_PER_REQUEST;
 
     let suggestedAmount = SellerPaymentManager.DEFAULT_SUGGESTED_AMOUNT;
@@ -1520,10 +1555,23 @@ export class SellerPaymentManager {
       minBudgetPerRequest,
       suggestedAmount: suggestedAmount.toString(),
       requestId,
+      ...(providerPricing ? { providerPricing: structuredClone(providerPricing) } : {}),
       ...(pricing?.inputUsdPerMillion != null ? { inputUsdPerMillion: pricing.inputUsdPerMillion } : {}),
       ...(pricing?.outputUsdPerMillion != null ? { outputUsdPerMillion: pricing.outputUsdPerMillion } : {}),
       ...(pricing?.cachedInputUsdPerMillion != null ? { cachedInputUsdPerMillion: pricing.cachedInputUsdPerMillion } : {}),
     };
+  }
+
+  private _getProviderPricing(buyerPeerId?: string): Record<string, ProviderPricing> | undefined {
+    if (!buyerPeerId) return undefined;
+    const channel = this.getChannelByPeer(buyerPeerId);
+    if (channel) return this._sessionProviderPricing.get(channel.sessionId) ?? this._channelStore.getSellerPricing(channel.sessionId);
+    return this._quotedProviderPricing.get(buyerPeerId);
+  }
+
+  getSessionProviderPricing(buyerPeerId: string, providerName: string): ProviderPricing | undefined {
+    const pricing = this._getProviderPricing(buyerPeerId)?.[providerName];
+    return pricing ? structuredClone(pricing) : undefined;
   }
 
   async drainPendingPayments(timeoutMs: number): Promise<void> {

--- a/packages/node/src/seller-request-handler.ts
+++ b/packages/node/src/seller-request-handler.ts
@@ -250,7 +250,11 @@ export class SellerRequestHandler {
         return;
       }
 
-      const requestPricing = this.resolveProviderPricing(provider, request);
+      const sessionPricing = this._deps.sellerPaymentManager?.getSessionProviderPricing?.(buyerPeerId, provider.name);
+      const requestedService = this._extractRequestedService(request);
+      const requestPricing = { ...(sessionPricing
+        ? (requestedService ? sessionPricing.services?.[requestedService] : undefined) ?? sessionPricing.defaults
+        : this.resolveProviderPricing(provider, request)) };
       const requestBilling = this._captureSellerBillingContext(provider, request);
       const unitBillingModel = requestBilling
         ? this.resolveProviderUnitBillingModel(provider, requestBilling.context)
@@ -269,11 +273,13 @@ export class SellerRequestHandler {
         } else {
           const requirements = spm?.getPaymentRequirements(
             request.requestId, buyerPeerId, requestPricing,
+            { provider: provider.name, service: requestedService ?? undefined },
           );
           if (requirements) {
             debugLog(`[SellerHandler] No payment session for ${buyerPeerId.slice(0, 12)}... — sending 402 + PaymentRequired`);
             const paymentBody = JSON.stringify({
               error: 'payment_required',
+              ...(requirements.providerPricing ? { providerPricing: requirements.providerPricing } : {}),
               minBudgetPerRequest: requirements.minBudgetPerRequest,
               suggestedAmount: requirements.suggestedAmount,
               ...(requirements.inputUsdPerMillion != null ? { inputUsdPerMillion: requirements.inputUsdPerMillion } : {}),
@@ -392,8 +398,12 @@ export class SellerRequestHandler {
             && estimatedRequestCost > effectiveEstimateLimit;
 
           if (isBlocked || (spent > 0n && (spent > accepted || isAtExactSpendLimit)) || estimatedCostExceedsLockedReserve) {
+            const target = spent;
+            const isAlreadyExhausted = reserveMax > 0n && (accepted >= reserveMax || target > reserveMax);
+            const isFullyExhausted = isBlocked || estimatedCostExceedsLockedReserve || isAlreadyExhausted;
             const baseRequirements = spm.getPaymentRequirements(
               request.requestId, buyerPeerId, requestPricing,
+              { newSession: isFullyExhausted, provider: provider.name, service: requestedService ?? undefined },
             );
             // Tell the buyer exactly how much delivered spend remains unsigned.
             // Do not add forward headroom here: SpendingAuth is claimable
@@ -401,9 +411,6 @@ export class SellerRequestHandler {
             // for work the seller has not delivered. The preflight reserve
             // check also returns target=spent: it is a hard stop before routing
             // work that cannot fit inside the currently locked reserve.
-            const target = spent;
-            const isAlreadyExhausted = reserveMax > 0n && (accepted >= reserveMax || target > reserveMax);
-            const isFullyExhausted = isBlocked || estimatedCostExceedsLockedReserve || isAlreadyExhausted;
             const requirements = {
               ...baseRequirements,
               requiredCumulativeAmount: target.toString(),
@@ -440,6 +447,7 @@ export class SellerRequestHandler {
               body: new TextEncoder().encode(JSON.stringify({
                 error: 'payment_required',
                 minBudgetPerRequest: requirements.minBudgetPerRequest,
+                ...(requirements.providerPricing ? { providerPricing: requirements.providerPricing } : {}),
                 suggestedAmount: requirements.suggestedAmount,
                 requiredCumulativeAmount: requirements.requiredCumulativeAmount,
                 currentSpent: requirements.currentSpent,

--- a/packages/node/src/storage/migrations/channels/006_add_seller_pricing.ts
+++ b/packages/node/src/storage/migrations/channels/006_add_seller_pricing.ts
@@ -1,0 +1,12 @@
+import type { Migration } from '../../migrate.js';
+
+export const migration: Migration = {
+  version: 6,
+  name: 'add_seller_pricing',
+  up: (db) => {
+    const columns = db.pragma('table_info(payment_channels)') as Array<{ name: string }>;
+    if (!columns.some((column) => column.name === 'seller_pricing_json')) {
+      db.exec('ALTER TABLE payment_channels ADD COLUMN seller_pricing_json TEXT');
+    }
+  },
+};

--- a/packages/node/src/storage/migrations/channels/index.ts
+++ b/packages/node/src/storage/migrations/channels/index.ts
@@ -4,5 +4,6 @@ import { migration as m002 } from './002_add_auth_sig_columns.js';
 import { migration as m003 } from './003_create_service_totals.js';
 import { migration as m004 } from './004_add_channel_kind.js';
 import { migration as m005 } from './005_add_output_images.js';
+import { migration as m006 } from './006_add_seller_pricing.js';
 
-export const channelMigrations: Migration[] = [m001, m002, m003, m004, m005];
+export const channelMigrations: Migration[] = [m001, m002, m003, m004, m005, m006];

--- a/packages/node/tests/announcer.test.ts
+++ b/packages/node/tests/announcer.test.ts
@@ -53,6 +53,30 @@ function makeBaseConfig(): AnnouncerConfig {
 }
 
 describe('PeerAnnouncer provider availability', () => {
+  it('reloads per-instance and cached-input prices without a stale announce overwriting them', async () => {
+    const base = makeBaseConfig();
+    base.providers.push({ provider: 'openai', services: ['second'], maxConcurrency: 1 });
+    const announcer = new PeerAnnouncer(base);
+    await announcer.refreshMetadata();
+    const oldMetadata = announcer.getLatestMetadata()!;
+    let finish!: () => void;
+    vi.spyOn(announcer as any, '_buildSignedMetadata').mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => { finish = resolve; });
+      return oldMetadata;
+    });
+    const staleAnnounce = announcer.announce();
+    announcer.updatePricing([
+      { defaults: { inputUsdPerMillion: 2, outputUsdPerMillion: 4, cachedInputUsdPerMillion: 1 } },
+      { defaults: { inputUsdPerMillion: 6, outputUsdPerMillion: 8 } },
+    ]);
+    await announcer.refreshMetadata();
+    finish();
+    await staleAnnounce;
+    const metadata = announcer.getLatestMetadata()!;
+    expect(metadata.providers[0]!.defaultPricing).toEqual({ inputUsdPerMillion: 2, outputUsdPerMillion: 4, cachedInputUsdPerMillion: 1 });
+    expect(metadata.providers[1]!.defaultPricing.inputUsdPerMillion).toBe(6);
+  });
+
   it('omits unavailable providers and restores them when they recover', async () => {
     let available = true;
     const announcer = new PeerAnnouncer({

--- a/packages/node/tests/buyer-request-handler.test.ts
+++ b/packages/node/tests/buyer-request-handler.test.ts
@@ -189,6 +189,39 @@ describe('BuyerRequestHandler payments-inactive 402 handling', () => {
 });
 
 describe('BuyerRequestHandler billing guards', () => {
+  it.each([true, false])('classifies free/paid requests using agreed session prices (paid=%s)', async (paid) => {
+    const negotiator = {
+      getOrCreatePaymentMux: vi.fn(() => ({})),
+      getSessionPricing: () => ({ inputUsdPerMillion: paid ? 1 : 0, outputUsdPerMillion: paid ? 2 : 0 }),
+      trackRequestBillingContext: vi.fn(), estimateCostFromResponse: vi.fn(),
+      trackFreeUsageRequestService: vi.fn(), prepareFreeUsageOpen: vi.fn(async () => {}),
+    };
+    const handler = new BuyerRequestHandler({}, {
+      localPeerId: 'b'.repeat(40), negotiator: negotiator as any,
+      verificationStorage: null, verificationSampler: null,
+      getConnection: vi.fn(async () => ({ state: ConnectionState.Open }) as any),
+      getMux: vi.fn(() => ({
+        sendProxyRequest: (request: SerializedHttpRequest, onResponse: (response: SerializedHttpResponse, metadata: { streamingStart: boolean }) => void) => {
+          onResponse({ requestId: request.requestId, statusCode: 200, headers: {}, body: new Uint8Array() }, { streamingStart: false });
+        },
+        cancelProxyRequest: vi.fn(),
+      }) as any),
+      getVerificationMux: vi.fn(() => ({} as any)), registerPaymentMux: vi.fn(),
+    });
+    const price = { inputUsdPerMillion: paid ? 0 : 1, outputUsdPerMillion: paid ? 0 : 2 };
+    const peer: PeerInfo = {
+      peerId: 'a'.repeat(40) as PeerInfo['peerId'], lastSeen: Date.now(), providers: ['openai'],
+      providerPricing: { openai: { defaults: price, services: { model: price } } },
+    };
+    await handler.sendRequest(peer, {
+      requestId: 'request', method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' },
+      body: new TextEncoder().encode(JSON.stringify({ model: 'model' })),
+    });
+    expect(negotiator.trackRequestBillingContext).toHaveBeenCalledTimes(paid ? 1 : 0);
+    expect(negotiator.estimateCostFromResponse).toHaveBeenCalledTimes(paid ? 1 : 0);
+    expect(negotiator.prepareFreeUsageOpen).toHaveBeenCalledTimes(paid ? 0 : 1);
+  });
+
   it('rejects paid image requests when metadata lacks a service unit billing model', async () => {
     const paymentMux = {};
     const negotiator = {

--- a/packages/node/tests/seller-hot-reload.test.ts
+++ b/packages/node/tests/seller-hot-reload.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SellerRequestHandler } from '../src/seller-request-handler.js';
+import { AntseedNode } from '../src/node.js';
+import type { Provider, ProviderStreamCallbacks } from '../src/interfaces/seller-provider.js';
+import { encodeHttpRequest } from '../src/proxy/request-codec.js';
+import { MessageType } from '../src/types/protocol.js';
+
+function harness() {
+  let finish!: () => void;
+  let callbacks!: ProviderStreamCallbacks;
+  const body = new TextEncoder().encode(JSON.stringify({ usage: { prompt_tokens: 2, completion_tokens: 3 } }));
+  const provider: Provider = {
+    name: 'openai', services: ['model'], maxConcurrency: 10,
+    pricing: { defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 2 } },
+    getCapacity: () => ({ current: 0, max: 10 }),
+    handleRequest: vi.fn(),
+    handleRequestStream: vi.fn(async (request, streamCallbacks) => {
+      callbacks = streamCallbacks;
+      callbacks.onResponseStart({ requestId: request.requestId, statusCode: 200, headers: { 'content-type': 'text/event-stream' }, body: new Uint8Array() });
+      await new Promise<void>((resolve) => { finish = resolve; });
+      callbacks.onResponseChunk({ requestId: request.requestId, data: body, done: true });
+      return { requestId: request.requestId, statusCode: 200, headers: {}, body };
+    }),
+  };
+  const frames: Uint8Array[] = [];
+  const recordSpend = vi.fn();
+  const sendNeedAuth = vi.fn();
+  const payments = {
+    hasSession: () => true, getChannelByPeer: () => ({ sessionId: 'channel', authMax: '1000000' }),
+    getAcceptedCumulative: () => 0n, getCumulativeSpend: () => 0n, getEffectiveReserveMax: () => 1_000_000n,
+    waitForPendingAuths: async () => {}, isChannelBlocked: () => false, hasClosingChannel: () => false,
+    beginBillableRequest: vi.fn(), endBillableRequest: vi.fn(), recordSpend,
+  };
+  const handler = new SellerRequestHandler({
+    identity: { peerId: 'a'.repeat(40) } as any, providers: [provider],
+    sellerPaymentManager: payments as any, channelsClient: {} as any, sessionTracker: null, announcer: null, emit: () => false,
+  });
+  const { mux } = handler.handleConnection({ send: (frame: Uint8Array) => frames.push(frame), hasRemoteCapability: () => false } as any,
+    'b'.repeat(40), { sendNeedAuth } as any, {} as any);
+  const send = (requestId: string) => mux.handleFrame({
+    type: MessageType.HttpRequest, messageId: 1,
+    payload: encodeHttpRequest({ requestId, method: 'POST', path: '/v1/chat/completions', headers: { 'content-type': 'application/json' }, body: new TextEncoder().encode(JSON.stringify({ model: 'model', stream: true })) }),
+  });
+  return { provider, handler, send, frames, recordSpend, sendNeedAuth, finish: () => finish(), started: () => Boolean(finish) };
+}
+
+describe('seller hot price reload', () => {
+  it('finishes an in-flight stream at its original price after a reload', async () => {
+    const state = harness();
+    state.send('running');
+    await vi.waitFor(() => expect(state.started()).toBe(true));
+    state.provider.pricing.defaults.inputUsdPerMillion = 100;
+    state.provider.pricing.defaults.outputUsdPerMillion = 200;
+    state.finish();
+    await vi.waitFor(() => expect(state.recordSpend).toHaveBeenCalledWith('channel', 8n));
+    expect(state.sendNeedAuth).toHaveBeenCalledOnce();
+    expect(state.provider.handleRequestStream).toHaveBeenCalledOnce();
+    expect(state.frames).toHaveLength(2);
+  });
+
+  it('updates pricing atomically and supports getter-only agent wrappers', async () => {
+    const state = harness();
+    const node = new AntseedNode({ role: 'seller' });
+    const wrapper = { ...state.provider, get pricing() { return state.provider.pricing; } };
+    node.registerProvider(wrapper);
+    await node.updateSellerPricing(new Map([[wrapper, { defaults: { inputUsdPerMillion: 3, outputUsdPerMillion: 6, cachedInputUsdPerMillion: 1 } }]]));
+    expect(state.provider.pricing.defaults.inputUsdPerMillion).toBe(3);
+    await expect(node.updateSellerPricing(new Map([[wrapper, { defaults: { inputUsdPerMillion: -1, outputUsdPerMillion: 0 } }]]))).rejects.toThrow();
+    expect(state.provider.pricing.defaults.inputUsdPerMillion).toBe(3);
+    await expect(node.updateSellerPricing(new Map([[state.provider, state.provider.pricing]]))).rejects.toThrow('Unknown provider');
+  });
+
+  it('does not mix pricing for two instances of the same provider plugin', async () => {
+    const first = harness().provider;
+    const second = harness().provider;
+    second.services = ['second-model'];
+    const node = new AntseedNode({ role: 'seller' });
+    node.registerProvider(first);
+    node.registerProvider(second);
+    await node.updateSellerPricing(new Map([
+      [first, { defaults: { inputUsdPerMillion: 3, outputUsdPerMillion: 6 } }],
+      [second, { defaults: { inputUsdPerMillion: 10, outputUsdPerMillion: 20 } }],
+    ]));
+    expect(first.pricing.defaults.inputUsdPerMillion).toBe(3);
+    expect(second.pricing.defaults.inputUsdPerMillion).toBe(10);
+    await expect(node.updateSellerPricing(new Map([
+      [first, { defaults: { inputUsdPerMillion: 50, outputUsdPerMillion: 60 } }],
+      [second, { defaults: { inputUsdPerMillion: -1, outputUsdPerMillion: 20 } }],
+    ]))).rejects.toThrow();
+    expect(first.pricing.defaults.inputUsdPerMillion).toBe(3);
+  });
+
+});

--- a/packages/node/tests/seller-payment-manager.test.ts
+++ b/packages/node/tests/seller-payment-manager.test.ts
@@ -189,6 +189,39 @@ describe('SellerPaymentManager', () => {
     expect(manager.hasSession(buyerIdentity.peerId)).toBe(true);
   });
 
+  it('pins a complete quote through reserve, reload, and seller restart', async () => {
+    let pricing = { openai: { defaults: { inputUsdPerMillion: 2, outputUsdPerMillion: 4 }, services: { model: { inputUsdPerMillion: 3, outputUsdPerMillion: 6 } } } };
+    const config: SellerPaymentConfig = {
+      rpcUrl: 'http://127.0.0.1:8545', channelsContractAddress: CONTRACT_ADDR,
+      chainId: CHAIN_ID, dataDir: tempDir, getProviderPricing: () => pricing,
+    };
+    manager = new SellerPaymentManager(sellerIdentity, config, store);
+    let finishReserve!: () => void;
+    vi.spyOn(manager.channelsClient, 'reserve').mockImplementation(async () => {
+      await new Promise<void>((resolve) => { finishReserve = resolve; });
+      return '0xreserve';
+    });
+    const quoted = manager.getPaymentRequirements('request', buyerIdentity.peerId, pricing.openai.defaults);
+    const original = structuredClone(pricing);
+    const payload = await buildSpendingAuth(buyerIdentity, sellerIdentity, makeChannelId(71), { isReserve: true });
+    const reserving = manager.handleSpendingAuth(buyerIdentity.peerId, payload, mux);
+    await vi.waitFor(() => expect(finishReserve).toBeTypeOf('function'));
+    pricing = { openai: { defaults: { inputUsdPerMillion: 20, outputUsdPerMillion: 40 }, services: { model: { inputUsdPerMillion: 30, outputUsdPerMillion: 60 } } } };
+    finishReserve();
+    expect(await reserving).toBe('reserved');
+    expect(manager.getSessionProviderPricing(buyerIdentity.peerId, 'openai')).toEqual(original.openai);
+    quoted.providerPricing!.openai!.defaults.inputUsdPerMillion = 999;
+    expect(manager.getSessionProviderPricing(buyerIdentity.peerId, 'openai')).toEqual(original.openai);
+    const newBuyer = createTestIdentity();
+    expect(manager.getPaymentRequirements('new-request', newBuyer.peerId).providerPricing).toEqual(pricing);
+    const renewal = manager.getPaymentRequirements('renewal', buyerIdentity.peerId, original.openai.defaults, { newSession: true, provider: 'openai', service: 'model' });
+    expect(renewal.providerPricing).toEqual(pricing);
+    expect(renewal.inputUsdPerMillion).toBe(30);
+    expect(manager.getSessionProviderPricing(buyerIdentity.peerId, 'openai')).toEqual(original.openai);
+    const restarted = new SellerPaymentManager(sellerIdentity, config, store);
+    expect(restarted.getSessionProviderPricing(buyerIdentity.peerId, 'openai')).toEqual(original.openai);
+  });
+
   it('waits for final spending authorization during drain, but respects the deadline', async () => {
     const channelId = makeChannelId(72);
     const payload = await buildSpendingAuth(buyerIdentity, sellerIdentity, channelId, { isReserve: true });

--- a/packages/protocol/src/messages.ts
+++ b/packages/protocol/src/messages.ts
@@ -169,6 +169,7 @@ export interface NeedFreeUsageAuthPayload {
  * Sent via PaymentMux alongside the HTTP 402 response.
  */
 export interface PaymentRequiredPayload {
+  providerPricing?: Record<string, import('./peer-pricing.js').ProviderPricingMatrixEntry>;
   minBudgetPerRequest: string;
   suggestedAmount: string;
   requestId: string;

--- a/packages/protocol/src/payment-codec.ts
+++ b/packages/protocol/src/payment-codec.ts
@@ -1,3 +1,4 @@
+import { parseProviderPricing } from './peer-pricing.js';
 import {
   PAYMENT_CODE_CHANNEL_EXHAUSTED,
   CLOSE_CHANNEL_REJECT_CODES,
@@ -159,6 +160,7 @@ export function decodePaymentRequired(data: Uint8Array): PaymentRequiredPayload 
     suggestedAmount: requireStringField(obj, 'suggestedAmount'),
     requestId: requireStringField(obj, 'requestId'),
   };
+  if (obj.providerPricing !== undefined) result.providerPricing = parseProviderPricing(obj.providerPricing);
   if (typeof obj.inputUsdPerMillion === 'number') result.inputUsdPerMillion = obj.inputUsdPerMillion;
   if (typeof obj.outputUsdPerMillion === 'number') result.outputUsdPerMillion = obj.outputUsdPerMillion;
   if (typeof obj.cachedInputUsdPerMillion === 'number') result.cachedInputUsdPerMillion = obj.cachedInputUsdPerMillion;

--- a/packages/protocol/src/peer-pricing.test.ts
+++ b/packages/protocol/src/peer-pricing.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { parseProviderPricing, snapshotProviderPricing } from './peer-pricing.js';
+import { decodePaymentRequired, encodePaymentRequired } from './payment-codec.js';
+
+describe('quoted provider prices', () => {
+  const pricing = { openai: { defaults: { inputUsdPerMillion: 2, outputUsdPerMillion: 4, cachedInputUsdPerMillion: 1 }, services: { model: { inputUsdPerMillion: 0, outputUsdPerMillion: 0 } } } };
+
+  it('round trips the complete price snapshot alongside legacy quote fields', () => {
+    const quote = { minBudgetPerRequest: '100', suggestedAmount: '1000', requestId: 'request', providerPricing: pricing };
+    expect(decodePaymentRequired(encodePaymentRequired(quote))).toEqual(quote);
+    const legacy = { minBudgetPerRequest: '100', suggestedAmount: '1000', requestId: 'request' };
+    expect(decodePaymentRequired(encodePaymentRequired(legacy))).toEqual(legacy);
+  });
+
+  it.each([null, [], { openai: null }, { openai: { defaults: { inputUsdPerMillion: -1, outputUsdPerMillion: 2 } } }, { openai: { defaults: { inputUsdPerMillion: 1, outputUsdPerMillion: 2, cachedInputUsdPerMillion: 3 } } }])('rejects malformed pricing %j', (value) => {
+    expect(() => parseProviderPricing(value)).toThrow();
+  });
+
+  it('expands defaults per service without mixing same-name provider instances', () => {
+    const snapshot = snapshotProviderPricing([
+      { provider: 'openai', services: ['first'], defaultPricing: { inputUsdPerMillion: 1, outputUsdPerMillion: 2 } },
+      { provider: 'openai', services: ['second'], defaultPricing: { inputUsdPerMillion: 3, outputUsdPerMillion: 4 } },
+    ]);
+    expect(snapshot.openai!.services!.first!.inputUsdPerMillion).toBe(1);
+    expect(snapshot.openai!.services!.second!.inputUsdPerMillion).toBe(3);
+  });
+});

--- a/packages/protocol/src/peer-pricing.ts
+++ b/packages/protocol/src/peer-pricing.ts
@@ -7,6 +7,54 @@ export interface ProviderPricingMatrixEntry {
   services?: Record<string, TokenPricingUsdPerMillion>;
 }
 
+export function snapshotProviderPricing(providers: ReadonlyArray<{
+  provider: string;
+  services: string[];
+  defaultPricing: TokenPricingUsdPerMillion;
+  servicePricing?: Record<string, TokenPricingUsdPerMillion>;
+}>): Record<string, ProviderPricingMatrixEntry> {
+  const result: Record<string, ProviderPricingMatrixEntry> = Object.create(null) as Record<string, ProviderPricingMatrixEntry>;
+  for (const provider of providers) {
+    const entry = result[provider.provider] ??= { defaults: { ...provider.defaultPricing }, services: Object.create(null) as Record<string, TokenPricingUsdPerMillion> };
+    for (const service of provider.services) {
+      entry.services![service] ??= { ...(provider.servicePricing?.[service] ?? provider.defaultPricing) };
+    }
+  }
+  return result;
+}
+
+export function parseProviderPricing(value: unknown): Record<string, ProviderPricingMatrixEntry> {
+  const record = (input: unknown): Record<string, unknown> => {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) throw new Error('Provider pricing must be an object');
+    return input as Record<string, unknown>;
+  };
+  const price = (input: unknown): TokenPricingUsdPerMillion => {
+    const fields = record(input);
+    for (const key of ['inputUsdPerMillion', 'outputUsdPerMillion', 'cachedInputUsdPerMillion']) {
+      const rate = fields[key];
+      if (key === 'cachedInputUsdPerMillion' && rate === undefined) continue;
+      if (typeof rate !== 'number' || !Number.isFinite(rate) || rate < 0) throw new Error(`Invalid pricing ${key}`);
+    }
+    if (fields.cachedInputUsdPerMillion !== undefined && (fields.cachedInputUsdPerMillion as number) > (fields.inputUsdPerMillion as number)) {
+      throw new Error('Cached input pricing cannot exceed input pricing');
+    }
+    return {
+      inputUsdPerMillion: fields.inputUsdPerMillion as number,
+      outputUsdPerMillion: fields.outputUsdPerMillion as number,
+      ...(fields.cachedInputUsdPerMillion !== undefined ? { cachedInputUsdPerMillion: fields.cachedInputUsdPerMillion as number } : {}),
+    };
+  };
+  return Object.fromEntries(Object.entries(record(value)).map(([name, input]) => {
+    const entry = record(input);
+    return [name, {
+      defaults: price(entry.defaults),
+      ...(entry.services !== undefined
+        ? { services: Object.fromEntries(Object.entries(record(entry.services)).map(([service, pricing]) => [service, price(pricing)])) }
+        : {}),
+    }];
+  }));
+}
+
 export interface ProviderServiceCategoryMatrixEntry {
   services: Record<string, string[]>;
 }


### PR DESCRIPTION
## Summary
Implements the hot-pricing-reload portion of #981. Refs #981; graceful shutdown is covered separately by #984.

- Watch the selected seller config file, debounce changes, support atomic saves, and poll every five seconds as a fallback. Invalid or missing config leaves current prices unchanged.
- Reload token pricing without restarting, preserve startup override precedence, and refresh discovery prices, including cached-input rates and separate instances of the same provider plugin.
- Pin full pricing snapshots for pending quotes and active payment channels. Persist agreed rates across seller restarts using migration `006_add_seller_pricing`.
- Carry optional validated pricing snapshots in `PaymentRequired`; updated buyers reject stale discovery quotes before opening a new channel and use negotiated session rates for billing.
- Document the behavior and compatibility limits in the CLI README and changelog.

## PR split / merge order
**Stacked on #984** (`feat/seller-graceful-shutdown`). This PR targets that branch so its diff contains only pricing changes and reuses its shutdown lifecycle guard.

Merge #984 first, then retarget this PR to `main`. Neither draft individually claims to close #981; together they address its pricing and shutdown requirements.

## Validation
- [x] Protocol, buyer-core, node, and CLI builds.
- [x] CLI typecheck and `git diff --check`.
- [x] Full node suite: 1,033 tests across 94 files, including the shutdown prerequisite.
- [x] CLI config and seller-command suite: 86 tests.
- [x] Buyer-core: 13 tests; protocol: 25 tests.
- [x] Regression coverage for atomic saves, invalid config, override precedence, in-flight pricing, persisted channel snapshots, renewal quotes, provider-instance isolation, cached-input rates, and stale buyer quotes.

## Compatibility / limits
- Only token pricing reloads. Credentials, provider/service membership, agent configuration, and unit/image billing still require a restart.
- Legacy channels without saved snapshots initialize their rates from startup configuration.
- The quote field is optional; upgrade buyers alongside sellers to get stale-discovery protection. Older buyers ignore the additional field.
- No live-chain deployment testing was performed.
