### PR TITLE
test(config): Expect active M001 deployment

### DIFF
--- a/apps/cli/src/cli/commands/seller/contract-clients.test.ts
+++ b/apps/cli/src/cli/commands/seller/contract-clients.test.ts
@@ -11,15 +11,16 @@ test('CLI local defaults use the registry nonce rather than the token nonce and 
   assert.equal(requireCryptoConfig({ ...base, payments: { ...base.payments, crypto: { ...base.payments!.crypto!, registryContractAddress: address } } }).registryContractAddress, address);
 });
 
-test('legacy factories use V2 and USDC staking with the pre-cutover ledger', () => {
+test('legacy factories use V2 and USDC staking with the active mainnet ledger', () => {
   const config = { payments: { crypto: { chainId: 'base-mainnet', rpcUrl: 'http://127.0.0.1:1' } } } as AntseedConfig;
   const chain = requireCryptoConfig(config);
   const emissions = createLegacyEmissionsClient(config);
   const staking = createLegacyStakingClient(config);
   try {
-    assert.equal(emissions.contractAddress, chain.emissionsContractAddress);
-    assert.notEqual(emissions.contractAddress, chain.legacyEmissionsContractAddress);
-    assert.equal(staking.contractAddress, chain.stakingContractAddress);
+    assert.equal(emissions.contractAddress, chain.legacyEmissionsContractAddress);
+    assert.notEqual(emissions.contractAddress, chain.emissionsContractAddress);
+    assert.equal(staking.contractAddress, chain.legacyStakingContractAddress);
+    assert.notEqual(staking.contractAddress, chain.stakingContractAddress);
   } finally {
     emissions.provider.destroy();
     staking.provider.destroy();

--- a/packages/node/tests/ants-clients.test.ts
+++ b/packages/node/tests/ants-clients.test.ts
@@ -75,7 +75,7 @@ describe('seller proof artifacts', () => {
 describe('recognized-usage chain defaults', () => {
   it('fills the individual contract fields from the deployment record without overriding explicit values', () => {
     const base = getChainConfig('base-mainnet');
-    expect(base.recognizedUsage?.status).toBe('deployed');
+    expect(base.recognizedUsage?.status).toBe('active');
     expect(base.sellerPoolsAddress?.toLowerCase()).toBe(base.recognizedUsage?.contracts.sellerPools.toLowerCase());
     expect(base.washTradingRegistryAddress?.toLowerCase()).toBe(base.recognizedUsage?.contracts.washTradingRegistry.toLowerCase());
     const overridden = resolveChainConfig({ chainId: 'base-mainnet', sellerPoolsAddress: '0x0000000000000000000000000000000000000001' });


### PR DESCRIPTION
## Description

Fix the stale recognized-usage chain-default assertion to expect `active` after M001 activation. This changes only the test; deployment records, contracts, and operational scripts are unchanged.

## Release Notes

No user-facing change. Test-only correction; no changelog entry required.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore (maintenance tasks, refactoring, or non-functional changes)

## Checklist

- [x] My code follows the code style of this project
- [x] I have added the necessary documentation (if appropriate)
- [x] I have added tests (if appropriate)
- [x] Full node unit test suite passes: 98 files, 1,063 tests
- [x] `git diff --check` passes