### PR TITLE
docs(protocol): Explain reward policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project uses selective package publishing. Each release entry lists the pub
 
 ### Added
 
+- Docs: added a dedicated reward-policy guide covering composition, configuration, failure handling, and the historical wash-trading rule with SP1 and canonical block authentication. Consolidated reward explanations and corrected stale legacy-reward, wallet-custody, routing-filter, and staking guidance without changing the network's presentation.
+
 - Docs: documented ANTS stake-move and early-withdrawal penalties, preserved reward claims, owner-configurable settings, and the legacy-USDC eligibility and expiry requirements for starter positions.
 
 - Docs: clarified the M002 release of 10% of cumulative locked seller rewards, less prior releases, with zero for flagged wash traders; distinguished the recognized-usage CLI starter-position command from legacy reward withdrawals and documented the activation requirements.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -13,9 +13,10 @@ Command-line interface and web dashboard for the AntSeed Network — a P2P netwo
 | **Providing** | |
 | `antseed seller start` | Start providing AI services on the P2P network |
 | `antseed seller register` | Register peer identity on-chain (ERC-8004) |
-| `antseed seller stake <amount>` | Stake USDC as a provider (min $10) |
-| `antseed seller unstake` | Withdraw staked USDC |
-| `antseed seller emissions claim` | Claim accumulated seller payouts |
+| **Legacy staking and emissions** | See the pre-migration setup below; these are not ANTS pool commands |
+| `antseed seller stake <amount>` | Stake legacy USDC (min $10) |
+| `antseed seller unstake` | Withdraw legacy USDC stake |
+| `antseed seller emissions claim` | Claim legacy seller ANTS emissions, not USDC payouts |
 | **Buying** | |
 | `antseed buyer start` | Start the buyer proxy and connect to sellers |
 | `antseed buyer start --router <name>` | Start the buyer proxy with a non-default router |
@@ -333,6 +334,8 @@ Payments run on **Base Mainnet** by default. Contract addresses are resolved aut
 See [Recognized Usage and ANTS Rewards](../website/docs/protocol/recognized-usage.md)
 for ANTS pool positions, seller eligibility, and usage rewards. The SDK exposes
 the contract inventory as `getChainConfig('base-mainnet').recognizedUsage`.
+See [Reward Policies](../website/docs/protocol/reward-policies.md) for how usage
+points are adjusted and historical wash-trading evidence affects rewards.
 
 Looking for pre-migration USDC staking or rewards? See
 [Legacy emissions and claims](../website/docs/protocol/legacy-emissions.md).

--- a/apps/website/docs/cli/commands.md
+++ b/apps/website/docs/cli/commands.md
@@ -24,10 +24,23 @@ antseed seller start                  Start providing AI services
 antseed seller start --base-rpc-url <url>
                                       Use a custom Base RPC URL for this run
 antseed seller register               Register peer identity on-chain (ERC-8004)
-antseed seller stake <amount>         Stake USDC as a provider (min $10)
-antseed seller unstake                Withdraw staked USDC
-antseed seller emissions claim        Claim accumulated seller payouts
 ```
+
+### Legacy staking and emissions
+
+These commands use the legacy USDC staking and emissions interfaces, not ANTS
+pool positions. Check which CLI version and contract endpoints you are using
+before a migration. USDC service payouts are automatic; `emissions claim` is
+for ANTS rewards, not seller USDC earnings.
+
+```bash
+antseed seller stake <amount>         Stake legacy USDC (min $10)
+antseed seller unstake                Withdraw legacy USDC stake
+antseed seller emissions claim        Claim legacy seller ANTS emissions
+```
+
+See [legacy claims](/docs/legacy-emissions) for pre-migration rewards and
+[recognized usage](/docs/recognized-usage) for ANTS positions and starter grants.
 
 ### Buying (consuming)
 

--- a/apps/website/docs/faq.mdx
+++ b/apps/website/docs/faq.mdx
@@ -270,7 +270,10 @@ Buyers pre-deposit USDC into the on-chain AntseedDeposits contract. Each session
 
 ### Are seller ANTS incentives claimable now?
 
-Seller ANTS emissions are currently tracked but routed into a dedicated Provider Pool and locked for now. They are not freely claimable yet. Future claimability is expected after stronger provider validation, audits, attestations, and proof systems are introduced, and may be subject to verification or slashing.
+ANTS rewards are separate from USDC payments. From epoch 22 (September 10, 2026),
+they depend on recognized usage, seller-pool power, and the configured
+[reward policies](/docs/reward-policies). Earlier rewards use the
+[legacy claim contracts](/docs/legacy-emissions).
 
 ### Where do protocol fees go?
 
@@ -278,7 +281,10 @@ Network fees are set to 4% and may be directed to ecosystem mechanisms such as r
 
 ### Are ANTS incentives guaranteed?
 
-No. ANTS incentives are designed for real usage and real contribution. Farming, fake volume, sybil behavior, spam, or value extraction may be capped, excluded, delayed, locked, or subject to future slashing. ANTS token economics are evolving, and more trust and utility mechanisms are planned.
+No. Paying for service does not guarantee ANTS rewards. Missing pool power or a
+wash-trading flag can exclude usage from rewards. If you stake ANTS, withdrawing
+before the lock ends also incurs a principal penalty. See
+[reward eligibility and staking terms](/docs/recognized-usage).
 
 ---
 

--- a/apps/website/docs/guides/become-a-provider.md
+++ b/apps/website/docs/guides/become-a-provider.md
@@ -14,7 +14,9 @@ AntSeed is designed for providers who build differentiated services — such as 
 :::
 
 :::info Seller ANTS emissions
-Starting from the current epoch, seller ANTS emissions are tracked but routed into a dedicated Provider Pool and locked for now. These incentives are not freely claimable yet. Future claimability is expected after stronger provider validation, audit, attestation, and proof systems are introduced, and may be subject to verification or slashing.
+From epoch 22 (September 10, 2026), ANTS rewards use recognized usage and
+seller-pool stake. USDC earnings are separate. See [ANTS rewards](/docs/recognized-usage)
+for the new model and [legacy claims](/docs/legacy-emissions) for earlier rewards.
 :::
 
 ## Prerequisites
@@ -22,8 +24,8 @@ Starting from the current epoch, seller ANTS emissions are tracked but routed in
 - Node.js 20+
 - An AI API key (Anthropic, OpenAI, Together AI, or a local model)
 - A secp256k1 private key (your node identity)
-- ETH on Base Mainnet (for gas, ~$0.01 per transaction)
-- USDC on Base Mainnet (minimum $10 for staking)
+- ETH on Base Mainnet for seller transaction fees; the cost varies with gas usage and network fees
+- Seller eligibility through the active staking registry; see [staking and starter positions](/docs/recognized-usage)
 
 ## 1. Install
 
@@ -342,10 +344,16 @@ This release emits discovery metadata v12. Older buyers reject newer metadata an
 
 USDC earnings are paid directly to your wallet address on each `settle()` or `close()` call. No claim step needed for USDC.
 
-Seller-side ANTS emissions are different: they are currently tracked but locked in the Provider Pool while stronger validation systems are developed. Provider ANTS claims may become available later and may be subject to verification or slashing.
+ANTS rewards are separate from USDC earnings. They depend on recognized usage,
+pool power, and [reward policies](/docs/reward-policies). Pre-migration rewards
+use the [legacy claims flow](/docs/legacy-emissions), including the M002 release
+rule for locked seller rewards.
 
 :::warning Real usage only
-ANTS incentives are designed for real provider contribution. Farming, fake volume, sybil behavior, spam, or value extraction may be capped, excluded, delayed, locked, or subject to future slashing.
+The historical wash-trading policy excludes new reward points for flagged
+sellers without blocking USDC settlement. ANTS stake also has an
+[early-withdrawal penalty](/docs/recognized-usage#moving-stake-and-early-withdrawal);
+that principal penalty is separate from the usage-points filter.
 :::
 
 ## Next Steps

--- a/apps/website/docs/guides/payments.md
+++ b/apps/website/docs/guides/payments.md
@@ -121,19 +121,12 @@ lANTS staking-position NFTs; pool power activates in the following epoch.
 Eligible sellers can initialize a starter position, including contract sellers
 whose authorized operator initializes on their behalf.
 
-Weekly allocation ceilings are:
-- 40% for seller-pool rewards.
-- 20% for buyer and seller/operator usage rewards.
-- 15% for the emissions reserve.
-- 15% for the team.
-- 10% for verification.
-
-Actual rewards depend on eligibility, pool power, usage, and the reward
-contracts' allocation rules. USDC payments can still settle even when no
-usage points are earned. Enabling ANTS trading is a separate action.
+Rewards depend on eligibility, pool power, usage, and the configured
+[reward policies](../protocol/reward-policies.md). USDC payments can still settle
+when no usage points are earned. Enabling ANTS transfers is a separate action.
 
 See [Recognized Usage and ANTS Rewards](../protocol/recognized-usage.md) for
-starter positions, pool staking, policies, and contract addresses.
+starter positions, staking exit terms, emission allocations, and contract addresses.
 
 **Looking for rewards or USDC staking from before migration?** See
 [Legacy emissions and claims](../protocol/legacy-emissions.md).

--- a/apps/website/docs/guides/using-the-api.md
+++ b/apps/website/docs/guides/using-the-api.md
@@ -16,7 +16,7 @@ There are two ways to get that proxy running:
 
 Everything in this guide works identically against both.
 
-If the client runs outside this computer—or uses a hosted backend that cannot reach `localhost`—open the VPR's **Agents** view and [define an authenticated internet-accessible endpoint](/docs/guides/agents#define-your-internet-accessible-antseed-endpoint).
+If the client runs outside this computer—or uses a hosted backend that cannot reach `localhost`—open the VPR's **Agents** view and [connect a remote agent](/docs/guides/agents#connect-a-remote-agent).
 
 ## Quick Start (CLI)
 

--- a/apps/website/docs/lightpaper.md
+++ b/apps/website/docs/lightpaper.md
@@ -103,7 +103,19 @@ Every settlement updates per-agent counters: channel count, ghost count (channel
 
 ### Buyer Safety
 
-The buyer never needs gas. All on-chain actions are either seller-initiated (reserve, settle, close) or operator-initiated (requestClose, withdraw). The buyer's hot wallet only signs EIP-712 messages — it never holds ETH, receives USDC, or submits transactions.
+The normal buyer funding and payment flow does not require the buyer to hold
+ETH: sellers submit payment authorizations, and relayers can sweep incoming USDC
+from the buyer's hot wallet into deposits. Direct on-chain actions, such as
+manual deposits or withdrawals by an operator, require gas from their sender.
+
+### ANTS Rewards and Policies
+
+USDC pays for service; ANTS rewards are separate. From epoch 22 (September 10,
+2026), rewards depend on recognized usage and seller-pool stake. Configured
+policies can exclude usage from rewards without reversing its payment. The
+historical wash-trading policy relies on SP1 proofs whose block references are
+authenticated against Base history.
+See [Reward Policies](/docs/reward-policies) for how the rule works.
 
 ## Who Buys
 

--- a/apps/website/docs/protocol/discovery.md
+++ b/apps/website/docs/protocol/discovery.md
@@ -201,6 +201,10 @@ Verifiers reject redirected proof URLs. Domain and GitHub proofs must be served 
 
 ## Peer Scoring
 
+The weights below belong to the generic router-core scorer. Model-only routing
+in the buyer proxy and desktop uses the shared Price + Trust ranking described
+in [Reputation](./reputation.md#buyer-route-scoring).
+
 | Dimension | Weight | Description |
 |---|---|---|
 | Price | 0.30 | Lower price scores higher (inverted min-max) |
@@ -210,6 +214,10 @@ Verifiers reject redirected proof URLs. Domain and GitHub proofs must be served 
 | Freshness | 0.10 | Recently seen peers score higher |
 | Reliability | 0.05 | Lower failure rate and streak scores higher |
 
-All factors are min-max normalized across the eligible candidate pool. By default there is no minimum reputation gate (`minPeerReputation: 0`); buyers can explicitly raise it to exclude lower-reputation peers before scoring. Peers in a failure cooldown (exponential backoff) are also excluded.
+The generic scorer normalizes its factors across eligible candidates. The
+lower-level `minPeerReputation` filter defaults to `0`, but model-only routing
+also applies `buyer.routingPreferences.minTrustScore`, which defaults to `60`.
+Setting the first filter to zero does not disable the second. Peers in a failure
+cooldown are also excluded.
 
 Buyers can filter by capability, Skill, minimum reputation, and price ceiling.

--- a/apps/website/docs/protocol/overview.md
+++ b/apps/website/docs/protocol/overview.md
@@ -49,6 +49,14 @@ AntSeed is a fully decentralized protocol for buying and selling AI services dir
 
 **Agent-to-agent commerce** — autonomous agents hold credits, discover providers by capability, evaluate reputation, consume services, and settle payment without human involvement.
 
+## Payments, rewards, and policies
+
+[USDC payments](./payments.md) settle authorized service usage. [ANTS
+rewards](./recognized-usage.md) use a separate accounting system based on usage
+and seller-pool power. [Reward policies](./reward-policies.md) determine which
+points count, including the historical wash-trading filter. A reward exclusion
+does not itself reverse a payment or slash principal.
+
 :::info Provider Compliance
 AntSeed is designed for providers who build differentiated services on top of AI APIs — not for raw resale of API keys or subscription credentials. Subscription-based provider plugins are for local testing only. Providers are independent operators and are solely responsible for their infrastructure, outputs, logs, privacy practices, data handling, security, sanctions/export compliance, tax obligations, applicable AI laws, and upstream API provider terms.
 :::

--- a/apps/website/docs/protocol/recognized-usage.md
+++ b/apps/website/docs/protocol/recognized-usage.md
@@ -91,18 +91,16 @@ for starter-position initialization. It creates a staking position;
 it does not withdraw locked legacy rewards. That separate release is described
 in [Locked seller rewards: M002](./legacy-emissions.md#locked-seller-rewards-m002).
 
-## Points policies and historical wash trading
+## Reward policies
 
-The owner-managed registry applies policies in registration order. Each policy
-receives `points(channelId, buyer, seller, sellerPoints, buyerPoints)` and returns
-`(sellerPoints, buyerPoints)`. This preserves the existing accounting interface.
-A zeroed side cannot be restored; evaluation ends when both sides are zero.
+Paid usage does not automatically earn ANTS. The registered points policies
+transform buyer and seller points before accounting records them. The historical
+wash-trading policy zeros both sides when the seller's finalized proven wash
+volume reaches 25% of its authenticated historical total. It does not block USDC
+settlement or starter positions, and it does not erase previously recorded points.
 
-The registered wash policy zeros both sides for a seller flagged by the
-historical proof registry's **25% authenticated seller-volume threshold**.
-Flagging affects future records only: it does not erase already credited points.
-The policy reads proofs accepted by the configured registry; submissions to a
-different registry are not automatically recognized.
+See [Reward Policies](./reward-policies.md) for how policies compose, the
+wash-trading rule, and how SP1 proofs are anchored to Base history.
 
 ## Emissions and destinations
 

--- a/apps/website/docs/protocol/reputation.md
+++ b/apps/website/docs/protocol/reputation.md
@@ -51,18 +51,16 @@ Buyers submit structured feedback via the deployed ERC-8004 ReputationRegistry (
 
 Feedback and routing reputation do not automatically grant ANTS or apply a
 fixed on-chain reward multiplier. Recognized-usage accounting applies the
-configured points policies; the registered historical wash-trading policy
+configured [reward policies](./reward-policies.md); the registered historical wash-trading policy
 can zero future rewards without changing settlement stats.
 
 ## ANTS Rewards
 
 **Protocol start: September 10, 2026 at 09:54:21 UTC (epoch 22).**
 
-ANTS rewards use recognized usage, seller-pool power, and epoch-based reward
-accounting. Allocation ceilings are 40% for pool rewards, 20% for buyer and
-seller/operator usage rewards, 15% for the reserve, 15% for the team, and 10%
-for verification. Actual pool and usage rewards depend on the contracts'
-eligibility and dynamic allocation rules.
+Routing reputation helps a buyer choose a seller. ANTS reward accounting is
+separate: it uses recognized usage, seller-pool power, and the configured policies.
+A high routing score does not override a reward exclusion.
 
 See [Recognized Usage and ANTS Rewards](./recognized-usage.md) for the standard
 reward model. **Looking for pre-migration emissions?** The [legacy guide](./legacy-emissions.md)

--- a/apps/website/docs/protocol/reward-policies.md
+++ b/apps/website/docs/protocol/reward-policies.md
@@ -1,0 +1,141 @@
+---
+sidebar_position: 7
+slug: /reward-policies
+title: Reward Policies
+hide_title: true
+---
+
+# Reward Policies
+
+Payment and rewards answer different questions. USDC settlement pays a seller
+for authorized service usage. Reward policies decide how that usage contributes
+to ANTS rewards. A paid request can settle successfully and earn no reward points.
+
+The recognized-usage reward model starts at **epoch 22, September 10, 2026 at
+09:54:21 UTC**, after the registry cutover. See [Recognized Usage and ANTS
+Rewards](./recognized-usage.md) for staking, allocations, and contract addresses.
+
+## Where policies apply
+
+`AntseedUsageAccounting` checks that the seller has a pool with enough epoch
+power, then sends the usage's raw points through its configured points policy.
+The deployed policy is `AntseedPointsPolicyRegistry`, which runs a list of
+modifiers. Accounting records the resulting buyer and seller points and derives
+pool-weighted points; separate reward contracts calculate and pay ANTS.
+
+A points modifier receives the channel, buyer, seller, and current point amounts.
+It returns the next seller and buyer amounts. It does not receive custody of
+USDC or staked ANTS, and changing points does not itself mint tokens, withdraw
+stake, or rewrite channel settlement records.
+
+## How policies compose
+
+Both sides start with the raw usage points. Modifiers run in registration order,
+and each sees the previous modifier's result. They can reduce or increase either
+amount, or set it to zero; they are not limited to multiplying by a percentage.
+
+For example, starting with 100 points, adding 10 and then halving produces 55.
+Halving and then adding 10 produces 60. This is why order is part of the policy.
+
+**Zero is final for each side.** Once seller points are zero, a later modifier
+cannot restore them; the same holds for buyer points. Processing stops when both
+are zero. With no registered modifiers, the raw points pass through unchanged.
+
+The registry owner can register or remove modifiers, up to eight at a time.
+Registration appends to the list; removal preserves the remaining order. The
+accounting owner can also replace the configured points policy. Inspect
+`policyCount()` and `policyAt(index)` for the configured list.
+
+Changes apply when usage is recorded, not retroactively to existing points.
+If a points policy reverts, accounting skips that usage record rather than
+blocking USDC settlement. Policy code therefore needs review for both its reward
+rules and its ability to execute reliably.
+
+## Historical wash-trading policy
+
+M001 registers `AntseedWashTradingPointsPolicy`. For each usage record, it asks
+the pinned `AntseedWashTradingRegistry` whether the seller is a proven wash
+trader. If yes, it returns zero buyer and seller points. Otherwise, it leaves
+both amounts unchanged.
+
+The evidence concerns conserved USDC loops, not high volume alone. Closed-loop
+evidence links buyer funding, paid settlements, and value returning toward the
+funder, with ordering, amount, and buyer-balance checks. Self-funded and reciprocal
+bundles use the corresponding checks in the pinned seller program. The program
+also rejects duplicate settlement IDs within the bundle.
+
+The registry flags a seller when:
+
+```text
+finalized proven wash volume / authenticated total seller volume >= 25%
+```
+
+The denominator is the seller's period-end volume counter from
+`AntseedChannels`, authenticated inside the proof. The configured historical
+period starts at protocol genesis, so no opening counter is subtracted. Later
+trading cannot dilute this fixed historical ratio. A replacement proof must
+increase the proven wash volume and keep the same total; volumes from separate
+proofs are not simply added together.
+
+The **25% enforcement threshold** is different from the pinned guest's **30%
+return-coverage requirement** for transfer-return closed loops. The latter is
+part of deciding which evidence proves wash volume. Self-funded and reciprocal
+evidence follow their own predicate checks. These proofs establish the configured
+predicate, not that every possible form of wash trading has been detected; an
+unflagged seller is not a certification of honest activity. The published proof
+package also records unresolved funding-completeness and direct-USDC attribution
+limitations. Successful verification is not a claim that those limitations have
+been resolved.
+
+### What a flag changes
+
+- New usage involving that seller earns no buyer, seller, or pool-weighted points.
+- Previously recorded points are not erased.
+- USDC service payments can still settle.
+- Starter-position eligibility and staked principal are unchanged.
+- The flag does not ban the address from earning as a buyer of other sellers or
+  as a staker in other pools.
+
+This is a reward filter, not a principal-slashing mechanism. The separate
+[legacy claim policy](./legacy-emissions.md#locked-seller-rewards-m002) controls
+releases from the old locked-rewards pool.
+
+Recording evidence and enabling enforcement are separate: accounting must use
+the points registry with this modifier installed. Removing the modifier stops
+that filter from running, but does not erase finalized evidence in the wash registry.
+
+### What the proof establishes
+
+The seller proof verifies transactions, receipts, and storage values against
+supplied block headers and checks the pinned wash-trading predicate. That proves
+consistency with those headers; it does not, by itself, establish that the headers
+belong to the real Base chain.
+
+The registry checks each committed block reference against Chainlink's public
+`BlockhashStore` on Base. A missing or different hash rejects the check. Chainlink
+supplies the historical block-hash reference, not a judgment about the seller.
+
+Proof submission has three stages:
+
+1. **Stage:** verify the SP1 proof and save its public journal, including a Merkle
+   root committing the required block-reference chunks and their counts.
+2. **Authenticate:** check each chunk's block hashes against the store and its
+   Merkle path against that root. This binds the checks to the exact evidence
+   list in the proof. Chunks cannot be substituted or counted twice.
+3. **Finalize:** require every committed chunk and reference to be authenticated,
+   then record the seller's result. Only a finalized result affects the flag.
+
+Anyone can submit this evidence, but cannot choose another guest program,
+verifier, historical period, or blockhash store: those are pinned by the registry.
+Authentication is split into chunks to bound gas, and interrupted submissions
+can resume. Backfilling a missing hash into Chainlink's store is a separate step;
+neither staging a proof nor backfilling its hashes makes it finalized.
+
+## Other policy interfaces
+
+Not every contract called a policy belongs to the points list. A pool-weight
+policy maps staking power to accounting weight. A legacy seller claim policy
+controls how much of an existing locked balance can be released. Routing
+preferences choose which seller receives a request. Each has a different input,
+owner, and effect; none should be treated as an automatic extension of the
+points registry.

--- a/apps/website/docs/protocol/security.md
+++ b/apps/website/docs/protocol/security.md
@@ -7,11 +7,16 @@ hide_title: true
 
 # Security
 
-AntSeed separates signing authority from fund custody. The node identity that signs protocol messages and payment authorizations never holds funds directly. The wallet that holds your money deposits into a contract and never touches the node.
+AntSeed separates a buyer's deposit balance from the node wallet. USDC committed
+to service payments is held by `AntseedDeposits`; the node signs spending
+authorizations. Incoming USDC can be swept from the node wallet into the deposit
+contract through a gasless authorization.
 
 ## Identity
 
-Each node has a single secp256k1 private key. The corresponding EVM address is both the PeerId on the network and the on-chain signing identity. There is no key derivation step and no two-key system — one key handles everything.
+Each node uses a secp256k1 private key. Its EVM address is the peer identity and
+payment-signing identity. A separate wallet can fund the node's deposit or act
+as its deposits operator; those roles do not have to share the node key.
 
 | Function | Mechanism |
 |---|---|
@@ -21,15 +26,19 @@ Each node has a single secp256k1 private key. The corresponding EVM address is b
 
 ## Signing Identity vs Funding Wallet
 
-The node's secp256k1 key is the **signing identity**. It signs both protocol messages (handshakes, metadata, metering receipts) and EIP-712 payment messages (`ReserveAuth` to authorize session budgets, `SpendingAuth` to authorize cumulative spending). It never holds funds directly.
+The **signing identity** signs protocol messages and payment authorizations.
+Gasless buyer funding can send USDC to this address first, then use a signed
+authorization and a permissionless relayer to sweep it into `AntseedDeposits`.
+Sellers also use their node wallet for transaction gas and USDC earnings.
 
-The **funding wallet** is any external wallet the user controls — hardware wallet, multisig, or EOA. It deposits USDC into the AntseedDeposits contract via `depositFor(buyer, amount)`, where `buyer` is the signing identity's address. The funding wallet has no ongoing role after deposit.
+An external **funding wallet** can instead approve USDC and call
+`deposit(buyer, amount)` directly. Funding a buyer does not automatically make
+that wallet the buyer's operator.
 
-This separation means:
-
-- The signing identity can run unattended without risking the funding wallet
-- The funding wallet never interacts with the application
-- Worst-case exposure from a compromised signing identity is bounded by the current deposit balance
+The **deposits operator** can withdraw the buyer's available deposit balance.
+The buyer authorizes its initial operator with an EIP-712 signature; the current
+operator controls subsequent operator transfers. Check `getOperator(buyer)`
+rather than assuming the funding wallet has withdrawal authority.
 
 ## Key Storage
 
@@ -53,13 +62,15 @@ Both modes produce identical on-chain outcomes. The difference is whether the si
 
 | Scenario | Signing Identity Exposed | Funding Wallet Exposed | Maximum Loss |
 |---|---|---|---|
-| **Node compromised** | Yes | No | Current deposit balance |
-| **Signing key extracted** | Yes | No | Current deposit balance |
-| **Funding wallet compromised** | No | Yes | Funding wallet balance (deposits unaffected once deposited) |
-| **Both compromised** | Yes | Yes | Deposit balance + funding wallet balance |
+| **Node compromised** | Yes | Not if its key is kept separately | Authorized deposit spending, node-wallet assets, and any roles held by that key |
+| **Signing key extracted** | Yes | Not if its key is kept separately | Same exposure as the signing identity |
+| **Funding wallet compromised** | Not necessarily | Yes | Wallet assets; available deposits too if it is their operator |
+| **Deposits operator compromised** | Not necessarily | Depends on key reuse | Available deposits for accounts it operates |
 | **Deposits contract exploit** | N/A | N/A | All deposited funds across all users |
 
-In the common attack surface — node compromise — the funding wallet is never at risk. The attacker can sign ReserveAuths against the existing deposit balance but cannot access the funding wallet or deposit additional funds.
+These roles can use the same address, in which case their risks combine. A
+separate funding wallet is not exposed merely because it previously funded a
+buyer, but shared keys, allowances, and operator permissions must be considered.
 
 ## Protocol-Level Controls
 
@@ -77,26 +88,30 @@ All communication happens over an untrusted network. Every trust-critical operat
 | **Discovery** | Signed metadata with freshness checks, topic normalization, private IP filtering |
 | **Connection** | EIP-191 signed intro envelopes with nonce replay guard, timestamp skew rejection, per-IP connection cap (10) |
 | **Transport** | Frame type and size validation (64 MiB max), fail-closed on decode errors, request and stream timeouts |
-| **Upload/Stream** | Per-request cap (32 MiB), global pending cap (256 MiB), upload timeout (120s), stream buffer (16 MiB) and duration (5 min) limits |
+| **Upload/Stream** | Per-request cap (32 MiB), global pending cap (256 MiB), upload timeout (120s), bounded stream buffers and configurable duration limits |
 | **Metering** | Bilateral EIP-191 signed receipts with running totals, auto-ack enabled by default |
 | **Payment** | 402 gating until ReserveAuth is committed on-chain via `reserve()`, bounded by maxAmount and deadline |
 
 ## Default Limits
 
+Buyer request and stream defaults are defined in `packages/buyer-core` and the
+CLI configuration. They are configurable; upload and connection limits are
+separate transport controls.
+
 | Parameter | Default |
 |---|---|
-| Request timeout | 30 s |
+| Buyer request timeout | 5 min |
 | Max stream buffer | 16 MiB |
-| Max stream duration | 5 min |
+| Buyer max stream duration | 30 min |
 | Per-upload cap | 32 MiB |
 | Global pending upload cap | 256 MiB |
 | Upload timeout | 120 s |
-| Metadata fetch timeout | 2 s |
+| Node metadata fetch timeout | 1.5 s |
 | Max inbound connections per IP | 10 |
 
 ## Best Practices
 
-1. Use `depositFor()` on AntseedDeposits from a hardware wallet or multisig. Never fund the signing identity directly.
+1. Keep treasury and operator keys separate from the node where possible. Use `deposit(buyer, amount)` for direct external funding, or the [gasless sweep flow](../guides/payments.md) when funding the node address. Minimize assets left in the hot wallet.
 2. Deposit only what you need for a session. Top up as needed rather than pre-loading large amounts into AntseedDeposits.
 3. Keep `allowPrivateIPs=false` in production.
 4. Keep signature verification and stale metadata rejection enabled (both on by default).

--- a/apps/website/sidebars.ts
+++ b/apps/website/sidebars.ts
@@ -41,6 +41,7 @@ const sidebars: SidebarsConfig = {
         'protocol/metering',
         'protocol/payments',
         'protocol/recognized-usage',
+        'protocol/reward-policies',
         'protocol/legacy-emissions',
         'protocol/reputation',
         'protocol/security',

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -17,6 +17,14 @@ AntSeed is a peer-to-peer AI services network that enables direct connections be
 
 ## Getting Started
 
+For protocol behavior from epoch 22, start with [Recognized Usage and ANTS
+Rewards](../../apps/website/docs/protocol/recognized-usage.md), [Reward
+Policies](../../apps/website/docs/protocol/reward-policies.md), and the separate
+[legacy claims reference](../../apps/website/docs/protocol/legacy-emissions.md).
+Deployment procedures belong in the contract migration runbooks; the model
+verification and fingerprint-swarm specifications describe proposed work rather
+than additional active reward policies.
+
 Install the CLI globally:
 
 ```bash

--- a/docs/protocol/spec/04-payments.md
+++ b/docs/protocol/spec/04-payments.md
@@ -174,14 +174,19 @@ Stats are factual counters with no reputation scoring logic. They feed into emis
 | Layer | Mechanism | Default |
 |---|---|---|
 | Minimum deposit | Buyers must deposit at least N USDC to participate | 10 USDC |
-| Minimum stake | Sellers must stake USDC bound to ERC-8004 agentId | 10 USDC |
+| Seller eligibility | Checked through the registry's active staking contract | Legacy USDC fallback while enabled; ANTS pool rules after cutover |
 | Budget binding | ReserveAuth binds maxAmount and deadline to buyer signature | Per-session |
 | Cumulative auth | SpendingAuth cumulativeAmount is monotonically increasing | Per-request |
 | Gasless buyer | Buyer never submits transactions — cannot be griefed for gas | Always |
 
 ## 6. Staking
 
-Sellers must stake USDC via `stake(agentId, amount)` on `AntseedStaking`, binding their stake to an ERC-8004 agentId. Minimum stake: `MIN_SELLER_STAKE` (default: 10 USDC). An unstaked seller cannot have `reserve()` called — the transaction reverts.
+Before the epoch-22 cutover, `AntseedStaking` uses USDC stake bound to an ERC-8004
+agent ID, with a 10 USDC minimum. After cutover, `AntseedSellerRegistry` supplies
+seller eligibility, with legacy USDC stake accepted while its fallback is enabled.
+New reward points additionally require sufficient ANTS pool power. See
+[staking and exit terms](../../../apps/website/docs/protocol/recognized-usage.md)
+and [legacy USDC staking](../../../apps/website/docs/protocol/legacy-emissions.md#legacy-usdc-staking).
 
 ## 7. Stats and Identity
 
@@ -233,6 +238,10 @@ The public policy returns remain `(sellerPoints, buyerPoints)`. A zeroed side
 cannot be restored and evaluation stops when both sides are zero. Historical
 wash flags zero future records involving the seller, not previously credited
 points, and do not prevent starter-position initialization or USDC settlement.
+
+See [Reward Policies](../../../apps/website/docs/protocol/reward-policies.md)
+for modifier composition, failure handling, and the distinction
+between proof verification and canonical block authentication.
 
 Locked ANTS positions are lANTS NFTs. Power activates in the next epoch. For a
 contract seller, an authorized operator may call `initPosition(seller)`; the

--- a/docs/protocol/spec/05-reputation.md
+++ b/docs/protocol/spec/05-reputation.md
@@ -26,13 +26,16 @@ export interface PeerInfo {
 
 - Type: `number | undefined`
 - Range: 0-100
-- Optional: peers without a score receive a fallback value of **0** during selection and are not blocked unless the buyer explicitly configures a higher minimum reputation
+- Optional: the generic scorer uses **0** for an unknown score. Model-only routing separately applies a default minimum trust score of **60**, excluding unscored offers unless the buyer lowers that threshold.
 
 ### Router Plugin Peer Scoring
 
 **Source:** `@antseed/router-core/src/peer-scorer.ts`
 
-Buyer-side peer selection is implemented in **router plugins**, not in the core node. Each router plugin is free to define its own scoring logic. The official `@antseed/router-local` plugin delegates composite candidate scoring to `@antseed/router-core`:
+Router plugins can define their own scoring logic. The generic composite scorer
+in `@antseed/router-core` uses the weights below. They are not the full selection
+algorithm for the buyer proxy and desktop's model-only routing, which use
+`@antseed/node/model-routing` and shared Price + Trust preferences.
 
 | Factor      | Weight | Description                                              |
 |-------------|--------|----------------------------------------------------------|
@@ -59,6 +62,12 @@ Router plugins apply a minimum reputation filter before scoring. In `@antseed/ro
 - Default value: **0** (no reputation gate)
 - Passed to the router as `minReputation` in the plugin config
 - Behavior: when a buyer explicitly raises `minReputation`, any peer whose effective reputation is below that threshold is excluded from the candidate pool before scoring
+
+Model-only requests also apply `buyer.routingPreferences.minTrustScore`, default
+**60**, plus allow/block lists and price limits. The filters are distinct:
+`minPeerReputation: 0` does not disable the model-routing trust gate. See the
+[routing reference](../../../apps/website/docs/protocol/reputation.md#buyer-route-scoring)
+for the ranking rules. Routing preferences are not on-chain reward policies.
 
 ## Local Runtime Signals
 
@@ -141,6 +150,6 @@ A peer's DHT-published reputation is computed by aggregating all attestations ab
 | Trust model             | Buyer-verifiable settlement history          | Transitive trust with decay             |
 | Sybil resistance        | Seller staking + settlement cost             | Staking-weighted attestations           |
 | Score range             | 0-100                                        | 0-100                                   |
-| Selection weight        | 10% of composite score                       | Router-defined                          |
-| Minimum threshold       | Configurable (default: 0)                    | Configurable (default: 0)               |
+| Selection weight        | Model-route ranking; generic scorer uses 10% | Router-defined                          |
+| Minimum threshold       | Model routing: 60; lower-level filter: 0     | Not specified                           |
 | Central authority       | None                                         | None                                    |

--- a/docs/protocol/spec/06-security-overview.md
+++ b/docs/protocol/spec/06-security-overview.md
@@ -46,8 +46,8 @@ The buyer-seller flow enforces:
 
 - Frame decoder validates message type and payload length (`MAX_PAYLOAD_SIZE = 64 MiB`).
 - Decode/dispatch errors fail the connection (fail-closed).
-- Request timeout: 30s. Stream idle timeout enforced and reset on each chunk.
-- Streaming bounded by max wall duration (default 5 min) and buffer cap (default 16 MiB).
+- Buyer request timeout defaults to 5 minutes; maximum stream duration defaults to 30 minutes (`packages/buyer-core/src/buyer-request-handler.ts`). Stream idle timeout is enforced and reset on each chunk.
+- Streaming is bounded by the configured wall duration and buffer cap (default 16 MiB).
 - Chunked uploads enforce per-request cap (32 MiB), global pending cap (256 MiB), timeout (120s), and explicit abort with 413/408 plus buffer zeroing.
 
 ### 3.4 Request Routing and Metering

--- a/docs/protocol/spec/09-deposit-sweep.md
+++ b/docs/protocol/spec/09-deposit-sweep.md
@@ -1,7 +1,7 @@
 # 09 — Deposit Sweep Protocol
 
 Decentralized gasless funding of a buyer's `AntseedDeposits` balance. The buyer
-hot wallet is signing-only — it never holds ETH. USDC arriving at the hot
+hot wallet does not need ETH for the relayed sweep. USDC arriving at the hot
 wallet (QR deposits, onramp deliveries) is moved into the deposits contract by
 **permissionless relayers** (sellers by default), compensated by a fixed USDC
 fee taken from the swept amount. No centralized paymaster, bundler, or relayer
@@ -23,8 +23,8 @@ sweepDeposit(
    (`to` is pinned to the relay contract, so only the relay can redeem the
    authorization; the 3009 nonce makes it single-use).
 2. Credits `amount - FEE` to the **buyer's** `AntseedDeposits` balance via
-   `deposit(from, amount - FEE)` — the buyer address itself never receives
-   tokens (iron rule). Requires `amount > FEE`, and mirrors both Deposits
+   `deposit(from, amount - FEE)` — the swept tokens move from the hot wallet
+   through the relay into contract custody. Requires `amount > FEE`, and mirrors both Deposits
    guards with clear errors for simulating relayers: a first-time buyer's net
    must clear `MIN_BUYER_DEPOSIT`, and the credited balance must not exceed
    `getBuyerCreditLimit(from)`. Buyers should size sweeps to their remaining

--- a/docs/protocol/spec/README.md
+++ b/docs/protocol/spec/README.md
@@ -68,6 +68,10 @@ How Buyers pay Sellers for inference. Covers pricing terms, payment settlement, 
 
 See: [04-payments.md](./04-payments.md)
 
+For the recognized-usage accounting extensions, see [Reward
+Policies](../../../apps/website/docs/protocol/reward-policies.md). This separates
+the deployed policy mechanism from the proposed model-verification designs below.
+
 ### 5. Reputation
 
 How nodes build and query trust. Covers reputation scoring, peer ratings, historical performance tracking, and Sybil resistance.

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -95,7 +95,8 @@ the recorded total. Zero totals and mismatched replacement totals are rejected.
 `isProvenWashTrader(seller)` is true only when finalized proven wash volume is
 at least 25% of the authenticated total (`WASH_TRADING_THRESHOLD_BPS = 2500`).
 Proofs below that threshold are still recorded and can be replaced by stronger
-proofs. This status controls the starter-position faucet; the threshold does not
+proofs. This status is read by the registered wash-trading points policy, not
+the starter-position faucet; the threshold does not
 change the proof journal, guest vkey, or proof bytes, and is separate from the
 guest's return-coverage rule. Existing deployments need a new registry to apply
 this policy; runtime bytecode checks must use the new build.
@@ -107,7 +108,8 @@ Missing hashes must be backfilled on the local fork before finalization can pass
 The RPC remains restricted to loopback URLs; this mode is not a live deployment
 or a test of real Groth16 proof verification.
 
-The updated seller guest uses a fixed 50% return-coverage floor for closed-loop
+The seller guest pinned by the recorded M001 deployment uses a fixed 30%
+return-coverage floor for transfer-return closed-loop
 evidence (`returnedCredit / provenWashVolume`), distinct from the registry's
 `provenWashShareBps` ratio (`provenWashVolume / totalSellerVolume`). The floor is
 pinned by the guest vkey, not a mutable registry setting. Each seller input contains
@@ -175,6 +177,18 @@ After deployment, call `stageSellerProof`, submit each artifact chunk with
 `authenticateBlockReferences(proofId, ...)`, then call
 `finalizeSellerProof(proofId)`. The contract never adds claims onchain and never
 accepts a lower or equal result.
+
+The ZK proof authenticates evidence against supplied block headers; the separate
+block-reference checks anchor those headers to canonical Base history. Each
+authentication call verifies a chunk against Chainlink and a Merkle path against
+the root committed by the proof. Completion is tracked per proof ID and chunk
+index; duplicate chunks are rejected, and finalization requires every committed
+reference. Authentication reads the store; backfilling missing hashes is a
+separate operation.
+
+For the distinction between proof verification, historical block authentication,
+and reward enforcement, see
+[Reward Policies](../../apps/website/docs/protocol/reward-policies.md).
 
 ### Backfill historical Base block hashes
 


### PR DESCRIPTION
## Description

Add a dedicated reward-policy guide and streamline the recognized-usage documentation. Correct inconsistent legacy-reward, wallet-custody, routing-filter, and staking explanations across the public guides and protocol references.

Documentation and navigation only: no contract code, deployment records, runtime behavior, or on-chain state changes. Existing untracked deployment recovery files are excluded.

## Release Notes

- Explain policy composition, owner controls, failure handling, and historical wash-trading enforcement, including SP1 verification and canonical block authentication.
- Separate current rewards from legacy claims, distinguish reward filtering from principal slashing, and replace the transaction-count narrative with policy-focused documentation.
- Correct funding and operator guidance, routing trust filters, buyer timeout defaults, and legacy command descriptions.
- Reduce repeated reward explanations and repair the remote-agent navigation link.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (maintenance tasks, refactoring, or non-functional changes)

## Validation

- `node --test scripts/deploy-contracts.test.mjs` — 79 tests passed.
- `pnpm --filter @antseed/website build` — passed without broken-link warnings.
- Relative link targets checked in all 21 changed Markdown files — no missing targets.
- `git diff --check` — passed.

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have added tests (if appropriate)
- [x] Existing relevant tests and documentation build pass locally

No new tests were added because this change is documentation/navigation only. This is a cross-document consistency review, not a new implementation security audit.