### PR TITLE
feat(contracts): Allow operator position init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- Contracts: `AntseedPositionInit.initPosition(seller)` lets a seller's authorized operator initialize its starter pool position. Seller eligibility, wash status, and the one-time grant remain seller-based; the calling operator owns the position and its staker reward/withdrawal rights, allowing existing seller proxies to bootstrap without receiving NFTs. Self-initialization remains available.
 - Contracts: M001 now deploys the historical wash-trading registry in its first broadcast and pins it into `AntseedPositionInit`, which refuses starter positions to proven wash traders; the deploy records provenance and validates the wiring on restart. Operators provide the verifier, proof program, and historical block range instead of a separately deployed registry; fork rehearsals use the real registry with a test-only verifier.
 - Contracts: migrated the historical wash-trading registry to schema 1 direct seller proofs. Deployments now pin one `sellerProgramVKey`; journals no longer carry closed-loop or reciprocal child vkeys, while receipt/transaction/storage proof verification, settlement deduplication, evidence digests, and Chainlink `BlockhashStore` authentication remain enforced inside the direct seller proof flow.
 - Contracts: added a historical SP1 wash-trading registry that accepts authenticated seller proofs independently, records each seller's strongest proven wash-volume lower bound, and does not implement historical claims or ongoing epoch penalties.

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -571,7 +571,14 @@ location for inspection; remove that directory manually when no longer needed.
 The same broadcast deploys `AntseedPositionInit`, an immutable starter-position
 faucet for eligible legacy sellers. Fund it conservatively and have sellers call
 `initPosition()` before the first rewarded epoch if their usage must count from
-that epoch. Every starter position uses the shared `POSITION_INIT_END_EPOCH`, so
+that epoch. For a seller contract such as the DIEM proxy, an authorized operator
+can call `initPosition(seller)`: the seller must return true from
+`isOperator(msg.sender)`. Eligibility and the one-time grant are checked against
+the seller, and the stake supports its agent pool, but the calling operator owns
+the lANTS position, its staker rewards, and its withdrawal rights. Revoking the
+operator later does not revoke position ownership. The proxy does not need to
+receive an NFT or call the faucet itself.
+Every starter position uses the shared `POSITION_INIT_END_EPOCH`, so
 claiming later never gives a seller more power than an earlier claimant. The
 same M001 broadcast first deploys `AntseedWashTradingRegistry`, then pins it
 into the faucet. Configure `SP1_VERIFIER`, `SP1_VERIFIER_HASH`,

--- a/packages/contracts/script/migrations/M001RecognizedUsage/README.md
+++ b/packages/contracts/script/migrations/M001RecognizedUsage/README.md
@@ -137,9 +137,13 @@ Writes `history/001-recognized-usage-activated.json` and updates
 
 ## Post-flip checklist (manual)
 
-- Create and seed an ANTS seller pool for the proxy's agent id right after the
-  flip: usage of pool-less agents is not accounted, so the proxy earns nothing
-  in the new stack until it has a pool.
+- Seed the proxy's agent pool before the flip boundary to activate its power
+  in the first rewarded epoch. Once the faucet is funded and historical proofs
+  are finalized, an authorized proxy operator can call
+  `AntseedPositionInit.initPosition(proxyAddress)`. The operator owns the lANTS
+  position, staker rewards, and withdrawal rights; the proxy's agent pool gets
+  the stake. Operator revocation does not remove those position rights. Usage
+  of pool-less agents is not accounted, and late stake activates next epoch.
 - Do **not** renounce `AntseedEmissionsGate` ownership before the verification
   rollout: that rollout rotates the editable 10% controller from
   `VERIFICATION_WALLET` to `AntseedVerification`.

--- a/packages/contracts/sellers/AntseedPositionInit.sol
+++ b/packages/contracts/sellers/AntseedPositionInit.sol
@@ -9,6 +9,10 @@ import { IAntseedSellerPools } from "../interfaces/IAntseedSellerPools.sol";
 import { IAntseedStaking } from "../interfaces/IAntseedStaking.sol";
 import { IAntseedWashTradingStatus } from "../interfaces/IAntseedWashTradingStatus.sol";
 
+interface ISellerDelegation {
+    function isOperator(address account) external view returns (bool);
+}
+
 /**
  * @title AntseedPositionInit
  * @notice One-shot ANTS starter positions that bootstrap seller-pool
@@ -21,7 +25,7 @@ import { IAntseedWashTradingStatus } from "../interfaces/IAntseedWashTradingStat
  *         own agent pool, turning their accounting on.
  *
  *         Eligibility is anchored to the legacy USDC staking contract: the
- *         caller must have an agent binding there and stake above the legacy
+ *         seller must have an agent binding there and stake above the legacy
  *         minimum, so only sellers who put up real USDC stake can claim.
  *         Sellers the wash-trading registry has proven as wash traders are
  *         refused: a starter position is what switches their recognized-usage
@@ -68,6 +72,7 @@ contract AntseedPositionInit is ReentrancyGuard {
     error AlreadyInitialized();
     error InitDepleted();
     error InitExpired();
+    error NotOperator();
 
     // ─── Constructor ─────────────────────────────────────────────────
     constructor(
@@ -108,9 +113,24 @@ contract AntseedPositionInit is ReentrancyGuard {
      *         are refused.
      */
     function initPosition() external nonReentrant returns (uint256 positionId) {
-        uint256 agentId = legacyStaking.getAgentId(msg.sender);
-        if (agentId == 0 || !legacyStaking.isStakedAboveMin(msg.sender)) revert NotLegacySeller();
-        if (washTradingRegistry.isProvenWashTrader(msg.sender)) revert WashTrader();
+        return _initPosition(msg.sender);
+    }
+
+    function initPosition(address seller) external nonReentrant returns (uint256 positionId) {
+        return _initPosition(seller);
+    }
+
+    function _initPosition(address seller) internal returns (uint256 positionId) {
+        if (seller == address(0)) revert InvalidAddress();
+        if (seller != msg.sender) {
+            (bool success, bytes memory result) =
+                seller.staticcall(abi.encodeCall(ISellerDelegation.isOperator, (msg.sender)));
+            if (!success || result.length != 32 || abi.decode(result, (uint256)) != 1) revert NotOperator();
+        }
+
+        uint256 agentId = legacyStaking.getAgentId(seller);
+        if (agentId == 0 || !legacyStaking.isStakedAboveMin(seller)) revert NotLegacySeller();
+        if (washTradingRegistry.isProvenWashTrader(seller)) revert WashTrader();
         if (agentInitialized[agentId]) revert AlreadyInitialized();
         if (antsToken.balanceOf(address(this)) < initAmount) revert InitDepleted();
 
@@ -122,7 +142,7 @@ contract AntseedPositionInit is ReentrancyGuard {
 
         agentInitialized[agentId] = true;
         positionId = sellerPools.stakeFor(msg.sender, agentId, initAmount, stakeEpochs);
-        emit PositionInitialized(msg.sender, agentId, positionId, initAmount, stakeEpochs);
+        emit PositionInitialized(seller, agentId, positionId, initAmount, stakeEpochs);
     }
 
     // ═══════════════════════════════════════════════════════════════════

--- a/packages/contracts/test/AntseedPositionInit.t.sol
+++ b/packages/contracts/test/AntseedPositionInit.t.sol
@@ -44,6 +44,14 @@ contract MockLegacySellerStaking {
     }
 }
 
+contract MockSellerOperatorsForInit {
+    mapping(address => bool) public isOperator;
+
+    function setOperator(address operator, bool enabled) external {
+        isOperator[operator] = enabled;
+    }
+}
+
 contract AntseedPositionInitTest is Test {
     uint256 constant EPOCH_DURATION = 1 weeks;
     uint256 constant INIT_AMOUNT = 1 ether;
@@ -135,6 +143,123 @@ contract AntseedPositionInitTest is Test {
         assertEq(pools.positionWeightAtEpoch(positionId, 1), INIT_AMOUNT * (INIT_END_EPOCH - 1));
         assertEq(pools.poolWeightAtEpoch(agentId, 1), INIT_AMOUNT * (INIT_END_EPOCH - 1));
         assertEq(pools.poolActiveStakeAtEpoch(agentId, 1), INIT_AMOUNT);
+    }
+
+    function test_explicitSellerCanInitItself() public {
+        vm.prank(seller);
+        uint256 positionId = positionInit.initPosition(seller);
+        assertEq(pools.ownerOf(positionId), seller);
+        assertTrue(positionInit.agentInitialized(agentId));
+
+        vm.prank(seller);
+        vm.expectRevert(AntseedPositionInit.AlreadyInitialized.selector);
+        positionInit.initPosition();
+    }
+
+    function test_operatorOwnsPositionInContractSellersPool() public {
+        MockSellerOperatorsForInit proxy = new MockSellerOperatorsForInit();
+        uint256 proxyAgentId = _registerLegacySeller(address(proxy));
+        proxy.setOperator(outsider, true);
+        washRegistry.set(outsider, true);
+
+        vm.expectEmit(true, true, false, true, address(positionInit));
+        emit AntseedPositionInit.PositionInitialized(
+            address(proxy), proxyAgentId, pools.nextPositionId(), INIT_AMOUNT, 104
+        );
+        vm.prank(outsider);
+        uint256 positionId = positionInit.initPosition(address(proxy));
+
+        assertFalse(token.transfersEnabled());
+        assertEq(pools.ownerOf(positionId), outsider);
+        (, uint256 positionAgentId, uint256 amount,,,,,) = pools.positions(positionId);
+        assertEq(positionAgentId, proxyAgentId);
+        assertEq(amount, INIT_AMOUNT);
+        assertTrue(positionInit.agentInitialized(proxyAgentId));
+        assertEq(positionInit.remainingInits(), 9);
+
+        vm.warp(block.timestamp + EPOCH_DURATION);
+        assertEq(pools.poolActiveStakeAtEpoch(proxyAgentId, 1), INIT_AMOUNT);
+        assertEq(pools.poolWeightAtEpoch(proxyAgentId, 1), INIT_AMOUNT * 104);
+    }
+
+    function test_differentOperatorsCannotClaimSameSellerTwice() public {
+        MockSellerOperatorsForInit proxy = new MockSellerOperatorsForInit();
+        _registerLegacySeller(address(proxy));
+        proxy.setOperator(outsider, true);
+        proxy.setOperator(otherSeller, true);
+        vm.prank(outsider);
+        positionInit.initPosition(address(proxy));
+
+        vm.prank(otherSeller);
+        vm.expectRevert(AntseedPositionInit.AlreadyInitialized.selector);
+        positionInit.initPosition(address(proxy));
+    }
+
+    function test_unauthorizedAndRevokedOperatorsCannotInit() public {
+        MockSellerOperatorsForInit proxy = new MockSellerOperatorsForInit();
+        uint256 proxyAgentId = _registerLegacySeller(address(proxy));
+        vm.prank(outsider);
+        vm.expectRevert(AntseedPositionInit.NotOperator.selector);
+        positionInit.initPosition(address(proxy));
+
+        proxy.setOperator(outsider, true);
+        proxy.setOperator(outsider, false);
+        vm.prank(outsider);
+        vm.expectRevert(AntseedPositionInit.NotOperator.selector);
+        positionInit.initPosition(address(proxy));
+        assertFalse(positionInit.agentInitialized(proxyAgentId));
+        assertEq(positionInit.remainingInits(), 10);
+    }
+
+    function test_operatorCannotBypassSellerEligibilityOrWashStatus() public {
+        MockSellerOperatorsForInit proxy = new MockSellerOperatorsForInit();
+        uint256 proxyAgentId = _registerLegacySeller(address(proxy));
+        proxy.setOperator(seller, true);
+        legacyStaking.setStakedAboveMin(address(proxy), false);
+        vm.prank(seller);
+        vm.expectRevert(AntseedPositionInit.NotLegacySeller.selector);
+        positionInit.initPosition(address(proxy));
+
+        legacyStaking.setStakedAboveMin(address(proxy), true);
+        washRegistry.set(address(proxy), true);
+        vm.prank(seller);
+        vm.expectRevert(AntseedPositionInit.WashTrader.selector);
+        positionInit.initPosition(address(proxy));
+        assertFalse(positionInit.agentInitialized(proxyAgentId));
+        assertEq(positionInit.remainingInits(), 10);
+    }
+
+    function test_otherEoaAndContractWithoutOperatorGetterReject() public {
+        vm.startPrank(outsider);
+        vm.expectRevert(AntseedPositionInit.NotOperator.selector);
+        positionInit.initPosition(seller);
+        vm.expectRevert(AntseedPositionInit.NotOperator.selector);
+        positionInit.initPosition(address(legacyStaking));
+        vm.stopPrank();
+    }
+
+    function test_revertingOrMalformedOperatorGetterRejects() public {
+        MockSellerOperatorsForInit proxy = new MockSellerOperatorsForInit();
+        bytes memory query = abi.encodeWithSignature("isOperator(address)", outsider);
+        vm.mockCallRevert(address(proxy), query, abi.encode("unavailable"));
+        vm.prank(outsider);
+        vm.expectRevert(AntseedPositionInit.NotOperator.selector);
+        positionInit.initPosition(address(proxy));
+        vm.clearMockedCalls();
+
+        vm.mockCall(address(proxy), query, hex"01");
+        vm.prank(outsider);
+        vm.expectRevert(AntseedPositionInit.NotOperator.selector);
+        positionInit.initPosition(address(proxy));
+        vm.mockCall(address(proxy), query, abi.encode(uint256(2)));
+        vm.prank(outsider);
+        vm.expectRevert(AntseedPositionInit.NotOperator.selector);
+        positionInit.initPosition(address(proxy));
+    }
+
+    function test_zeroSellerRejects() public {
+        vm.expectRevert(AntseedPositionInit.InvalidAddress.selector);
+        positionInit.initPosition(address(0));
     }
 
     function test_latePositionNeverOutweighsEarlyPosition() public {


### PR DESCRIPTION
## Description

Adds `AntseedPositionInit.initPosition(seller)` so an authorized operator can bootstrap a seller contract's pool without requiring the contract to call the faucet or receive an NFT. When the caller differs from the seller, authorization uses the generic `ISellerDelegation.isOperator` interface; existing self-initialization remains available.

Eligibility, wash status, and the one-time grant remain seller/agent-based. The calling operator owns the lANTS position, its staker rewards, and its withdrawal rights; later operator revocation does not revoke position ownership. The stake supports the seller's agent pool.

## Release Notes

- Authorized seller operators can initialize starter positions for existing seller contracts, including the DIEM proxy.
- Updated the bootstrap documentation and changelog to explain operator ownership and next-epoch activation.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (maintenance tasks, refactoring, or non-functional changes)

## Validation

- Full contract suite: 797 tests passed, zero failures or skips; excludes the separate, uncommitted readiness reproduction fixture.
- Deployment runner: 73 tests passed.
- After replacing the proxy-specific interface with the generic interface: all 20 faucet tests passed and runtime bytecode remained unchanged.
- Solidity formatting and `git diff --check` passed.
- Regression coverage includes unauthorized/revoked operators, malformed or reverting authorization getters, duplicate grants across operators, seller-based eligibility/wash checks, and contract-seller initialization with token transfers disabled.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Formatting and unit tests pass locally with my changes

## Deployment Notes

No mainnet deployment is included. Regenerate the M001 deployment plan against the merged code before deployment. Dry-run artifacts and the separate readiness reproduction test are excluded from this PR. Historical eligibility and proof-predicate policy are unchanged.