### PR TITLE
chore: Bump versions for npm release

### DIFF
--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -22,7 +22,7 @@ For every public package, list commits touching it since its version was last bu
 for p in packages/protocol packages/api-adapter packages/buyer-core packages/node \
          packages/provider-core packages/router-core packages/ant-agent \
          packages/web-sdk plugins/* apps/cli apps/payments apps/network-stats \
-         apps/relay; do
+         apps/ants apps/relay; do
   bump=$(git log origin/main -1 --format=%H -G'"version": ' -- $p/package.json)
   echo "=== $p"
   git log --oneline --no-merges $bump..origin/main -- $p
@@ -39,7 +39,7 @@ pnpm resolves `workspace:*` **regular dependencies** to exact versions at publis
 2. Add every public dependent that declares one of them as a regular `workspace:` dependency, recursively.
 3. Peer dependencies with ranges (e.g. provider-core/router-core/ant-agent declare `@antseed/node >=0.1.0`) do NOT cascade.
 
-Known chains: cli + payments pin node; node pins protocol/buyer-core/api-adapter; all provider plugins pin provider-core; router-local pins router-core; cli also pins payments, api-adapter, ant-agent, provider-core.
+Known chains: cli + payments + ants pin node; node pins protocol/buyer-core/api-adapter; web-sdk pins buyer-core/protocol; all provider plugins pin provider-core; router-local pins router-core; cli also pins ants, payments, api-adapter, ant-agent, provider-core.
 
 Don't compute this by hand and hope — step 4 validates it mechanically.
 
@@ -112,10 +112,10 @@ Confirm exactly ONE `@antseed/node` version appears (the 0.1.139 incident check)
 ```
 packages/*   @antseed/node, @antseed/protocol, @antseed/buyer-core,
              @antseed/api-adapter, @antseed/ant-agent,
-             @antseed/provider-core, @antseed/router-core
+             @antseed/provider-core, @antseed/router-core, @antseed/web-sdk
 plugins/*    provider-anthropic, provider-claude-code, provider-claude-oauth,
              provider-openai, provider-openai-responses, provider-local-llm,
              router-local
 apps/*       @antseed/cli, @antseed/network-stats, @antseed/payments
-             @antseed/relay
+             @antseed/ants, @antseed/relay
 ```

--- a/apps/ants/package.json
+++ b/apps/ants/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/ants",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ANTS staking dashboard and service layer for the AntSeed CLI",
   "files": [
     "dist"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/cli",
-  "version": "0.1.157",
+  "version": "0.1.158",
   "description": "Antseed Network CLI and Web Dashboard",
   "type": "module",
   "files": [

--- a/apps/payments/package.json
+++ b/apps/payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/payments",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "Buyer payments portal for AntSeed",
   "files": [
     "dist"

--- a/packages/buyer-core/package.json
+++ b/packages/buyer-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/buyer-core",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Transport-agnostic AntSeed buyer machinery: request handling, payment negotiation, channel accounting. Portable — no Node-only dependencies",
   "type": "module",
   "files": [

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/node",
-  "version": "0.2.117",
+  "version": "0.2.118",
   "description": "Antseed Network protocol SDK — P2P inference marketplace",
   "type": "module",
   "files": [

--- a/packages/web-sdk/package.json
+++ b/packages/web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antseed/web-sdk",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Browser buyer SDK for AntSeed: connect to sellers over WebRTC via a signaling relay, pay with in-browser EIP-712 signatures",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Description

Prepare the npm release from fetched main at 07e322360, including merged PR #994. Apply patch bumps and update the release skill's public-package inventory and exact-pin chains for ANTS and web-sdk. The workflow already includes ANTS.

### Changed directly
- @antseed/buyer-core: 0.1.8 → 0.1.9 — longer RPC request timeout and shared-provider support.
- @antseed/node: 0.2.117 → 0.2.118 — recognized-usage/payment clients, contract address resolution, legacy claims, and channel-close/payment-auth fixes.
- @antseed/ants: 0.1.0 → 0.1.1 — first npm release of the staking dashboard and shared ANTS service, including review fixes.
- @antseed/cli: 0.1.157 → 0.1.158 — ANTS commands/dashboard and seller registration, staking, rewards, and withdrawal updates.

### Cascade (exact pins)
- @antseed/payments: 0.1.44 → 0.1.45 — pins @antseed/node.
- @antseed/web-sdk: 0.1.2 → 0.1.3 — pins @antseed/buyer-core.

### Skipped packages
Already published and unchanged: @antseed/ant-agent, @antseed/api-adapter, @antseed/protocol, @antseed/provider-core, @antseed/router-core, @antseed/provider-anthropic, @antseed/provider-claude-code, @antseed/provider-claude-oauth, @antseed/provider-local-llm, @antseed/provider-openai, @antseed/provider-openai-responses, @antseed/router-local, @antseed/network-stats, and @antseed/relay. Private packages are excluded.

## Release Notes

No new user-facing behavior in this PR: only package versions and internal release instructions change. Runtime changes are already merged and documented in CHANGELOG.md.

## Validation

- Computed the recursive regular workspace-dependency closure mechanically: exactly six packages.
- `node scripts/npm-publish-plan.mjs` passed against npm: exactly the six intended PUBLISH rows; all other packages skip; no cascade or behind-registry violations.
- `git diff --check` passed.
- Runtime builds/tests were not rerun for this version-only change; PR CI and the publish workflow run their configured validation.

## Publishing

Nothing has been published and no workflow was dispatched. After merge, manually run Actions → Publish npm packages on main (optionally dry_run first). CI owns building, testing, and publishing.