### PR TITLE
chore(contracts): Record mainnet M001 deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- Docs: documented ANTS stake-move and early-withdrawal penalties, preserved reward claims, owner-configurable settings, and the legacy-USDC eligibility and expiry requirements for starter positions.
+
 - Docs: clarified the M002 release of 10% of cumulative locked seller rewards, less prior releases, with zero for flagged wash traders; distinguished the recognized-usage CLI starter-position command from legacy reward withdrawals and documented the activation requirements.
 
 - Protocol: documented recognized usage as the reward model starting September 10, 2026 (epoch 22), published all 11 contract addresses, and added a separate legacy-emissions guide with the corrected 65% seller / 5% buyer allocation. SDK chain configuration exposes `recognizedUsage` deployment metadata while active staking/emissions endpoints continue following the confirmed deployment ledger.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- Protocol: documented recognized usage as the reward model starting September 10, 2026 (epoch 22), published all 11 contract addresses, and added a separate legacy-emissions guide with the corrected 65% seller / 5% buyer allocation. SDK chain configuration exposes `recognizedUsage` deployment metadata while active staking/emissions endpoints continue following the confirmed deployment ledger.
+
 - Contracts: simplified `AntseedPointsPolicyRegistry` to chain each policy's returned seller/buyer points in registration order. Zeroed sides cannot be restored, and evaluation stops as soon as both sides reach zero. Removed category merging and multiplier caps/floors without changing the accounting contract or its original seller-first policy returns.
 - Contracts: moved historical wash-trading filtering from starter-position eligibility into `AntseedWashTradingPointsPolicy`. M001 registers this modifier so usage with proven wash-trading sellers earns zero seller and buyer points without blocking initialization or USDC settlement. Existing points, proof formats, and the 25% threshold are unchanged.
 - Contracts: `AntseedPositionInit.initPosition(seller)` lets a seller's authorized operator initialize its starter pool position. Seller eligibility and the one-time grant remain seller-based; the calling operator owns the position and its staker reward/withdrawal rights, allowing existing seller proxies to bootstrap without receiving NFTs. Self-initialization remains available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- Docs: clarified the M002 release of 10% of cumulative locked seller rewards, less prior releases, with zero for flagged wash traders; distinguished the recognized-usage CLI starter-position command from legacy reward withdrawals and documented the activation requirements.
+
 - Protocol: documented recognized usage as the reward model starting September 10, 2026 (epoch 22), published all 11 contract addresses, and added a separate legacy-emissions guide with the corrected 65% seller / 5% buyer allocation. SDK chain configuration exposes `recognizedUsage` deployment metadata while active staking/emissions endpoints continue following the confirmed deployment ledger.
 
 - Contracts: simplified `AntseedPointsPolicyRegistry` to chain each policy's returned seller/buyer points in registration order. Zeroed sides cannot be restored, and evaluation stops as soon as both sides reach zero. Removed category merging and multiplier caps/floors without changing the accounting contract or its original seller-first policy returns.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -329,7 +329,17 @@ For tools that can only set a model name, use `<peerId>@<model>` as the model. T
 
 Payments run on **Base Mainnet** by default. Contract addresses are resolved automatically — no manual configuration needed.
 
-### Provider Setup (Selling)
+**Protocol start: September 10, 2026 at 09:54:21 UTC (epoch 22).**
+See [Recognized Usage and ANTS Rewards](../website/docs/protocol/recognized-usage.md)
+for ANTS pool positions, seller eligibility, and usage rewards. The SDK exposes
+the contract inventory as `getChainConfig('base-mainnet').recognizedUsage`.
+
+Looking for pre-migration USDC staking or rewards? See
+[Legacy emissions and claims](../website/docs/protocol/legacy-emissions.md).
+The setup commands below use that legacy USDC interface; they do not create
+ANTS pool positions.
+
+### Legacy USDC Provider Setup (Pre-Migration)
 
 ```bash
 # 1. Set your identity (secp256k1 private key)

--- a/apps/website/docs/guides/payments.md
+++ b/apps/website/docs/guides/payments.md
@@ -113,44 +113,46 @@ For a one-off run, use `antseed seller start --base-rpc-url <url>`. For durable 
 
 Sellers relay buyer deposit sweeps by default: the node verifies and simulates each incoming sweep request, submits it on-chain, and earns the fixed relay fee (minus gas). Opt out with `relayer.enabled: false` in your config, or tune the profitability floor with `relayer.minProfitBaseUnits`.
 
-### Staking
+### Staking and ANTS Rewards {#ants-token-emissions}
 
-Providers must stake a minimum of $10 USDC to participate:
+**Starting September 10, 2026 at 09:54:21 UTC (epoch 22)**, ANTS rewards use
+recognized service usage and locked seller-pool stake. Participants hold
+lANTS staking-position NFTs; pool power activates in the following epoch.
+Eligible sellers can initialize a starter position, including contract sellers
+whose authorized operator initializes on their behalf.
 
-```bash
-antseed seller stake 10
-```
+Weekly allocation ceilings are:
+- 40% for seller-pool rewards.
+- 20% for buyer and seller/operator usage rewards.
+- 15% for the emissions reserve.
+- 15% for the team.
+- 10% for verification.
 
-Staking binds your wallet to an on-chain agent identity (ERC-8004). To withdraw your stake:
+Actual rewards depend on eligibility, pool power, usage, and the reward
+contracts' allocation rules. USDC payments can still settle even when no
+usage points are earned. Enabling ANTS trading is a separate action.
 
-```bash
-antseed seller unstake
-```
+See [Recognized Usage and ANTS Rewards](../protocol/recognized-usage.md) for
+starter positions, pool staking, policies, and contract addresses.
 
-### ANTS Token Emissions
-
-Providers and buyers earn ANTS tokens based on eligible USDC volume. Emissions are distributed per epoch (1 week):
-- 50% to providers (proportional to USDC earned, capped at 50% of the seller bucket per seller per epoch)
-- 20% to buyers (proportional to USDC spent, capped at 5% of the buyer bucket per buyer per epoch)
-- 15% to protocol reserve, plus seller and buyer cap overages
-- 15% to contributors/team
-
-Check your pending emissions:
-
-```bash
-antseed seller emissions info
-```
+**Looking for rewards or USDC staking from before migration?** See
+[Legacy emissions and claims](../protocol/legacy-emissions.md).
 
 ## Contract Addresses (Base Mainnet)
+
+These are the settlement and accounting endpoints for the protocol starting
+**September 10, 2026**. The [full ANTS contract list](../protocol/recognized-usage.md#mainnet-contracts)
+includes pools, reward contracts, and starter positions. Historical claims use
+[legacy addresses](../protocol/legacy-emissions.md#legacy-contract-addresses).
 
 | Contract | Address |
 |---|---|
 | USDC (Circle) | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
 | AntseedDeposits | `0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2` |
 | AntseedChannels | `0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d` |
-| AntseedStaking | `0x3652E6B22919bd322A25723B94BB207602E5c8e6` |
+| AntseedSellerRegistry | `0x99c533BCc6Ca646E543dbA835Fdbb9C2ee02Cb60` |
 | AntseedDepositRelay | `0x34a44542e76f9b4cff3a31902eDF14AbF2C3B3DD` |
-| AntseedEmissionsV2 | `0xF13bE52c4A3afC6AE29536f073588d01A0564088` |
+| AntseedUsageAccounting | `0xAdd2D85316153D7bfaF7921EE9Bf1Bb6c7A1cBc9` |
 | ANTSToken | `0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263` |
 
 All contracts verified on [BaseScan](https://basescan.org). For testnet (Base Sepolia), set `payments.crypto.chainId` to `base-sepolia` in your config.

--- a/apps/website/docs/protocol/legacy-emissions.md
+++ b/apps/website/docs/protocol/legacy-emissions.md
@@ -52,6 +52,26 @@ require moving or re-creating those points.
 Use the legacy contract addresses below for these claims. The recognized-usage
 accounting contract is not a replacement claim endpoint for old V2 epochs.
 
+## Locked seller rewards: M002
+
+The M002 migration releases **10% of each eligible seller's cumulative
+locked legacy ANTS**, less anything already released. This is 10% of the
+seller's locked rewards, not a `10 / 65` adjustment to the legacy seller bucket.
+For example, 1,000 ANTS cumulatively locked permits 100 ANTS in total releases;
+repeating a claim does not release another 10%. The remainder stays locked.
+
+Sellers proven as wash traders by the configured wash-trading registry, or
+flagged manually by the claim-policy owner, receive **zero** from this policy.
+This restriction is separate from starter-position initialization, which is
+not blocked by historical wash flags.
+
+M002 is a separate deployment after M001 activation. It installs the
+legacy seller claim policy and enables the locked-rewards pool to transfer ANTS
+before global token transfers are enabled. The September 10 protocol start does
+not automatically unlock these rewards. Claims through the pool become
+available only after M002 is installed; its default is an immediate
+10% entitlement, with release and vesting parameters verified at deployment.
+
 ## Escrow and flushes {#escrow-and-flushes}
 
 Since M001 phase 1, V2's registry points to `AntseedLegacyEmissionsEscrow`.

--- a/apps/website/docs/protocol/legacy-emissions.md
+++ b/apps/website/docs/protocol/legacy-emissions.md
@@ -1,0 +1,100 @@
+---
+sidebar_position: 7
+slug: /legacy-emissions
+title: Legacy Emissions and Claims
+hide_title: true
+---
+
+# Legacy Emissions and Claims
+
+This reference covers **pre-migration rewards**, before the epoch-22 protocol
+start on **September 10, 2026 at 09:54:21 UTC**. For staking positions and rewards
+from that start date, see [Recognized Usage and ANTS Rewards](./recognized-usage.md).
+
+Migration does not erase historical points or claims. Legacy V2 continues to
+serve those claims after the recognized-usage accounting endpoint takes over.
+
+## Legacy allocation
+
+The pre-migration configuration is:
+
+| Recipient | Share of epoch emissions |
+|---|---|
+| Sellers | **65%** |
+| Buyers | **5%** |
+| Protocol reserve | **15%** |
+| Team | **15%** |
+
+These values were checked on legacy V2 at Base block **50,956,120** on
+September 6, 2026. The old 50% seller / 20% buyer description is not the
+pre-migration configuration. Parameters are snapshotted per epoch, so older
+epochs must use their recorded values, not today's percentages.
+
+Rewards are proportional to a participant's points within each finalized
+epoch. The per-recipient caps are **50% of the seller bucket per seller** and
+**5% of the buyer bucket per buyer**; those are caps within a bucket, not its
+share of total emissions. Cap overages accumulate for the protocol reserve.
+
+Epochs last one week. Legacy V2 inherits the emission clock and schedule from
+V1, with a 104-epoch halving interval on Base mainnet.
+
+## Claiming historical rewards
+
+Sellers call `claimSellerEmissions(epochs[])` on legacy V2 for finalized epochs.
+If the seller-unlock policy permits a direct claim, the seller receives ANTS;
+otherwise rewards go to the legacy locked-rewards pool.
+
+For buyers, the deposits operator calls `claimBuyerEmissions(buyer, epochs[])`.
+The payout goes to that operator. V2 also reads V1's historical points and claim
+state for the V1-to-V2 migration epochs, so the later M001 migration does not
+require moving or re-creating those points.
+
+Use the legacy contract addresses below for these claims. The recognized-usage
+accounting contract is not a replacement claim endpoint for old V2 epochs.
+
+## Escrow and flushes {#escrow-and-flushes}
+
+Since M001 phase 1, V2's registry points to `AntseedLegacyEmissionsEscrow`.
+Its existing `mint()` calls now transfer pre-minted ANTS from the escrow;
+they do not create additional token supply.
+
+The V2 owner can call:
+
+- `flushReserve()` to pay accumulated reserve ANTS to the main registry's
+  `protocolReserve()` address.
+- `flushTeam()` to pay accumulated team ANTS to the main registry's
+  `teamWallet()` address.
+
+Each flush drains its current nonzero accumulator. These are not one-time
+operations: later legacy claims can account additional amounts to flush.
+The new emissions-reserve wallet does not replace the legacy reserve-flush
+destination. Do not sweep the escrow while legitimate legacy claims remain.
+
+## Legacy USDC staking
+
+Before migration, sellers register their ERC-8004 identity and stake at least
+10 USDC through `AntseedStaking`. The legacy CLI calls are:
+
+```bash
+antseed seller stake 10
+antseed seller unstake
+```
+
+These are not ANTS pool-position commands. Following migration, legacy stake
+can continue satisfying seller eligibility while the fallback is enabled,
+but new usage rewards require seller-pool power. The new seller registry does
+not support the old USDC stake/unstake methods; consult the migration runbook
+before attempting legacy withdrawals after the registry switch.
+
+## Legacy contract addresses {#legacy-contract-addresses}
+
+| Contract | Base mainnet address |
+|---|---|
+| AntseedStaking | `0x3652E6B22919bd322A25723B94BB207602E5c8e6` |
+| AntseedEmissionsV2 | `0xF13bE52c4A3afC6AE29536f073588d01A0564088` |
+| AntseedEmissions V1 | `0x36877fBa8Fa333aa46a1c57b66D132E4995C86b5` |
+| AntseedSellerRewardsPool | `0xA065C0dE80dbd3d824F7b584E231b76b9fefB261` |
+| AntseedLegacyEmissionsEscrow | `0x4d0fC3C0BBb5233Af6c4Ce33223e5330c34db9ab` |
+
+Buyer deposits, Channels, and ANTSToken are shared with the
+[recognized-usage protocol](./recognized-usage.md); they are not replaced by migration.

--- a/apps/website/docs/protocol/payments.md
+++ b/apps/website/docs/protocol/payments.md
@@ -138,33 +138,49 @@ USDC on Base. 6 decimal places. All on-chain amounts are in USDC atomic units (1
 
 ## Smart Contracts
 
+The recognized-usage protocol starts **September 10, 2026 at 09:54:21 UTC
+(epoch 22)**. Its contracts separate USDC settlement from ANTS eligibility,
+accounting, and rewards:
+
 ```text title="contract architecture"
-AntseedRegistry            Central address book for all protocol contracts
-AntseedStaking             Seller staking (holds stake USDC, binds to ERC-8004 agentId)
-AntseedDeposits            Buyer deposits, seller payouts (holds buyer USDC)
-AntseedChannels            Payment channel lifecycle (swappable, holds NO USDC)
-AntseedEmissionsV2         ANTS token emissions (backward-compatible replacement)
-AntseedSellerRewardsPool   Locked ANTS reserves for sellers pending unlock
-AntseedSellerUnlockPolicy  On-chain policy controlling when sellers can claim
-AntseedEmissions (legacy)  Original emissions contract — depleted since epoch 4
-ANTSToken                  ANTS ERC-20 token (1.04B max supply)
+AntseedRegistry               Central address book
+AntseedDeposits               Buyer deposits and seller payouts in USDC
+AntseedChannels               Signed payment channels; holds no USDC
+ANTSToken                     ANTS token; mint authority is the emissions gate
+AntseedEmissionsGate          Emission schedule and reward allocations
+AntseedSellerRegistry         Seller eligibility and ERC-8004 agent lookup
+AntseedSellerPools            Locked ANTS positions and epoch pool power
+AntseedUsageAccounting        Recognized buyer/seller usage points
+AntseedPointsPolicyRegistry   Ordered usage-point policies
+AntseedWashTradingPointsPolicy  Filters usage by historically flagged sellers
+AntseedSellerPoolsRewards     Staker rewards
+AntseedUsageRewards           Buyer and seller/operator rewards
+AntseedPositionInit           Starter-position grants
 ```
+
+Looking for the pre-migration contracts or older rewards?
+See [Legacy emissions and claims](./legacy-emissions.md).
 
 Network fees are set to 4% of settlement and flow to the Protocol Reserve, not to a company. The Protocol Reserve is intended to support long-term network sustainability, trust, utility, and alignment.
 
 ### Emissions
 
-`AntseedEmissionsV2` replaced the original `AntseedEmissions` contract at epoch 4. It is backward-compatible: historical points from epochs 1–4 remain claimable through V2, while all new points accrue in V2's own ledger.
+ANTS rewards combine recognized service usage with seller-pool stake. From
+**epoch 22**, allocation ceilings are 40% for seller-pool rewards, 20% for
+buyer and seller/operator usage rewards, 15% for the reserve, 15% for the team,
+and 10% for verification. Pool and usage allocations vary dynamically with
+eligibility and utilization; the ceilings are not guaranteed payouts.
 
-Each epoch's ANTS are split: 50% to sellers, 20% to buyers, 15% to the Protocol Reserve, and 15% to the team.
+USDC settlement and reward eligibility are separate. A seller without enough
+pool power, or usage filtered by a points policy, can still settle payment
+without earning recognized-usage rewards. Historical wash flags zero both
+buyer and seller points for future records involving the flagged seller.
 
-**For sellers:** ANTS rewards from finalized epochs are minted to a locked rewards pool (`AntseedSellerRewardsPool`) by default. Sellers can only claim unlocked tokens when the on-chain `AntseedSellerUnlockPolicy` allows it — typically after stake/activity criteria are met.
+See [Recognized Usage and ANTS Rewards](./recognized-usage.md) for staking,
+policies, claims, and the complete contract inventory. For rewards earned
+before the start date, use [Legacy emissions and claims](./legacy-emissions.md).
 
-**For buyers:** Buyer emissions are claimable via an operator address through `claimBuyerEmissions`.
-
-Per finalized epoch, rewards are subject to recipient caps. Each seller is capped at `maxSellerSharePct` (currently 50% of the seller bucket), and each buyer is capped at `maxBuyerSharePct` (currently 5% of the buyer bucket). Cap overages are redirected to the Protocol Reserve.
-
-**Stable contracts** (Staking, Deposits) hold funds and rarely change. The **swappable contract** (Channels) holds no USDC and can be redeployed by re-pointing via the Registry.
+Deposits holds buyer USDC; Channels holds no USDC. Seller pools hold ANTS stake.
 
 Identity uses the deployed [ERC-8004](https://eips.ethereum.org/EIPS/eip-8004) IdentityRegistry on Base.
 
@@ -179,15 +195,19 @@ Contract addresses are built into the CLI for each chain — no manual configura
 
 ### Base Mainnet Contract Addresses
 
+Protocol addresses from the **September 10, 2026** start date are below.
+See the [full rewards inventory](./recognized-usage.md#mainnet-contracts) or
+[pre-migration addresses](./legacy-emissions.md#legacy-contract-addresses).
+
 | Contract | Address |
 |---|---|
 | USDC (Circle) | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
 | AntseedRegistry | `0xf33fC901BFa97326379A369401F4490E231B69B0` |
 | AntseedDeposits | `0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2` |
 | AntseedChannels | `0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d` |
-| AntseedStaking | `0x3652E6B22919bd322A25723B94BB207602E5c8e6` |
+| AntseedSellerRegistry | `0x99c533BCc6Ca646E543dbA835Fdbb9C2ee02Cb60` |
 | AntseedStats | `0x15649ff076BFa5e37e24EE3154a00503149954Fd` |
-| AntseedEmissionsV2 | `0xF13bE52c4A3afC6AE29536f073588d01A0564088` |
+| AntseedUsageAccounting | `0xAdd2D85316153D7bfaF7921EE9Bf1Bb6c7A1cBc9` |
 | ANTSToken | `0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263` |
 | ERC-8004 IdentityRegistry | `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` |
 

--- a/apps/website/docs/protocol/recognized-usage.md
+++ b/apps/website/docs/protocol/recognized-usage.md
@@ -1,0 +1,134 @@
+---
+sidebar_position: 6
+slug: /recognized-usage
+title: Recognized Usage and ANTS Rewards
+hide_title: true
+---
+
+# Recognized Usage and ANTS Rewards
+
+**Protocol start: September 10, 2026 at 09:54:21 UTC — epoch 22.**
+
+Recognized usage connects ANTS rewards to paid service delivery and seller-pool
+stake. This page describes the protocol from that start date: seller eligibility,
+locked staking positions, usage points, and reward distribution. Buyer USDC
+deposits, payment channels, and settlement signatures are unchanged.
+
+**Looking for rewards earned before migration?** See
+[Legacy emissions and claims](./legacy-emissions.md).
+
+## Seller pools and recognized usage
+
+Recognized usage requires an eligible seller pool with sufficient epoch power.
+Accounting applies the registered points policies and tracks buyer/seller
+points and pool-weighted points. A missing pool or filtered record earns no
+new usage points; this does not prevent the underlying USDC settlement.
+
+`AntseedSellerPools` holds locked ANTS positions represented by lANTS NFTs.
+Staking power activates in the following epoch. Initialize or seed seller pools
+before an epoch boundary to have power in that epoch.
+Legacy USDC staking remains an eligibility fallback until explicitly disabled;
+the new seller registry does not expose the legacy USDC withdrawal flow.
+
+## Starter positions and seller proxies
+
+Fund `AntseedPositionInit` with ANTS separately. Before global transfers are
+enabled, the funding wallet must be a whitelisted sender. Fund conservatively:
+the faucet has no owner or sweep function, so unused funds cannot be recovered.
+
+An eligible seller can call `initPosition()`. For a contract seller, an
+authorized operator can call `initPosition(seller)`. When caller and seller
+differ, the seller's `isOperator(caller)` must return true. Owning the proxy or
+staking DIEM does not by itself satisfy that check.
+
+The caller owns the resulting position, its staking rewards, and withdrawal
+rights; the seller's agent pool receives the power. There is one starter grant
+per agent. Historical wash flags do not prevent initialization.
+
+## Points policies and historical wash trading
+
+The owner-managed registry applies policies in registration order. Each policy
+receives `points(channelId, buyer, seller, sellerPoints, buyerPoints)` and returns
+`(sellerPoints, buyerPoints)`. This preserves the existing accounting interface.
+A zeroed side cannot be restored; evaluation ends when both sides are zero.
+
+The registered wash policy zeros both sides for a seller flagged by the
+historical proof registry's **25% authenticated seller-volume threshold**.
+Flagging affects future records only: it does not erase already credited points.
+The policy reads proofs accepted by the configured registry; submissions to a
+different registry are not automatically recognized.
+
+## Emissions and destinations
+
+The gate uses weekly epochs and a 104-epoch halving interval. Its genesis is
+April 9, 2026 at 09:54:21 UTC. The token's maximum supply remains 1.04 billion ANTS.
+Allocation ceilings from epoch 22 are:
+
+- **40% seller-pool rewards**, with the effective share determined dynamically.
+- **20% usage rewards**, with dynamic buyer and seller/operator shares.
+- **15% team**.
+- **15% emissions reserve**.
+- **10% verification**.
+
+These are not a promise that every bucket is fully paid to users. Reward
+eligibility, pool power, utilization, and the contracts' remainder rules apply.
+
+The configured destinations are:
+
+- USDC protocol fees and legacy reserve flushes: registry reserve
+  `0xBF348D3eEDA2012c60375ebFe4Eb46511859f70F`.
+- Team emissions and legacy team flushes: registry team wallet
+  `0x47151b68e2f34500A4f8886885cE69b179Bf5B0B`.
+- New ANTS reserve emissions: `0x3B4f9f426B9E465621037dF72b6DEBDD8EF1fD8c`.
+- Initial verification controller: `0x5B3A59088bD5BD5f722571420c09a9251a03AAdb`.
+
+The verification allocation initially belongs to a wallet, not a deployed
+verification contract. Keep gate ownership so its editable controller can later
+be transferred to that contract. Enabling ANTS trading is also a separate,
+one-way action; M001 does not enable it.
+
+For pre-migration claims and reserve/team flushes, see
+[Legacy emissions and claims](./legacy-emissions.md#escrow-and-flushes).
+
+## Deployed M001 contracts — Base mainnet {#mainnet-contracts}
+
+These are the Base mainnet contracts for the protocol starting at epoch 22.
+All 11 were deployed on September 6, 2026 and verified on Basescan.
+
+| Contract | Address |
+|---|---|
+| AntseedWashTradingRegistry | `0xc02a111CB94332Cc31C08E079cbe781880b2121C` |
+| AntseedEmissionsGate | `0xE60a31E6CD2F8455503cA0B3f6545Dd3DDF543BD` |
+| AntseedSellerPools | `0x8Bf4d39AA13F3CB03F87D9500767fBc4D0940652` |
+| AntseedSellerRegistry | `0x99c533BCc6Ca646E543dbA835Fdbb9C2ee02Cb60` |
+| AntseedPositionInit | `0xB68AD13b681319fcEB6b0A640c2fd96C0138CBc8` |
+| AntseedUsageAccounting | `0xAdd2D85316153D7bfaF7921EE9Bf1Bb6c7A1cBc9` |
+| AntseedPointsPolicyRegistry | `0x212D2C1058b84507de248a147aaFeB08fb19E3b6` |
+| AntseedWashTradingPointsPolicy | `0x7a605aaa3c725aa25012dfDeD6B5dddcC561D6e5` |
+| AntseedSellerPoolsRewards | `0x83cc5B9AA0c8cB8683F35462c385a5BAAa755EE5` |
+| AntseedUsageRewards | `0x78330bF154172F1137219Bb559d4F3A270B3201F` |
+| AntseedLegacyEmissionsEscrow | `0x4d0fC3C0BBb5233Af6c4Ce33223e5330c34db9ab` |
+
+The [payments address list](./payments.md#base-mainnet-contract-addresses)
+contains the settlement contracts. Pre-migration endpoints are listed in the
+[legacy guide](./legacy-emissions.md#legacy-contract-addresses).
+
+## SDK configuration
+
+`getChainConfig('base-mainnet').recognizedUsage` exposes all 11 addresses under
+`contracts`, plus `effectiveEpoch` and a recorded `status` of `deployed` or
+`active`. This metadata is generated from the deployment ledger, not a live
+RPC query. A scheduled epoch passing does not automatically change its status.
+
+`emissionsContractAddress` and `stakingContractAddress` follow the committed
+active `current.json`; the gate is not an accounting endpoint. Pool and reward
+contracts use their own interfaces; legacy CLI staking commands are not
+starter-position initialization commands.
+
+## Deployment and activation
+
+The start date is scheduled; activation is a separate operator transaction,
+not an automatic timestamp switch. The mainnet deployment record is
+`packages/contracts/deployments/base-mainnet/history/001-recognized-usage-deployed.json`.
+For operational sequencing, proof submission, funding, and pointer checks, use
+`packages/contracts/script/migrations/M001RecognizedUsage/README.md` in the repository.

--- a/apps/website/docs/protocol/recognized-usage.md
+++ b/apps/website/docs/protocol/recognized-usage.md
@@ -30,13 +30,48 @@ before an epoch boundary to have power in that epoch.
 Legacy USDC staking remains an eligibility fallback until explicitly disabled;
 the new seller registry does not expose the legacy USDC withdrawal flow.
 
+### Moving stake and early withdrawal
+
+Moving stake preserves the full ANTS principal and the original lock and
+early-exit terms. Rewards already accrued remain claimable using the old
+position ID; future rewards follow the new seller pool when the move takes
+effect, normally in the next epoch. Moving does not bypass the lock.
+
+The Base mainnet settings checked on **September 6, 2026** are:
+
+- **Move-weight penalty: 0%** (`moveWeightPenaltyBps = 0`). If configured above
+  zero, this penalty reduces the moved position's future staking weight, not
+  its principal or already-accrued rewards.
+- **Maximum early-withdrawal slash: 50%** (`maxSlashBps = 5000`).
+- **Minimum early-withdrawal slash: 5%** (`minEarlyExitSlashBps = 500`).
+
+Before the lock ends, the principal penalty is:
+
+```text
+slash percentage = max(5%, min(50%, 50% × remaining lock epochs / total lock epochs))
+```
+
+For example, withdrawing 1,000 ANTS halfway through the lock slashes 250 ANTS
+and returns 750 ANTS. The calculation uses whole epochs, with integer rounding
+in the contract. **At or after lock expiry, the slash is zero.** Withdrawal
+does not slash previously earned rewards, but it removes the position's power
+from the withdrawal epoch onward.
+
+These percentages are owner-configurable settings, not immutable guarantees.
+Check the pool contract's current values before moving or withdrawing stake.
+
 ## Starter positions and seller proxies
 
 Fund `AntseedPositionInit` with ANTS separately. Before global transfers are
 enabled, the funding wallet must be a whitelisted sender. Fund conservatively:
 the faucet has no owner or sweep function, so unused funds cannot be recovered.
 
-An eligible seller can call `initPosition()`. For a contract seller, an
+Starter grants require an agent ID registered in **legacy USDC staking** and
+legacy stake meeting its minimum: `legacyStaking.getAgentId(seller) != 0` and
+`legacyStaking.isStakedAboveMin(seller) == true`. Eligibility through the new
+seller registry or ANTS pools alone does not qualify a seller for this grant.
+
+A qualifying seller can call `initPosition()`. For a contract seller, an
 authorized operator can call `initPosition(seller)`. When caller and seller
 differ, the seller's `isOperator(caller)` must return true. Owning the proxy or
 staking DIEM does not by itself satisfy that check.
@@ -44,6 +79,12 @@ staking DIEM does not by itself satisfy that check.
 The caller owns the resulting position, its staking rewards, and withdrawal
 rights; the seller's agent pool receives the power. There is one starter grant
 per agent. Historical wash flags do not prevent initialization.
+
+All starter positions share the faucet's fixed `initEndEpoch`. Initialization
+requires `currentEpoch() + stakeActivationDelay() < initEndEpoch`; at or beyond
+that limit, it reverts with `InitExpired`. Claiming later does not extend the
+lock's end epoch. The faucet must also hold at least `initAmount` ANTS for each
+grant.
 
 With the recognized-usage CLI, use `antseed seller legacy claim-starter`
 for starter-position initialization. It creates a staking position;

--- a/apps/website/docs/protocol/recognized-usage.md
+++ b/apps/website/docs/protocol/recognized-usage.md
@@ -45,6 +45,11 @@ The caller owns the resulting position, its staking rewards, and withdrawal
 rights; the seller's agent pool receives the power. There is one starter grant
 per agent. Historical wash flags do not prevent initialization.
 
+With the recognized-usage CLI, use `antseed seller legacy claim-starter`
+for starter-position initialization. It creates a staking position;
+it does not withdraw locked legacy rewards. That separate release is described
+in [Locked seller rewards: M002](./legacy-emissions.md#locked-seller-rewards-m002).
+
 ## Points policies and historical wash trading
 
 The owner-managed registry applies policies in registration order. Each policy

--- a/apps/website/docs/protocol/reputation.md
+++ b/apps/website/docs/protocol/reputation.md
@@ -32,7 +32,11 @@ No counter can be incremented without a corresponding on-chain state transition 
 
 ## Staking
 
-Sellers stake USDC via AntseedStaking, binding their stake to an ERC-8004 agentId. Minimum stake: 10 USDC. An unstaked seller cannot have `reserve()` called on AntseedChannels.
+From **September 10, 2026 at 09:54:21 UTC (epoch 22)**, seller eligibility is
+resolved through AntseedSellerRegistry and ANTS pool positions contribute epoch
+power. Legacy USDC stake can remain an eligibility fallback while enabled;
+recognized-usage rewards require pool power. See [Recognized Usage](./recognized-usage.md)
+and [legacy USDC staking](./legacy-emissions.md#legacy-usdc-staking).
 
 ## ERC-8004 Feedback
 
@@ -45,51 +49,24 @@ Buyers submit structured feedback via the deployed ERC-8004 ReputationRegistry (
 | Accuracy | uint8 | 0-100 |
 | Reliability | uint8 | 0-100 |
 
-Feedback produces a multiplier on the seller's emission rate:
+Feedback and routing reputation do not automatically grant ANTS or apply a
+fixed on-chain reward multiplier. Recognized-usage accounting applies the
+configured points policies; the registered historical wash-trading policy
+can zero future rewards without changing settlement stats.
 
-```
-feedbackMultiplier = 0.5 + (avgFeedbackScore / 100)
-// Range: 0.5x (score=0) to 1.5x (score=100)
-```
+## ANTS Rewards
 
-Feedback does not affect core stats counters. It modulates emission only.
+**Protocol start: September 10, 2026 at 09:54:21 UTC (epoch 22).**
 
-## ANTS Emission
+ANTS rewards use recognized usage, seller-pool power, and epoch-based reward
+accounting. Allocation ceilings are 40% for pool rewards, 20% for buyer and
+seller/operator usage rewards, 15% for the reserve, 15% for the team, and 10%
+for verification. Actual pool and usage rewards depend on the contracts'
+eligibility and dynamic allocation rules.
 
-Token emission is tied to proven delivery. Points accumulate per-interaction and convert to ANTS via a Synthetix-style reward-per-point distribution (O(1) per interaction, no epoch batching).
-
-### Seller Points
-
-```
-sellerPoints = V(P) * feedbackMultiplier
-```
-
-Where:
-- `V(P)` = USDC volume settled in the session
-- `feedbackMultiplier` = feedback-derived multiplier (0.5x to 1.5x)
-
-### Buyer Points
-
-```
-buyerPoints = usagePoints + feedbackPoints + diversityBonus
-```
-
-- `usagePoints`: proportional to USDC spent in qualified sessions
-- `feedbackPoints`: awarded for submitting feedback (incentivizes signal)
-- `diversityBonus`: bonus for transacting with more unique sellers
-
-### Distribution Split
-
-| Recipient | Share |
-|---|---|
-| Seller / Provider Pool | 50% |
-| Buyer | 20% |
-| Protocol reserve | 15% |
-| Contributors / team | 15% |
-
-Seller rewards are capped at 50% of the seller bucket per seller per epoch. Buyer rewards are capped at 5% of the buyer bucket per buyer per epoch. Cap overages are redirected to the Protocol Reserve.
-
-ANTS tokens are non-transferable until network maturity. This prevents early speculation from distorting incentives.
+See [Recognized Usage and ANTS Rewards](./recognized-usage.md) for the standard
+reward model. **Looking for pre-migration emissions?** The [legacy guide](./legacy-emissions.md)
+covers the 65% seller / 5% buyer split and historical claims.
 
 ## Buyer Route Scoring
 

--- a/apps/website/sidebars.ts
+++ b/apps/website/sidebars.ts
@@ -40,6 +40,8 @@ const sidebars: SidebarsConfig = {
         'protocol/transport',
         'protocol/metering',
         'protocol/payments',
+        'protocol/recognized-usage',
+        'protocol/legacy-emissions',
         'protocol/reputation',
         'protocol/security',
       ],

--- a/docs/protocol/spec/04-payments.md
+++ b/docs/protocol/spec/04-payments.md
@@ -201,116 +201,74 @@ For local testing only. Simulates the ERC-8004 registry interface so contracts c
 
 ### ANTS Token
 
-ERC-20 on Base. No pre-mine. No initial supply. All ANTS distributed through verified work over 10 years.
+ERC-20 on Base with a 1.04 billion ANTS maximum supply and zero initial supply.
+Scheduled emissions fund participant rewards and protocol allocations. M001
+pre-mints the remaining pre-effective-epoch schedule into the legacy escrow;
+that reserve is not a new user reward or freely claimable balance.
 
-**Phase 1 (current):** Non-transferable. `transfer()` and `transferFrom()` revert. Participants earn and claim but cannot trade. Owner calls `enableTransfers()` (one-way toggle) when the network matures.
+**Transfer-restricted phase:** Ordinary transfers are disabled; minting and transfers by whitelisted senders are allowed. Owner calls `enableTransfers()` as a separate, irreversible action. M001 does not enable trading.
 
-Mint authority restricted to `AntseedEmissionsV2` contract (`setEmissionsContract()` — one-time setter).
+After M001 phase 1 on September 6, 2026, `ANTSToken.registry()` points to
+`AntseedEmissionsGate` (`0xE60a31E6CD2F8455503cA0B3f6545Dd3DDF543BD`). The gate
+controls minting; legacy V2's unchanged mint calls now transfer from
+`AntseedLegacyEmissionsEscrow` (`0x4d0fC3C0BBb5233Af6c4Ce33223e5330c34db9ab`).
 
-### AntseedEmissionsV2
+### Recognized Usage (From Epoch 22)
 
-Deployed upgrade of the original `AntseedEmissions`. Backward-compatible with V1 by reading V1's genesis, epoch constants, and combining V1 + V2 points for the migration epoch and all earlier epochs.
+**Protocol start: September 10, 2026 at 09:54:21 UTC (epoch 22).**
 
-- **Base mainnet address:** `0xF13bE52c4A3afC6AE29536f073588d01A0564088`
-- **Genesis:** copied from V1 (`legacyEmissions.genesis()`)
-- **Epoch duration / halving interval:** copied from V1
+The standard reward model combines eligible usage with ANTS seller-pool power.
+`AntseedRegistry.staking()` resolves to `AntseedSellerRegistry`
+(`0x99c533BCc6Ca646E543dbA835Fdbb9C2ee02Cb60`) and `emissions()` to
+`AntseedUsageAccounting` (`0xAdd2D85316153D7bfaF7921EE9Bf1Bb6c7A1cBc9`)
+after activation. Buyer USDC deposits, channel signatures, and settlement are unchanged.
 
-#### Epochs
+Allocation ceilings are 40% seller-pool rewards, 20% usage rewards, 15% team,
+15% reserve, and 10% verification. Pool and usage payouts follow dynamic
+allocation and eligibility rules rather than paying their ceiling unconditionally.
+The gate uses weekly epochs and a 104-epoch halving interval.
 
-Epochs advance automatically via block timestamp:
+Accounting tracks raw and pool-weighted points and applies sequential policies.
+The public policy returns remain `(sellerPoints, buyerPoints)`. A zeroed side
+cannot be restored and evaluation stops when both sides are zero. Historical
+wash flags zero future records involving the seller, not previously credited
+points, and do not prevent starter-position initialization or USDC settlement.
 
-```
-currentEpoch = (block.timestamp - genesis) / EPOCH_DURATION
-```
+Locked ANTS positions are lANTS NFTs. Power activates in the next epoch. For a
+contract seller, an authorized operator may call `initPosition(seller)`; the
+caller owns the resulting position and its rewards/withdrawal rights.
 
-No manual `advanceEpoch()` is required. Epoch parameters (share percentages and per-epoch caps) are snapshotted on first V2 touch of each epoch and remain immutable for that epoch.
+See [Recognized Usage and ANTS Rewards](../../../apps/website/docs/protocol/recognized-usage.md)
+for the full specification guide and address inventory. Activation is an
+explicit registry-pointer operation; operational sequencing remains in the M001 runbook.
 
-#### Emission Schedule
+### Pre-Migration Emissions
 
-- Epoch emission: `e_e = e_0 / 2^(epoch / HALVING_INTERVAL)` — halving every ~6 months
-- Epoch duration: configurable (default 1 week, 26 epochs per halving interval)
-
-#### Emission Split (per-epoch snapshot)
-
-| Bucket | Default | Purpose |
-|---|---|---|
-| Seller share | 50% | Proven delivery (locked rewards pool until unlocked) |
-| Buyer share | 20% | Rewards network usage and feedback |
-| Reserve share | 15% | Protocol Reserve (network sustainability, liquidity) |
-| Team share | 15% | Protocol team |
-
-#### Points Accrual
-
-During `settle()` / `close()`, `AntseedChannels` calls one of:
-
-- `accrueSellerPoints(seller, pointsDelta)`
-- `accrueBuyerPoints(buyer, pointsDelta)`
-- `accruePoints(channelId, buyer, seller, pointsDelta)` — optional pair-aware hook for future channels
-
-For epochs `<= MIGRATION_EPOCH`, V1 points are combined with V2 points on claim. For later epochs, only V2 points are used.
-
-#### Points Policy Hook
-
-An optional `IAntseedPointsPolicy` can be set by owner. If set and its `points()` call succeeds, it returns weighted seller/buyer points. If not set, or if the call reverts, raw points are used.
-
-#### Per-Epoch Pro-Rata Distribution
-
-Claiming computes rewards per finalized epoch:
-
-```
-sellerBudget = epochEmission * sellerSharePct / 100
-sellerReward = (userSellerPoints / epochTotalSellerPoints) * sellerBudget
-
-buyerBudget  = epochEmission * buyerSharePct / 100
-buyerReward  = (userBuyerPoints / epochTotalBuyerPoints) * buyerBudget
-```
-
-#### Per-Epoch Caps
-
-- **Seller cap:** `maxSellerSharePct` (default 50% of the seller bucket). Excess redirected to reserve.
-- **Buyer cap:** `maxBuyerSharePct` (default 5% of the buyer bucket). Excess redirected to reserve.
-
-#### Seller Claiming
-
-Sellers call `claimSellerEmissions(epochs[])` for finalized epochs.
-
-If `sellerUnlockPolicy.canClaimSellerUnlocked(seller)` returns true, ANTS are minted directly to the seller.
-
-If the policy returns false (or is not set), ANTS are minted to `AntseedSellerRewardsPool` and recorded as locked for that seller. They remain locked until the unlock policy later allows release.
-
-#### Buyer Claiming
-
-Anyone can call `claimBuyerEmissions(buyer, epochs[])` provided `msg.sender == Deposits.getOperator(buyer)`. Reward is minted to `msg.sender`.
-
-#### Reserve & Team
-
-Reserve and team shares accumulate in the contract until flushed by owner:
-
-- `flushReserve()` — mints accumulated reserve ANTS to `registry.protocolReserve()`
-- `flushTeam()` — mints accumulated team ANTS to `registry.teamWallet()`
-
-### Legacy V1 Backward Compatibility
-
-`AntseedEmissionsV2` reads the legacy `AntseedEmissions` contract for:
-
-- `genesis`, `EPOCH_DURATION`, `HALVING_INTERVAL`, `INITIAL_EMISSION`
-- Claimed state for epochs `< MIGRATION_EPOCH`
-- User points and total points for epochs `<= MIGRATION_EPOCH`
-
-This ensures sellers and buyers do not lose historical points during the upgrade.
+**Looking for legacy emissions or historical claims?** See
+[Legacy emissions and claims](../../../apps/website/docs/protocol/legacy-emissions.md).
+The pre-migration V2 configuration is **65% sellers, 5% buyers, 15% reserve,
+15% team**, with per-epoch snapshots governing historical rewards. Legacy V2
+continues paying historical claims and owner-triggered team/reserve flushes
+from the pre-minted escrow after migration.
 
 ## 9. Contract Architecture
 
 ```
-ANTSToken (ERC-20)              ── mint restricted to AntseedEmissionsV2
-AntseedDeposits                 ── buyer USDC deposits, holds ALL buyer USDC
-AntseedChannels                 ── Reserve→Settle/Close lifecycle (holds NO USDC, swappable)
-AntseedStaking                  ── seller stake bound to ERC-8004 agentId
-AntseedStats                    ── factual per-agent session metrics
-AntseedEmissionsV2              ── USDC volume-based epoch emissions (backward-compatible with V1)
-AntseedSellerRewardsPool        ── holds locked ANTS for sellers pending unlock policy
-AntseedSellerUnlockPolicy       ── on-chain policy determining if seller can claim unlocked
-MockERC8004Registry             ── local testing only (mainnet: deployed ERC-8004)
+ANTSToken                     ── mint authority is AntseedEmissionsGate
+AntseedDeposits                ── holds buyer USDC deposits and seller payouts
+AntseedChannels                ── signed payment channels, holds no USDC
+AntseedSellerRegistry          ── ERC-8004 seller eligibility
+AntseedSellerPools             ── locked ANTS positions and pool power
+AntseedUsageAccounting         ── recognized usage and pool-weighted points
+AntseedPointsPolicyRegistry    ── sequential points transformations
+AntseedWashTradingRegistry     ── authenticated historical seller proofs
+AntseedWashTradingPointsPolicy ── zeros future points for flagged sellers
+AntseedSellerPoolsRewards      ── staker rewards
+AntseedUsageRewards            ── buyer and seller/operator usage rewards
+AntseedPositionInit            ── starter-position faucet
+AntseedEmissionsGate           ── emission schedule and allocations
+AntseedLegacyEmissionsEscrow   ── funds pre-migration claims and flushes
+AntseedStats                   ── factual per-agent session metrics
 ```
 
 Contracts reference each other by address (set at deployment, updateable by owner). No inheritance between contracts — only interface calls.

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -2,15 +2,35 @@
 
 Solidity contracts implementing the streaming payment, staking, stats, and emission system.
 
+**Protocol start: September 10, 2026 at 09:54:21 UTC (epoch 22).**
+Recognized usage combines service delivery, ANTS pool positions, and epoch-based
+rewards. See the [protocol guide](../../apps/website/docs/protocol/recognized-usage.md)
+and [contract addresses](#deployed-contracts).
+
+Looking for the pre-migration system? See
+[Legacy emissions and claims](../../apps/website/docs/protocol/legacy-emissions.md).
+Deployment/cutover procedures are in the M001 operator runbook.
+
 ## Contract Architecture
 
 ```
-ANTSToken (ERC-20)          ── phase-locked transfers, mint restricted to AntseedEmissions
+ANTSToken (ERC-20)          ── phase-locked transfers, mint controlled by AntseedEmissionsGate
 AntseedDeposits             ── buyer USDC deposits, holds ALL buyer USDC
 AntseedChannels             ── Reserve→Settle/Close lifecycle, EIP-712 (swappable, holds NO USDC)
-AntseedStaking              ── seller stake bound to ERC-8004 agentId
+AntseedStaking              ── legacy USDC stake bound to ERC-8004 agentId
 AntseedStats                ── optional external metadata sink (buyer/agent token + request stats)
-AntseedEmissions            ── USDC volume-based epoch emissions
+AntseedEmissionsV2          ── legacy usage ledger and claims, now paid from escrow
+AntseedEmissionsGate        ── emission schedule and mint authority
+AntseedSellerPools          ── locked ANTS positions and epoch pool power
+AntseedSellerRegistry       ── new eligibility endpoint, activated at cutover
+AntseedUsageAccounting      ── recognized usage ledger, activated at cutover
+AntseedPointsPolicyRegistry ── ordered seller/buyer point transformations
+AntseedWashTradingRegistry  ── authenticated historical seller proof status
+AntseedWashTradingPointsPolicy ── zeros future points for flagged sellers
+AntseedPositionInit         ── separately funded starter-position faucet
+AntseedSellerPoolsRewards   ── staker rewards and restaking
+AntseedUsageRewards         ── buyer and seller/operator usage rewards
+AntseedLegacyEmissionsEscrow ── pre-minted pot for legacy claims and flushes
 MockERC8004Registry         ── mock ERC-8004 IdentityRegistry (local testing only)
 ```
 
@@ -627,7 +647,9 @@ archive-capable RPC to pin the check to a specific block.
 
 ## Configuration
 
-All constants are configurable by the contract owner via dedicated setter functions (e.g., `setFirstSignCap()`, `setWithdrawalDelay()`).
+Administrative parameters use their contract's dedicated setters where available.
+The emissions gate's schedule constants are immutable; do not treat legacy
+owner-configurable emissions parameters as configuration for the standard gate.
 
 ### AntseedDeposits / AntseedChannels / AntseedStaking
 
@@ -639,35 +661,70 @@ All constants are configurable by the contract owner via dedicated setter functi
 | `PLATFORM_FEE_BPS` | 500 (5%) | Platform fee in basis points |
 | `MAX_PLATFORM_FEE_BPS` | 1000 (10%) | Maximum platform fee |
 
-### AntseedEmissions
+### Legacy Emissions Configuration
 
-| Constant | Default | Description |
+Pre-migration V2 settings (historical epochs use their own snapshots):
+
+| Constant | Pre-migration value | Description |
 |---|---|---|
 | `EPOCH_DURATION` | 1 week | Duration of each emission epoch |
 | `HALVING_INTERVAL` | 104 epochs (~2 years) | Epochs between emission halvings |
 | `INITIAL_EMISSION` | Set at deployment | Total ANTS emitted in epoch 0 |
 | `SELLER_SHARE_PCT` | 65% | Seller share of epoch emissions |
-| `BUYER_SHARE_PCT` | 25% | Buyer share of epoch emissions |
-| `RESERVE_SHARE_PCT` | 10% | Reserve share of epoch emissions |
-| `MAX_SELLER_SHARE_PCT` | 15% | Per-seller cap of seller pool |
+| `BUYER_SHARE_PCT` | 5% | Buyer share of epoch emissions |
+| `RESERVE_SHARE_PCT` | 15% | Reserve share of epoch emissions |
+| `TEAM_SHARE_PCT` | 15% | Team share of epoch emissions |
+| `MAX_SELLER_SHARE_PCT` | 50% | Per-seller cap within the seller bucket |
+| `MAX_BUYER_SHARE_PCT` | 5% | Per-buyer cap within the buyer bucket |
 
 ### Deployed Contracts
 
 #### Base Mainnet (Production)
+
+Protocol addresses for the **September 10, 2026** start date are listed below.
+See [legacy addresses](../../apps/website/docs/protocol/legacy-emissions.md#legacy-contract-addresses)
+for pre-migration staking and claims.
 
 | Contract | Address |
 |---|---|
 | **USDC (Circle)** | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
 | **ANTSToken** | `0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263` |
 | **AntseedRegistry** | `0xf33fC901BFa97326379A369401F4490E231B69B0` |
-| **AntseedStaking** | `0x3652E6B22919bd322A25723B94BB207602E5c8e6` |
+| **AntseedSellerRegistry** | `0x99c533BCc6Ca646E543dbA835Fdbb9C2ee02Cb60` |
 | **AntseedDeposits** | `0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2` |
 | **AntseedChannels** | `0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d` |
 | **AntseedStats** | `0x15649ff076BFa5e37e24EE3154a00503149954Fd` |
-| **AntseedEmissionsV2** | `0xF13bE52c4A3afC6AE29536f073588d01A0564088` |
+| **AntseedUsageAccounting** | `0xAdd2D85316153D7bfaF7921EE9Bf1Bb6c7A1cBc9` |
 | **ERC-8004 IdentityRegistry** | `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` (external) |
 
 All verified on [BaseScan](https://basescan.org). Contract addresses are built into `@antseed/node` chain-config — no manual configuration needed when `chainId: "base-mainnet"` is set.
+
+##### M001 deployed stack
+
+All 11 contracts below were deployed in phase 1 and verified. Their canonical
+provenance is in `deployments/base-mainnet/history/001-recognized-usage-deployed.json`.
+The protocol starts at epoch 22; use the operator runbook for the activation procedure.
+
+| Contract | Address |
+|---|---|
+| AntseedWashTradingRegistry | `0xc02a111CB94332Cc31C08E079cbe781880b2121C` |
+| AntseedEmissionsGate | `0xE60a31E6CD2F8455503cA0B3f6545Dd3DDF543BD` |
+| AntseedSellerPools | `0x8Bf4d39AA13F3CB03F87D9500767fBc4D0940652` |
+| AntseedSellerRegistry | `0x99c533BCc6Ca646E543dbA835Fdbb9C2ee02Cb60` |
+| AntseedPositionInit | `0xB68AD13b681319fcEB6b0A640c2fd96C0138CBc8` |
+| AntseedUsageAccounting | `0xAdd2D85316153D7bfaF7921EE9Bf1Bb6c7A1cBc9` |
+| AntseedPointsPolicyRegistry | `0x212D2C1058b84507de248a147aaFeB08fb19E3b6` |
+| AntseedWashTradingPointsPolicy | `0x7a605aaa3c725aa25012dfDeD6B5dddcC561D6e5` |
+| AntseedSellerPoolsRewards | `0x83cc5B9AA0c8cB8683F35462c385a5BAAa755EE5` |
+| AntseedUsageRewards | `0x78330bF154172F1137219Bb559d4F3A270B3201F` |
+| AntseedLegacyEmissionsEscrow | `0x4d0fC3C0BBb5233Af6c4Ce33223e5330c34db9ab` |
+
+`getChainConfig('base-mainnet').recognizedUsage` exposes these addresses and
+the recorded deployment status without changing the active legacy aliases.
+The metadata is generated from the history record and `current.json`, not
+inferred from wall-clock time. Update the active record and regenerate only
+after a successful cutover. Existing legacy client methods are not adapters
+for the new pool and reward interfaces.
 
 #### Base Sepolia (Testnet)
 

--- a/packages/contracts/deployments/README.md
+++ b/packages/contracts/deployments/README.md
@@ -21,8 +21,12 @@ Each network contains:
 10. Deployment records are created atomically and may never be overwritten, including by a resumed run.
 11. Non-fork deployment phases require `BASESCAN_API_KEY` (an Etherscan V2 key) and submit source verification during broadcast.
 
-`packages/node/src/payments/generated-contract-addresses.ts` is generated from
-each network's `current.json`. A successful canonical migration regenerates it
+`packages/node/src/payments/generated-contract-addresses.ts` uses each network's
+`current.json` for active routing addresses and M001's deployed history record
+for the optional `recognizedUsage` address inventory and effective epoch.
+That inventory is marked `active` only when both committed emissions/staking
+aliases point to the new stack; deployment or passage of time is insufficient.
+A successful canonical migration regenerates it
 automatically; `pnpm contracts:check` reports any stale generated output.
 
 `M001RecognizedUsage` has two records because deployment and activation happen in separate epochs:
@@ -80,7 +84,7 @@ setting (the legacy baseline) are not compared.
    documents the same shape for editor tooling.
 2. Invariants that apply only to the releases one migration owns, declared as
    `recordErrors(record)` on the migration. M001 proves the verification bucket
-   remains editable at 10%, that no points policy is active, and that both
+remains editable at 10%, that exactly one wash-trading points policy is registered, and that both
    administrative contracts have recorded owners.
 
 ## Commands

--- a/packages/contracts/deployments/base-mainnet/history/001-recognized-usage-deployed.json
+++ b/packages/contracts/deployments/base-mainnet/history/001-recognized-usage-deployed.json
@@ -1,0 +1,400 @@
+{
+  "release": "001-recognized-usage-deployed",
+  "status": "deployed",
+  "sourceCommit": "859a10ec889671f04e5827a7bdd48bd80d2add79",
+  "effectiveEpoch": 22,
+  "verificationConfiguration": {
+    "washTradingRegistry": "0xc02a111CB94332Cc31C08E079cbe781880b2121C",
+    "washTradingPointsPolicy": "0x7a605aaa3c725aa25012dfDeD6B5dddcC561D6e5",
+    "verificationMinterController": "0x5B3A59088bD5BD5f722571420c09a9251a03AAdb",
+    "verificationMinterShareBps": 10000,
+    "verificationMinterEditable": true,
+    "pointsPolicyCount": 1,
+    "emissionsGateOwner": "0x48F4142F4AbF7b77a03f0cDffcd511eDD9B6d54a",
+    "pointsPolicyRegistryOwner": "0x48F4142F4AbF7b77a03f0cDffcd511eDD9B6d54a"
+  },
+  "transactions": [
+    {
+      "action": "deploy AntseedWashTradingRegistry",
+      "hash": "0xba4b22bc506b8ea320c361b674726a9e4d3a7532eaf09ef781d14801397b47a8",
+      "blockNumber": 50955026,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": null
+    },
+    {
+      "action": "deploy AntseedEmissionsGate",
+      "hash": "0xfac7210de465ca15bf39be60a3cdd1d5b9270ace0059337a21dd309c5fcdf84a",
+      "blockNumber": 50955027,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": null
+    },
+    {
+      "action": "setMinterController(bytes32,address)",
+      "hash": "0x366fc704df4c250501176702cc64bce2e1578361218e6a1243cc79cb83e96a9f",
+      "blockNumber": 50955028,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xe60a31e6cd2f8455503ca0b3f6545dd3ddf543bd"
+    },
+    {
+      "action": "deploy AntseedSellerPools",
+      "hash": "0x4bc7c19033a6521a2d6de7bccf0fb071fea9b9aef62b5e9d72649ecc6f7da6f1",
+      "blockNumber": 50955029,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": null
+    },
+    {
+      "action": "deploy AntseedSellerRegistry",
+      "hash": "0x30bb68fb86e94b75190edf54dcfc00c499b341e6e13e79369066d2d5b75580bb",
+      "blockNumber": 50955030,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": null
+    },
+    {
+      "action": "setStakingSource(address)",
+      "hash": "0xf0a7fdb897ca2753f374e6e9fea20948281a4af4d2ffae533f4b6f71d62374e1",
+      "blockNumber": 50955031,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0x8bf4d39aa13f3cb03f87d9500767fbc4d0940652"
+    },
+    {
+      "action": "setMinter(bytes32,address,uint32,bool)",
+      "hash": "0xcf7bfb7092d33c97afcda7f65e58707b6fee70ac3be40bb04e6faf57f09ec835",
+      "blockNumber": 50955032,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xe60a31e6cd2f8455503ca0b3f6545dd3ddf543bd"
+    },
+    {
+      "action": "deploy AntseedPositionInit",
+      "hash": "0xc5c3b33138a59222871104acfe987076f7fd40f3c1a89907a40e11e3373be09e",
+      "blockNumber": 50955033,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": null
+    },
+    {
+      "action": "deploy AntseedUsageAccounting",
+      "hash": "0xdd65cec51382558aa745f8f48b906a045b7df231af62a2a679d2f8457b65c31d",
+      "blockNumber": 50955034,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": null
+    },
+    {
+      "action": "deploy AntseedPointsPolicyRegistry",
+      "hash": "0xb6e24df4541042e39c7f76e1f07e7968a9f581acf64d90f4cb24a0bac5df4997",
+      "blockNumber": 50955035,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": null
+    },
+    {
+      "action": "deploy AntseedWashTradingPointsPolicy",
+      "hash": "0x7852bf9f71b8d46a332f20238ae0cdf2862fa1c38fcdf4488832ff3aae25fc82",
+      "blockNumber": 50955036,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": null
+    },
+    {
+      "action": "registerPolicy(address)",
+      "hash": "0xa2cf2241cd7071859e2a5f659cbc13433766698a9d7c0e9b2d832c725a03dab1",
+      "blockNumber": 50955037,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0x212d2c1058b84507de248a147aafeb08fb19e3b6"
+    },
+    {
+      "action": "setPointsPolicy(address)",
+      "hash": "0xc50506ab60243ada53ffe9da5eed29fe3fc4735c2e9e94b7df969f1889cdbf20",
+      "blockNumber": 50955038,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xadd2d85316153d7bfaf7921ee9bf1bb6c7a1cbc9"
+    },
+    {
+      "action": "deploy AntseedSellerPoolsRewards",
+      "hash": "0x86f2c86d56f978e5ba0d7646c6ebc0b7a0ddb0f044f5dff4790519be925013ae",
+      "blockNumber": 50955039,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": null
+    },
+    {
+      "action": "deploy AntseedUsageRewards",
+      "hash": "0xcedecb746657edb2a0b16217ced1780ccb1d45a654f9f34a83e865d7fa5c4cbc",
+      "blockNumber": 50955040,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": null
+    },
+    {
+      "action": "setSellerPools(address)",
+      "hash": "0x6d253c1dedea2d6003d53b396aff82ad634dd23b60b34f464c1bbe55bbbe5396",
+      "blockNumber": 50955041,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0x78330bf154172f1137219bb559d4f3a270b3201f"
+    },
+    {
+      "action": "setUsageRewards(address)",
+      "hash": "0xa2deedfc1bc1a73dae9435f8f420d14c00f2a512f5cf641877035de6944ac162",
+      "blockNumber": 50955042,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xadd2d85316153d7bfaf7921ee9bf1bb6c7a1cbc9"
+    },
+    {
+      "action": "setClaimForwarder(address)",
+      "hash": "0xc1079f6ea95677d0b9b94f0f4842d6bff7f374ab080073e63f633164512245d8",
+      "blockNumber": 50955043,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0x78330bf154172f1137219bb559d4f3a270b3201f"
+    },
+    {
+      "action": "deploy AntseedLegacyEmissionsEscrow",
+      "hash": "0xd19e9a6960cf3b5fba4a603396e68cce913eefbc3b1a835280de962812d3b8b4",
+      "blockNumber": 50955044,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": null
+    },
+    {
+      "action": "setTransferWhitelist(address,bool)",
+      "hash": "0x3de9aa2128c485a50cccd2ecf9f424eb3d648eead033f99fd635cf1410ec4ea5",
+      "blockNumber": 50955045,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xa87ee81b2c0bc659307ca2d9ffdc38514dd85263"
+    },
+    {
+      "action": "setTransferWhitelist(address,bool)",
+      "hash": "0xefc95f1b461b728cad8089f5df0c466ed7389b41b4e44837176d32818aefb0bd",
+      "blockNumber": 50955046,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xa87ee81b2c0bc659307ca2d9ffdc38514dd85263"
+    },
+    {
+      "action": "setTransferWhitelist(address,bool)",
+      "hash": "0xf524d3bbb310c6ce31531cf97b60eff1ce92711f0b24dca1a58ee9a52a24f37c",
+      "blockNumber": 50955047,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xa87ee81b2c0bc659307ca2d9ffdc38514dd85263"
+    },
+    {
+      "action": "setTransferWhitelist(address,bool)",
+      "hash": "0xc02136fd7d7cf81fddc54bc0e3c699d207321309612d4fbda85e9e02e2ceaddf",
+      "blockNumber": 50955048,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xa87ee81b2c0bc659307ca2d9ffdc38514dd85263"
+    },
+    {
+      "action": "setTransferWhitelist(address,bool)",
+      "hash": "0xe265f58dc327a6faa31476e3ec549060156355df22cf1ca1ee2d2c7659a0f1c0",
+      "blockNumber": 50955049,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xa87ee81b2c0bc659307ca2d9ffdc38514dd85263"
+    },
+    {
+      "action": "setRewardStaker(address,bool)",
+      "hash": "0xa66508e884cf64491ff860decd541fe28afc24abd5abf2bfb44c45e62e86d28e",
+      "blockNumber": 50955050,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0x8bf4d39aa13f3cb03f87d9500767fbc4d0940652"
+    },
+    {
+      "action": "setMinter(bytes32,address,uint32,bool)",
+      "hash": "0x07e4da3f6710ffff897787bffdc7c76368c768d35c429419f80f69fe7f4ce21c",
+      "blockNumber": 50955051,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xe60a31e6cd2f8455503ca0b3f6545dd3ddf543bd"
+    },
+    {
+      "action": "setMinter(bytes32,address,uint32,bool)",
+      "hash": "0x73dd603d107c4860f67de5deb27b3310de1040775a48e859927194f8762d18ef",
+      "blockNumber": 50955052,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xe60a31e6cd2f8455503ca0b3f6545dd3ddf543bd"
+    },
+    {
+      "action": "setRegistry(address)",
+      "hash": "0x9d4910c6e732812a15095c815acb6d2d92f0a6f8f885abe74c690778f480913b",
+      "blockNumber": 50955053,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xa87ee81b2c0bc659307ca2d9ffdc38514dd85263"
+    },
+    {
+      "action": "fundLegacyEscrow(address)",
+      "hash": "0x6995c518046c045443f78681c4b054923043d3b1e1e6e33265c7658387fe7d44",
+      "blockNumber": 50955054,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xe60a31e6cd2f8455503ca0b3f6545dd3ddf543bd"
+    },
+    {
+      "action": "setRegistry(address)",
+      "hash": "0x32c7f8fb5bc4138f5bb124003802d68ed0fd012231531d400ebe577a05ad7e87",
+      "blockNumber": 50955055,
+      "from": "0x48f4142f4abf7b77a03f0cdffcd511edd9b6d54a",
+      "to": "0xf13be52c4a3afc6ae29536f073588d01a0564088"
+    }
+  ],
+  "contracts": {
+    "washTradingRegistry": {
+      "address": "0xc02a111cb94332cc31c08e079cbe781880b2121c",
+      "deploymentBlock": 50955026,
+      "transactionHash": "0xba4b22bc506b8ea320c361b674726a9e4d3a7532eaf09ef781d14801397b47a8",
+      "runtimeCodeHash": "0x67fa7bb03a8c7fe09b122f883447e116a18abbaf84086d4d4f5bfc6045e2d6ff",
+      "version": "1",
+      "external": false,
+      "deployedInRelease": true,
+      "constructorArguments": [
+        "0xb69f2584CBcFf99a58C4e7002E8b89Af54a6f4e2",
+        "0x4388a21c687fdd5f218d7e3d13190cac4c5355818d3605fd5fb811df468ee696",
+        "0x78b69899C8cD252126cBB1A50171ec37286C3877",
+        "0x0028d499469d8bdb345427dccf15bbbf3f1c582625a0a5690e7ac3576ef6ed99",
+        "44471575",
+        "50672526"
+      ],
+      "owner": null
+    },
+    "emissionsGate": {
+      "address": "0xe60a31e6cd2f8455503ca0b3f6545dd3ddf543bd",
+      "deploymentBlock": 50955027,
+      "transactionHash": "0xfac7210de465ca15bf39be60a3cdd1d5b9270ace0059337a21dd309c5fcdf84a",
+      "runtimeCodeHash": "0xb21dff09dee3cac86317150974860d4fbe966483b545b078fee3a74d82cb46dc",
+      "version": "1",
+      "external": false,
+      "deployedInRelease": true,
+      "constructorArguments": [
+        "0x47151b68e2f34500A4f8886885cE69b179Bf5B0B",
+        "0xBF348D3eEDA2012c60375ebFe4Eb46511859f70F",
+        "15000",
+        "15000"
+      ],
+      "owner": "0x48F4142F4AbF7b77a03f0cDffcd511eDD9B6d54a"
+    },
+    "sellerPools": {
+      "address": "0x8bf4d39aa13f3cb03f87d9500767fbc4d0940652",
+      "deploymentBlock": 50955029,
+      "transactionHash": "0x4bc7c19033a6521a2d6de7bccf0fb071fea9b9aef62b5e9d72649ecc6f7da6f1",
+      "runtimeCodeHash": "0x48116d40565f6fa87f8d7c8761c4e7b42c55329553ae551078b6eda53688bcc7",
+      "version": "1",
+      "external": false,
+      "deployedInRelease": true,
+      "constructorArguments": [
+        "0xa87EE81b2C0Bc659307ca2D9ffdC38514DD85263",
+        "0xE60a31E6CD2F8455503cA0B3f6545Dd3DDF543BD",
+        "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+        "0x3652E6B22919bd322A25723B94BB207602E5c8e6"
+      ],
+      "owner": "0x48F4142F4AbF7b77a03f0cDffcd511eDD9B6d54a"
+    },
+    "sellerRegistry": {
+      "address": "0x99c533bcc6ca646e543dba835fdbb9c2ee02cb60",
+      "deploymentBlock": 50955030,
+      "transactionHash": "0x30bb68fb86e94b75190edf54dcfc00c499b341e6e13e79369066d2d5b75580bb",
+      "runtimeCodeHash": "0xbdaad6c0cae85a32a97f5be14fc3e2e2ce508f91375d05f25bec5ec843d8e2b1",
+      "version": "1",
+      "external": false,
+      "deployedInRelease": true,
+      "constructorArguments": [
+        "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+        "0x8Bf4d39AA13F3CB03F87D9500767fBc4D0940652",
+        "0x3652E6B22919bd322A25723B94BB207602E5c8e6"
+      ],
+      "owner": "0x48F4142F4AbF7b77a03f0cDffcd511eDD9B6d54a"
+    },
+    "positionInit": {
+      "address": "0xb68ad13b681319fceb6b0a640c2fd96c0138cbc8",
+      "deploymentBlock": 50955033,
+      "transactionHash": "0xc5c3b33138a59222871104acfe987076f7fd40f3c1a89907a40e11e3373be09e",
+      "runtimeCodeHash": "0x9f6dba20123fb76038260727debc888564222276c0cde6ecc86e5de703b30584",
+      "version": "1",
+      "external": false,
+      "deployedInRelease": true,
+      "constructorArguments": [
+        "0x8Bf4d39AA13F3CB03F87D9500767fBc4D0940652",
+        "0x3652E6B22919bd322A25723B94BB207602E5c8e6",
+        "1000000000000000000",
+        "126"
+      ],
+      "owner": null
+    },
+    "usageAccounting": {
+      "address": "0xadd2d85316153d7bfaf7921ee9bf1bb6c7a1cbc9",
+      "deploymentBlock": 50955034,
+      "transactionHash": "0xdd65cec51382558aa745f8f48b906a045b7df231af62a2a679d2f8457b65c31d",
+      "runtimeCodeHash": "0xcdf2de6c1d951523ba8bf500fabe12cd8f8d0dcebf8dbebde9ad1598542ec240",
+      "version": "1",
+      "external": false,
+      "deployedInRelease": true,
+      "constructorArguments": [
+        "0x8Bf4d39AA13F3CB03F87D9500767fBc4D0940652",
+        "0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d",
+        "0xE60a31E6CD2F8455503cA0B3f6545Dd3DDF543BD"
+      ],
+      "owner": "0x48F4142F4AbF7b77a03f0cDffcd511eDD9B6d54a"
+    },
+    "pointsPolicyRegistry": {
+      "address": "0x212d2c1058b84507de248a147aafeb08fb19e3b6",
+      "deploymentBlock": 50955035,
+      "transactionHash": "0xb6e24df4541042e39c7f76e1f07e7968a9f581acf64d90f4cb24a0bac5df4997",
+      "runtimeCodeHash": "0x011a54dc5072a8fa530e761141605426534c2e27f02f6b6b9dec22cb94647e77",
+      "version": "1",
+      "external": false,
+      "deployedInRelease": true,
+      "constructorArguments": [
+        "0x48F4142F4AbF7b77a03f0cDffcd511eDD9B6d54a"
+      ],
+      "owner": "0x48F4142F4AbF7b77a03f0cDffcd511eDD9B6d54a"
+    },
+    "washTradingPointsPolicy": {
+      "address": "0x7a605aaa3c725aa25012dfded6b5dddcc561d6e5",
+      "deploymentBlock": 50955036,
+      "transactionHash": "0x7852bf9f71b8d46a332f20238ae0cdf2862fa1c38fcdf4488832ff3aae25fc82",
+      "runtimeCodeHash": "0xbfdfba63c3df125c64714eadb0d6827b8cc425a3a340f68650fddd4bcd93079b",
+      "version": "1",
+      "external": false,
+      "deployedInRelease": true,
+      "constructorArguments": [
+        "0xc02a111CB94332Cc31C08E079cbe781880b2121C"
+      ],
+      "owner": null
+    },
+    "sellerPoolsRewards": {
+      "address": "0x83cc5b9aa0c8cb8683f35462c385a5baaa755ee5",
+      "deploymentBlock": 50955039,
+      "transactionHash": "0x86f2c86d56f978e5ba0d7646c6ebc0b7a0ddb0f044f5dff4790519be925013ae",
+      "runtimeCodeHash": "0x65a6cbebfea1d0a2eb79cd90b55fb3500e75e1d0eac94e86faf74c56d758c525",
+      "version": "1",
+      "external": false,
+      "deployedInRelease": true,
+      "constructorArguments": [
+        "0xE60a31E6CD2F8455503cA0B3f6545Dd3DDF543BD",
+        "0x8Bf4d39AA13F3CB03F87D9500767fBc4D0940652",
+        "0xAdd2D85316153D7bfaF7921EE9Bf1Bb6c7A1cBc9"
+      ],
+      "owner": "0x48F4142F4AbF7b77a03f0cDffcd511eDD9B6d54a"
+    },
+    "usageRewards": {
+      "address": "0x78330bf154172f1137219bb559d4f3a270b3201f",
+      "deploymentBlock": 50955040,
+      "transactionHash": "0xcedecb746657edb2a0b16217ced1780ccb1d45a654f9f34a83e865d7fa5c4cbc",
+      "runtimeCodeHash": "0x9b5d26ab4a2d6b53089e8cc3b0b30d18d77031fca1f3c16f81c9ac2936f37992",
+      "version": "1",
+      "external": false,
+      "deployedInRelease": true,
+      "constructorArguments": [
+        "0xE60a31E6CD2F8455503cA0B3f6545Dd3DDF543BD",
+        "0xAdd2D85316153D7bfaF7921EE9Bf1Bb6c7A1cBc9",
+        "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+        "0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2"
+      ],
+      "owner": "0x48F4142F4AbF7b77a03f0cDffcd511eDD9B6d54a"
+    },
+    "legacyEmissionsEscrow": {
+      "address": "0x4d0fc3c0bbb5233af6c4ce33223e5330c34db9ab",
+      "deploymentBlock": 50955044,
+      "transactionHash": "0xd19e9a6960cf3b5fba4a603396e68cce913eefbc3b1a835280de962812d3b8b4",
+      "runtimeCodeHash": "0x073d4df09a9bc3bc5fef42511af1df02378abc82629e76b17af7a582f6e15515",
+      "version": "1",
+      "external": false,
+      "deployedInRelease": true,
+      "constructorArguments": [
+        "0xf33fC901BFa97326379A369401F4490E231B69B0",
+        "0xF13bE52c4A3afC6AE29536f073588d01A0564088"
+      ],
+      "owner": "0x48F4142F4AbF7b77a03f0cDffcd511eDD9B6d54a"
+    }
+  },
+  "$schema": "../../schema.json",
+  "network": "base-mainnet",
+  "chainId": 8453
+}

--- a/packages/contracts/script/migrations/M001RecognizedUsage/README.md
+++ b/packages/contracts/script/migrations/M001RecognizedUsage/README.md
@@ -1,5 +1,31 @@
 # M001 — Recognized usage cutover
 
+## Recorded Base mainnet deployment
+
+Phase 1 completed on September 6, 2026: 30 transactions in blocks
+50,955,026–50,955,055 and 11 verified contracts. The append-only record is
+`deployments/base-mainnet/history/001-recognized-usage-deployed.json`.
+The token now points to the gate and legacy emissions to its funded escrow.
+The main registry's staking/emissions pointers are still legacy.
+
+The next operation on this deployment is **cutover**, not another deployment.
+Effective epoch 22 begins September 10, 2026 at 09:54:21 UTC; run the waiting
+cutover process before 09:53:21 UTC and leave signing available. Initialization
+and historical proof submission must be prepared before that boundary.
+See the [full contract inventory](../../../README.md#m001-deployed-stack).
+
+The deployment key `0x48F4142F4AbF7b77a03f0cDffcd511eDD9B6d54a` held all five
+M001 signer roles at the phase-1 preflight. Recheck owners before cutover and
+after any ownership handoff. DIEM staking is not proxy operator authorization:
+starter initialization requires an operator and is a separate transaction.
+
+The phase-1 runner's RPC `codehash` read failed after all transactions and
+explorer verifications completed. Its history was recovered from confirmed
+receipts using hashes of fetched runtime bytecode, then checked against the
+local build. Do not repeat deployment to repair a local recording failure.
+
+## General workflow
+
 Two CLI broadcast runs: deploy during the current epoch, then activate at the
 next epoch boundary. They are not necessarily a full epoch apart. For the
 step-by-step operator walkthrough, see
@@ -125,15 +151,16 @@ Roles are never defaulted from one another. Required for the cutover:
 | `diemStaker` | address with DIEM staked on the proxy (mainnet, or when `DIEM_STAKING_PROXY` is set) |
 | `sellerRewardsPoolOwner` | `AntseedSellerRewardsPool.owner()` (same condition) |
 
-On Base mainnet today every role is one of two EOAs, so the full command is:
+For the recorded mainnet deployment, the same keystore can supply all five
+roles while ownership and DIEM stake remain unchanged:
 
 ```bash
 pnpm contracts:deploy -- M001 --network base-mainnet --broadcast \
-  --signer deployer=account:antseed-owner \
-  --signer registryOwner=account:antseed-owner \
-  --signer channelsOwner=account:antseed-ops \
-  --signer sellerRewardsPoolOwner=account:antseed-ops \
-  --signer diemStaker=account:antseed-ops
+  --signer deployer=account:antseed-deployer \
+  --signer registryOwner=account:antseed-deployer \
+  --signer channelsOwner=account:antseed-deployer \
+  --signer sellerRewardsPoolOwner=account:antseed-deployer \
+  --signer diemStaker=account:antseed-deployer
 ```
 
 `USAGE_ACCOUNTING`, `SELLER_REGISTRY`, and the `EXPECTED_*` legacy addresses

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -224,7 +224,7 @@ export type { SellerPaymentConfig } from './payments/seller-payment-manager.js';
 export { ChannelStore } from './payments/channel-store.js';
 export type { StoredChannel, StoredReceipt } from './payments/channel-store.js';
 export { getChainConfig, resolveChainConfig, DEFAULT_CHAIN_ID, CHAIN_CONFIGS } from './payments/chain-config.js';
-export type { ChainConfig } from './payments/chain-config.js';
+export type { ChainConfig, RecognizedUsageDeployment } from './payments/chain-config.js';
 export { formatUsdc, parseUsdc } from './payments/usdc-utils.js';
 export { ProxyMux } from './proxy/proxy-mux.js';
 export { SweepMux, type SweepMessageHandler } from './p2p/sweep-mux.js';

--- a/packages/node/src/payments/chain-config.ts
+++ b/packages/node/src/payments/chain-config.ts
@@ -1,6 +1,24 @@
 import type { ChainId } from './types.js';
 import { DEPLOYED_CONTRACT_ADDRESSES } from './generated-contract-addresses.js';
 
+export interface RecognizedUsageDeployment {
+  status: 'deployed' | 'active';
+  effectiveEpoch: number;
+  contracts: {
+    washTradingRegistry: string;
+    emissionsGate: string;
+    sellerPools: string;
+    sellerRegistry: string;
+    positionInit: string;
+    usageAccounting: string;
+    pointsPolicyRegistry: string;
+    washTradingPointsPolicy: string;
+    sellerPoolsRewards: string;
+    usageRewards: string;
+    legacyEmissionsEscrow: string;
+  };
+}
+
 export interface ChainConfig {
   chainId: ChainId;
   evmChainId: number;
@@ -12,6 +30,7 @@ export interface ChainConfig {
    * after the primary).
    */
   fallbackRpcUrls?: string[];
+  registryContractAddress?: string;
   depositsContractAddress: string;
   channelsContractAddress: string;
   /** Optional AntseedFreeUsage contract address for zero-price signed usage. */
@@ -22,6 +41,7 @@ export interface ChainConfig {
   emissionsContractAddress?: string;
   legacyEmissionsContractAddress?: string;
   antsTokenAddress?: string;
+  recognizedUsage?: RecognizedUsageDeployment;
   /** Block when Channels contract was deployed. Floor for event log scans. */
   channelsDeployBlock?: number;
   /** AntseedStats contract address. Populated only where an indexer aggregates it. */

--- a/packages/node/src/payments/generated-contract-addresses.ts
+++ b/packages/node/src/payments/generated-contract-addresses.ts
@@ -3,6 +3,7 @@
 export const DEPLOYED_CONTRACT_ADDRESSES = {
   'base-mainnet': {
     evmChainId: 8453,
+    registryContractAddress: '0xf33fC901BFa97326379A369401F4490E231B69B0',
     usdcContractAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
     depositsContractAddress: '0x0F7a3a8f4Da01637d1202bb5443fcF7F88F99fD2',
     channelsContractAddress: '0xBA66d3b4fbCf472F6F11D6F9F96aaCE96516F09d',
@@ -16,9 +17,27 @@ export const DEPLOYED_CONTRACT_ADDRESSES = {
     depositRelayAddress: '0x34a44542e76f9b4cff3a31902eDF14AbF2C3B3DD',
     channelsDeployBlock: 44469557,
     statsDeployBlock: 44469557,
+    recognizedUsage: {
+      "status": "deployed",
+      "effectiveEpoch": 22,
+      "contracts": {
+        "washTradingRegistry": "0xc02a111cb94332cc31c08e079cbe781880b2121c",
+        "emissionsGate": "0xe60a31e6cd2f8455503ca0b3f6545dd3ddf543bd",
+        "sellerPools": "0x8bf4d39aa13f3cb03f87d9500767fbc4d0940652",
+        "sellerRegistry": "0x99c533bcc6ca646e543dba835fdbb9c2ee02cb60",
+        "positionInit": "0xb68ad13b681319fceb6b0a640c2fd96c0138cbc8",
+        "usageAccounting": "0xadd2d85316153d7bfaf7921ee9bf1bb6c7a1cbc9",
+        "pointsPolicyRegistry": "0x212d2c1058b84507de248a147aafeb08fb19e3b6",
+        "washTradingPointsPolicy": "0x7a605aaa3c725aa25012dfded6b5dddcc561d6e5",
+        "sellerPoolsRewards": "0x83cc5b9aa0c8cb8683f35462c385a5baaa755ee5",
+        "usageRewards": "0x78330bf154172f1137219bb559d4f3a270b3201f",
+        "legacyEmissionsEscrow": "0x4d0fc3c0bbb5233af6c4ce33223e5330c34db9ab"
+      }
+    },
   },
   'base-sepolia': {
     evmChainId: 84532,
+    registryContractAddress: '0x81562e904D228Ee05DB473f5c9453F0f0D65ad5A',
     usdcContractAddress: '0xcA04797CaB6B412Cee6798B7314a05AdFDc3Cf23',
     depositsContractAddress: '0x96f083A9801AFdcE7D764651954A1A9Fbd489FEA',
     channelsContractAddress: '0x3b0b94AC27C042CAC17103A897Fb5cEb7D8b4cf7',

--- a/packages/node/tests/chain-config.test.ts
+++ b/packages/node/tests/chain-config.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { getChainConfig, resolveChainConfig } from '../src/payments/chain-config.js';
+import { DEPLOYED_CONTRACT_ADDRESSES } from '../src/payments/generated-contract-addresses.js';
+
+describe('recognized-usage deployment configuration', () => {
+  it('exposes the generated inventory separately from active endpoints', () => {
+    const config = getChainConfig('base-mainnet');
+    const generated = DEPLOYED_CONTRACT_ADDRESSES['base-mainnet'];
+    expect(config.recognizedUsage).toEqual(generated.recognizedUsage);
+    expect(config.recognizedUsage?.contracts.emissionsGate).toBeDefined();
+    expect(config.registryContractAddress).toBe(generated.registryContractAddress);
+    expect(config.emissionsContractAddress).toBe(generated.emissionsContractAddress);
+    expect(config.stakingContractAddress).toBe(generated.stakingContractAddress);
+  });
+
+  it('preserves inventory when overriding an RPC endpoint', () => {
+    const config = resolveChainConfig({ chainId: 'base-mainnet', rpcUrl: 'http://localhost:8545' });
+    expect(config.recognizedUsage).toEqual(getChainConfig('base-mainnet').recognizedUsage);
+    expect(config.rpcUrl).toBe('http://localhost:8545');
+    expect(config.fallbackRpcUrls).toEqual([]);
+  });
+
+  it('does not expose mainnet deployment metadata for local chains', () => {
+    expect(getChainConfig('base-local').recognizedUsage).toBeUndefined();
+  });
+});

--- a/scripts/deploy-contracts.test.mjs
+++ b/scripts/deploy-contracts.test.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import { broadcastPath, mergeBroadcast, parseBroadcast, runForgeScript } from './deployments/runtime/foundry.mjs';
+import { renderNetwork } from './generate-contract-chain-config.mjs';
 
 import {
   buildMigrationRegistry,
@@ -1733,4 +1734,59 @@ test('a dry run before the epoch boundary simulates instead of waiting', async (
   assert.equal(forkRequests[0].timestamp, 1001, 'only the disposable fork advances past the boundary');
   assert.deepEqual(scriptRpcs, ['http://127.0.0.1:9998']);
   assert.equal(result.endStateVerified, false);
+});
+
+test('chain config exposes deployed M001 addresses without activating legacy aliases', async () => {
+  const current = {
+    chainId: 8453,
+    status: 'active',
+    contracts: {
+      emissions: { address: '0x0000000000000000000000000000000000000001' },
+      staking: { address: '0x0000000000000000000000000000000000000002' },
+    },
+  };
+  const deployed = JSON.parse(await readFile('packages/contracts/deployments/base-mainnet/history/001-recognized-usage-deployed.json', 'utf8'));
+  const config = renderNetwork(current, deployed);
+  assert.equal(config.stakingContractAddress, current.contracts.staking.address);
+  assert.equal(config.emissionsContractAddress, current.contracts.emissions.address);
+  assert.equal(config.recognizedUsage.status, 'deployed');
+  assert.equal(config.recognizedUsage.effectiveEpoch, deployed.effectiveEpoch);
+  assert.equal(Object.keys(config.recognizedUsage.contracts).length, 11);
+  for (const [name, contract] of Object.entries(deployed.contracts)) {
+    assert.equal(config.recognizedUsage.contracts[name], contract.address);
+  }
+});
+
+test('chain config activates M001 metadata only after both active aliases match', async () => {
+  const current = {
+    chainId: 8453,
+    status: 'active',
+    contracts: {
+      emissions: { address: '0x0000000000000000000000000000000000000001' },
+      staking: { address: '0x0000000000000000000000000000000000000002' },
+    },
+  };
+  const deployed = JSON.parse(await readFile('packages/contracts/deployments/base-mainnet/history/001-recognized-usage-deployed.json', 'utf8'));
+  current.contracts.emissions = deployed.contracts.usageAccounting;
+  assert.equal(renderNetwork(current, deployed).recognizedUsage.status, 'deployed');
+  current.contracts.staking = deployed.contracts.sellerRegistry;
+  const config = renderNetwork(current, deployed);
+  assert.equal(config.recognizedUsage.status, 'active');
+  assert.equal(config.emissionsContractAddress, deployed.contracts.usageAccounting.address);
+  assert.equal(config.stakingContractAddress, deployed.contracts.sellerRegistry.address);
+});
+
+test('chain config does not invent an M001 deployment on another network', async () => {
+  const current = JSON.parse(await readFile('packages/contracts/deployments/base-sepolia/current.json', 'utf8'));
+  assert.equal(renderNetwork(current).recognizedUsage, undefined);
+});
+
+test('published M001 address inventories match the immutable deployment record', async () => {
+  const deployed = JSON.parse(await readFile('packages/contracts/deployments/base-mainnet/history/001-recognized-usage-deployed.json', 'utf8'));
+  for (const file of ['packages/contracts/README.md', 'apps/website/docs/protocol/recognized-usage.md']) {
+    const document = (await readFile(file, 'utf8')).toLowerCase();
+    for (const [name, contract] of Object.entries(deployed.contracts)) {
+      assert.ok(document.includes(contract.address.toLowerCase()), `${file} is missing ${name}`);
+    }
+  }
 });

--- a/scripts/generate-contract-chain-config.mjs
+++ b/scripts/generate-contract-chain-config.mjs
@@ -13,6 +13,7 @@ export const generatedChainConfigFile = path.join(
 );
 
 const contractFields = {
+  registry: 'registryContractAddress',
   usdc: 'usdcContractAddress',
   deposits: 'depositsContractAddress',
   channels: 'channelsContractAddress',
@@ -30,7 +31,18 @@ async function readDeployment(network) {
   return JSON.parse(await readFile(path.join(deploymentsRoot, network, 'current.json'), 'utf8'));
 }
 
-function renderNetwork(record) {
+async function readRecognizedUsageDeployment(network) {
+  try {
+    return JSON.parse(await readFile(path.join(
+      deploymentsRoot, network, 'history', '001-recognized-usage-deployed.json',
+    ), 'utf8'));
+  } catch (error) {
+    if (error.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+export function renderNetwork(record, recognizedUsageDeployment = null) {
   const values = { evmChainId: record.chainId };
   for (const [contractName, field] of Object.entries(contractFields)) {
     const contract = record.contracts[contractName];
@@ -42,6 +54,19 @@ function renderNetwork(record) {
   if (record.contracts.stats?.deploymentBlock != null) {
     values.statsDeployBlock = record.contracts.stats.deploymentBlock;
   }
+  if (recognizedUsageDeployment) {
+    const contracts = Object.fromEntries(Object.entries(recognizedUsageDeployment.contracts)
+      .map(([name, contract]) => [name, contract.address]));
+    const sameAddress = (left, right) => Boolean(left && right && left.toLowerCase() === right.toLowerCase());
+    const active = record.status === 'active'
+      && sameAddress(record.contracts.emissions?.address, contracts.usageAccounting)
+      && sameAddress(record.contracts.staking?.address, contracts.sellerRegistry);
+    values.recognizedUsage = {
+      status: active ? 'active' : 'deployed',
+      effectiveEpoch: recognizedUsageDeployment.effectiveEpoch,
+      contracts,
+    };
+  }
   return values;
 }
 
@@ -49,9 +74,12 @@ export async function renderContractChainConfig() {
   const networks = ['base-mainnet', 'base-sepolia'];
   const entries = [];
   for (const network of networks) {
-    const values = renderNetwork(await readDeployment(network));
+    const values = renderNetwork(await readDeployment(network), await readRecognizedUsageDeployment(network));
     const properties = Object.entries(values)
-      .map(([key, value]) => `    ${key}: ${typeof value === 'number' ? value : `'${value}'`},`)
+      .map(([key, value]) => {
+        const rendered = typeof value === 'string' ? `'${value}'` : JSON.stringify(value, null, 2).replaceAll('\n', '\n    ');
+        return `    ${key}: ${rendered},`;
+      })
       .join('\n');
     entries.push(`  '${network}': {\n${properties}\n  },`);
   }


### PR DESCRIPTION
## Description

Preserve the executed M001 phase-1 Base mainnet deployment as an append-only history record: 30 confirmed transactions and 11 deployed contracts, including constructor arguments, owners, runtime code hashes, and source commit `859a10ec889671f04e5827a7bdd48bd80d2add79`.

All 11 contracts passed Basescan source verification. The deployment completed on chain.

The migration is awaiting epoch 22, starting September 10, 2026 at 09:54:21 UTC. This PR does not perform cutover, change `current.json`, broadcast transactions, or include stale pending plans.

## Release Notes

No additional user-facing behavior change. This records an already executed deployment for cutover and recovery; no contract source or application configuration changes.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (maintenance tasks, refactoring, or non-functional changes)

## Validation

- `node scripts/validate-contract-deployments.mjs` passed.
- All 30 recorded transactions match successful Foundry receipts and block numbers.
- All 11 deployed contracts' runtime bytecode matched local build artifacts during recovery.
- Checked the record for configured secrets; none found.
- `git diff --cached --check` passed before committing.

## Checklist

- [x] My code follows the code style of this project
- [x] Necessary deployment provenance is included
- [x] Deployment-record validation passes
- [x] Only the recovered history record is included